### PR TITLE
fix(cli): Add -n alias for --name

### DIFF
--- a/cmd/helm/deploy.go
+++ b/cmd/helm/deploy.go
@@ -42,7 +42,7 @@ func deployCmd() cli.Command {
 				Usage: "The configuration YAML file for this deployment.",
 			},
 			cli.StringFlag{
-				Name:  "name",
+				Name:  "name,n",
 				Usage: "Name of deployment, used for deploy and update commands (defaults to template name)",
 			},
 			// TODO: I think there is a Generic flag type that we can implement parsing with.

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -39,7 +39,7 @@ const desc = `Helm: the package and deployment manager for Kubernetes
    Once the in-cluster portion is running, you can use 'helm deploy' to
    deploy a new application:
 
-      $ helm deploy CHARTNAME
+      $ helm deploy -n NAME CHART
 
    For more information on Helm commands, you can use the following tools:
 


### PR DESCRIPTION
On 'helm deploy', add '-n' as an alias for '--name', and also
update docs to make it neutral about whether '-n'/'--name' is required.
