### PR TITLE
fix(gitignore): ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ nohup.out
 /rootfs/resourcifier/bin/v1.*
 /rootfs/expandybird/bin/expandybird
 /rootfs/expandybird/opt/expansion
+.DS_Store


### PR DESCRIPTION
On OSX, a few things we have (notably, docs) cause OS X to generate
.DS_Store caches. These should not get checked into Git.
