### PR TITLE
Dockerfile and Makefile for cross-compile of dm

### DIFF
--- a/dm/Dockerfile
+++ b/dm/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.4-cross
+
+ENV GOLANG_CROSSPLATFORMS \
+	darwin/amd64 \
+	freebsd/386 freebsd/amd64 freebsd/arm \
+	linux/386 linux/amd64 linux/arm \
+	windows/386 windows/amd64
+
+RUN mkdir -p "$GOPATH/src/github.com" && chmod -R 777 "$GOPATH/src/github.com"
+
+COPY . "$GOPATH"/src/dm
+
+WORKDIR "$GOPATH"/src/dm
+
+RUN go-wrapper download
+RUN set -ex \
+    && for platform in $GOLANG_CROSSPLATFORMS; do \
+		GOOS=${platform%/*} \
+		GOARCH=${platform##*/} \
+		go build -v -o dm-${platform%/*}-${platform##*/}; \
+    done

--- a/dm/Makefile
+++ b/dm/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+
+GOLANG_CROSSPLATFORMS="darwin/386 darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm windows/386 windows/amd64"
+
+all: build binary
+
+build:
+	docker build -t dm .
+
+binary:
+	docker run --name dm dm
+	for platform in $$GOLANG_CROSSPLATFORMS; do \
+		echo $$platform; \
+		docker cp dm:/go/src/dm/dm-$${platform%/*}-$${platform##*/} .; \
+	done
+
+clean:
+	docker rm dm
+	docker rmi dm
+	rm dm-*


### PR DESCRIPTION
I am not feeling strongly about this, we can do better by doing this within a complete CI for the project.

But this is a Dockerfile and Makefile to build dm cli entirely in a container and get the binaries back on the host.
It does not use volumes mounts either.
