### PR TITLE
chore(helm): set default version

### DIFF
--- a/helm.go
+++ b/helm.go
@@ -8,7 +8,12 @@ import (
 	"github.com/helm/helm/log"
 )
 
-var version = "0.0.1"
+// version is the version of the app.
+//
+// This value is overwritten by the linker during build. The default version
+// here is SemVer 2, but basically indicates that this was a one-off build
+// and should not be trusted.
+var version = "0.1.0-unstable"
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
Not long ago @bacongobbler  rightly noted that the default version should
not be 0.0.1, but 0.1.0 (following SemVer 2). I added the -unstable flag
to distinguish this from an actually tagged release.