### PR TITLE
feat(*): Exit(1) when log.Err is called

### DIFF
--- a/action/remove.go
+++ b/action/remove.go
@@ -30,7 +30,8 @@ var kubeGet kubeGetter = func(m string) string {
 func Remove(chart, homedir string, force bool) {
 	chartPath := filepath.Join(homedir, WorkspaceChartPath, chart)
 	if _, err := os.Stat(chartPath); err != nil {
-		log.Die("Chart not found. %s", err)
+		log.Err("Chart not found. %s", err)
+		return
 	}
 
 	if !force {

--- a/helm.go
+++ b/helm.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/codegangsta/cli"
@@ -41,6 +42,13 @@ ENVIRONMENT:
 `
 	app.Version = version
 	app.EnableBashCompletion = true
+	app.After = func(c *cli.Context) error {
+		if log.ErrorState {
+			return errors.New("Exiting with errors")
+		}
+
+		return nil
+	}
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -344,7 +352,7 @@ experience with helm is trouble-free.
 		return nil
 	}
 
-	app.Run(os.Args)
+	app.RunAndExitOnError()
 }
 
 // home runs the --home flag through os.ExpandEnv.

--- a/log/log.go
+++ b/log/log.go
@@ -23,6 +23,9 @@ var Stdin io.Reader = os.Stdin
 // IsDebugging toggles whether or not to enable debug output and behavior.
 var IsDebugging = false
 
+// ErrorState denotes if application is in an error state.
+var ErrorState = false
+
 // New creates a *log.Logger that writes to this source.
 func New() *log.Logger {
 	ll := log.New(Stdout, pretty.Colorize("{{.Yellow}}--->{{.Default}} "), 0)
@@ -55,6 +58,7 @@ func CleanExit(format string, v ...interface{}) {
 func Err(format string, v ...interface{}) {
 	fmt.Fprint(Stderr, pretty.Colorize("{{.Red}}[ERROR]{{.Default}} "))
 	fmt.Fprintf(Stderr, appendNewLine(format), v...)
+	ErrorState = true
 }
 
 // Info prints a green-tinted message.


### PR DESCRIPTION
This causes helm to always exit(1) when `log.Err()` is called. Even if `log.Err()` is called and helm continues.