### PR TITLE
Add maintainers document.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,51 @@
+# Helm Maintainers
+
+This document explains the leadership structure of the Kubernetes Helm project, and list the current project maintainers.
+
+The Helm project welcomes contributions from any interested parties. This document explains the role of what we call "Core Maintainers". Core Maintainers play the special role of curating the project.
+
+## What is a Core Maintainer?
+
+(Unabashedly stolen from the [Docker](https://github.com/docker/docker/blob/master/MAINTAINERS) project)
+
+There are different types of maintainers, with different responsibilities, but
+all maintainers have 3 things in common:
+
+1. They share responsibility in the project's success.
+2. They have made a long-term, recurring time investment to improve the project.
+3. They spend that time doing whatever needs to be done, not necessarily what
+is the most interesting or fun.
+
+## Helm Core Maintainers
+
+The duties of a core maintainer include:
+
+* Classify and respond to GitHub issues and review pull requests
+* Perform code reviews (see below)
+* Shape the Helm roadmap and lead efforts to accomplish roadmap milestones
+* Participate actively in feature development and bug fixing
+* Answer questions and help users
+
+The current core maintainers of Helm (in alphabetical order):
+
+* Ville Aikas - PREFERRED EMAIL ([@vaikas-google](https://github.com/vaikas-google))
+* Matt Butcher - <butcher@deis.com> ([@technosophos](https://github.com/technosophos))
+* Jack Greenfield - PREFERRED EMAIL ([@jackgr](https://github.com/jackgr)) 
+* Brendan Melville - PREFERRED EMAIL ([@bmelville](https://github.com/bmelville))
+* Michelle Noorali - <michelle@deis.com> ([@michelleN](https://github.com/michelleN)]
+* Adam Reese - <areese@deis.com> ([@adamreese](https://github.com/adamreese))
+
+### Code Reviews
+
+Before being merged, every pull request must have at least two LGTMs ("Looks Good To Me"), and at least one of these must come from one of the core maintainers listed above.
+
+## Becoming a maintainer
+
+Generally, potential maintainers are selected by the Helm core maintainers based in
+part on the following criteria:
+
+* Sustained contributions to the project over a period of time (usually months)
+* A willingness to help users on GitHub and in IRC
+* A friendly attitude :)
+
+The Helm core maintainers must unanimously agree before inviting a community member to join as a maintainer, although in many cases the candidate has already been acting in the capacity of a contributing maintainer for some time, and has been consulted on issues, pull requests, etc.


### PR DESCRIPTION
Rather than change the existing governance docs, I'm proposing that we just add this one. It's based on the MAINTAINERS.md file that all of the Deis projects use. It's purpose is just to make it easy for the community to understand who's responsible for the project.

TODO: This still has placeholders for email addresses. Let me know which addresses you'd like, and I'll amend the commit.
