### PR TITLE
fix(manager): add stub for context with Manager

### DIFF
--- a/cmd/manager/deployments_test.go
+++ b/cmd/manager/deployments_test.go
@@ -3,13 +3,18 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/kubernetes/helm/cmd/manager/router"
+	"github.com/kubernetes/helm/pkg/common"
+	"github.com/kubernetes/helm/pkg/httputil"
+	"github.com/kubernetes/helm/pkg/registry"
 )
 
 func TestHealthz(t *testing.T) {
-	c := mockContext()
+	c := stubContext()
 	s := httpHarness(c, "GET /", healthz)
 	defer s.Close()
 
@@ -33,7 +38,88 @@ func httpHarness(c *router.Context, route string, fn router.HandlerFunc) *httpte
 	return httptest.NewServer(h)
 }
 
-func mockContext() *router.Context {
-	// TODO: We need mocks for credentials and manager.
-	return &router.Context{}
+// stubContext creates a stub of a Context object.
+//
+// This creates a stub context with the following properties:
+// - Config is initialized to empty values
+// - Encoder is initialized to httputil.DefaultEncoder
+// - CredentialProvider is initialized to registry.InmemCredentialProvider
+// - Manager is initialized to mockManager.
+func stubContext() *router.Context {
+	return &router.Context{
+		Config:             &router.Config{},
+		Manager:            &mockManager{},
+		CredentialProvider: registry.NewInmemCredentialProvider(),
+		Encoder:            httputil.DefaultEncoder,
+	}
+}
+
+type mockManager struct{}
+
+func (m *mockManager) ListDeployments() ([]common.Deployment, error) {
+	return []common.Deployment{}, nil
+}
+func (m *mockManager) GetDeployment(name string) (*common.Deployment, error) {
+	return &common.Deployment{}, nil
+}
+func (m *mockManager) CreateDeployment(t *common.Template) (*common.Deployment, error) {
+	return &common.Deployment{}, nil
+}
+func (m *mockManager) DeleteDeployment(name string, forget bool) (*common.Deployment, error) {
+	return &common.Deployment{}, nil
+}
+func (m *mockManager) PutDeployment(name string, t *common.Template) (*common.Deployment, error) {
+	return &common.Deployment{}, nil
+}
+
+func (m *mockManager) ListManifests(deploymentName string) (map[string]*common.Manifest, error) {
+	return map[string]*common.Manifest{}, nil
+}
+func (m *mockManager) GetManifest(deploymentName string, manifest string) (*common.Manifest, error) {
+	return &common.Manifest{}, nil
+}
+func (m *mockManager) Expand(t *common.Template) (*common.Manifest, error) {
+	return &common.Manifest{}, nil
+}
+
+func (m *mockManager) ListTypes() ([]string, error) {
+	return []string{}, nil
+}
+func (m *mockManager) ListInstances(typeName string) ([]*common.TypeInstance, error) {
+	return []*common.TypeInstance{}, nil
+}
+func (m *mockManager) GetRegistryForType(typeName string) (string, error) {
+	return "", nil
+}
+func (m *mockManager) GetMetadataForType(typeName string) (string, error) {
+	return "", nil
+}
+
+func (m *mockManager) ListRegistries() ([]*common.Registry, error) {
+	return []*common.Registry{}, nil
+}
+func (m *mockManager) CreateRegistry(pr *common.Registry) error {
+	return nil
+}
+func (m *mockManager) GetRegistry(name string) (*common.Registry, error) {
+	return &common.Registry{}, nil
+}
+func (m *mockManager) DeleteRegistry(name string) error {
+	return nil
+}
+
+func (m *mockManager) ListRegistryTypes(registryName string, regex *regexp.Regexp) ([]registry.Type, error) {
+	return []registry.Type{}, nil
+}
+func (m *mockManager) GetDownloadURLs(registryName string, t registry.Type) ([]*url.URL, error) {
+	return []*url.URL{}, nil
+}
+func (m *mockManager) GetFile(registryName string, url string) (string, error) {
+	return "", nil
+}
+func (m *mockManager) CreateCredential(name string, c *common.RegistryCredential) error {
+	return nil
+}
+func (m *mockManager) GetCredential(name string) (*common.RegistryCredential, error) {
+	return &common.RegistryCredential{}, nil
 }


### PR DESCRIPTION
This adds testing fixtures for the manager. It includes a stub context
that has either default or stub implementations for each object.
