### PR TITLE
Adjust chart representation to have schema as a separate file on disk.

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -115,7 +115,7 @@ type ChartFile struct {
 type Chart struct {
 	Name     string       `json:"name"`
 	Expander *Expander    `json:"expander"`
-	Schema   interface{}  `json:"schema"`
+	Schema   string       `json:"schema"`
 	Files    []*ChartFile `json:"files"`
 }
 


### PR DESCRIPTION
@michelleN @jackgr 

The idea is that the chart.yaml will have a field schema: "somefile.yaml" which contains the schema.  We could also hardcode this filename like we do with LICENSE for example.  We have a few options here.  This change makes the chart rep in master match the one in the dm-charts branch, where I have modified expandybird to understand this representation.
