### PR TITLE
fix(*): allow local docker registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /vendor/*
 /rootfs/manager/bin/manager
 /rootfs/manager/bin/kubectl
+/rootfs/manager/bin/v1.*
 /rootfs/resourcifier/bin/resourcifier
 /rootfs/resourcifier/bin/kubectl
+/rootfs/resourcifier/bin/v1.*
 /rootfs/expandybird/bin/expandybird
 /rootfs/expandybird/opt/expansion

--- a/rootfs/manager/Makefile
+++ b/rootfs/manager/Makefile
@@ -19,8 +19,3 @@ include ../include.mk
 
 .PHONY: extras
 extras: kubectl
-
-.PHONY: kubectl
-kubectl:
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-	chmod +x bin/kubectl

--- a/rootfs/resourcifier/Makefile
+++ b/rootfs/resourcifier/Makefile
@@ -19,8 +19,3 @@ include ../include.mk
 
 .PHONY: extras
 extras: kubectl
-
-.PHONY: kubectl
-kubectl:
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-	chmod +x bin/kubectl


### PR DESCRIPTION
This fix supersedes #323. It applies basically the same fixes:
- local docker registries are now supported
- kubectl is not downloaded on every build

Also, added a fix for the case where `docker version` failed because the
Docker daemon crashed, and consequently spuriously propmted the user to
re-install docker.

I added support for $DOCKER_PROJECT instead of just $PROJECT because the
later is a little too generic for a shell env var. We can deprecate
$PROJECT later.

I did not add back in the better tool checks in bootstrap because
CircleCI doesn't have the `command` command.
