### PR TITLE
fix(remove): prevent removing installed charts from workspace

### DIFF
--- a/action/remove.go
+++ b/action/remove.go
@@ -1,25 +1,88 @@
 package action
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/helm/helm/log"
+	"github.com/helm/helm/manifest"
 )
+
+// kubeGetter wraps the kubectl command, override in tests
+type kubeGetter func(string) string
+
+var kubeGet kubeGetter = func(m string) string {
+	log.Debug("Getting manifests from %s", m)
+
+	a := []string{"get", "-f", m}
+	out, err := exec.Command("kubectl", a...).CombinedOutput()
+	if err != nil {
+		log.Err("Could not get manifest. %s", err)
+	}
+	return string(out)
+}
 
 // Remove removes a chart from the workdir.
 //
 // - chart is the source
 // - homedir is the home directory for the user
-func Remove(chart string, homedir string) {
+// - force will remove installed charts from workspace
+func Remove(chart, homedir string, force bool) {
 	chartPath := filepath.Join(homedir, WorkspaceChartPath, chart)
 	if _, err := os.Stat(chartPath); err != nil {
 		log.Die("Chart not found. %s", err)
 	}
 
-	if err := os.RemoveAll(chartPath); err != nil {
-		log.Die("%s", err)
+	var connectionFailure bool
+
+	// check if any chart manifests are installed
+	installed, err := checkManifests(chartPath)
+	if err != nil {
+		if strings.Contains(err.Error(), "unable to connect") {
+			connectionFailure = true
+		} else {
+			log.Die(err.Error())
+		}
 	}
 
-	log.Info("All clear! You have successfully removed %s from your workspace.", chart)
+	if !force && connectionFailure {
+		log.Err("Could not determine if %s is installed.  To remove the chart --force flag must be set.", chart)
+	} else if !force && len(installed) > 0 {
+		log.Err("Found %d installed manifests for %s.  To remove a chart that has been installed the --force flag must be set.", len(installed), chart)
+	} else {
+		// remove local chart files
+		if err := os.RemoveAll(chartPath); err != nil {
+			log.Die("Could not remove chart. %s", err)
+		}
+
+		log.Info("All clear! You have successfully removed %s from your workspace.", chart)
+	}
+}
+
+// checkManifests gets any installed manifests within a chart
+func checkManifests(chartPath string) ([]string, error) {
+	var foundManifests []string
+
+	manifests, err := manifest.Files(chartPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range manifests {
+		out := kubeGet(m)
+
+		if strings.Contains(out, "unable to connect") {
+			return nil, fmt.Errorf(out)
+		}
+		if !strings.Contains(out, "not found") {
+			foundManifests = append(foundManifests, m)
+		}
+	}
+
+	log.Debug("Found %d installed manifests", len(foundManifests))
+
+	return foundManifests, nil
 }

--- a/action/remove_test.go
+++ b/action/remove_test.go
@@ -2,28 +2,85 @@ package action
 
 import (
 	"bytes"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
-	pretty "github.com/deis/pkg/prettyprint"
 	"github.com/helm/helm/log"
 )
 
-func TestRemove(t *testing.T) {
-	tmpHome := createTmpHome()
-	fakeUpdate(tmpHome)
+var (
+	// save globals for reset
+	defaultKubeGet func(string) string
+	defaultLogErr  io.Writer
+	defaultLogOut  io.Writer
 
-	Fetch("kitchensink", "", tmpHome)
+	// output stores command output
+	output bytes.Buffer
 
-	var output bytes.Buffer
-	log.Stderr = &output
+	// mock responses from kubectl
+	mockFoundGetter    = func(string) string { return "installed" }
+	mockNotFoundGetter = func(string) string { return "not found" }
+	mockFailConnection = func(string) string { return "unable to connect to a server" }
+)
 
-	Remove("kitchensink", tmpHome)
+func saveDefaults() {
+	defaultKubeGet = kubeGet
+	defaultLogErr = log.Stderr
+	defaultLogOut = log.Stdout
+}
 
-	expected := pretty.Colorize("{{.Green}}--->{{.Default}} ") + "All clear! You have successfully removed kitchensink from your workspace.\n"
+func rmCmdTeardown() {
+	kubeGet = defaultKubeGet
+	log.Stderr = defaultLogErr
+	log.Stdout = defaultLogOut
+	output.Reset()
+}
 
-	expect(t, output.String(), expected)
+func TestTRemove(t *testing.T) {
+	saveDefaults()
 
-	// reset log
-	log.Stdout = os.Stdout
+	tests := []struct {
+		chartName string
+		getter    kubeGetter
+		force     bool
+		match     string
+	}{
+		{"kitchensink", mockNotFoundGetter, false, "All clear! You have successfully removed kitchensink from your workspace."},
+
+		// when manifests are installed
+		{"kitchensink", mockFoundGetter, false, "Found 7 installed manifests for kitchensink.  To remove a chart that has been installed the --force flag must be set."},
+
+		// when manifests are installed and force is set
+		{"kitchensink", mockNotFoundGetter, true, "All clear! You have successfully removed kitchensink from your workspace."},
+
+		// when kubectl cannot connect
+		{"kitchensink", mockFailConnection, false, "Could not determine if kitchensink is installed.  To remove the chart --force flag must be set."},
+
+		// when kubectl cannot connect and force is set
+		{"kitchensink", mockFailConnection, true, "All clear! You have successfully removed kitchensink from your workspace."},
+	}
+
+	for _, tt := range tests {
+		tmpHome := createTmpHome()
+		fakeUpdate(tmpHome)
+
+		Fetch("kitchensink", "", tmpHome)
+
+		log.Stderr = &output
+		log.Stdout = &output
+
+		// set the mock getter
+		kubeGet = tt.getter
+
+		Remove(tt.chartName, tmpHome, tt.force)
+
+		if !strings.Contains(output.String(), tt.match) {
+			t.Errorf("\nExpected\n%s\nTo contain\n%s\n", output.String(), tt.match)
+		}
+
+		os.Remove(tmpHome)
+		rmCmdTeardown()
+	}
 }

--- a/helm.go
+++ b/helm.go
@@ -114,6 +114,12 @@ the 'nginx' chart into a directory named 'www' in your workspace.
 			Usage:     "Removes a Chart from your working directory.",
 			ArgsUsage: "[chart-name]",
 			Action:    remove,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "force",
+					Usage: "Remove Chart from working directory and leave packages installed.",
+				},
+			},
 		},
 		{
 			Name:  "install",
@@ -344,13 +350,11 @@ func fetch(c *cli.Context) {
 }
 
 func remove(c *cli.Context) {
-	home := home(c)
 	minArgs(c, 1, "remove")
+	h := home(c)
+	force := c.Bool("force")
 
-	a := c.Args()
-	chart := a[0]
-
-	action.Remove(chart, home)
+	action.Remove(c.Args()[0], h, force)
 }
 
 func install(c *cli.Context) {


### PR DESCRIPTION
Fixes: https://github.com/helm/helm/issues/183

Introduces a `--force` option on `helm remove` to remove charts from workspace that are installed.

TODO
- [x] handle kubectl not connected to cluster