### PR TITLE
fix(gitignore): ignore logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nohup.out
 /rootfs/expandybird/bin/expandybird
 /rootfs/expandybird/opt/expansion
 .DS_Store
+/log/


### PR DESCRIPTION
The lolca-start.sh script creates a local logs directory. Ignore it.
