### PR TITLE
Deployment now has top-level error for deployment-level failures

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -37,13 +37,24 @@ type Deployment struct {
 	DeployedAt     time.Time        `json:"deployedAt,omitempty"`
 	ModifiedAt     time.Time        `json:"modifiedAt,omitempty"`
 	DeletedAt      time.Time        `json:"deletedAt,omitempty"`
-	Status         DeploymentStatus `json:"status,omitempty"`
+	State          *DeploymentState `json:"state,omitempty"`
 	LatestManifest string           `json:"latestManifest,omitEmpty"`
 }
 
 // NewDeployment creates a new deployment.
 func NewDeployment(name string) *Deployment {
-	return &Deployment{Name: name, CreatedAt: time.Now(), Status: CreatedStatus}
+	return &Deployment{
+		Name:      name,
+		CreatedAt: time.Now(),
+		State:     &DeploymentState{Status: CreatedStatus},
+	}
+}
+
+// DeploymentState describes the state of a resource. It is set to the terminal
+// state depending on the outcome of an operation on the deployment.
+type DeploymentState struct {
+	Status DeploymentStatus `json:"status,omitempty"`
+	Errors []string         `json:"errors,omitempty"`
 }
 
 // DeploymentStatus is an enumeration type for the status of a deployment.

--- a/examples/guestbook/guestbook.yaml
+++ b/examples/guestbook/guestbook.yaml
@@ -7,9 +7,6 @@ resources:
     external_service: true
     replicas: 3
     image: gcr.io/google_containers/example-guestbook-php-redis:v3
-    env:
-    - name: redis-master
-      value: $(ref.redis-master.name)
 - name: redis
   type: github.com/kubernetes/application-dm-templates/storage/redis:v1
   properties: null

--- a/manager/manager/manager_test.go
+++ b/manager/manager/manager_test.go
@@ -134,7 +134,7 @@ type repositoryStub struct {
 	TypeInstancesCleared   bool
 	GetTypeInstancesCalled bool
 	ListTypesCalled        bool
-	DeploymentStatuses     []common.DeploymentStatus
+	DeploymentStates       []*common.DeploymentState
 }
 
 func (repository *repositoryStub) reset() {
@@ -148,7 +148,7 @@ func (repository *repositoryStub) reset() {
 	repository.TypeInstancesCleared = false
 	repository.GetTypeInstancesCalled = false
 	repository.ListTypesCalled = false
-	repository.DeploymentStatuses = make([]common.DeploymentStatus, 0)
+	repository.DeploymentStates = []*common.DeploymentState{}
 }
 
 func newRepositoryStub() *repositoryStub {
@@ -176,8 +176,8 @@ func (repository *repositoryStub) GetValidDeployment(d string) (*common.Deployme
 	return &deployment, nil
 }
 
-func (repository *repositoryStub) SetDeploymentStatus(name string, status common.DeploymentStatus) error {
-	repository.DeploymentStatuses = append(repository.DeploymentStatuses, status)
+func (repository *repositoryStub) SetDeploymentState(name string, state *common.DeploymentState) error {
+	repository.DeploymentStates = append(repository.DeploymentStates, state)
 	return nil
 }
 
@@ -340,7 +340,7 @@ func TestCreateDeployment(t *testing.T) {
 			testDeployer.Created[0], configuration)
 	}
 
-	if testRepository.DeploymentStatuses[0] != common.DeployedStatus {
+	if testRepository.DeploymentStates[0].Status != common.DeployedStatus {
 		t.Fatal("CreateDeployment success did not mark deployment as deployed")
 	}
 
@@ -369,7 +369,7 @@ func TestCreateDeploymentCreationFailure(t *testing.T) {
 			testRepository.Created[0])
 	}
 
-	if testRepository.DeploymentStatuses[0] != common.FailedStatus {
+	if testRepository.DeploymentStates[0].Status != common.FailedStatus {
 		t.Fatal("CreateDeployment failure did not mark deployment as failed")
 	}
 
@@ -399,7 +399,7 @@ func TestCreateDeploymentCreationResourceFailure(t *testing.T) {
 			testRepository.Created[0])
 	}
 
-	if testRepository.DeploymentStatuses[0] != common.FailedStatus {
+	if testRepository.DeploymentStates[0].Status != common.FailedStatus {
 		t.Fatal("CreateDeployment failure did not mark deployment as failed")
 	}
 
@@ -455,6 +455,10 @@ func TestDeleteDeploymentForget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteDeployment failed with %v", err)
 	}
+	if d.State.Status != common.DeletedStatus {
+		t.Fatalf("Expected DeletedStatus on deleted deployment")
+	}
+
 	// Make sure the resources were deleted through deployer.
 	if len(testDeployer.Deleted) > 0 {
 		c := testDeployer.Deleted[0]

--- a/manager/repository/repository_test.go
+++ b/manager/repository/repository_test.go
@@ -140,7 +140,7 @@ func TestRepositoryDeleteWorksWithNoLatestManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteDeployment failed: %v", err)
 	}
-	if dDeleted.Status != common.DeletedStatus {
+	if dDeleted.State.Status != common.DeletedStatus {
 		t.Fatalf("Deployment Status is not deleted")
 	}
 	if _, err := r.ListManifests(deploymentName); err == nil {
@@ -165,7 +165,7 @@ func TestRepositoryDeleteDeploymentWorksNoForget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteDeployment failed: %v", err)
 	}
-	if dDeleted.Status != common.DeletedStatus {
+	if dDeleted.State.Status != common.DeletedStatus {
 		t.Fatalf("Deployment Status is not deleted")
 	}
 }
@@ -187,7 +187,7 @@ func TestRepositoryDeleteDeploymentWorksForget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteDeployment failed: %v", err)
 	}
-	if dDeleted.Status != common.CreatedStatus {
+	if dDeleted.State.Status != common.CreatedStatus {
 		t.Fatalf("Deployment Status is not created")
 	}
 }


### PR DESCRIPTION
Deployment status is now deployment state, which contains both status
and errors, which are set for deployment-level failure.

Some common failures that will show up here are expansion, type
resolution, and reference failures.

Fixes #144 
