### PR TITLE
fix(cli): change deployment delete to remove

### DIFF
--- a/cmd/helm/deployment.go
+++ b/cmd/helm/deployment.go
@@ -51,8 +51,8 @@ func deploymentCommands() cli.Command {
 				ArgsUsage: "DEPLOYMENT",
 			},
 			{
-				Name:      "delete",
-				Aliases:   []string{"del"},
+				Name:      "remove",
+				Aliases:   []string{"rm"},
 				Usage:     "Deletes the named deployment(s).",
 				ArgsUsage: "DEPLOYMENT [DEPLOYMENT [...]]",
 				Action:    func(c *cli.Context) { run(c, deleteDeployment) },


### PR DESCRIPTION
This is for consistency. Other commands use 'remove,rm' as removal
verbs. Example: 'helm repo rm'
