### PR TITLE
fix(validate-go): show the errors gofmt found

### DIFF
--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -48,6 +48,7 @@ if [[ -n "${failed_fmt}" ]]; then
   echo "${red}"
   echo "gofmt check failed:"
   echo "$failed_fmt"
+  find_go_files | xargs gofmt -s -d
   echo "${reset}"
   exit_code=1
 fi


### PR DESCRIPTION
Rather than just listing files that have errors, this now shows
the diff of what gofmt thinks should be the case, and what is
the case.
