### PR TITLE
fix(Makefile): Install Glide with go get -u

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ ifndef HAS_PIP
 	$(error Please install the latest version of Python pip)
 endif
 ifndef HAS_GLIDE
-	go get github.com/Masterminds/glide
+	go get -u github.com/Masterminds/glide
 endif
 ifndef HAS_GOLINT
 	go get -u github.com/golang/lint/golint


### PR DESCRIPTION
go get -u is used to install and handle the other dependencies,
such as gox, golint, and vet. Use the same method for Glide.
