### PR TITLE
Introducing binaries hosted from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,17 @@ for the Kubernetes configuration SIG.
 
 ## Installing Deployment Manager
 
-Follow these 3 steps to install DM:
+From a Linux or Mac OS X client:
 
-1. Make sure your Kubernetes cluster is up and running, and that you can run
-`kubectl` commands against it.
-1. Clone this repository into the src folder of your GOPATH, if you haven't already.
-See the [Kubernetes developer documentation](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md)
-for information on how to setup Go and use the repository.
-1. Use `kubectl` to install DM into your cluster `kubectl create -f
-install.yaml`
+```
+curl -s https://raw.githubusercontent.com/kubernetes/deployment-manager/master/get-install.sh | sh
+```
+
+and then install the DM services into your Kubernetes cluster:
+
+```
+kubectl create -f install.yaml
+```
 
 That's it. You can now use `kubectl` to see DM running in your cluster:
 
@@ -84,85 +86,37 @@ is up and running!
 
 ## Using Deployment Manager
 
-### Setting up the client
-
-The easiest way to interact with Deployment Manager is through the `dm` tool
-hitting a `kubectl` proxy. To set that up:
-
-1. Build the tool by running `make` in the deployment-manager repository.
-1. Run `kubectl proxy --port=8001 --namespace=dm &` to start a proxy that lets you interact
-with the Kubernetes API server through port 8001 on localhost. `dm` uses
-`http://localhost:8001/api/v1/proxy/namespaces/dm/services/manager-service:manager`
-as the default service address for DM.
-
-### Using the client
-
-The DM client, `dm`, can deploy configurations from the command line. It can also
-pull templates from a template registry, generate configurations from them using
-parameters supplied on the command line, and deploy the resulting configurations.
-
-#### Deploying a configuration
-
-`dm` can deploy a configuration from a file, or read one from `stdin`. This
-command deploys the Guestbook example using the configuration shown above from
-the examples directory in this project:
+Run a Kubernetes proxy to allow the dm client to connect to the cluster:
 
 ```
-dm deploy examples/guestbook/guestbook.yaml
+kubectl proxy --port=8001 --namespace=dm &
 ```
 
-You can now use `kubectl` to see Guestbook running:
+### Deploy an app
+To deploy a simple guestbook app:
 
 ```
-kubectl get service
+$ dm deploy examples/guestbook/guestbook.yaml
+$ kubectl get service
 ```
 
-Look for frontend-service. If your cluster supports external load balancing, it
-will have an external IP assigned to it, and you can navigate to it in your browser
-to see the guestbook in action. 
+The `frontend-service` should have an external IP that you can navigate to in
+your browser to play with.
 
 For more information about this example, see [examples/guestbook/README.md](examples/guestbook/README.md)
 
-#### Deploying a template directly
+### Deploying a template
 
