### PR TITLE
Use bash to install helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ helm repo add charts https://github.com/helm/charts
 
 From a Linux or Mac OS X client:
 ```
-curl -s https://get.helm.sh | sh
+curl -s https://get.helm.sh | bash
 ```
 
 *or*:


### PR DESCRIPTION
Doing `curl -s https://get.helm.sh | sh` results in `sh: 13: set: Illegal option -o pipefail`. I guess the installation script is not POSIX-compliant.