### PR TITLE
grab the CA bundle for proper auth to Google storage

### DIFF
--- a/rootfs/manager/Dockerfile
+++ b/rootfs/manager/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM alpine:3.3
+RUN apk --update add ca-certificates
 COPY . /
 EXPOSE 8080
 CMD ["/bin/manager", "--kubectl=/bin/kubectl"]

--- a/rootfs/resourcifier/Dockerfile
+++ b/rootfs/resourcifier/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM alpine:3.3
+RUN apk --update add ca-certificates
 COPY . /
 EXPOSE 8080
 CMD ["/bin/resourcifier", "--kubectl=/bin/kubectl"]


### PR DESCRIPTION
Fetching the charts on gs fails due to lack of certs in the images.
This adds the CA bundle
