### PR TITLE
fixing shell variable references

### DIFF
--- a/get-install.sh
+++ b/get-install.sh
@@ -21,7 +21,7 @@ DEFAULT_PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 DEFAULT_ARCH=$(uname -m)
 
 STORAGE_URL=http://get-dm.storage.googleapis.com
-ZIP=dm-${TAG:-DEFAULT_TAG}-${PLATFORM:-DEFAULT_PLATFORM}-${ARCH:-DEFAULT_ARCH}.zip
+ZIP=dm-${TAG:-${DEFAULT_TAG}}-${PLATFORM:-${DEFAULT_PLATFORM}}-${ARCH:-${DEFAULT_ARCH}}.zip
 
 echo "Downloading ${ZIP}..."
 curl -Ls "${STORAGE_URL}/${ZIP}" -O


### PR DESCRIPTION
There are also two other bugs:
- `uname -m` returns `x86_64` for me, but there is only `dm-v1.2-darwin-amd64.zip` on `http://get-dm.storage.googleapis.com`
- line 32 doesn't work because the file inside the zip is not named `dm`, but something like `dm-darwin-amd64`.
