### PR TITLE
feat(manifest.go): adding support for yml extensions in manifests (WIP)

### DIFF
--- a/chart/chart_test.go
+++ b/chart/chart_test.go
@@ -22,7 +22,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	if len(c.Kind["Pod"]) != 3 {
-		t.Errorf("Expected 3 pods, got %d", len(c.Kind["Pod"]))
+		t.Fatalf("Expected 3 pods, got %d", len(c.Kind["Pod"]))
 	}
 
 	if len(c.Kind["ReplicationController"]) == 0 {

--- a/chart/chartfile_test.go
+++ b/chart/chartfile_test.go
@@ -8,7 +8,7 @@ import (
 func TestRepoName(t *testing.T) {
 	name := RepoName(".")
 	if name == "" {
-		t.Errorf("Expected a git URL.")
+		t.Fatalf("Expected a git URL.")
 	}
 	if !strings.HasSuffix(name, ".git") {
 		t.Errorf("Expected %s to end with '.git'", name)

--- a/glide-full.yaml
+++ b/glide-full.yaml
@@ -32,6 +32,10 @@ import:
   version: v1.1.1
   subpackages:
   - /pkg
+  - /pkg/api
+  - /pkg/api/v1
+  - /pkg/api/unversioned
+  - /pkg/apis/extensions/v1beta1
 - package: github.com/aokoli/goutils
 - package: github.com/codegangsta/negroni
   version: 8d75e11374a1928608c906fe745b538483e7aeb2

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,6 +11,10 @@ import:
   version: v1.1.1
   subpackages:
   - /pkg
+  - /pkg/api
+  - /pkg/api/v1
+  - /pkg/api/unversioned
+  - /pkg/apis/extensions/v1beta1
 - package: speter.net/go/exp/math/dec/inf
 - package: golang.org/x/crypto
 - package: github.com/aokoli/goutils

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -35,7 +35,7 @@ func Files(chartDir string) ([]string, error) {
 			return nil
 		}
 
-		if filepath.Ext(fname) == ".yaml" {
+		if filepath.Ext(fname) == ".yaml" || filepath.Ext(fname) == ".yml" {
 			files = append(files, fname)
 		}
 
@@ -106,7 +106,7 @@ func ParseDir(chartDir string) ([]*Manifest, error) {
 			return nil
 		}
 
-		if filepath.Ext(fname) != ".yaml" {
+		if filepath.Ext(fname) != ".yaml" && filepath.Ext(fname) != ".yml" {
 			log.Debug("Skipping %s. Not a YAML file.", fname)
 			return nil
 		}


### PR DESCRIPTION
Fixes https://github.com/helm/helm/issues/248

This does not include support for `.yml` extensions in charts. @sgoings @michelleN @technosophos (others?) I'd like us to support `Chart.yml` at some point but not in this PR, and IMO we should error if both a `Chart.yml` and a `Chart.yaml` exist.