-You can also deploy a template directly, without a configuration. This command
-deploys a redis cluster with two slaves from the redis template in the [Kubernetes
+To deploy a redis template from the [Kubernetes
 Template Registry](https://github.com/kubernetes/application-dm-templates):
-
-```
-dm deploy storage/redis:v1
-```
-
-You can optionally supply values for template parameters on the command line,
-like this:
 
 ```
 dm --properties workers=3 deploy storage/redis:v1
 ```
 
-When you deploy a template directly, without a configuration, `dm` generates a
-configuration from the template and the supplied parameters, and then deploys the
-configuration.
-
 For more information about deploying templates from a template registry or adding
-types to a template registry, see [the template registry documentation](docs/templates/registry.md).
-
-### Additional commands
-
-Here's a list of available `dm` commands:
-
-```
-expand              Expands the supplied configuration(s)
-deploy              Deploys the named template or the supplied configuration(s)
-list                Lists the deployments in the cluster
-get                 Retrieves the named deployment
-delete              Deletes the named deployment
-update              Updates a deployment using the supplied configuration(s)
-deployed-types      Lists the types deployed in the cluster
-deployed-instances  Lists the instances of the named type deployed in the cluster
-templates           Lists the templates in a given template registry
-describe            Describes the named template in a given template registry
-```
+types to a template registry, see
+[the template registry documentation](docs/templates/registry.md).
 
 ## Uninstalling Deployment Manager
 

--- a/docs/pushing.md
+++ b/docs/pushing.md
@@ -1,0 +1,30 @@
+# Pushing DM
+
+This details the requirements and steps for doing a DM push.
+
+## Prerequisites
+
+In order to build and push DM, you must:
+
+* be an editor or owner on the GCP project `dm-k8s-testing`
+* have `docker` installed and runnable in your current environment
+* have `gcloud` installed
+* have `gsutil` installed
+
+## Pushing
+
+To build and push the service containers:
+
+```
+$ cd ${GOPATH}/src/github.com/kubernetes/deployment-manager
+$ export PROJECT=dm-k8s-testing
+$ make push
+```
+
+To push the client binaries, run the following for both Mac OS X and Linux
+environments:
+
+```
+$ hack/dm-push.sh
+```
+

--- a/get-install.sh
+++ b/get-install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+STORAGE_URL=http://get-dm.storage.googleapis.com
+ZIP=dm-latest-${PLATFORM}-${ARCH}.zip
+
+echo "Downloading ${ZIP}..."
+curl -Ls "${STORAGE_URL}/${ZIP}" -O
+
+unzip -qo ${ZIP}
+rm ${ZIP}
+
+chmod +x dm
+
+cat <<EOF
+
+dm is now available in your current directory.
+
+Before using it, please install the Deployment Manager service in your
+kubernetes cluster by running
+
+  $ kubectl create -f install.yaml
+
+To get started, run:
+
+  $ ./dm
+
+EOF
+

--- a/hack/dm-push.sh
+++ b/hack/dm-push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Run this from deployment-manager root to build and push the dm client into
-# the publicly readable GCS bucket gs://get-dm.
+# Run this from deployment-manager root to build and push the dm client plus
+# kubernetes install config into the publicly readable GCS bucket gs://get-dm.
 #
 # Must have EDIT permissions on the dm-k8s-testing GCP project.
 
@@ -17,7 +17,7 @@ echo "Building..."
 make
 
 echo "Zipping ${ZIP}..."
-zip -j ${ZIP} ${GOPATH}/bin/dm
+zip -j ${ZIP} ${GOPATH}/bin/dm install.yaml
 
 echo "Uploading ${ZIP} to ${STORAGE_BUCKET}..."
 gsutil cp ${ZIP} ${STORAGE_BUCKET}

--- a/hack/dm-push.sh
+++ b/hack/dm-push.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Run this from deployment-manager root to build and push the dm client into
+# the publicly readable GCS bucket gs://get-dm.
+#
+# Must have EDIT permissions on the dm-k8s-testing GCP project.
+
+set -euo pipefail
+
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+STORAGE_BUCKET=gs://get-dm
+ZIP=dm-latest-${PLATFORM}-${ARCH}.zip
+
+echo "Building..."
+make
+
+echo "Zipping ${ZIP}..."
+zip -j ${ZIP} ${GOPATH}/bin/dm
+
+echo "Uploading ${ZIP} to ${STORAGE_BUCKET}..."
+gsutil cp ${ZIP} ${STORAGE_BUCKET}
+rm ${ZIP}
+
+echo "Done."
+


### PR DESCRIPTION
Prebuilt binaries are now available from get-dm.storage.googleapis.com/dm-latest-<platform>-<arch>.zip.

Added script for pushing the binaries, and documentation on what needs to be done when pushing a new version of DM in addition to the container push.

Finally, the main README.md has been updated to a simplified install/getting started experience which curls a script to download the binaries and install.yaml.

Fixes #109 
