### PR TITLE
fix(rootfs): improve Makefiles for docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /vendor/*
 /rootfs/manager/bin/manager
 /rootfs/manager/bin/kubectl
+/rootfs/manager/bin/v1*
 /rootfs/resourcifier/bin/resourcifier
 /rootfs/resourcifier/bin/kubectl
+/rootfs/resourcifier/bin/v1*
 /rootfs/expandybird/bin/expandybird
 /rootfs/expandybird/opt/expansion

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ HAS_GLIDE := $(shell command -v glide)
 HAS_GOLINT := $(shell command -v golint)
 HAS_GOVET := $(shell command -v go tool vet)
 HAS_GOX := $(shell command -v gox)
+HAS_DOCKER := $(shell command -v docker)
 
 .PHONY: bootstrap
 bootstrap:
@@ -94,12 +95,19 @@ ifndef HAS_GOX
 	go get -u github.com/mitchellh/gox
 endif
 	glide install
+ifndef HAS_DOCKER
+	$(warning You must install Docker manually)
+endif
 
 .PHONY: .project
 .project:
-	@if [[ -z "${PROJECT}" ]]; then echo "PROJECT variable must be set"; exit 1; fi
+	$(info Docker registry: $(PREFIX))
+ifeq ($(PREFIX),gcr.io)
+	$(error "You must set at least one of the following environment variables: DOCKER_PROJECT, DOCKER_REGISTRY")
+endif
 
 .PHONY: .docker
 .docker:
-	@if [[ -z `which docker` ]] || ! docker version &> /dev/null; then echo "docker is not installed correctly"; exit 1; fi
-
+ifndef HAS_DOCKER
+	$(error You must install docker)
+endif

--- a/rootfs/manager/Makefile
+++ b/rootfs/manager/Makefile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DOCKER_REGISTRY := gcr.io
-PREFIX := $(DOCKER_REGISTRY)/$(PROJECT)
+include ../docker.mk
+
 IMAGE ?= manager
 TAG ?= git-$(shell git rev-parse --short HEAD)
 FULL_IMAGE := $(PREFIX)/$(IMAGE)
@@ -22,7 +22,7 @@ KUBE_VERSION ?= v1.1.7
 .PHONY: container
 container: binary kubectl
 	docker build -t $(FULL_IMAGE):latest -f Dockerfile .
-	docker tag $(FULL_IMAGE):latest $(FULL_IMAGE):$(TAG)
+	docker tag -f $(FULL_IMAGE):latest $(FULL_IMAGE):$(TAG)
 
 .PHONY: push
 push: container
@@ -35,6 +35,3 @@ endif
 binary:
 	cp ../../bin/linux-amd64/manager ./bin
 
-kubectl:
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-	chmod +x bin/kubectl

--- a/rootfs/resourcifier/Makefile
+++ b/rootfs/resourcifier/Makefile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DOCKER_REGISTRY := gcr.io
-PREFIX := $(DOCKER_REGISTRY)/$(PROJECT)
+include ../docker.mk
+
 IMAGE ?= resourcifier
 TAG ?= git-$(shell git rev-parse --short HEAD)
 FULL_IMAGE := $(PREFIX)/$(IMAGE)
@@ -21,8 +21,8 @@ KUBE_VERSION ?= v1.1.7
 
 .PHONY: container
 container: binary kubectl
-	docker build -t $(FULL_IMAGE):latest -f Dockerfile .
-	docker tag $(FULL_IMAGE):latest $(FULL_IMAGE):$(TAG)
+	docker build -t $(FULL_IMAGE):$(TAG) -f Dockerfile .
+	docker tag -f $(FULL_IMAGE):$(TAG) $(FULL_IMAGE):latest
 
 .PHONY: push
 push: container
@@ -34,7 +34,3 @@ endif
 
 binary:
 	cp ../../bin/linux-amd64/resourcifier ./bin
-
-kubectl:
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-	chmod +x bin/kubectl


### PR DESCRIPTION
This introduces a docker.mk file that now has shared logic between the
different builds. This will also create docker images that are stored in
non-public registries, which is great for cases where internet is
spotty or down. Some of the changes are just to normalize the Makefiles,
using more make and less arbitrary shell.

This partially addresses #292.
Closes #293.
