### PR TITLE
Move type references from /examples to /types.

### DIFF
--- a/examples/bootstrap/bootstrap.yaml
+++ b/examples/bootstrap/bootstrap.yaml
@@ -1,6 +1,6 @@
 resources:
 - name: expandybird
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     service_port: 8081
     target_port: 8080
@@ -11,7 +11,7 @@ resources:
     labels:
       app: dm
 - name: resourcifier
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     service_port: 8082
     target_port: 8080
@@ -22,7 +22,7 @@ resources:
     labels:
       app: dm
 - name: manager
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     service_port: 8080
     target_port: 8080

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -40,7 +40,7 @@ The front end is a replicated service with 3 replicas:
 
 ```
 - name: frontend
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     service_port: 80
     container_port: 80
@@ -63,7 +63,7 @@ which is a [Jinja](http://jinja.pocoo.org/) template with a [schema](../../types
 
 resources:
 - name: redis-master
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     # This has to be overwritten since service names are hard coded in the code
     service_name: redis-master
@@ -75,7 +75,7 @@ resources:
     image: redis
 
 - name: redis-slave
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     # This has to be overwritten since service names are hard coded in the code
     service_name: redis-slave
@@ -99,7 +99,7 @@ You can see the types you deployed to the cluster using the `deployed-types` com
 ```
 dm deployed-types 
 
-["Service","ReplicationController","redis.jinja","https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py"]
+["Service","ReplicationController","redis.jinja","https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py"]
 ```
 
 This output shows 2 primitive types (Service and ReplicationController), and 2

--- a/examples/guestbook/guestbook.yaml
+++ b/examples/guestbook/guestbook.yaml
@@ -1,6 +1,6 @@
 resources:
 - name: frontend
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     service_port: 80
     container_port: 80
@@ -8,5 +8,5 @@ resources:
     replicas: 3
     image: gcr.io/google_containers/example-guestbook-php-redis:v3
 - name: redis
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/redis/redis.jinja
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/redis/v1/redis.jinja
   properties: null

--- a/types/redis/v1/redis.jinja
+++ b/types/redis/v1/redis.jinja
@@ -3,7 +3,7 @@
 
 resources:
 - name: redis-master
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     # This has to be overwritten since service names are hard coded in the code
     service_name: redis-master
@@ -15,7 +15,7 @@ resources:
     image: redis
 
 - name: redis-slave
-  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/examples/replicatedservice/replicatedservice.py
+  type: https://raw.githubusercontent.com/kubernetes/deployment-manager/master/types/replicatedservice/v1/replicatedservice.py
   properties:
     # This has to be overwritten since service names are hard coded in the code
     service_name: redis-slave


### PR DESCRIPTION
The type references in various files were still pointing to the original locations of the types in the examples folder. This change updates the references to point to the new locations of the types in the types folder.
