### PR TITLE
Adding schemas for examples and adding redis as its own example

### DIFF
--- a/examples/guestbook/guestbook.yaml
+++ b/examples/guestbook/guestbook.yaml
@@ -1,5 +1,7 @@
 imports:
 - path: redis.jinja
+- path: redis.jinja.schema
+
 resources:
 - name: frontend
   type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py

--- a/examples/guestbook/redis.jinja
+++ b/examples/guestbook/redis.jinja
@@ -1,5 +1,5 @@
 {% set REDIS_PORT = 6379 %}
-{% set WORKERS = properties['workers'] or 2 %}
+{% set WORKERS = properties['workers'] %}
 
 resources:
 - name: redis-master

--- a/examples/guestbook/redis.jinja
+++ b/examples/guestbook/redis.jinja
@@ -1,5 +1,5 @@
 {% set REDIS_PORT = 6379 %}
-{% set WORKERS = properties['workers'] %}
+{% set WORKERS = properties['workers'] or 2 %}
 
 resources:
 - name: redis-master

--- a/examples/guestbook/redis.jinja.schema
+++ b/examples/guestbook/redis.jinja.schema
@@ -1,0 +1,10 @@
+info:
+  title: Redis cluster
+  description: Defines a redis cluster, using a single replica
+    replicatedservice for master and replicatedservice for workers.
+
+properties:
+  workers:
+    type: int
+    default: 2
+    description: Number of worker replicas.

--- a/examples/redis/redis.jinja
+++ b/examples/redis/redis.jinja
@@ -1,0 +1,32 @@
+{% set REDIS_PORT = 6379 %}
+{% set WORKERS = properties['workers'] or 2 %}
+
+resources:
+- name: redis-master
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  properties:
+    # This has to be overwritten since service names are hard coded in the code
+    service_name: redis-master
+    service_port: {{ REDIS_PORT }}
+    target_port: {{ REDIS_PORT }}
+    container_port: {{ REDIS_PORT }}
+    replicas: 1
+    container_name: master
+    image: redis
+
+- name: redis-slave
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  properties:
+    # This has to be overwritten since service names are hard coded in the code
+    service_name: redis-slave
+    service_port: {{ REDIS_PORT }}
+    container_port: {{ REDIS_PORT }}
+    replicas: {{ WORKERS }}
+    container_name: worker
+    image: kubernetes/redis-slave:v2
+    # An example of how to specify env variables.
+    env:
+    - name: GET_HOSTS_FROM
+      value: env
+    - name: REDIS_MASTER_SERVICE_HOST
+      value: redis-master

--- a/examples/redis/redis.jinja.schema
+++ b/examples/redis/redis.jinja.schema
@@ -1,0 +1,10 @@
+info:
+  title: Redis cluster
+  description: Defines a redis cluster, using a single replica
+    replicatedservice for master and replicatedservice for workers.
+
+properties:
+  workers:
+    type: int
+    default: 2
+    description: Number of worker replicas.

--- a/examples/replicatedservice/replicatedservice.py
+++ b/examples/replicatedservice/replicatedservice.py
@@ -15,25 +15,7 @@ def GenerateConfig(context):
   """Generates a Replication Controller and a matching Service.
 
   Args:
-    context: Template context, which can contain the following properties:
-             container_name - Name to use for container. If omitted, name is
-                              used.
-             namespace - Namespace to create the resources in. If omitted,
-                         'default' is used.
-             service_name - Name to use for service. If omitted name-service is
-                            used.
-             protocol - Protocol to use for the service
-             service_port - Port to use for the service
-             target_port - Target port for the service
-             container_port - Container port to use
-             replicas - Number of replicas to create in RC
-             image - Docker image to use for replicas. Required.
-             labels - labels to apply.
-             env - Environmental variables to apply (list of maps). Format
-                   should be:
-                      [{'name': ENV_VAR_NAME, 'value':'ENV_VALUE'},
-                       {'name': ENV_VAR_NAME_2, 'value':'ENV_VALUE_2'}]
-             external_service - If set to true, enable external Load Balancer
+    context: Template context. See schema for context properties.
 
   Returns:
     A Container Manifest as a YAML string.

--- a/examples/replicatedservice/replicatedservice.py.schema
+++ b/examples/replicatedservice/replicatedservice.py.schema
@@ -1,0 +1,57 @@
+info:
+  title: Replicated Service
+  description: |
+    Defines a ReplicatedService type by creating both a Service and an RC.
+
+    This module creates a typical abstraction for running a service in a
+    Kubernetes cluster, namely a replication controller and a service packaged
+    together into a single unit.
+
+required:
+- image
+
+properties:
+  container_name:
+    type: string
+    description: Name to use for container. If omitted, name is used.
+  service_name:
+    type: string
+    description: Name to use for service. If omitted, name-service is used.
+  namespace:
+    type: string
+    description: Namespace to create resources in. If omitted, 'default' is
+      used.
+    default: default
+  protocol:
+    type: string
+    description: Protocol to use for the service.
+  service_port:
+    type: int
+    description: Port to use for the service.
+  target_port:
+    type: int
+    description: Target port to use for the service.
+  container_port:
+    type: int
+    description: Port to use for the container.
+  replicas:
+    type: int
+    description: Number of replicas to create in RC.
+  image:
+    type: string
+    description: Docker image to use for replicas.
+  labels:
+    type: object
+    description: Labels to apply.
+  env:
+    type: object
+    description: Environment variables to apply.
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+  external_service:
+    type: boolean
+    description: If set to true, enable external load balancer.
+


### PR DESCRIPTION
This leaves redis in guestbook as well until it's available on github, at which point it will be removed and guestbook will point to the version on github.
