### PR TITLE
fix(client): fix append deployments url

### DIFF
--- a/pkg/client/deployments.go
+++ b/pkg/client/deployments.go
@@ -121,6 +121,6 @@ func (c *Client) PostDeployment(res *common.Resource) error {
 	}
 
 	var out struct{}
-	_, err = c.Post("/deployments", data, &out)
+	_, err = c.Post("deployments", data, &out)
 	return err
 }


### PR DESCRIPTION
Fixes issue when base url has a prefix
