### PR TITLE
Supports describing a type

### DIFF
--- a/dm/dm.go
+++ b/dm/dm.go
@@ -175,10 +175,10 @@ func main() {
 
 func callService(path, method, action string, reader io.ReadCloser) {
 	u := fmt.Sprintf("%s/%s", *service, path)
-	callAndPrintHttp(u, method, action, reader)
+	fmt.Println(callHttp(u, method, action, reader))
 }
 
-func callAndPrintHttp(path, method, action string, reader io.ReadCloser) {
+func callHttp(path, method, action string, reader io.ReadCloser) string {
 	request, err := http.NewRequest(method, path, reader)
 	request.Header.Add("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(request)
@@ -198,11 +198,12 @@ func callAndPrintHttp(path, method, action string, reader io.ReadCloser) {
 		log.Fatalf("cannot %s: %s\n", action, message)
 	}
 
-	fmt.Println(string(body))
+	return string(body)
 }
 
-// describeType prints the schema for  a type specified by either a
-// template URL or a fully qualified registry type name.
+// describeType prints the schema for a type specified by either a
+// template URL or a fully qualified registry type name (e.g.,
+// <type-name>:<version>)
 func describeType(args []string) {
 	if len(args) != 2 {
 		fmt.Fprintln(os.Stderr, "No type name or URL supplied")
@@ -230,7 +231,7 @@ func describeType(args []string) {
 	}
 
 	schemaUrl := tUrl + ".schema"
-	callAndPrintHttp(schemaUrl, "GET", "get schema for type ("+tUrl+")", nil)
+	fmt.Println(callHttp(schemaUrl, "GET", "get schema for type ("+tUrl+")", nil))
 }
 
 func loadTemplate(args []string) *expander.Template {

--- a/dm/dm.go
+++ b/dm/dm.go
@@ -118,7 +118,7 @@ func main() {
 			fmt.Printf("\tdownload URL: %s\n", downloadURL)
 		}
 	case "describe":
-		fmt.Printf("the describe feature is not yet implemented")
+		describeType(args)
 	case "expand":
 		backend := expander.NewExpander(*binary)
 		template := loadTemplate(args)
@@ -175,7 +175,11 @@ func main() {
 
 func callService(path, method, action string, reader io.ReadCloser) {
 	u := fmt.Sprintf("%s/%s", *service, path)
-	request, err := http.NewRequest(method, u, reader)
+	callAndPrintHttp(u, method, action, reader)
+}
+
+func callAndPrintHttp(path, method, action string, reader io.ReadCloser) {
+	request, err := http.NewRequest(method, path, reader)
 	request.Header.Add("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
@@ -195,6 +199,38 @@ func callService(path, method, action string, reader io.ReadCloser) {
 	}
 
 	fmt.Println(string(body))
+}
+
+// describeTemplate prints the schema for  a type specified by either a
+// template URL or a fully qualified registry type name.
+func describeType(args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "No template name supplied")
+		usage()
+	}
+
+	var tUrl string
+
+	if strings.HasPrefix(args[1], "http://") || strings.HasPrefix(args[1], "https://") {
+		// User can pass raw URL to template.
+		tUrl = args[1]
+	} else {
+		// User can pass registry type.
+		t := getRegistryType(args[1])
+		if t == nil {
+			log.Fatalf("Invalid type name, must be in the form \"<type-name>:<version>\": %s", args[1])
+		}
+
+		git := getGitRegistry()
+		url, err := git.GetURL(*t)
+		if err != nil {
+			log.Fatalf("Failed to fetch type information for %s: %s", args[1], err)
+		}
+		tUrl = url
+	}
+
+	schemaUrl := tUrl + ".schema"
+	callAndPrintHttp(schemaUrl, "GET", "get schema for type", nil)
 }
 
 func loadTemplate(args []string) *expander.Template {

--- a/dm/dm.go
+++ b/dm/dm.go
@@ -201,11 +201,11 @@ func callAndPrintHttp(path, method, action string, reader io.ReadCloser) {
 	fmt.Println(string(body))
 }
 
-// describeTemplate prints the schema for  a type specified by either a
+// describeType prints the schema for  a type specified by either a
 // template URL or a fully qualified registry type name.
 func describeType(args []string) {
 	if len(args) != 2 {
-		fmt.Fprintln(os.Stderr, "No template name supplied")
+		fmt.Fprintln(os.Stderr, "No type name or URL supplied")
 		usage()
 	}
 
@@ -230,7 +230,7 @@ func describeType(args []string) {
 	}
 
 	schemaUrl := tUrl + ".schema"
-	callAndPrintHttp(schemaUrl, "GET", "get schema for type", nil)
+	callAndPrintHttp(schemaUrl, "GET", "get schema for type ("+tUrl+")", nil)
 }
 
 func loadTemplate(args []string) *expander.Template {


### PR DESCRIPTION
Types can be described in one of two ways:

1) by type name: dm describe redis:v1
2) by URL: dm describe https://raw.githubusercontent.com/kubernetes/deployment-manager/master/templates/redis/v1/redis.jinja

Describing a type returns the template schema, which includes
descriptive information as well as the schema for properties on the
type.

Fixes #23 .
