### PR TITLE
fix(Makefile): add quicktest target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ clean:
 .PHONY: test
 test: build test-style test-unit test-flake8
 
+.PHONY: quicktest
+quicktest: test-style
+	go test $(GO_PKGS)
+
 ROOTFS := rootfs
 
 .PHONY: push


### PR DESCRIPTION
This is good for running a quick test during dev to check for failures
without having to read a gazillion lines of output.
