### PR TITLE
Removed collaborator terminology

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,12 +16,12 @@ is the most interesting or fun.
 
 ## Types of Maintainers
 
-The Helm project includes two types of official maintainers: collaborators and core maintainers.
+The Helm project includes two types of official maintainers: maintainers and core maintainers.
 
-### Helm Collaborators
+### Helm Maintainers
 
-Helm collaborators are developers who have commit access to the Helm repository.
-The duties of a collaborator include:
+Helm maintainers are developers who have commit access to the Helm repository.
+The duties of a maintainer include:
 
 * Classify and respond to GitHub issues and review pull requests
 * Perform code reviews
@@ -32,7 +32,7 @@ The duties of a collaborator include:
 
 ### Helm Core Maintainers
 
-In addition to the duties of a Collaborator, Helm Core Maintainers also:
+In addition to the duties of a Maintainer, Helm Core Maintainers also:
 
 * Coordinate planning meetings
 * Triage GitHub issues for milestone planning


### PR DESCRIPTION
Currently, MAINTAINERS.md uses the term `collaborator` for maintainers who are not core maintainers.

This term has a different meaning in the broader Kubernetes community. There, it refers to people who work on the project, but don't have write access to the repository.

Accordingly, there are `<repo>-collaborators` teams in the Kubernetes organization that confer read rights on their members. Strictly speaking, granting explicit read access is unnecessary in a public repo, since the public can read. However, there may be other motivations for maintaining a list of people who work on the project, but don't have write access to the repository, such as generating invitations to team meetings.

Given this difference in definition, I'm submitting this PR to align our terminology with the terminology used by the broader Kubernetes community by changing all instances of the term `collaborator` into `maintainer` in MAINTAINERS.md.

If and when this PR is merged, then I will also delete the `helm-collaborators` team, since we don't have any need to track people who work on the project, but don't have write access to the repository, other than through the usual community interactions.

If and when the time comes when we do need to track them, then we can reinstate the `helm-collaborators` team for that purpose, following the general pattern used in the Kubernetes organization.

This PR also changes the language requiring unanimous agreement on nominating new maintainers, so that only a quorum is required.
