### PR TITLE
Set image tag to timestamp.

### DIFF
--- a/expandybird/Makefile
+++ b/expandybird/Makefile
@@ -19,7 +19,6 @@ include ../include.mk
 DOCKER_REGISTRY := gcr.io
 PREFIX := $(DOCKER_REGISTRY)/$(PROJECT)
 IMAGE := expandybird
-TAG := latest
 
 ROOT_DIR := $(abspath ./..)
 DIR = $(ROOT_DIR)

--- a/include.mk
+++ b/include.mk
@@ -5,6 +5,8 @@ info:
 	@echo "Project: ${PROJECT}"
 	@echo "Image: ${IMAGE}"
 
+TAG := $(shell echo `date +"%s"`_`date +"%N"`)
+
 .PHONY: test-unit
 test-unit:
 	@echo Running tests...

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -19,7 +19,6 @@ include ../include.mk
 DOCKER_REGISTRY := gcr.io
 PREFIX := $(DOCKER_REGISTRY)/$(PROJECT)
 IMAGE := manager
-TAG := latest
 
 ROOT_DIR := $(abspath ./..)
 DIR = $(ROOT_DIR)

--- a/resourcifier/Makefile
+++ b/resourcifier/Makefile
@@ -21,7 +21,6 @@ include ../include.mk
 DOCKER_REGISTRY := gcr.io
 PREFIX := $(DOCKER_REGISTRY)/$(PROJECT)
 IMAGE := resourcifier
-TAG := latest
 
 ROOT_DIR := $(abspath ./..)
 DIR = $(ROOT_DIR)


### PR DESCRIPTION
Currently, DM image builds default the tag to `latest`. They should set it to something explicit and unique. This change sets a nanosecond timestamp as the default tag value. The value can be overridden in each individual makefile, if so desired.
