### PR TITLE
Failures during config creation no longer leave deployments undeleteable

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -28,30 +28,6 @@ type Schema struct {
 	Imports []SchemaImport `json:"imports"`
 }
 
-// Repository manages storage for all Deployment Manager entities, as well as
-// the common operations to store, access and manage them.
-type Repository interface {
-	// Deployments.
-	ListDeployments() ([]Deployment, error)
-	GetDeployment(name string) (*Deployment, error)
-	GetValidDeployment(name string) (*Deployment, error)
-	CreateDeployment(name string) (*Deployment, error)
-	DeleteDeployment(name string, forget bool) (*Deployment, error)
-	SetDeploymentStatus(name string, status DeploymentStatus) error
-
-	// Manifests.
-	AddManifest(deploymentName string, manifest *Manifest) error
-	ListManifests(deploymentName string) (map[string]*Manifest, error)
-	GetManifest(deploymentName string, manifestName string) (*Manifest, error)
-	GetLatestManifest(deploymentName string) (*Manifest, error)
-
-	// Types.
-	ListTypes() []string
-	GetTypeInstances(typeName string) []*TypeInstance
-	ClearTypeInstances(deploymentName string)
-	SetTypeInstances(deploymentName string, instances map[string][]*TypeInstance)
-}
-
 // Deployment defines a deployment that describes
 // the creation, modification and/or deletion of a set of resources.
 type Deployment struct {

--- a/manager/manager/manager_test.go
+++ b/manager/manager/manager_test.go
@@ -127,6 +127,7 @@ type repositoryStub struct {
 	FailListDeployments    bool
 	Created                []string
 	ManifestAdd            map[string]*common.Manifest
+	ManifestSet            map[string]*common.Manifest
 	Deleted                []string
 	GetValid               []string
 	TypeInstances          map[string][]string
@@ -140,6 +141,7 @@ func (repository *repositoryStub) reset() {
 	repository.FailListDeployments = false
 	repository.Created = make([]string, 0)
 	repository.ManifestAdd = make(map[string]*common.Manifest)
+	repository.ManifestSet = make(map[string]*common.Manifest)
 	repository.Deleted = make([]string, 0)
 	repository.GetValid = make([]string, 0)
 	repository.TypeInstances = make(map[string][]string)
@@ -191,6 +193,11 @@ func (repository *repositoryStub) DeleteDeployment(d string, forget bool) (*comm
 
 func (repository *repositoryStub) AddManifest(d string, manifest *common.Manifest) error {
 	repository.ManifestAdd[d] = manifest
+	return nil
+}
+
+func (repository *repositoryStub) SetManifest(d string, manifest *common.Manifest) error {
+	repository.ManifestSet[d] = manifest
 	return nil
 }
 
@@ -323,6 +330,11 @@ func TestCreateDeployment(t *testing.T) {
 			"to begin with manifest-.", testRepository.ManifestAdd[template.Name].Name)
 	}
 
+	if !strings.HasPrefix(testRepository.ManifestSet[template.Name].Name, "manifest-") {
+		t.Fatalf("Repository SetManifest was called with %s but expected manifest name"+
+			"to begin with manifest-.", testRepository.ManifestSet[template.Name].Name)
+	}
+
 	if !reflect.DeepEqual(*testDeployer.Created[0], configuration) || err != nil {
 		t.Fatalf("Deployer CreateConfiguration was called with %s but expected %s.",
 			testDeployer.Created[0], configuration)
@@ -396,6 +408,11 @@ func TestCreateDeploymentCreationResourceFailure(t *testing.T) {
 			"to begin with manifest-.", testRepository.ManifestAdd[template.Name].Name)
 	}
 
+	if !strings.HasPrefix(testRepository.ManifestSet[template.Name].Name, "manifest-") {
+		t.Fatalf("Repository SetManifest was called with %s but expected manifest name"+
+			"to begin with manifest-.", testRepository.ManifestSet[template.Name].Name)
+	}
+
 	if err != nil || !reflect.DeepEqual(d, &deployment) {
 		t.Fatalf("Expected a different set of response values from invoking CreateDeployment.\n"+
 			"Received: %v, %v. Expected: %v, %v.", d, err, &deployment, "nil")
@@ -423,6 +440,11 @@ func TestDeleteDeploymentForget(t *testing.T) {
 	if !strings.HasPrefix(testRepository.ManifestAdd[template.Name].Name, "manifest-") {
 		t.Fatalf("Repository AddManifest was called with %s but expected manifest name"+
 			"to begin with manifest-.", testRepository.ManifestAdd[template.Name].Name)
+	}
+
+	if !strings.HasPrefix(testRepository.ManifestSet[template.Name].Name, "manifest-") {
+		t.Fatalf("Repository SetManifest was called with %s but expected manifest name"+
+			"to begin with manifest-.", testRepository.ManifestSet[template.Name].Name)
 	}
 
 	if !reflect.DeepEqual(*testDeployer.Created[0], configuration) || err != nil {

--- a/manager/repository/repository_test.go
+++ b/manager/repository/repository_test.go
@@ -82,9 +82,13 @@ func testCreateDeploymentWithManifests(t *testing.T, count int) {
 		if err != nil {
 			t.Fatalf("AddManifest failed: %v", err)
 		}
-		_, err = r.GetDeployment(deploymentName)
+		d, err = r.GetDeployment(deploymentName)
 		if err != nil {
 			t.Fatalf("GetDeployment failed: %v", err)
+		}
+
+		if d.LatestManifest != manifestName {
+			t.Fatalf("AddManifest did not update LatestManifest: %#v", d)
 		}
 
 		mListNew, err := r.ListManifests(deploymentName)


### PR DESCRIPTION
Previously a failure would prematurely exit the creation flow without
attaching the manifest to the deployment. This now always attaches the
manifest, and then updates it in place with the outcome of
resourcification.
