### PR TITLE
Using static kubectl binary

### DIFF
--- a/rootfs/include.mk
+++ b/rootfs/include.mk
@@ -85,6 +85,6 @@ binary:
 kubectl:
 ifeq ("$(wildcard bin/$(KUBE_VERSION))", "")
 	touch bin/$(KUBE_VERSION)
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
+	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/386/kubectl
 	chmod +x bin/kubectl
 endif


### PR DESCRIPTION
/cc @runseb, @sparkprime 

This PR installs the linux 386 kubectl image, which is a static build in the official distros.

Closes #542.

Note: we may want to fall back to debian:wheezy and derivatives in future builds, since there are [known issues with alpine: 3.3](http://www.skippbox.com/thoughts-on-the-use-of-alpine-linux-in-docker-images/).

For now, however, things are working, so let's see how far we can go with the skinny images. :0)
