### PR TITLE
ref(lint): cleaner lint validations

### DIFF
--- a/action/lint.go
+++ b/action/lint.go
@@ -90,6 +90,13 @@ func Lint(chartPath string) {
 		return err == nil && chartfile.Maintainers != nil
 	})
 
+	cv.AddWarning("README.md is present", func(path string, v *validation.Validation) bool {
+		readmePath := filepath.Join(path, "README.md")
+		stat, err := os.Stat(readmePath)
+
+		return err == nil && stat.Mode().IsRegular()
+	})
+
 	if cv.Valid() {
 		log.Info("Chart[%s] has passed all necessary checks", cv.ChartName())
 	} else {

--- a/action/lint.go
+++ b/action/lint.go
@@ -93,11 +93,11 @@ func Lint(chartPath string) {
 		return cv.Chartfile.Maintainers != nil
 	})
 
-	chartPresenceValidation.AddWarning("README.md is present", func(path string, v *validation.Validation) bool {
+	chartPresenceValidation.AddWarning("README.md is present and not empty", func(path string, v *validation.Validation) bool {
 		readmePath := filepath.Join(path, "README.md")
 		stat, err := os.Stat(readmePath)
 
-		return err == nil && stat.Mode().IsRegular()
+		return err == nil && stat.Mode().IsRegular() && stat.Size() > 0
 	})
 
 	manifestsValidation := chartPresenceValidation.AddError("Manifests directory is present", func(path string, v *validation.Validation) bool {
@@ -115,7 +115,7 @@ func Lint(chartPath string) {
 		return err == nil && cv.Manifests != nil
 	})
 
-	manifestsParsingValidation.AddError("Manifests have correct and valid metadata", func(path string, v *validation.Validation) bool {
+	manifestsParsingValidation.AddWarning("Manifests have correct and valid metadata", func(path string, v *validation.Validation) bool {
 
 		success := true
 		validKinds := InstallOrder

--- a/action/lint.go
+++ b/action/lint.go
@@ -1,19 +1,14 @@
 package action
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/google/go-github/github"
-	"github.com/helm/helm/chart"
 	"github.com/helm/helm/log"
-	"github.com/helm/helm/manifest"
 	"github.com/helm/helm/util"
 	"github.com/helm/helm/validation"
-	"gopkg.in/yaml.v2"
 )
 
 // Owner is default Helm repository owner or organization.
@@ -53,156 +48,51 @@ func LintAll(homedir string) {
 //
 // - chartPath path to chart directory
 func Lint(chartPath string) {
-	v := new(validation.Validation)
-	chartName := filepath.Base(chartPath)
+	cv := new(validation.ChartValidation)
+	cv.Path = chartPath
 
-	//makes sure all files are in place
-	structure := directoryStructure(chartPath, v)
+	//TODO: chartPresenceValidation := v.AddError("Chart found", func(path string, v *ChartValidation) bool { }
 
-	if v.Valid() {
-		checkDirectoryStructure(structure, chartPath, v)
-	}
+	chartYamlValidation := cv.AddError("Chart.yaml is present", func(path string, v *validation.Validation) bool {
+		stat, err := os.Stat(v.ChartYamlPath())
 
-	//checks to see if chart name is unique
-	verifyChartNameUnique(chartName, v)
-	verifyMetadata(chartPath, v)
-	verifyManifests(chartPath, v)
+		return err == nil && stat.Mode().IsRegular()
+	})
 
-	numErrors := len(v.Errors)
+	chartYamlNameValidation := chartYamlValidation.AddError("Chart.yaml has a name field", func(path string, v *validation.Validation) bool {
+		chartfile, err := v.Chartfile()
 
-	if len(v.Warnings) > 0 || numErrors > 0 {
-		for _, warning := range v.Warnings {
-			log.Warn(warning)
-		}
-		for _, err := range v.Errors {
-			log.Err(err)
-		}
+		return err == nil && chartfile.Name != ""
+	})
 
-		if numErrors > 0 {
-			log.Err("Chart [%s] failed some checks", chartName)
-		} else {
-			log.Warn("Chart [%s] failed some checks", chartName)
-		}
+	chartYamlNameValidation.AddError("Name declared in Chart.yaml is the same as chart name.", func(path string, v *validation.Validation) bool {
+		chartfile, err := v.Chartfile()
+
+		return err == nil && chartfile.Name == cv.ChartName()
+
+	})
+
+	chartYamlValidation.AddError("Chart.yaml has a version field", func(path string, v *validation.Validation) bool {
+		chartfile, err := v.Chartfile()
+
+		return err == nil && chartfile.Version != ""
+	})
+
+	chartYamlValidation.AddWarning("Chart.yaml has a description field", func(path string, v *validation.Validation) bool {
+		chartfile, err := v.Chartfile()
+
+		return err == nil && chartfile.Description != ""
+	})
+
+	chartYamlValidation.AddWarning("Chart.yaml has a maintainers field", func(path string, v *validation.Validation) bool {
+		chartfile, err := v.Chartfile()
+
+		return err == nil && chartfile.Maintainers != nil
+	})
+
+	if cv.Valid() {
+		log.Info("Chart[%s] has passed all necessary checks", cv.ChartName())
 	} else {
-		log.Info("Chart [%s] has passed all necessary checks", chartName)
-	}
-}
-
-func directoryStructure(chartPath string, v *validation.Validation) map[string]os.FileInfo {
-	structure := make(map[string]os.FileInfo)
-
-	chartInfo, err := os.Stat(chartPath)
-	if err != nil {
-		v.AddError(fmt.Sprintf("Chart %s not found in workspace. Error: %v", chartPath, err))
-		return structure
-	}
-
-	if chartInfo.IsDir() {
-		files, _ := ioutil.ReadDir(chartPath)
-		for _, f := range files {
-			structure[f.Name()] = f
-		}
-	} else {
-		v.AddError(fmt.Sprintf("Chart Path [%s] is not a directory.", chartPath))
-	}
-
-	return structure
-}
-
-func checkDirectoryStructure(structure map[string]os.FileInfo, chartPath string, v *validation.Validation) {
-	if _, ok := structure["README.md"]; ok != true {
-		v.AddWarning(fmt.Sprintf("A README file was not found in %s", chartPath))
-	}
-
-	manifestInfo, ok := structure["manifests"]
-
-	if ok && manifestInfo.IsDir() {
-		// manifest files logic
-	} else {
-		v.AddError(fmt.Sprintf("A manifests directory was not found in %s", chartPath))
-	}
-}
-
-// verifyMetadata checks the Chart.yaml file for a Name, Version, Description, and Maintainers
-func verifyMetadata(chartPath string, v *validation.Validation) {
-	var y *chart.Chartfile
-
-	file := filepath.Join(chartPath, Chartfile)
-	chartDir := filepath.Base(chartPath)
-	b, err := ioutil.ReadFile(file)
-
-	if err != nil {
-		v.AddError("A Chart.yaml file was not found")
-		return
-	}
-
-	if err = yaml.Unmarshal(b, &y); err != nil {
-		v.AddError(fmt.Sprint(err))
-		return
-	}
-
-	// require name, version, description, maintaners
-	if y.Name == "" {
-		v.AddError("Missing Name specification in Chart.yaml file")
-	}
-	if y.Name != chartDir {
-		v.AddError(fmt.Sprintf("Chart.yaml name (%s) is not the same as its directory (%s)", y.Name, chartDir))
-	}
-	if y.Version == "" {
-		v.AddError("Missing Version specification in Chart.yaml file")
-	}
-	if y.Description == "" {
-		v.AddWarning("Missing description in Chart.yaml file")
-	}
-	if y.Maintainers == nil {
-		v.AddWarning("Missing maintainers information in Chart.yaml file")
-	}
-}
-
-func verifyManifests(chartPath string, v *validation.Validation) {
-	manifests, err := manifest.ParseDir(chartPath)
-
-	if err != nil {
-		v.AddError(fmt.Sprintf("Error walking manifest files. Err: %s", err))
-	}
-
-	for _, m := range manifests {
-		meta, _ := m.VersionedObject.Meta()
-		if meta.Name == "" {
-			v.AddWarning(fmt.Sprintf("missing name in %s", m.Source))
-		}
-
-		val, ok := meta.Labels["heritage"]
-		if !ok || (val != "helm") {
-			v.AddWarning(fmt.Sprintf("Missing a label: `heritage: helm` in %s", m.Source))
-		}
-
-		kind := meta.Kind
-		validKinds := InstallOrder
-
-		if valid := validKind(kind, validKinds); !valid {
-			v.AddError(fmt.Sprintf("%s is not a valid `kind` value for manifest. Here are valid kinds of manifests: %v", kind, validKinds))
-		}
-	}
-}
-
-func validKind(kind string, validKinds []string) bool {
-	for _, validKind := range validKinds {
-		if kind == validKind {
-			return true
-		}
-	}
-	return false
-}
-
-func verifyChartNameUnique(chartName string, v *validation.Validation) {
-	if RepoService == nil {
-		RepoService = github.NewClient(nil).Repositories
-	}
-
-	chartPath := filepath.Join(chartName, Chartfile)
-
-	if _, err := RepoService.DownloadContents(Owner, Project, chartPath, nil); err == nil {
-		v.AddWarning(fmt.Sprintf("Chart name %s already exists in charts repository [github.com/helm/charts]. If you're planning on submitting this chart to the charts repo, please consider changing the chart name.", chartName))
+		log.Err("Chart [%s] is not completely valid", cv.ChartName())
 	}
 }

--- a/action/lint_test.go
+++ b/action/lint_test.go
@@ -44,7 +44,7 @@ func TestLintMissingReadme(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectContains(t, output, "README.md is present : false")
+	test.ExpectContains(t, output, "README.md is present and not empty : false")
 }
 
 func TestLintMissingChartYaml(t *testing.T) {

--- a/action/lint_test.go
+++ b/action/lint_test.go
@@ -44,7 +44,7 @@ func TestLintMissingReadme(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectContains(t, output, "A README file was not found")
+	test.ExpectContains(t, output, "README.md is present : false")
 }
 
 func TestLintMissingChartYaml(t *testing.T) {
@@ -61,8 +61,8 @@ func TestLintMissingChartYaml(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectContains(t, output, "A Chart.yaml file was not found")
-	test.ExpectContains(t, output, "Chart [badChart] failed some checks")
+	test.ExpectContains(t, output, "Chart.yaml is present : false")
+	test.ExpectContains(t, output, "Chart [badChart] has failed some necessary checks.")
 }
 
 func TestLintMismatchedChartNameAndDir(t *testing.T) {
@@ -76,7 +76,7 @@ func TestLintMismatchedChartNameAndDir(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartDir))
 	})
 
-	test.ExpectContains(t, output, fmt.Sprintf("Chart.yaml name (%s) is not the same as its directory (%s)", chartName, chartDir))
+	test.ExpectContains(t, output, "Name declared in Chart.yaml is the same as directory name. : false")
 }
 
 func TestLintMissingManifestDirectory(t *testing.T) {
@@ -93,8 +93,8 @@ func TestLintMissingManifestDirectory(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectMatches(t, output, fmt.Sprintf("A manifests directory was not found.*%s", chartName))
-	test.ExpectContains(t, output, fmt.Sprintf("Chart [%s] failed some checks", chartName))
+	test.ExpectMatches(t, output, "Manifests directory is present : false")
+	test.ExpectContains(t, output, "Chart ["+chartName+"] has failed some necessary checks")
 }
 
 func TestLintEmptyChartYaml(t *testing.T) {
@@ -116,11 +116,11 @@ func TestLintEmptyChartYaml(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectContains(t, output, "Missing Name specification in Chart.yaml file")
-	test.ExpectContains(t, output, "Missing Version specification in Chart.yaml file")
-	test.ExpectContains(t, output, "Missing description in Chart.yaml file")
-	test.ExpectContains(t, output, "Missing maintainers information in Chart.yaml file")
-	test.ExpectContains(t, output, fmt.Sprintf("Chart [%s] failed some checks", chartName))
+	test.ExpectContains(t, output, "Chart.yaml has a name field : false")
+	test.ExpectContains(t, output, "Chart.yaml has a version field : false")
+	test.ExpectContains(t, output, "Chart.yaml has a description field : false")
+	test.ExpectContains(t, output, "Chart.yaml has a maintainers field : false")
+	test.ExpectContains(t, output, fmt.Sprintf("Chart [%s] has failed some necessary checks", chartName))
 }
 
 func TestLintBadPath(t *testing.T) {
@@ -131,5 +131,6 @@ func TestLintBadPath(t *testing.T) {
 		Lint(util.WorkspaceChartDirectory(tmpHome, chartName))
 	})
 
-	test.ExpectContains(t, output, chartName+" not found in workspace")
+	msg := "Chart found at " + tmpHome + "/workspace/charts/" + chartName + " : false"
+	test.ExpectContains(t, output, msg)
 }

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/helm/helm/chart"
+	"github.com/helm/helm/manifest"
 	"gopkg.in/yaml.v2"
 )
 
@@ -13,6 +14,8 @@ import (
 type ChartValidation struct {
 	Path        string
 	Validations []*Validation
+	Chartfile   *chart.Chartfile
+	Manifests   []*manifest.Manifest
 }
 
 const (
@@ -36,7 +39,7 @@ func (v *Validation) ChartYamlPath() string {
 
 //ChartManifestsPath - path to Manifests directory
 func (v *Validation) ChartManifestsPath() string {
-	return filepath.Join(v.Path, "Manifests")
+	return filepath.Join(v.Path, "manifests")
 }
 
 func (v *Validation) Chartfile() (*chart.Chartfile, error) {

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ChartValidation represents a specific instance of validation against a specific directory
+// ChartValidation represents a specific instance of validation against a specific directory.
 type ChartValidation struct {
 	Path         string
 	Validations  []*Validation
@@ -27,7 +27,7 @@ const (
 	errorLevel   = 2
 )
 
-// Validation - hold messages related to validation of something
+// Validation represents a single validation of a ChartValidation.
 type Validation struct {
 	children  []*Validation
 	path      string
@@ -36,16 +36,17 @@ type Validation struct {
 	level     int
 }
 
-//ChartYamlPath - path to Chart.yaml
+// ChartYamlPath returns the fully qualified path to the "Chart.yaml" file.
 func (v *Validation) ChartYamlPath() string {
 	return filepath.Join(v.path, "Chart.yaml")
 }
 
-//ChartManifestsPath - path to Manifests directory
+// ChartManifestsPath returns the fully qualified path to the "Manifests" directory.
 func (v *Validation) ChartManifestsPath() string {
 	return filepath.Join(v.path, "manifests")
 }
 
+// Charfile returns a chart.Chartfile object formed from the Chart.yaml file.
 func (v *Validation) Chartfile() (*chart.Chartfile, error) {
 	var y *chart.Chartfile
 	b, err := ioutil.ReadFile(v.ChartYamlPath())
@@ -71,7 +72,7 @@ func (v *Validation) addValidator(child *Validation) {
 	v.children = append(v.children, child)
 }
 
-// AddError - add error level validation to ChartValidation
+// AddError adds error level validation to a ChartValidation.
 func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
 	v := new(Validation)
 	v.Message = message
@@ -84,7 +85,7 @@ func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
 	return v
 }
 
-// AddWarning - add warning level validation to ChartValidation
+// AddWarning adds a warning level validation to a ChartValidation
 func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation {
 	v := new(Validation)
 	v.Message = message
@@ -97,7 +98,7 @@ func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation 
 	return v
 }
 
-// AddError - add error level validation to Validation
+// AddError adds an error level validation to a Validation.
 func (v *Validation) AddError(message string, fn validator) *Validation {
 	child := new(Validation)
 	child.Message = message
@@ -110,7 +111,7 @@ func (v *Validation) AddError(message string, fn validator) *Validation {
 	return child
 }
 
-// AddWarning - add warning level validation to Validation
+// AddWarning adds a warning level validation to a Validation.
 func (v *Validation) AddWarning(message string, fn validator) *Validation {
 	child := new(Validation)
 	child.Message = message
@@ -123,6 +124,7 @@ func (v *Validation) AddWarning(message string, fn validator) *Validation {
 	return child
 }
 
+// ChartName returns the name of the chart directory.
 func (cv *ChartValidation) ChartName() string {
 	return filepath.Base(cv.Path)
 }
@@ -147,7 +149,7 @@ func (cv *ChartValidation) walk(talker func(v *Validation) bool) {
 	}
 }
 
-// Valid - true if every validation passes
+// Valid returns true if every validation passes.
 func (cv *ChartValidation) Valid() bool {
 	var valid bool = true
 
@@ -172,7 +174,7 @@ func (cv *ChartValidation) Valid() bool {
 		}
 
 		valid = valid && vv
-		return valid // TODO:unnecessary?
+		return valid
 	})
 
 	return valid

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -31,7 +31,7 @@ const (
 type Validation struct {
 	children  []*Validation
 	path      string
-	validator validator
+	validator Validator
 	Message   string
 	level     int
 }
@@ -62,7 +62,8 @@ func (v *Validation) Chartfile() (*chart.Chartfile, error) {
 	return y, nil
 }
 
-type validator func(path string, v *Validation) (result bool)
+// Validator is a declared function that returns the result of a Validation.
+type Validator func(path string, v *Validation) (result bool)
 
 func (cv *ChartValidation) addValidator(v *Validation) {
 	cv.Validations = append(cv.Validations, v)
@@ -73,7 +74,7 @@ func (v *Validation) addValidator(child *Validation) {
 }
 
 // AddError adds error level validation to a ChartValidation.
-func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
+func (cv *ChartValidation) AddError(message string, fn Validator) *Validation {
 	v := new(Validation)
 	v.Message = message
 	v.validator = fn
@@ -86,7 +87,7 @@ func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
 }
 
 // AddWarning adds a warning level validation to a ChartValidation
-func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation {
+func (cv *ChartValidation) AddWarning(message string, fn Validator) *Validation {
 	v := new(Validation)
 	v.Message = message
 	v.validator = fn
@@ -99,7 +100,7 @@ func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation 
 }
 
 // AddError adds an error level validation to a Validation.
-func (v *Validation) AddError(message string, fn validator) *Validation {
+func (v *Validation) AddError(message string, fn Validator) *Validation {
 	child := new(Validation)
 	child.Message = message
 	child.validator = fn
@@ -112,7 +113,7 @@ func (v *Validation) AddError(message string, fn validator) *Validation {
 }
 
 // AddWarning adds a warning level validation to a Validation.
-func (v *Validation) AddWarning(message string, fn validator) *Validation {
+func (v *Validation) AddWarning(message string, fn Validator) *Validation {
 	child := new(Validation)
 	child.Message = message
 	child.validator = fn
@@ -133,7 +134,7 @@ func (v *Validation) valid() bool {
 	return v.validator(v.path, v)
 }
 
-func (v *Validation) walk(talker func(_ *Validation) bool) {
+func (v *Validation) walk(talker func(*Validation) bool) {
 	validResult := talker(v)
 
 	if validResult {

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -23,7 +23,7 @@ const (
 // Validation - hold messages related to validation of something
 type Validation struct {
 	children  []*Validation
-	path      string
+	Path      string
 	validator validator
 	Message   string
 	level     int
@@ -31,7 +31,12 @@ type Validation struct {
 
 //ChartYamlPath - path to Chart.yaml
 func (v *Validation) ChartYamlPath() string {
-	return filepath.Join(v.path, "Chart.yaml")
+	return filepath.Join(v.Path, "Chart.yaml")
+}
+
+//ChartManifestsPath - path to Manifests directory
+func (v *Validation) ChartManifestsPath() string {
+	return filepath.Join(v.Path, "Manifests")
 }
 
 func (v *Validation) Chartfile() (*chart.Chartfile, error) {
@@ -65,7 +70,7 @@ func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
 	v.Message = message
 	v.validator = fn
 	v.level = errorLevel
-	v.path = cv.Path
+	v.Path = cv.Path
 
 	cv.addValidator(v)
 
@@ -78,7 +83,7 @@ func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation 
 	v.Message = message
 	v.validator = fn
 	v.level = warningLevel
-	v.path = cv.Path
+	v.Path = cv.Path
 
 	cv.addValidator(v)
 
@@ -91,7 +96,7 @@ func (v *Validation) AddError(message string, fn validator) *Validation {
 	child.Message = message
 	child.validator = fn
 	child.level = errorLevel
-	child.path = v.path
+	child.Path = v.Path
 
 	v.addValidator(child)
 
@@ -104,7 +109,7 @@ func (v *Validation) AddWarning(message string, fn validator) *Validation {
 	child.Message = message
 	child.validator = fn
 	child.level = warningLevel
-	child.path = v.path
+	child.Path = v.Path
 
 	v.addValidator(child)
 
@@ -116,7 +121,7 @@ func (cv *ChartValidation) ChartName() string {
 }
 
 func (v *Validation) valid() bool {
-	return v.validator(v.path, v)
+	return v.validator(v.Path, v)
 }
 
 func (v *Validation) walk(talker func(_ *Validation) bool) {

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1,22 +1,150 @@
 package validation
 
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/helm/helm/chart"
+	"gopkg.in/yaml.v2"
+)
+
+// ChartValidation represents a specific instance of validation against a specific directory
+type ChartValidation struct {
+	Path        string
+	Validations []*Validation
+}
+
+const (
+	warningLevel = 0
+	errorLevel   = 1
+)
+
 // Validation - hold messages related to validation of something
 type Validation struct {
-	Errors   []string
-	Warnings []string
+	children  []*Validation
+	path      string
+	validator validator
+	Message   string
+	level     int
 }
 
-// AddWarning - add warning to validation
-func (v *Validation) AddWarning(w string) {
-	v.Warnings = append(v.Warnings, w)
+//ChartYamlPath - path to Chart.yaml
+func (v *Validation) ChartYamlPath() string {
+	return filepath.Join(v.path, "Chart.yaml")
 }
 
-// AddError - add error to validation
-func (v *Validation) AddError(e string) {
-	v.Errors = append(v.Errors, e)
+func (v *Validation) Chartfile() (*chart.Chartfile, error) {
+	var y *chart.Chartfile
+	b, err := ioutil.ReadFile(v.ChartYamlPath())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err = yaml.Unmarshal(b, &y); err != nil {
+		return nil, err
+	}
+
+	return y, nil
 }
 
-// Valid - return true if no errors or warnings
-func (v *Validation) Valid() bool {
-	return len(v.Errors) == 0 && len(v.Warnings) == 0
+type validator func(path string, v *Validation) (result bool)
+
+func (cv *ChartValidation) addValidator(v *Validation) {
+	cv.Validations = append(cv.Validations, v)
+}
+
+func (v *Validation) addValidator(child *Validation) {
+	v.children = append(v.children, child)
+}
+
+// AddError - add error level validation to ChartValidation
+func (cv *ChartValidation) AddError(message string, fn validator) *Validation {
+	v := new(Validation)
+	v.Message = message
+	v.validator = fn
+	v.level = errorLevel
+	v.path = cv.Path
+
+	cv.addValidator(v)
+
+	return v
+}
+
+// AddWarning - add warning level validation to ChartValidation
+func (cv *ChartValidation) AddWarning(message string, fn validator) *Validation {
+	v := new(Validation)
+	v.Message = message
+	v.validator = fn
+	v.level = warningLevel
+	v.path = cv.Path
+
+	cv.addValidator(v)
+
+	return v
+}
+
+// AddError - add error level validation to Validation
+func (v *Validation) AddError(message string, fn validator) *Validation {
+	child := new(Validation)
+	child.Message = message
+	child.validator = fn
+	child.level = errorLevel
+	child.path = v.path
+
+	v.addValidator(child)
+
+	return child
+}
+
+// AddWarning - add warning level validation to Validation
+func (v *Validation) AddWarning(message string, fn validator) *Validation {
+	child := new(Validation)
+	child.Message = message
+	child.validator = fn
+	child.level = warningLevel
+	child.path = v.path
+
+	v.addValidator(child)
+
+	return child
+}
+
+func (cv *ChartValidation) ChartName() string {
+	return filepath.Base(cv.Path)
+}
+
+func (v *Validation) valid() bool {
+	return v.validator(v.path, v)
+}
+
+func (v *Validation) walk(talker func(_ *Validation) bool) {
+	validResult := talker(v)
+
+	if validResult {
+		for _, child := range v.children {
+			child.walk(talker)
+		}
+	}
+}
+
+func (cv *ChartValidation) walk(talker func(v *Validation) bool) {
+	for _, v := range cv.Validations {
+		v.walk(talker)
+	}
+}
+
+// Valid - true if every validation passes
+func (cv *ChartValidation) Valid() bool {
+	var valid bool = true
+
+	cv.walk(func(v *Validation) bool {
+		vv := v.valid()
+		fmt.Println(fmt.Sprintf(v.Message+" : %v", vv))
+		valid = valid && vv
+		return valid
+	})
+
+	return valid
 }


### PR DESCRIPTION
ChartValidation struct keeps track of a linting instance. Validation struct keeps track of a validation and its
dependent validations as well. This will help us link validations in a proper format and be able to more easily see and define validations rather than rely on logic nested in loops and arbitrary functions.