### PR TITLE
feat(install): add -g to run generator

### DIFF
--- a/action/install.go
+++ b/action/install.go
@@ -30,7 +30,7 @@ var UninstallOrder = []string{"Service", "Pod", "ReplicationController", "Daemon
 // If the chart is not found in the workspace, it is fetched and then installed.
 //
 // During install, manifests are sent to Kubernetes in the ordered specified by InstallOrder.
-func Install(chartName, home, namespace string, force bool, client kubectl.Runner) {
+func Install(chartName, home, namespace string, force bool, generate bool, exclude []string, client kubectl.Runner) {
 	ochart := chartName
 	r := mustConfig(home).Repos
 	table, chartName := r.RepoChart(chartName)
@@ -62,6 +62,11 @@ func Install(chartName, home, namespace string, force bool, client kubectl.Runne
 		if !force {
 			log.Die("Stopping install. Re-run with --force to install anyway.")
 		}
+	}
+
+	// Run the generator if -g is set.
+	if generate {
+		Generate(chartName, home, exclude)
 	}
 
 	CheckKubePrereqs()

--- a/action/install_test.go
+++ b/action/install_test.go
@@ -71,7 +71,7 @@ func TestInstall(t *testing.T) {
 
 	for _, tt := range tests {
 		actual := test.CaptureOutput(func() {
-			Install(tt.chart, tmpHome, "", tt.force, tt.client)
+			Install(tt.chart, tmpHome, "", tt.force, false, []string{}, tt.client)
 		})
 
 		for _, exp := range tt.expected {

--- a/cli/install.go
+++ b/cli/install.go
@@ -35,6 +35,14 @@ var installCmd = cli.Command{
 			Name:  "dry-run",
 			Usage: "Fetch the chart, but only display the underlying kubectl commands.",
 		},
+		cli.BoolFlag{
+			Name:  "generate,g",
+			Usage: "Run the generator before installing.",
+		},
+		cli.StringSliceFlag{
+			Name:  "exclude,x",
+			Usage: "Files or directories to exclude from the generator (if -g is set).",
+		},
 	},
 }
 
@@ -49,6 +57,6 @@ func install(c *cli.Context) {
 	}
 
 	for _, chart := range c.Args() {
-		action.Install(chart, h, c.String("namespace"), force, client)
+		action.Install(chart, h, c.String("namespace"), force, c.Bool("generate"), c.StringSlice("exclude"), client)
 	}
 }


### PR DESCRIPTION
This adds the `-g` and `-x` flags to `helm install`.

To run generators: `helm install -g CHART`

To exclude the manifests directory: `helm install -g -x manifests CHART`