### PR TITLE
docs(README): update README in light of merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ are organized. So, for example, you can ask questions like:
 * What Redis master and slave services are part of this Redis instance?
 * What pods are part of this Redis slave?
 
+The official Helm repository of charts is available in the
+[kubernetes/charts](https://github.com/kubernetes/charts) repository.
+
 Please hang out with us in [the Slack chat room](https://kubernetes.slack.com/messages/helm/).
 
 ## Installing Helm
@@ -56,6 +59,14 @@ You can uninstall Deployment Manager using the same configuration:
 
 ```
 helm dm uninstall
+```
+
+## Installing Charts
+
+To quickly deploy a chart, you can use the Helm command line tool:
+
+```
+$ helm deploy CHARTNAME
 ```
 
 ## Design of Deployment Manager

--- a/README.md
+++ b/README.md
@@ -1,43 +1,13 @@
-# Deployment Manager
+# Helm
 
 [![Circle CI](https://circleci.com/gh/kubernetes/helm.svg?style=svg)](https://circleci.com/gh/kubernetes/helm) [![Go Report Card](http://goreportcard.com/badge/kubernetes/helm)](http://goreportcard.com/report/kubernetes/helm)
 
-Deployment Manager (DM) `dm` makes it easy to create, describe, update and
+Helm makes it easy to create, describe, update and
 delete Kubernetes resources using declarative configuration. A configuration is
 just a `YAML` file that configures Kubernetes resources or supplies parameters
-to templates. Templates are just YAML files with [Jinja](http://jinja.pocoo.org/)
-mark up or Python scripts.
+to templates.
 
-For example, this simple configuration deploys the Guestbook example:
-
-```
-resources:
-- name: frontend
-  type: github.com/kubernetes/application-dm-templates/common/replicatedservice:v1
-  properties:
-    service_port: 80
-    container_port: 80
-    external_service: true
-    replicas: 3
-    image: gcr.io/google_containers/example-guestbook-php-redis:v3
-- name: redis
-  type: github.com/kubernetes/application-dm-templates/storage/redis:v1
-  properties: null
-```
-
-It uses two templates. The front end is a
-[replicated service](https://github.com/kubernetes/application-dm-templates/tree/master/common/replicatedservice/v1),
-which creates a service and replication controller with matching selectors, and
-the back end is a
-[Redis cluster](https://github.com/kubernetes/application-dm-templates/tree/master/storage/redis/v1),
-which creates a Redis master and two Redis slaves.
-
-Templates can use other templates, making it easy to create larger structures
-from smaller building blocks. For example, the Redis template uses the replicated
-service template to create the Redis master, and then again to create each Redis
-slave.
-
-DM runs server side, in your Kubernetes cluster, so it can tell you what templates
+Helm Manager runs server side, in your Kubernetes cluster, so it can tell you what templates
 you've instantiated there, what resources they created, and even how the resources
 are organized. So, for example, you can ask questions like:
 
@@ -45,22 +15,9 @@ are organized. So, for example, you can ask questions like:
 * What Redis master and slave services are part of this Redis instance?
 * What pods are part of this Redis slave?
 
-Because DM stores its state in the cluster, not on your workstation, you can ask
-those questions from any client at any time.
+Please hang out with us in [the Slack chat room](https://kubernetes.slack.com/messages/helm/).
 
-Templates live in ordinary Github repositories called template registries. See
-the [Kubernetes Template Registry](https://github.com/kubernetes/application-dm-templates)
-for curated Kubernetes applications using Deployment Manager templates.
-
-For more information about configurations and templates, see the
-[design document](docs/design/design.md#types).
-
-Please hang out with us in
-[the Slack chat room](https://kubernetes.slack.com/messages/sig-configuration/)
-and/or [the Google Group](https://groups.google.com/forum/#!forum/kubernetes-sig-config)
-for the Kubernetes configuration SIG.
-
-## Installing Deployment Manager
+## Installing Helm
 
 Note: if you're exploring or using the project, you'll probably want to pull
 (the latest release)[https://github.com/kubernetes/helm/releases/latest],
@@ -69,13 +26,10 @@ since there may be undiscovered or unresolved issues at HEAD.
 From a Linux or Mac OS X client:
 
 ```
-curl -s https://raw.githubusercontent.com/kubernetes/helm/master/get-install.sh | sh
-```
-
-and then install the DM services into your Kubernetes cluster:
-
-```
-helm dm install
+$ git clone https://github.com/kubernetes/deployment-manager.git
+$ cd deployment-manager
+$ make build
+$ bin/helm dm install
 ```
 
 That's it. You can now use `kubectl` to see DM running in your cluster:
@@ -88,7 +42,7 @@ If you see expandybird-service, manager-service, resourcifier-service, and
 expandybird-rc, manager-rc and resourcifier-rc with pods that are READY, then DM
 is up and running!
 
-## Using Deployment Manager
+## Using Helm
 
 Run a Kubernetes proxy to allow the dm client to connect to the cluster:
 
@@ -96,50 +50,13 @@ Run a Kubernetes proxy to allow the dm client to connect to the cluster:
 kubectl proxy --port=8001 --namespace=dm &
 ```
 
-### Deploy an app
-To deploy a simple guestbook app:
-
-```
-$ dm deploy examples/guestbook/guestbook.yaml
-$ kubectl get service
-```
-
-The `frontend-service` should have an external IP that you can navigate to in
-your browser to play with.
-
-For more information about this example, see [examples/guestbook/README.md](examples/guestbook/README.md)
-
-### Deploying a template
-
-To deploy a redis template from the [Kubernetes
-Template Registry](https://github.com/kubernetes/application-dm-templates):
-
-```
-dm --properties workers=3 deploy storage/redis:v1
-```
-
-For more information about deploying templates from a template registry or adding
-types to a template registry, see
-[the template registry documentation](docs/templates/registry.md).
-
-## Uninstalling Deployment Manager
+## Uninstalling Helm from Kubernetes
 
 You can uninstall Deployment Manager using the same configuration:
 
 ```
-helm dm delete
+helm dm uninstall
 ```
-
-## Building the Container Images
-
-This project runs Deployment Manager on Kubernetes as three replicated services.
-By default, `helm` uses prebuilt images stored in Google Container Registry
-to install them. However, you can build your own container images and push them
-to your own project in the Google Container Registry:
-
-1. Set the environment variable `PROJECT` to the name of a project known to
-GCloud.
-1. Run `make push`
 
 ## Design of Deployment Manager
 
@@ -158,6 +75,6 @@ We use the same [workflow](https://github.com/kubernetes/kubernetes/blob/master/
 [License](LICENSE) and [Contributor License Agreement](CONTRIBUTING.md) as the main Kubernetes repository.
 
 ## Relationship to Google Cloud Platform
-DM uses the same concepts and languages as
+DM uses many of the same concepts and languages as
 [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/overview),
 but creates resources in Kubernetes clusters, not in Google Cloud Platform projects.


### PR DESCRIPTION
This strips the README back to an accurate representation of the current
state of the project. We can begin adding to it again as it
re-stabilizes.

Closes #304.
