### PR TITLE
fix(release): update helm owner to helm org

### DIFF
--- a/release/latest.go
+++ b/release/latest.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Owner is default Helm repository owner or organization.
-var Owner = "deis"
+var Owner = "helm"
 
 // Project is the default Helm repository name.
 var Project = "helm"


### PR DESCRIPTION
Important for commands like `helm update`. Replaces #232 in order to get CI to run on this PR.