### PR TITLE
Add support for CredentialProvider 

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -184,18 +184,11 @@ type RegistryCredential struct {
 // Registry describes a template registry
 // TODO(jackr): Fix ambiguity re: whether or not URL has a scheme.
 type Registry struct {
-	Name   string         `json:"name,omitempty"`   // Friendly name for the registry
-	Type   RegistryType   `json:"type,omitempty"`   // Technology implementing the registry
-	URL    string         `json:"name,omitempty"`   // URL to the root of the registry
-	Format RegistryFormat `json:"format,omitempty"` // Format of the registry
-}
-
-// AuthenticatedRegistry describes a type registry with credential.
-// Broke this out of Registry, so that we can pass around instances of Registry
-// without worrying about secrets.
-type AuthenticatedRegistry struct {
-	Registry
-	Credential RegistryCredential `json:"credential,omitempty"`
+	Name           string         `json:"name,omitempty"`           // Friendly name for the registry
+	Type           RegistryType   `json:"type,omitempty"`           // Technology implementing the registry
+	URL            string         `json:"name,omitempty"`           // URL to the root of the registry
+	Format         RegistryFormat `json:"format,omitempty"`         // Format of the registry
+	CredentialName string         `json:"credentialname,omitempty"` // Name of the credential to use
 }
 
 // RegistryType defines the technology that implements the registry
@@ -233,16 +226,22 @@ type RegistryService interface {
 	// Get a registry
 	Get(name string) (*Registry, error)
 	// Get a registry with credential.
-	GetAuthenticatedRegistry(name string) (*AuthenticatedRegistry, error)
+	GetRegistry(name string) (*Registry, error)
 	// Delete a registry
 	Delete(name string) error
 	// Find a registry that backs the given URL
 	GetByURL(URL string) (*Registry, error)
-	// GetAuthenticatedRegistryByURL returns an authenticated registry that handles the types for a given URL.
-	GetAuthenticatedRegistryByURL(URL string) (*AuthenticatedRegistry, error)
+	// GetRegistryByURL returns a registry that handles the types for a given URL.
+	GetRegistryByURL(URL string) (*Registry, error)
+}
+
+// CredentialProvider provides credentials for registries.
+type CredentialProvider interface {
 	// Set the credential for a registry.
 	// May not be supported by some registry services.
-	SetCredential(name string, credential RegistryCredential) error
-	// Get the credential for a registry.
-	GetCredential(name string) (RegistryCredential, error)
+	SetCredential(name string, credential *RegistryCredential) error
+
+	// GetCredential returns the specified credential or nil if there's no credential.
+	// Error is non-nil if fetching the credential failed.
+	GetCredential(name string) (*RegistryCredential, error)
 }

--- a/manager/manager/manager_test.go
+++ b/manager/manager/manager_test.go
@@ -254,8 +254,9 @@ var testExpander = &expanderStub{}
 var testRepository = newRepositoryStub()
 var testDeployer = newDeployerStub()
 var testRegistryService = registry.NewInmemRegistryService()
-var testProvider = registry.NewRegistryProvider(nil, registry.NewTestGithubRegistryProvider("", nil))
-var testManager = NewManager(testExpander, testDeployer, testRepository, testProvider, testRegistryService)
+var testCredentialProvider = registry.NewInmemCredentialProvider()
+var testProvider = registry.NewRegistryProvider(nil, registry.NewTestGithubRegistryProvider("", nil), testCredentialProvider)
+var testManager = NewManager(testExpander, testDeployer, testRepository, testProvider, testRegistryService, testCredentialProvider)
 
 func TestListDeployments(t *testing.T) {
 	testRepository.reset()

--- a/manager/manager/typeresolver_test.go
+++ b/manager/manager/typeresolver_test.go
@@ -313,7 +313,7 @@ func TestShortGithubUrl(t *testing.T) {
 		importOut:        finalImports,
 		urlcount:         4,
 		responses:        responses,
-		registryProvider: registry.NewRegistryProvider(nil, grp),
+		registryProvider: registry.NewRegistryProvider(nil, grp, registry.NewInmemCredentialProvider()),
 	}
 
 	testDriver(test, t)

--- a/registry/filebased_credential_provider.go
+++ b/registry/filebased_credential_provider.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/ghodss/yaml"
+	"github.com/kubernetes/deployment-manager/common"
+
+	/*
+		"net/url"
+		"regexp"
+		"strings"
+		"sync"
+	*/)
+
+// CredentialProvider provides credentials for registries.
+type FilebasedCredentialProvider struct {
+	// Actual backing store
+	backingCredentialProvider common.CredentialProvider
+}
+
+type NamedRegistryCredential struct {
+	Name string `json:"name,omitempty"`
+	common.RegistryCredential
+}
+
+func NewFilebasedCredentialProvider(filename string) (common.CredentialProvider, error) {
+	icp := NewInmemCredentialProvider()
+	c, err := readCredentialsFile(filename)
+	if err != nil {
+		return &FilebasedCredentialProvider{}, err
+	}
+	for _, nc := range c {
+		log.Printf("Adding credential %s", nc.Name)
+		icp.SetCredential(nc.Name, &nc.RegistryCredential)
+	}
+
+	return &FilebasedCredentialProvider{icp}, nil
+}
+
+func readCredentialsFile(filename string) ([]NamedRegistryCredential, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return []NamedRegistryCredential{}, err
+	}
+	return parseCredentials(bytes)
+}
+
+func parseCredentials(bytes []byte) ([]NamedRegistryCredential, error) {
+	r := []NamedRegistryCredential{}
+	if err := yaml.Unmarshal(bytes, &r); err != nil {
+		return []NamedRegistryCredential{}, fmt.Errorf("cannot unmarshal credentials file (%#v)", err)
+	}
+	return r, nil
+}
+
+func (fcp *FilebasedCredentialProvider) GetCredential(name string) (*common.RegistryCredential, error) {
+	return fcp.backingCredentialProvider.GetCredential(name)
+}
+
+func (fcp *FilebasedCredentialProvider) SetCredential(name string, credential *common.RegistryCredential) error {
+	return fmt.Errorf("SetCredential operation not supported with FilebasedCredentialProvider")
+}

