### PR TITLE
Treat token based auth properly in resourcifier

### DIFF
--- a/resourcifier/configurations.go
+++ b/resourcifier/configurations.go
@@ -217,7 +217,7 @@ func getConfigurator() *configurator.Configurator {
 				}
 			}
 
-			if *kubeToken == "" {
+			if *kubeToken != "" {
 				args = append(args, fmt.Sprintf("--token=%s", *kubeToken))
 			} else {
 				if *kubeUsername != "" {


### PR DESCRIPTION
Wrong operator for token based auth.
If a token was specified this was asking for username and password.
