### PR TITLE
Add registry.ParseType.

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -17,6 +17,8 @@ limitations under the License.
 package registry
 
 import (
+	"strings"
+
 	"github.com/kubernetes/deployment-manager/common"
 )
 
@@ -44,6 +46,26 @@ type Type struct {
 	Collection string
 	Name       string
 	Version    string
+}
+
+// ParseType takes a registry name and parses it into a *registry.Type.
+func ParseType(name string) *Type {
+	tt := &Type{}
+
+	tList := strings.Split(name, ":")
+	if len(tList) == 2 {
+		tt.Version = tList[1]
+	}
+
+	cList := strings.Split(tList[0], "/")
+
+	if len(cList) == 1 {
+		tt.Name = tList[0]
+	} else {
+		tt.Collection = cList[0]
+		tt.Name = cList[1]
+	}
+	return tt
 }
 
 // Registry abstracts type interactions.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,28 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestParseType(t *testing.T) {
+	// TODO: Are there some real-world examples we want to valide here?
+	tests := map[string]*Type{
+		"foo":                   &Type{Name: "foo"},
+		"foo:v1":                &Type{Name: "foo", Version: "v1"},
+		"github.com/foo":        &Type{Name: "foo", Collection: "github.com"},
+		"github.com/foo:v1.2.3": &Type{Name: "foo", Collection: "github.com", Version: "v1.2.3"},
+	}
+
+	for in, expect := range tests {
+		out := ParseType(in)
+		if out.Name != expect.Name {
+			t.Errorf("Expected name to be %q, got %q", expect.Name, out.Name)
+		}
+		if out.Version != expect.Version {
+			t.Errorf("Expected version to be %q, got %q", expect.Version, out.Version)
+		}
+		if out.Collection != expect.Collection {
+			t.Errorf("Expected collection to be %q, got %q", expect.Collection, out.Collection)
+		}
+	}
+}


### PR DESCRIPTION
ParseType parses a string and returns a *registry.Type. The client
code currently uses this functionality, but it seems like it's better
treated as part of the registry library, rather than as a one-off.
