### PR TITLE
fix(cli): revert to older deploy formatting

### DIFF
--- a/cmd/helm/deploy.go
+++ b/cmd/helm/deploy.go
@@ -102,7 +102,7 @@ func deploy(c *cli.Context) error {
 		}
 	}
 
-	return NewClient(c).PostDeployment(cfg)
+	return NewClient(c).PostDeployment(cfg.Resources[0].Name, cfg)
 }
 
 // isLocalChart returns true if the given path can be statted.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -169,7 +169,7 @@ func TestPostDeployment(t *testing.T) {
 	}
 	defer fc.teardown()
 
-	if err := fc.setup().PostDeployment(cfg); err != nil {
+	if err := fc.setup().PostDeployment("foo", cfg); err != nil {
 		t.Fatalf("failed to post deployment: %s", err)
 	}
 }


### PR DESCRIPTION
Prior to merging the projects, the version of `helm deploy` used a different REST API (one without YAML in JSON). There was a partially complete version in the old repo. Post-merge, we need to revert back to the original common.Template version.

As part of this, I switched an io.ReadCloser back to an io.Reader because there is nowhere where the Closer part is used. The http lib does not close a reader passed to it.
