### PR TITLE
Fix #400 - add docs to readthedocs mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,6 @@ pages:
  - Workspace Layout: workspace.md
  - Authoring Chart Basics: authoring_charts.md
  - Authoring Awesome Charts: awesome.md
- - Helm Generate and Template: generate-and-template.md
- - Helm Plugins: plugins.md
+ - Generate and Template: generate-and-template.md
+ - Plugin Support: plugins.md
 theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,5 +5,8 @@ pages:
  - Using Labels: using_labels.md
  - Modeling Services: modeling_services.md
  - Workspace Layout: workspace.md
- - Authoring Charts: authoring_charts.md
+ - Authoring Chart Basics: authoring_charts.md
+ - Authoring Awesome Charts: awesome.md
+ - Helm Generate and Template: generate-and-template.md
+ - Helm Plugins: plugins.md
 theme: readthedocs


### PR DESCRIPTION
This pr fixes issue #400 by adding missing doc files to the mkdocs.yml used to build the readthedocs site.