### PR TITLE
feat(e2e): add script for local kubernetes cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ nohup.out
 /rootfs/expandybird/opt/expansion
 .DS_Store
 /log/
+/scripts/env.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -27,6 +27,10 @@ error_exit() {
   exit 1
 }
 
+is_osx() {
+  [[ "$(uname)" == "Darwin" ]]
+}
+
 assign_version() {
   if [[ -z "${VERSION:-}" ]]; then
     VERSION=$(version_from_git)

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+DOCKER_HOST_IP=$(echo $DOCKER_HOST | awk -F'[/:]' '{print $4}')
+: ${DOCKER_HOST_IP:=$(ifconfig docker0 \
+    | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
+    | grep -Eo '([0-9]*\.){3}[0-9]*')}
+
+is_docker_machine() {
+  [[ $(docker-machine active 2>/dev/null) ]]
+}
+
+active_docker_machine() {
+  if command -v docker-machine >/dev/null 2>&1; then
+    docker-machine active
+  fi
+}
+
+dev_registry() {
+  if docker inspect registry >/dev/null 2>&1; then
+    docker start registry
+  else
+    docker run --restart="always" -d -p 5000:5000 --name registry registry:2
+  fi
+}

--- a/scripts/kube-down.sh
+++ b/scripts/kube-down.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+[[ "$TRACE" ]] && set -x
+
+HELM_ROOT="${BASH_SOURCE[0]%/*}/.."
+source "${HELM_ROOT}/scripts/common.sh"
+source "${HELM_ROOT}/scripts/docker.sh"
+
+KUBE_PORT=${KUBE_PORT:-8080}
+KUBE_HOST=${KUBE_HOST:-$DOCKER_HOST_IP}
+KUBE_HOST=${KUBE_HOST:-localhost}
+KUBECTL="kubectl -s ${KUBE_HOST}:${KUBE_PORT}"
+
+delete_kube_resources() {
+  echo "Deleting resources in kubernetes..."
+
+  $KUBECTL delete replicationcontrollers,services,pods,secrets --all > /dev/null 2>&1 || :
+  $KUBECTL delete replicationcontrollers,services,pods,secrets --all --namespace=kube-system > /dev/null 2>&1 || :
+  $KUBECTL delete namespace kube-system > /dev/null 2>&1 || :
+}
+
+delete_hyperkube_containers() {
+  echo "Stopping main kubelet..."
+
+  docker stop helm_kubelet > /dev/null 2>&1 || true
+  docker rm --force --volumes helm_kubelet > /dev/null 2>&1 || true
+
+  echo "Stopping remaining kubernetes containers..."
+
+  local kube_containers=$(docker ps -aqf "name=k8s_")
+  if [ ! -z "$kube_containers" ]; then
+    docker stop $kube_containers > /dev/null 2>&1
+    docker wait $kube_containers > /dev/null 2>&1
+    docker rm --force --volumes $kube_containers > /dev/null 2>&1
+  fi
+}
+
+main() {
+  echo "Bringing down the kube..."
+
+  delete_kube_resources
+  delete_hyperkube_containers
+
+  echo "done."
+}
+
+main "$@"
+
+exit 0

--- a/scripts/kube-down.sh
+++ b/scripts/kube-down.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Tear down kubernetes in docker
+
 set -eo pipefail
 [[ "$TRACE" ]] && set -x
 

--- a/scripts/kube-up.sh
+++ b/scripts/kube-up.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Start a kubenetes cluster in docker
+#
+# Tested on darwin using docker-machine and linux
+
 set -eo pipefail
 [[ "$TRACE" ]] && set -x
 

--- a/scripts/kube-up.sh
+++ b/scripts/kube-up.sh
@@ -65,9 +65,9 @@ setup_iptables() {
 start_kubernetes() {
   echo "Getting the party going..."
 
-  if docker ps --filter "name=helm_kubelet" >/dev/null; then
-    error_exit "Kubernetes already running"
-  fi
+  #if docker ps --filter "name=helm_kubelet" >/dev/null; then
+    #error_exit "Kubernetes already running"
+  #fi
 
   docker run \
     --name=helm_kubelet \

--- a/scripts/kube-up.sh
+++ b/scripts/kube-up.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+[[ "$TRACE" ]] && set -x
+
+HELM_ROOT="${BASH_SOURCE[0]%/*}/.."
+source "${HELM_ROOT}/scripts/common.sh"
+source "${HELM_ROOT}/scripts/docker.sh"
+
+K8S_VERSION=${K8S_VERSION:-1.2.0}
+KUBE_PORT=${KUBE_PORT:-8080}
+KUBE_HOST=${KUBE_HOST:-$DOCKER_HOST_IP}
+KUBE_HOST=${KUBE_HOST:-localhost}
+KUBECTL="kubectl -s ${KUBE_HOST}:${KUBE_PORT}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error_exit "Cannot find command ${1}"
+  fi
+}
+
+verify_prereqs() {
+  echo "Verifying Prerequisites...."
+
+  require_command docker
+  require_command kubectl
+
+  if is_osx; then
+    require_command docker-machine
+  fi
+
+  if ! docker info > /dev/null 2>&1 ; then
+    error_exit "Can't connect to 'docker' daemon.  please fix and retry."
+  fi
+  echo "You are golden, carry on..."
+}
+
+setup_iptables() {
+  local machine=$(active_docker_machine)
+  if [ -z "$machine" ]; then
+    return
+  fi
+
+  echo "Adding iptables hackery for docker-machine..."
+
+  local machine_ip=$(docker-machine ip "$machine")
+  if ! docker-machine ssh "${machine}" sudo /usr/local/sbin/iptables -t nat -L -n | grep -q "$machine_ip" | grep -q :8080; then
+    docker-machine ssh "${machine}" sudo /usr/local/sbin/iptables -t nat -I PREROUTING -p tcp -d "$machine_ip" --dport 8080 -j DNAT --to-destination 127.0.0.1:8080
+  fi
+}
+
+start_kubernetes() {
+  echo "Getting the party going..."
+
+  docker run \
+    --name=helm_kubelet \
+    --volume=/:/rootfs:ro \
+    --volume=/sys:/sys:ro \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --pid=host \
+    --privileged=true \
+    -d \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+    /hyperkube kubelet \
+        --containerized \
+        --hostname-override="127.0.0.1" \
+        --address="0.0.0.0" \
+        --api-servers="http://localhost:${KUBE_PORT}" \
+        --config=/etc/kubernetes/manifests \
+        --cluster-dns=10.0.0.10 \
+        --cluster-domain=cluster.local \
+        --allow-privileged=true --v=2
+}
+
+wait_for_kubernetes() {
+  echo "Waiting for Kubernetes cluster to become available..."
+  until $($KUBECTL cluster-info &> /dev/null); do
+    sleep 1
+  done
+  echo "Kubernetes cluster is up."
+}
+
+create_kube_system_namespace() {
+  echo "Creating kube-system namespace..."
+
+  $KUBECTL create -f - << EOF
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-system
+  labels:
+    name: kube-system
+EOF
+}
+
+create_kube_dns() {
+  echo "Setting up internal dns..."
+
+  $KUBECTL --namespace=kube-system create -f - <<EOF
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kube-dns
+  namespace: kube-system
+subsets:
+- addresses:
+  - ip: $DOCKER_HOST_IP
+  ports:
+  - port: 53
+    protocol: UDP
+    name: dns
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: kube-dns
+  namespace: kube-system
+spec:
+  clusterIP: 10.0.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+EOF
+}
+
+main() {
+  verify_prereqs
+
+  if is_docker_machine; then
+    setup_iptables
+  fi
+
+  start_kubernetes
+  wait_for_kubernetes
+  create_kube_system_namespace
+  create_kube_dns
+
+  $KUBECTL cluster-info
+}
+
+main "$@"
+
+exit 0

--- a/scripts/kube-up.sh
+++ b/scripts/kube-up.sh
@@ -57,8 +57,8 @@ setup_iptables() {
   echo "Adding iptables hackery for docker-machine..."
 
   local machine_ip=$(docker-machine ip "$machine")
-  if ! docker-machine ssh "${machine}" sudo /usr/local/sbin/iptables -t nat -L -n | grep -q "$machine_ip" | grep -q :8080; then
-    docker-machine ssh "${machine}" sudo /usr/local/sbin/iptables -t nat -I PREROUTING -p tcp -d "$machine_ip" --dport 8080 -j DNAT --to-destination 127.0.0.1:8080
+  if ! docker-machine ssh "${machine}" "sudo /usr/local/sbin/iptables -t nat -L -n" | grep -q "${machine_ip}" | grep -q ":${KUBE_PORT}"; then
+    docker-machine ssh "${machine}" "sudo /usr/local/sbin/iptables -t nat -I PREROUTING -p tcp -d ${machine_ip} --dport ${KUBE_PORT} -j DNAT --to-destination 127.0.0.1:${KUBE_PORT}"
   fi
 }
 

--- a/scripts/kube-up.sh
+++ b/scripts/kube-up.sh
@@ -65,6 +65,10 @@ setup_iptables() {
 start_kubernetes() {
   echo "Getting the party going..."
 
+  if docker ps --filter "name=helm_kubelet" >/dev/null; then
+    error_exit "Kubernetes already running"
+  fi
+
   docker run \
     --name=helm_kubelet \
     --volume=/:/rootfs:ro \

--- a/scripts/kubectl.sh
+++ b/scripts/kubectl.sh
@@ -20,7 +20,6 @@ HELM_ROOT="${BASH_SOURCE[0]%/*}/.."
 source "${HELM_ROOT}/scripts/common.sh"
 source "${HELM_ROOT}/scripts/docker.sh"
 
-K8S_VERSION=${K8S_VERSION:-1.2.0}
 KUBE_PORT=${KUBE_PORT:-8080}
 KUBE_HOST=${KUBE_HOST:-localhost}
 

--- a/scripts/kubectl.sh
+++ b/scripts/kubectl.sh
@@ -18,25 +18,11 @@ set -eo pipefail
 
 HELM_ROOT="${BASH_SOURCE[0]%/*}/.."
 source "${HELM_ROOT}/scripts/common.sh"
-
-if [ -f "${HELM_ROOT}/scripts/env.sh" ]; then
-  source "${HELM_ROOT}/scripts/env.sh"
-fi
+source "${HELM_ROOT}/scripts/docker.sh"
 
 K8S_VERSION=${K8S_VERSION:-1.2.0}
 KUBE_PORT=${KUBE_PORT:-8080}
-KUBE_CONFIG="${HELM_ROOT}/scripts/kubeconfig"
 KUBE_HOST=${KUBE_HOST:-localhost}
-
-is_docker_machine() {
-  [[ $(docker-machine active 2>/dev/null) ]]
-}
-
-active_docker_machine() {
-  if command -v docker-machine >/dev/null 2>&1; then
-    docker-machine active
-  fi
-}
 
 if is_docker_machine; then
   KUBE_HOST=$(docker-machine ip "$(active_docker_machine)")

--- a/scripts/kubectl.sh
+++ b/scripts/kubectl.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+[[ "$TRACE" ]] && set -x
+
+HELM_ROOT="${BASH_SOURCE[0]%/*}/.."
+source "${HELM_ROOT}/scripts/common.sh"
+
+if [ -f "${HELM_ROOT}/scripts/env.sh" ]; then
+  source "${HELM_ROOT}/scripts/env.sh"
+fi
+
+K8S_VERSION=${K8S_VERSION:-1.2.0}
+KUBE_PORT=${KUBE_PORT:-8080}
+KUBE_CONFIG="${HELM_ROOT}/scripts/kubeconfig"
+KUBE_HOST=${KUBE_HOST:-localhost}
+
+is_docker_machine() {
+  [[ $(docker-machine active 2>/dev/null) ]]
+}
+
+active_docker_machine() {
+  if command -v docker-machine >/dev/null 2>&1; then
+    docker-machine active
+  fi
+}
+
+if is_docker_machine; then
+  KUBE_HOST=$(docker-machine ip "$(active_docker_machine)")
+fi
+
+kubectl -s ${KUBE_HOST}:${KUBE_PORT} "$@"


### PR DESCRIPTION
This adds a scripts to bring up and teardown a local kubernetes cluster in docker.  It's main driver is for e2e tests, but can be used for local development.
