### PR TITLE
Fix build on GNU make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,10 @@ vet:
 	done
 	@echo -----------------
 
-HAS_GLIDE := $(shell command -v glide)
-HAS_GOLINT := $(shell command -v golint)
-HAS_GOVET := $(shell command -v go tool vet)
-HAS_GOX := $(shell command -v gox)
+HAS_GLIDE := $(shell command -v glide;)
+HAS_GOLINT := $(shell command -v golint;)
+HAS_GOVET := $(shell command -v go tool vet;)
+HAS_GOX := $(shell command -v gox;)
 
 .PHONY: bootstrap
 bootstrap:


### PR DESCRIPTION
GNU make optimizes $(shell ...) to use fork/exec unless it detects that it has to use system()

Force that detection by adding a semicolon