--- a/registry/filebased_credential_provider_test.go
+++ b/registry/filebased_credential_provider_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/kubernetes/deployment-manager/common"
+)
+
+var filename = "./test/test_credentials_file.yaml"
+
+type filebasedTestCase struct {
+	name   string
+	exp    *common.RegistryCredential
+	expErr error
+}
+
+func TestNotExistFilebased(t *testing.T) {
+	cp, err := NewFilebasedCredentialProvider(filename)
+	if err != nil {
+		t.Fatalf("Failed to create a new FilebasedCredentialProvider %s : %v", filename, err)
+	}
+	tc := &testCase{"nonexistent", nil, createMissingError("nonexistent")}
+	testGetCredential(t, cp, tc)
+}
+
+func TestGetApiTokenFilebased(t *testing.T) {
+	cp, err := NewFilebasedCredentialProvider(filename)
+	if err != nil {
+		t.Fatalf("Failed to create a new FilebasedCredentialProvider %s : %v", filename, err)
+	}
+	tc := &testCase{"test1", &common.RegistryCredential{APIToken: "token"}, nil}
+	testGetCredential(t, cp, tc)
+}
+
+func TestSetAndGetBasicAuthFilebased(t *testing.T) {
+	cp, err := NewFilebasedCredentialProvider(filename)
+	if err != nil {
+		t.Fatalf("Failed to create a new FilebasedCredentialProvider %s : %v", filename, err)
+	}
+	tc := &testCase{"test2",
+		&common.RegistryCredential{
+			BasicAuth: common.BasicAuthCredential{"user", "password"}}, nil}
+	testGetCredential(t, cp, tc)
+}

--- a/registry/github_package_registry.go
+++ b/registry/github_package_registry.go
@@ -41,11 +41,14 @@ type GithubPackageRegistry struct {
 }
 
 // NewGithubPackageRegistry creates a GithubPackageRegistry.
