### PR TITLE
fix(action/lint.go): Chart validation

### DIFF
--- a/action/lint.go
+++ b/action/lint.go
@@ -18,6 +18,9 @@ const (
 
 	// Project is the default Charts repository name.
 	Project = "charts"
+
+	// Maximum length of Metadata.name allowed by kubernetes
+	MaxMetadataNameLength = 24
 )
 
 // RepoService is a GitHub client instance.
@@ -124,7 +127,7 @@ func Lint(chartPath string) {
 
 		for _, m := range cv.Manifests {
 			meta, _ := m.VersionedObject.Meta()
-			if meta.Name == "" {
+			if meta.Name == "" || len(meta.Name) > MaxMetadataNameLength {
 				success = false
 			}
 

--- a/action/lint.go
+++ b/action/lint.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/google/go-github/github"
 	"github.com/helm/helm/log"
@@ -128,6 +129,10 @@ func Lint(chartPath string) {
 		for _, m := range cv.Manifests {
 			meta, _ := m.VersionedObject.Meta()
 			if meta.Name == "" || len(meta.Name) > MaxMetadataNameLength {
+				success = false
+			}
+
+			if match, _ := regexp.MatchString(`[a-z]([-a-z0-9]*[a-z0-9])?`, meta.Name); !match {
 				success = false
 			}
 


### PR DESCRIPTION
Added maximum Metadata.name length (=24) constraint

Closes #412