### PR TITLE
Fix typos and run gofmt

### DIFF
--- a/codec/object.go
+++ b/codec/object.go
@@ -85,7 +85,7 @@ func (m *Object) JSON() ([]byte, error) {
 // Meta returns a *Metadata
 //
 // This contains more information than an ObjectReference. It is valid for the
-// core Kubernetes kinds, but is not guranteed to work for all possible kinds.
+// core Kubernetes kinds, but is not guaranteed to work for all possible kinds.
 func (m *Object) Meta() (*Metadata, error) {
 	u := &Metadata{}
 	err := m.dec(m.data, u)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/helm/helm/log"
 )
 
+// GeneratorKeyword is used to generate new charts
 const GeneratorKeyword = "helm:generate "
 
 // Walk walks a chart directory and executes generators as it finds them.

--- a/search/search.go
+++ b/search/search.go
@@ -1,4 +1,4 @@
-/* Package search provides search features for Helm. */
+// Package search provides search features for Helm.
 package search
 
 import (
@@ -135,7 +135,7 @@ func (i *Index) SearchRegexp(re string, threshold int) ([]*Result, error) {
 // ErrNoChart indicates that a chart is not in the chart cache.
 var ErrNoChart = errors.New("no such chart")
 
-// Get the *Chartfile for a chart that was found during search.
+// Chart gets the *Chartfile for a chart that was found during search.
 //
 // This is a convenience method for retrieving a cached chart that was located
 // during search indexing.
@@ -147,7 +147,7 @@ func (i *Index) Chart(name string) (*chart.Chartfile, error) {
 	return c, nil
 }
 
-// Sort does an in-place sort of the results.
+// SortScore does an in-place sort of the results.
 //
 // Lowest scores are highest on the list. Matching scores are subsorted alphabetically.
 func SortScore(r []*Result) {

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -11,18 +11,18 @@ var testConfig = &config.Configfile{
 	Repos: &config.Repos{
 		Default: "charts",
 		Tables: []*config.Table{
-			&config.Table{Name: "charts", Repo: "https://github.com/helm/charts"},
+			{Name: "charts", Repo: "https://github.com/helm/charts"},
 		},
 	},
 }
 
 func TestSortScore(t *testing.T) {
 	in := []*Result{
-		&Result{Name: "bbb", Score: 0},
-		&Result{Name: "aaa", Score: 5},
-		&Result{Name: "abb", Score: 5},
-		&Result{Name: "aab", Score: 0},
-		&Result{Name: "bab", Score: 5},
+		{Name: "bbb", Score: 0},
+		{Name: "aaa", Score: 5},
+		{Name: "abb", Score: 5},
+		{Name: "aab", Score: 0},
+		{Name: "bab", Score: 5},
 	}
 	expect := []string{"aab", "bbb", "aaa", "abb", "bab"}
 	expectScore := []int{0, 0, 5, 5, 5}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -46,7 +46,7 @@ func (v *Validation) ChartManifestsPath() string {
 	return filepath.Join(v.path, "manifests")
 }
 
-// Charfile returns a chart.Chartfile object formed from the Chart.yaml file.
+// Chartfile returns a chart.Chartfile object formed from the Chart.yaml file.
 func (v *Validation) Chartfile() (*chart.Chartfile, error) {
 	var y *chart.Chartfile
 	b, err := ioutil.ReadFile(v.ChartYamlPath())
@@ -152,7 +152,7 @@ func (cv *ChartValidation) walk(talker func(v *Validation) bool) {
 
 // Valid returns true if every validation passes.
 func (cv *ChartValidation) Valid() bool {
-	var valid bool = true
+	var valid = true
 
 	fmt.Printf("\nVerifying %s chart is a valid chart...\n", cv.ChartName())
 	cv.walk(func(v *Validation) bool {


### PR DESCRIPTION
Noticed some easy fixes on https://goreportcard.com/report/github.com/helm/helm so I addressed most of them:

* guranteed -> guaranteed
* `gofmt -w -s search/search_test.go`
* Add missing comments, or fix golint comment format "methodName ..."
* Address golint unnecessary type validation