-func NewGithubPackageRegistry(name, shortURL string, service RepositoryService) (*GithubPackageRegistry, error) {
+func NewGithubPackageRegistry(name, shortURL string, service GithubRepositoryService, client *github.Client) (*GithubPackageRegistry, error) {
 	format := fmt.Sprintf("%s;%s", common.UnversionedRegistry, common.OneLevelRegistry)
 	if service == nil {
-		client := github.NewClient(nil)
-		service = client.Repositories
+		if client == nil {
+			service = github.NewClient(nil).Repositories
+		} else {
+			service = client.Repositories
+		}
 	}
 
 	gr, err := newGithubRegistry(name, shortURL, common.RegistryFormat(format), service)

--- a/registry/github_registry.go
+++ b/registry/github_registry.go
@@ -25,20 +25,23 @@ import (
 	"strings"
 )
 
-// githubRegistry implements the Registry interface and talks to github.
+// githubRegistry is the base class for the Registry interface and talks to github. Actual implementations are
+// in GithubPackageRegistry and GithubTemplateRegistry.
 // The registry short URL and format determine how types are laid out in the
 // registry.
 type githubRegistry struct {
-	name       string
-	shortURL   string
-	owner      string
-	repository string
-	path       string
-	format     common.RegistryFormat
-	service    RepositoryService
+	name           string
+	shortURL       string
+	owner          string
+	repository     string
+	path           string
+	format         common.RegistryFormat
+	credentialName string
+	service        GithubRepositoryService
 }
 
-type RepositoryService interface {
+// GithubRepositoryService defines the interface that's defined in github.com/go-github/repos_contents.go GetContents method.
+type GithubRepositoryService interface {
 	GetContents(
 		owner, repo, path string,
 		opt *github.RepositoryContentGetOptions,
@@ -51,7 +54,7 @@ type RepositoryService interface {
 }
 
 // newGithubRegistry creates a githubRegistry.
-func newGithubRegistry(name, shortURL string, format common.RegistryFormat, service RepositoryService) (*githubRegistry, error) {
+func newGithubRegistry(name, shortURL string, format common.RegistryFormat, service GithubRepositoryService) (*githubRegistry, error) {
 	trimmed := util.TrimURLScheme(shortURL)
 	owner, repository, path, err := parseGithubShortURL(trimmed)
 	if err != nil {

--- a/registry/github_template_registry.go
+++ b/registry/github_template_registry.go
@@ -54,10 +54,9 @@ type GithubTemplateRegistry struct {
 }
 
 // NewGithubTemplateRegistry creates a GithubTemplateRegistry.
-func NewGithubTemplateRegistry(name, shortURL string, service RepositoryService) (*GithubTemplateRegistry, error) {
+func NewGithubTemplateRegistry(name, shortURL string, service GithubRepositoryService, client *github.Client) (*GithubTemplateRegistry, error) {
 	format := fmt.Sprintf("%s;%s", common.VersionedRegistry, common.CollectionRegistry)
 	if service == nil {
-		client := github.NewClient(nil)
 		service = client.Repositories
 	}
 

--- a/registry/inmem_credential_provider.go
+++ b/registry/inmem_credential_provider.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"github.com/kubernetes/deployment-manager/common"
+
+	"fmt"
+)
+
+type InmemCredentialProvider struct {
+	credentials map[string]*common.RegistryCredential
+}
+
+func NewInmemCredentialProvider() common.CredentialProvider {
+	return &InmemCredentialProvider{credentials: make(map[string]*common.RegistryCredential)}
+}
+
+func (fcp *InmemCredentialProvider) GetCredential(name string) (*common.RegistryCredential, error) {
+	if val, ok := fcp.credentials[name]; ok {
+		return val, nil
+	}
+	return nil, fmt.Errorf("no such credential : %s", name)
+}
+
+func (fcp *InmemCredentialProvider) SetCredential(name string, credential *common.RegistryCredential) error {
+	fcp.credentials[name] = &common.RegistryCredential{credential.APIToken, credential.BasicAuth}
+	return nil
+}

--- a/registry/inmem_credential_provider_test.go
+++ b/registry/inmem_credential_provider_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/deployment-manager/common"
+)
+
+type testCase struct {
+	name   string
+	exp    *common.RegistryCredential
+	expErr error
+}
+
+func createMissingError(name string) error {
+	return fmt.Errorf("no such credential : %s", name)
+}
+
+func testGetCredential(t *testing.T, cp common.CredentialProvider, tc *testCase) {
+	actual, actualErr := cp.GetCredential(tc.name)
+	if !reflect.DeepEqual(actual, tc.exp) {
+		t.Fatalf("failed on: %s : expected %#v but got %#v", tc.name, tc.exp, actual)
+	}
+	if !reflect.DeepEqual(actualErr, tc.expErr) {
+		t.Fatalf("failed on: %s : expected error %#v but got %#v", tc.name, tc.expErr, actualErr)
+	}
+}
+
+func verifySetAndGetCredential(t *testing.T, cp common.CredentialProvider, tc *testCase) {
+	err := cp.SetCredential(tc.name, tc.exp)
+	if err != nil {
+		t.Fatalf("Failed to SetCredential on %s : %v", tc.name, err)
+	}
+	testGetCredential(t, cp, tc)
+}
+
+func TestNotExist(t *testing.T) {
+	cp := NewInmemCredentialProvider()
+	tc := &testCase{"nonexistent", nil, createMissingError("nonexistent")}
+	testGetCredential(t, cp, tc)
+}
+
+func TestSetAndGetApiToken(t *testing.T) {
+	cp := NewInmemCredentialProvider()
+	tc := &testCase{"testcredential", &common.RegistryCredential{APIToken: "some token here"}, nil}
+	verifySetAndGetCredential(t, cp, tc)
+}
+
+func TestSetAndGetBasicAuth(t *testing.T) {
+	cp := NewInmemCredentialProvider()
+	tc := &testCase{"testcredential",
+		&common.RegistryCredential{
+			BasicAuth: common.BasicAuthCredential{"user", "pass"}}, nil}
+	verifySetAndGetCredential(t, cp, tc)
+}

--- a/registry/registryprovider.go
+++ b/registry/registryprovider.go
@@ -169,7 +169,11 @@ func (grp githubRegistryProvider) createGithubClient(credentialName string) (*gi
 			return github.NewClient(tc), nil
 		}
 		if c.BasicAuth.Username != "" && c.BasicAuth.Password != "" {
-
+			tp := github.BasicAuthTransport{
+				Username: c.BasicAuth.Username,
+				Password: c.BasicAuth.Password,
+			}
+			return github.NewClient(tp.Client()), nil
 		}
 
 	}

--- a/registry/registryprovider_test.go
+++ b/registry/registryprovider_test.go
@@ -45,7 +45,7 @@ func TestShortGithubUrlTemplateMapping(t *testing.T) {
 	}
 
 	grp := NewTestGithubRegistryProvider("github.com/kubernetes/application-dm-templates", githubUrlMaps)
-	testUrlConversionDriver(NewRegistryProvider(nil, grp), tests, t)
+	testUrlConversionDriver(NewRegistryProvider(nil, grp, NewInmemCredentialProvider()), tests, t)
 }
 
 func TestShortGithubUrlPackageMapping(t *testing.T) {
@@ -60,5 +60,5 @@ func TestShortGithubUrlPackageMapping(t *testing.T) {
 	}
 
 	grp := NewTestGithubRegistryProvider("github.com/helm/charts", githubUrlMaps)
-	testUrlConversionDriver(NewRegistryProvider(nil, grp), tests, t)
+	testUrlConversionDriver(NewRegistryProvider(nil, grp, NewInmemCredentialProvider()), tests, t)
 }

--- a/registry/test/test_credentials_file.yaml
+++ b/registry/test/test_credentials_file.yaml
@@ -1,0 +1,6 @@
+- name: test1
+  apitoken: token
+- name: test2
+  basicauth:
+    username: user
+    password: password


### PR DESCRIPTION
This allows the customer to create a credential that should be used when talking to github (for example private repos). The client is not plumbed through all the way since there's some merging going on, but at least it's plumbed through on the backend.
