### PR TITLE
Preparation for api cleanup.

### DIFF
--- a/dm/dm.go
+++ b/dm/dm.go
@@ -166,6 +166,10 @@ func execute() {
 	switch args[0] {
 	case "templates":
 		path := fmt.Sprintf("registries/%s/types", *templateRegistry)
+		if *regexString != "" {
+			path += fmt.Sprintf("?%s", url.QueryEscape(*regexString))
+		}
+
 		callService(path, "GET", "list templates", nil)
 	case "describe":
 		if len(args) != 2 {

--- a/expandybird/expander/expander.go
+++ b/expandybird/expander/expander.go
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,6 +44,28 @@ type expander struct {
 // NewExpander returns a new initialized Expander.
 func NewExpander(binary string) Expander {
 	return &expander{binary}
+}
+
+func NewTemplateFromType(name, typeName string, properties map[string]interface{}) (*common.Template, error) {
+	resource := &common.Resource{
+		Name:       name,
+		Type:       typeName,
+		Properties: properties,
+	}
+
+	config := common.Configuration{Resources: []*common.Resource{resource}}
+	content, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("error: %s\ncannot marshal configuration: %v\n", err, config)
+	}
+
+	template := &common.Template{
+		Name:    name,
+		Content: string(content),
+		Imports: []*common.ImportFile{},
+	}
+
+	return template, nil
 }
 
 // NewTemplateFromArchive creates and returns a new template whose content

--- a/expandybird/expander/expander.go
+++ b/expandybird/expander/expander.go
@@ -46,6 +46,8 @@ func NewExpander(binary string) Expander {
 	return &expander{binary}
 }
 
+// NewTemplateFromType creates and returns a new template whose content
+// is a YAML marshaled resource assembled from the supplied arguments.
 func NewTemplateFromType(name, typeName string, properties map[string]interface{}) (*common.Template, error) {
 	resource := &common.Resource{
 		Name:       name,

--- a/expandybird/expander/expander_test.go
+++ b/expandybird/expander/expander_test.go
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/kubernetes/deployment-manager/common"
 )
 
@@ -105,6 +106,33 @@ func testExpandTemplateFromFile(t *testing.T, fileName, baseName string, importF
 
 	description := fmt.Sprintf("test expand template from file: %s", fileName)
 	expandAndVerifyOutput(t, actualOutput, description)
+}
+
+var (
+	testTemplateName       = "expandybird"
+	testTemplateType       = "replicatedservice.py"
+	testTemplateProperties = `
+service_port: 8080
+target_port: 8080
+container_port: 8080
+external_service: true
+replicas: 3
+image: gcr.io/dm-k8s-testing/expandybird
+labels:
+  app: expandybird
+`
+)
+
+func TestNewTemplateFromType(t *testing.T) {
+	var properties map[string]interface{}
+	if err := yaml.Unmarshal([]byte(testTemplateProperties), &properties); err != nil {
+		t.Fatalf("cannot unmarshal test data: %s", err)
+	}
+
+	_, err := NewTemplateFromType(testTemplateName, testTemplateType, properties)
+	if err != nil {
+		t.Fatalf("cannot create template from type %s: %s", testTemplateType, err)
+	}
 }
 
 func TestNewTemplateFromReader(t *testing.T) {

--- a/manager/deployments.go
+++ b/manager/deployments.go
@@ -495,12 +495,18 @@ func listRegistryTypesHandlerFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		util.LogAndReturnError(handler, http.StatusBadRequest, err, w)
+		return
+	}
+
 	var regex *regexp.Regexp
-	regexString, err := getPathVariable(w, r, "regex", handler)
-	if err == nil {
+	regexString := values.Get("regex")
+	if regexString != "" {
 		regex, err = regexp.Compile(regexString)
 		if err != nil {
-			util.LogAndReturnError(handler, http.StatusInternalServerError, err, w)
+			util.LogAndReturnError(handler, http.StatusBadRequest, err, w)
 			return
 		}
 	}

--- a/manager/deployments.go
+++ b/manager/deployments.go
@@ -53,6 +53,8 @@ var deployments = []Route{
 	{"Expand", "/expand", "POST", expandHandlerFunc, ""},
 	{"ListTypes", "/types", "GET", listTypesHandlerFunc, ""},
 	{"ListTypeInstances", "/types/{type}/instances", "GET", listTypeInstancesHandlerFunc, ""},
+	{"GetRegistryForType", "/types/{type}/registry", "GET", getRegistryForTypeHandlerFunc, ""},
+	{"GetMetadataForType", "/types/{type}/metadata", "GET", getMetadataForTypeHandlerFunc, ""},
 	{"ListRegistries", "/registries", "GET", listRegistriesHandlerFunc, ""},
 	{"GetRegistry", "/registries/{registry}", "GET", getRegistryHandlerFunc, ""},
 	{"CreateRegistry", "/registries/{registry}", "POST", createRegistryHandlerFunc, "JSON"},
@@ -376,6 +378,40 @@ func listTypeInstancesHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.LogHandlerExitWithJSON(handler, w, instances, http.StatusOK)
+}
+
+func getRegistryForTypeHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	handler := "manager: get type registry"
+	util.LogHandlerEntry(handler, r)
+	typeName, err := getPathVariable(w, r, "type", handler)
+	if err != nil {
+		return
+	}
+
+	registry, err := backend.GetRegistryForType(typeName)
+	if err != nil {
+		util.LogAndReturnError(handler, http.StatusBadRequest, err, w)
+		return
+	}
+
+	util.LogHandlerExitWithJSON(handler, w, registry, http.StatusOK)
+}
+
+func getMetadataForTypeHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	handler := "manager: get type metadata"
+	util.LogHandlerEntry(handler, r)
+	typeName, err := getPathVariable(w, r, "type", handler)
+	if err != nil {
+		return
+	}
+
+	metadata, err := backend.GetMetadataForType(typeName)
+	if err != nil {
+		util.LogAndReturnError(handler, http.StatusBadRequest, err, w)
+		return
+	}
+
+	util.LogHandlerExitWithJSON(handler, w, metadata, http.StatusOK)
 }
 
 // Putting Registry handlers here for now because deployments.go


### PR DESCRIPTION
Fixes #255. Fixes #258.

This PR also makes 3 additional changes in preparation for api cleanup:
- Removes the unnecessary use of download urls for computing type instances.
- Moves the construction of a template from a type name to the expander package.
- Moves metadata retrieval to the sever.

With these changes, the client no longer needs to fetch download urls for any purpose other than file download requests.

/cc @michelleN 
