### PR TITLE
Add resource state / errors to manifest. First step to #79, #80 

### DIFF
--- a/dm/dm.go
+++ b/dm/dm.go
@@ -41,6 +41,7 @@ var (
 	template_registry = flag.String("registry", "kubernetes/deployment-manager/templates", "Github based template registry (owner/repo[/path])")
 	service           = flag.String("service", "http://localhost:8001/api/v1/proxy/namespaces/dm/services/manager-service:manager", "URL for deployment manager")
 	binary            = flag.String("binary", "../expandybird/expansion/expansion.py", "Path to template expansion binary")
+	timeout           = flag.Int("timeout", 10, "Time in seconds to wait for response")
 )
 
 var commands = []string{
@@ -181,7 +182,12 @@ func callService(path, method, action string, reader io.ReadCloser) {
 func callHttp(path, method, action string, reader io.ReadCloser) string {
 	request, err := http.NewRequest(method, path, reader)
 	request.Header.Add("Content-Type", "application/json")
-	response, err := http.DefaultClient.Do(request)
+
+	client := http.Client{
+		Timeout: time.Duration(time.Duration(*timeout) * time.Second),
+	}
+
+	response, err := client.Do(request)
 	if err != nil {
 		log.Fatalf("cannot %s: %s\n", action, err)
 	}

--- a/manager/manager/deployer.go
+++ b/manager/manager/deployer.go
@@ -38,7 +38,7 @@ type Deployer interface {
 // NewDeployer returns a new initialized Deployer.
 // TODO(vaikas): Add a flag for setting the timeout.
 func NewDeployer(url string) Deployer {
-	return &deployer{url, 5}
+	return &deployer{url, 15}
 }
 
 type deployer struct {
@@ -126,7 +126,7 @@ func (d *deployer) callServiceWithConfiguration(method, operation string, config
 			return nil, fmt.Errorf("cannot unmarshal response: (%v)", err)
 		}
 	}
-	return result, err
+	return result, nil
 }
 
 func (d *deployer) callService(method, url string, reader io.Reader, callback formatter) ([]byte, error) {
@@ -140,9 +140,7 @@ func (d *deployer) callService(method, url string, reader io.Reader, callback fo
 	}
 
 	timeout := time.Duration(time.Duration(d.timeout) * time.Second)
-	client := http.Client{
-		Timeout: timeout,
-	}
+	client := http.Client{Timeout: timeout}
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, callback(err)

--- a/manager/manager/deployer_test.go
+++ b/manager/manager/deployer_test.go
@@ -165,7 +165,7 @@ func TestCreateConfiguration(t *testing.T) {
 		defer ts.Close()
 
 		deployer := NewDeployer(ts.URL)
-		err := deployer.CreateConfiguration(valid)
+		_, err := deployer.CreateConfiguration(valid)
 		if err != nil {
 			message := err.Error()
 			if !strings.Contains(message, dtc.Error) {
@@ -200,7 +200,7 @@ func TestDeleteConfiguration(t *testing.T) {
 		defer ts.Close()
 
 		deployer := NewDeployer(ts.URL)
-		err := deployer.DeleteConfiguration(valid)
+		_, err := deployer.DeleteConfiguration(valid)
 		if err != nil {
 			message := err.Error()
 			if !strings.Contains(message, dtc.Error) {
@@ -235,7 +235,7 @@ func TestPutConfiguration(t *testing.T) {
 		defer ts.Close()
 
 		deployer := NewDeployer(ts.URL)
-		err := deployer.PutConfiguration(valid)
+		_, err := deployer.PutConfiguration(valid)
 		if err != nil {
 			message := err.Error()
 			if !strings.Contains(message, dtc.Error) {

--- a/manager/manager/manager.go
+++ b/manager/manager/manager.go
@@ -104,9 +104,8 @@ func (m *manager) CreateDeployment(t *Template) (*Deployment, error) {
 		return nil, err
 	}
 
-	actualConfig, err := m.deployer.CreateConfiguration(manifest.ExpandedConfig)
-	log.Printf("Got Back %s", actualConfig)
-	if err != nil {
+	actualConfig, createErr := m.deployer.CreateConfiguration(manifest.ExpandedConfig)
+	if createErr != nil {
 		// Deployment failed, mark as failed
 		log.Printf("CreateConfiguration failed: %v", err)
 		m.repository.SetDeploymentStatus(t.Name, FailedStatus)
@@ -114,7 +113,7 @@ func (m *manager) CreateDeployment(t *Template) (*Deployment, error) {
 		// return the failure as such. Otherwise, we're going to add the manifest
 		// and hence resource specific errors down below.
 		if actualConfig == nil {
-			return nil, err
+			return nil, createErr
 		}
 	} else {
 		m.repository.SetDeploymentStatus(t.Name, DeployedStatus)
@@ -131,8 +130,8 @@ func (m *manager) CreateDeployment(t *Template) (*Deployment, error) {
 		// to a check fail (either deployment doesn't exist, or a manifest with the same
 		// name already exists).
 		// TODO(vaikas): Should we combine both errors and return a nicely formatted error for both?
-		if err != nil {
-			return nil, err
+		if createErr != nil {
+			return nil, createErr
 		} else {
 			return nil, aErr
 		}

--- a/manager/manager/manager.go
+++ b/manager/manager/manager.go
@@ -104,21 +104,40 @@ func (m *manager) CreateDeployment(t *Template) (*Deployment, error) {
 		return nil, err
 	}
 
-	err = m.repository.AddManifest(t.Name, manifest)
+	actualConfig, err := m.deployer.CreateConfiguration(manifest.ExpandedConfig)
+	log.Printf("Got Back %s", actualConfig)
 	if err != nil {
-		log.Printf("AddManifest failed %v", err)
-		m.repository.SetDeploymentStatus(t.Name, FailedStatus)
-		return nil, err
-	}
-
-	if err := m.deployer.CreateConfiguration(manifest.ExpandedConfig); err != nil {
-		// Deployment failed, mark as deleted
+		// Deployment failed, mark as failed
 		log.Printf("CreateConfiguration failed: %v", err)
 		m.repository.SetDeploymentStatus(t.Name, FailedStatus)
-		return nil, err
+		// If we failed before being able to create some of the resources, then
+		// return the failure as such. Otherwise, we're going to add the manifest
+		// and hence resource specific errors down below.
+		if actualConfig == nil {
+			return nil, err
+		}
+	} else {
+		m.repository.SetDeploymentStatus(t.Name, DeployedStatus)
+	}
+	
+	// Update the manifest with the actual state of the reified resources
+	manifest.ExpandedConfig = actualConfig
+	aErr := m.repository.AddManifest(t.Name, manifest)
+	if aErr != nil {
+		log.Printf("AddManifest failed %v", aErr)
+		m.repository.SetDeploymentStatus(t.Name, FailedStatus)
+		// If there's an earlier error, return that instead since it contains
+		// more applicable error message. Adding manifest failure is more akin
+		// to a check fail (either deployment doesn't exist, or a manifest with the same
+		// name already exists).
+		// TODO(vaikas): Should we combine both errors and return a nicely formatted error for both?
+		if err != nil {
+			return nil, err
+		} else {
+			return nil, aErr
+		}
 	}
 
-	m.repository.SetDeploymentStatus(t.Name, DeployedStatus)
 	// Finally update the type instances for this deployment.
 	m.addTypeInstances(t.Name, manifest.Name, manifest.Layout)
 	return m.repository.GetValidDeployment(t.Name)
@@ -183,7 +202,7 @@ func (m *manager) DeleteDeployment(name string, forget bool) (*Deployment, error
 	latest := getLatestManifest(d.Manifests)
 	if latest != nil {
 		log.Printf("Deleting resources from the latest manifest")
-		if err := m.deployer.DeleteConfiguration(latest.ExpandedConfig); err != nil {
+		if _, err := m.deployer.DeleteConfiguration(latest.ExpandedConfig); err != nil {
 			log.Printf("Failed to delete resources from the latest manifest: %v", err)
 			return nil, err
 		}
@@ -222,13 +241,15 @@ func (m *manager) PutDeployment(name string, t *Template) (*Deployment, error) {
 		return nil, err
 	}
 
-	err = m.repository.AddManifest(t.Name, manifest)
+	actualConfig, err := m.deployer.PutConfiguration(manifest.ExpandedConfig)
 	if err != nil {
 		m.repository.SetDeploymentStatus(name, FailedStatus)
 		return nil, err
 	}
 
-	if err := m.deployer.PutConfiguration(manifest.ExpandedConfig); err != nil {
+	manifest.ExpandedConfig = actualConfig
+	err = m.repository.AddManifest(t.Name, manifest)
+	if err != nil {
 		m.repository.SetDeploymentStatus(name, FailedStatus)
 		return nil, err
 	}

--- a/manager/manager/types.go
+++ b/manager/manager/types.go
@@ -169,7 +169,7 @@ type Resource struct {
 	Name       string                 `json:"name"`
 	Type       string                 `json:"type"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
-	State      ResourceState          `json:"state"`
+	State      *ResourceState          `json:"state,omitempty"`
 }
 
 // TypeInstance defines the metadata for an instantiation of a template type

--- a/resourcifier/configurations.go
+++ b/resourcifier/configurations.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/kubernetes/deployment-manager/manager/manager"
 	"github.com/kubernetes/deployment-manager/resourcifier/configurator"
 	"github.com/kubernetes/deployment-manager/util"
 
@@ -75,8 +76,8 @@ func listConfigurationsHandlerFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c := &configurator.Configuration{
-		[]configurator.Resource{
+	c := &manager.Configuration{
+		[]*manager.Resource{
 			{Type: rtype},
 		},
 	}
@@ -104,8 +105,8 @@ func getConfigurationHandlerFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c := &configurator.Configuration{
-		[]configurator.Resource{
+	c := &manager.Configuration{
+		[]*manager.Resource{
 			{Name: rname, Type: rtype},
 		},
 	}
@@ -252,7 +253,7 @@ func getPathVariable(w http.ResponseWriter, r *http.Request, variable, handler s
 	return unescaped, nil
 }
 
-func getConfiguration(w http.ResponseWriter, r *http.Request, handler string) *configurator.Configuration {
+func getConfiguration(w http.ResponseWriter, r *http.Request, handler string) *manager.Configuration {
 	b := io.LimitReader(r.Body, *maxLength*1024)
 	y, err := ioutil.ReadAll(b)
 	if err != nil {
@@ -275,7 +276,7 @@ func getConfiguration(w http.ResponseWriter, r *http.Request, handler string) *c
 		return nil
 	}
 
-	c := &configurator.Configuration{}
+	c := &manager.Configuration{}
 	if err := json.Unmarshal(j, c); err != nil {
 		e := errors.New(err.Error() + "\n" + string(j))
 		util.LogAndReturnError(handler, http.StatusBadRequest, e, w)


### PR DESCRIPTION
- Add a timeout to client and to deployer
- Set the Resource.State when deploying, or if things go bad, stash the error with resource
- remove configurator.go: Resource / Configuration and use the ones from manager instead

First changes to fully support: #80 and #79 
