### PR TITLE
Fix bug in Docker builds.

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -26,9 +26,9 @@ ENV KUBE_VERSION v1.0.5
 RUN curl -fsSL -o kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl \
     && chmod +x kubectl
 
-COPY . "$GOPATH"/src
+COPY . "$GOPATH"/src/github.com/kubernetes/deployment-manager
 
-WORKDIR "$GOPATH"/src/manager
+WORKDIR "$GOPATH"/src/github.com/kubernetes/deployment-manager/manager
 
 RUN go-wrapper download
 RUN go-wrapper install

--- a/resourcifier/Dockerfile
+++ b/resourcifier/Dockerfile
@@ -25,9 +25,9 @@ ENV KUBE_VERSION v1.0.5
 RUN curl -fsSL -o kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl \
     && chmod +x kubectl
 
-COPY . "$GOPATH"/src
+COPY . "$GOPATH"/src/github.com/kubernetes/deployment-manager
 
-WORKDIR "$GOPATH"/src/resourcifier
+WORKDIR "$GOPATH"/src/github.com/kubernetes/deployment-manager/resourcifier
 
 RUN go-wrapper download
 RUN go-wrapper install


### PR DESCRIPTION
Make Docker builds pull project relative package dependencies from the project, instead of from Github, for manager and resourcifier. dm still has this issue and expandybird uses the locally compiled binary, so all bets are off there.
