### PR TITLE
feat(*): add helm dm status command

### DIFF
--- a/cmd/helm/dm.go
+++ b/cmd/helm/dm.go
@@ -62,9 +62,16 @@ func dmCmd() cli.Command {
 				Name:      "status",
 				Usage:     "Show status of DM.",
 				ArgsUsage: "",
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "dry-run",
+						Usage: "Only display the underlying kubectl commands.",
+					},
+				},
 				Action: func(c *cli.Context) {
-					format.Err("Not yet implemented")
-					os.Exit(1)
+					if err := status(c.Bool("dry-run")); err != nil {
+						os.Exit(1)
+					}
 				},
 			},
 			{
@@ -107,6 +114,20 @@ func uninstall(dryRun bool) error {
 		format.Err("Error uninstalling: %s %s", out, err)
 	}
 	format.Msg(out)
+	return nil
+}
+
+func status(dryRun bool) error {
+	client := kubectl.Client
+	if dryRun {
+		client = kubectl.PrintRunner{}
+	}
+
+	out, err := client.GetByKind("pods", "", "dm")
+	if err != nil {
+		return err
+	}
+	format.Msg(string(out))
 	return nil
 }
 

--- a/pkg/kubectl/command.go
+++ b/pkg/kubectl/command.go
@@ -17,6 +17,7 @@ func command(args ...string) *cmd {
 }
 
 func assignStdin(cmd *cmd, in []byte) {
+	fmt.Println(string(in))
 	cmd.Stdin = bytes.NewBuffer(in)
 }
 

--- a/pkg/kubectl/get.go
+++ b/pkg/kubectl/get.go
@@ -13,7 +13,7 @@ func (r RealRunner) Get(stdin []byte, ns string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// GetByKind gets a named thing by kind.
+// GetByKind gets resources by kind, name(optional), and namespace(optional)
 func (r RealRunner) GetByKind(kind, name, ns string) (string, error) {
 	args := []string{"get", kind}
 
@@ -42,7 +42,7 @@ func (r PrintRunner) Get(stdin []byte, ns string) ([]byte, error) {
 	return []byte(cmd.String()), nil
 }
 
-// GetByKind gets a named thing by kind.
+// GetByKind gets resources by kind, name(optional), and namespace(optional)
 func (r PrintRunner) GetByKind(kind, name, ns string) (string, error) {
 	args := []string{"get", kind}
 

--- a/pkg/kubectl/get.go
+++ b/pkg/kubectl/get.go
@@ -15,7 +15,11 @@ func (r RealRunner) Get(stdin []byte, ns string) ([]byte, error) {
 
 // GetByKind gets a named thing by kind.
 func (r RealRunner) GetByKind(kind, name, ns string) (string, error) {
-	args := []string{"get", kind, name}
+	args := []string{"get", kind}
+
+	if name != "" {
+		args = append([]string{name}, args...)
+	}
 
 	if ns != "" {
 		args = append([]string{"--namespace=" + ns}, args...)
@@ -40,7 +44,11 @@ func (r PrintRunner) Get(stdin []byte, ns string) ([]byte, error) {
 
 // GetByKind gets a named thing by kind.
 func (r PrintRunner) GetByKind(kind, name, ns string) (string, error) {
-	args := []string{"get", kind, name}
+	args := []string{"get", kind}
+
+	if name != "" {
+		args = append([]string{name}, args...)
+	}
 
 	if ns != "" {
 		args = append([]string{"--namespace=" + ns}, args...)

--- a/pkg/kubectl/get_test.go
+++ b/pkg/kubectl/get_test.go
@@ -15,3 +15,15 @@ func TestGet(t *testing.T) {
 		t.Errorf("%s != %s", string(out), expects)
 	}
 }
+
+func TestGetByKind(t *testing.T) {
+	Client = TestRunner{
+		out: []byte("running the GetByKind command"),
+	}
+
+	expects := "running the GetByKind command"
+	out, _ := Client.GetByKind("pods", "", "")
+	if out != expects {
+		t.Errorf("%s != %s", out, expects)
+	}
+}

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -10,3 +10,7 @@ type TestRunner struct {
 func (r TestRunner) Get(stdin []byte, ns string) ([]byte, error) {
 	return r.out, r.err
 }
+
+func (r TestRunner) GetByKind(kind, name, ns string) (string, error) {
+	return string(r.out), r.err
+}


### PR DESCRIPTION
Allows a user to inspec their dm pods and state
in the running Kubernetes cluster. This resolves
issue #301.
