### PR TITLE
Fixing jinja template for redis to allow for no properties.

### DIFF
--- a/types/redis/v1/redis.jinja
+++ b/types/redis/v1/redis.jinja
@@ -1,5 +1,5 @@
 {% set REDIS_PORT = 6379 %}
-{% set WORKERS = properties['workers'] or 2 %}
+{% set WORKERS = properties['workers'] if properties and properties['workers'] else 2 %}
 
 resources:
 - name: redis-master

--- a/types/redis/v1/redis.yaml
+++ b/types/redis/v1/redis.yaml
@@ -4,4 +4,3 @@ imports:
 resources:
 - name: redis
   type: redis.jinja
-  properties: null


### PR DESCRIPTION
Previously it assumed properties would exist.

Fixes #35.
