### PR TITLE
Require schema

### DIFF
--- a/dm/dm.go
+++ b/dm/dm.go
@@ -98,15 +98,15 @@ func main() {
 			log.Fatalf("Cannot list %v err")
 		}
 
-		fmt.Printf("Types:")
+		fmt.Printf("Types:\n")
 		for _, t := range types {
-			fmt.Printf("%s:%s", t.Name, t.Version)
+			fmt.Printf("%s:%s\n", t.Name, t.Version)
 			downloadURL, err := git.GetURL(t)
 			if err != nil {
 				log.Printf("Failed to get download URL for type %s:%s", t.Name, t.Version)
 			}
 
-			fmt.Printf("\tdownload URL: %s", downloadURL)
+			fmt.Printf("\tdownload URL: %s\n", downloadURL)
 		}
 	case "describe":
 		fmt.Printf("this feature is not yet implemented")


### PR DESCRIPTION
Replaces #32 with just the required commits. From that PR:

Check that there's a schema file of the expected name (type.[jinja|py].schema).
Add newlines to types list.

Fixes #22.

In particular:
requiring a schema file in the version directory (e.g., types/redis/v1/redis.jinja.schema)
