### PR TITLE
Expand Readme to show e2e manual test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ bin/helm server install
 That's it. You can now use `kubectl` to see Helm running in your cluster like this:
 
 ```
-$ kubectl get pod,rc,service --namespace=dm
+$ kubectl get pod,rc,service --namespace=helm
 NAME                    READY        STATUS        RESTARTS   AGE
 expandybird-rc-e0whp    1/1          Running       0          35m
 expandybird-rc-zdp8w    1/1          Running       0          35m
@@ -80,13 +80,13 @@ Currently here is the step by step guide.
 First add a respository of Charts used for testing:
 
 ```
-$ helm repo add kubernetes-charts-testing gs://kubernetes-charts-testing
+$ bin/helm repo add kubernetes-charts-testing gs://kubernetes-charts-testing
 ```
 
 Then deploy a Chart from this repository. For example to start a Redis cluster:
 
 ```
-$ helm deploy --name test --properties "workers=2" gs://kubernetes-charts-testing/redis-2.tgz
+$ bin/helm deploy --name test --properties "workers=2" gs://kubernetes-charts-testing/redis-2.tgz
 ```
 
 Once images are downloaded you should see Redis rc, pods and services similar to this:
@@ -123,9 +123,9 @@ slave1:ip=172.17.0.11,port=6379,state=online,offset=925,lag=1
 Once you are done, you can delete your deployment with
 
 ```
-$ helm deployment list
+$ bin/helm deployment list
 test
-$ helm deployment rm test
+$ bin/helm deployment rm test
 ````
 
 ## Uninstalling Helm from Kubernetes
@@ -133,7 +133,7 @@ $ helm deployment rm test
 You can uninstall Helm entirely using the following command:
 
 ```
-$ helm server uninstall
+$ bin/helm server uninstall
 ```
 
 This command will remove everything in the Helm namespace being used.

--- a/README.md
+++ b/README.md
@@ -29,45 +29,114 @@ since there may be undiscovered or unresolved issues at HEAD.
 From a Linux or Mac OS X client:
 
 ```
-$ git clone https://github.com/kubernetes/deployment-manager.git
-$ cd deployment-manager
+$ git clone https://github.com/kubernetes/helm.git
+$ cd helm
 $ make build
 $ bin/helm server install
 ```
 
-That's it. You can now use `kubectl` to see DM running in your cluster:
+That's it. You can now use `kubectl` to see Helm running in your cluster like this:
 
 ```
-kubectl get pod,rc,service --namespace=dm
+$ kubectl get pod,rc,service --namespace=dm
+NAME                    READY        STATUS        RESTARTS   AGE
+expandybird-rc-e0whp    1/1          Running       0          35m
+expandybird-rc-zdp8w    1/1          Running       0          35m
+manager-rc-bl4i4        1/1          Running       0          35m
+resourcifier-rc-21clg   1/1          Running       0          35m
+resourcifier-rc-i2zhi   1/1          Running       0          35m
+NAME                    CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+expandybird-service     10.0.0.248   <none>        8081/TCP   35m
+manager-service         10.0.0.49    <none>        8080/TCP   35m
+resourcifier-service    10.0.0.184   <none>        8082/TCP   35m
+NAME                    DESIRED      CURRENT       AGE
+expandybird-rc          2            2             35m
+manager-rc              1            1             35m
+resourcifier-rc         2            2             35m
 ```
 
-If you see expandybird-service, manager-service, resourcifier-service, and
-expandybird-rc, manager-rc and resourcifier-rc with pods that are READY, then DM
-is up and running!
+If you see expandybird, manager and resourcifier services, as well as expandybird, manager and resourcifier replication controllers with pods that are READY, then Helm is up and running!
 
 ## Using Helm
 
-Run a Kubernetes proxy to allow the dm client to connect to the cluster:
+Run a Kubernetes proxy to allow the Helm client to connect to the remote cluster:
 
 ```
-kubectl proxy --port=8001 --namespace=dm &
+kubectl proxy --port=8001 &
 ```
 
-## Uninstalling Helm from Kubernetes
-
-You can uninstall Helm using the same configuration:
+Configure the HELM_HOST environment variable to let the local Helm client talk to the Helm manager service running in your remote Kubernetes cluster using the proxy.
 
 ```
-helm server uninstall
+export HELM_HOST=http://localhost:8001/api/v1/proxy/namespaces/helm/services/manager-service:manager
 ```
 
 ## Installing Charts
 
-To quickly deploy a chart, you can use the Helm command line tool:
+To quickly deploy a chart, you can use the Helm command line tool.
+
+Currently here is the step by step guide.
+
+First add a respository of Charts used for testing:
 
 ```
-$ helm deploy CHARTNAME
+$ helm repo add kubernetes-charts-testing gs://kubernetes-charts-testing
 ```
+
+Then deploy a Chart from this repository. For example to start a Redis cluster:
+
+```
+$ helm deploy --name test --properties "workers=2" gs://kubernetes-charts-testing/redis-2.tgz
+```
+
+Once images are downloaded you should see Redis rc, pods and services similar to this:
+
+```
+$ kubectl get pods,svc,rc
+NAME                    READY        STATUS        RESTARTS   AGE
+barfoo-barfoo           5/5          Running       0          45m
+redis-master-rc-8wrqt   1/1          Running       0          41m
+redis-slave-rc-6ptx6    1/1          Running       0          41m
+redis-slave-rc-yc12q    1/1          Running       0          41m
+NAME                    CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+kubernetes              10.0.0.1     <none>        443/TCP    45m
+redis-master            10.0.0.67    <none>        6379/TCP   41m
+redis-slave             10.0.0.168   <none>        6379/TCP   41m
+NAME                    DESIRED      CURRENT       AGE
+redis-master-rc         1            1             41m
+redis-slave-rc          2            2             41m
+```
+
+To connect to your Redis master with a local `redis-cli` just use `kubectl port-forward` in a similar manner to:
+
+```
+$ kubectl port-forward redis-master-rc-8wrqt 6379:639 &
+$ redis-cli
+127.0.0.1:6379> info
+...
+role:master
+connected_slaves:2
+slave0:ip=172.17.0.10,port=6379,state=online,offset=925,lag=0
+slave1:ip=172.17.0.11,port=6379,state=online,offset=925,lag=1
+```
+
+Once you are done, you can delete your deployment with
+
+```
+$ helm deployment list
+test
+$ helm deployment rm test
+````
+
+## Uninstalling Helm from Kubernetes
+
+You can uninstall Helm entirely using the following command:
+
+```
+$ helm server uninstall
+```
+
+This command will remove everything in the Helm namespace being used.
 
 ## Design of Helm
 
@@ -85,7 +154,8 @@ Your contributions are welcome.
 We use the same [workflow](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#git-setup),
 [License](LICENSE) and [Contributor License Agreement](CONTRIBUTING.md) as the main Kubernetes repository.
 
-## Relationship to Google Cloud Platform
-DM uses many of the same concepts and languages as
+## Relationship to Google Cloud Platform's Deployment Manager and Deis's Helm
+Kubernetes Helm represent a merge of Google's Deployment Manager (DM) and the original Helm from Deis.
+Kubernetes Helm uses many of the same concepts and languages as
 [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/overview),
-but creates resources in Kubernetes clusters, not in Google Cloud Platform projects.
+but creates resources in Kubernetes clusters, not in Google Cloud Platform projects. It also brings several concepts from the original Helm such as Charts.


### PR DESCRIPTION
Fixed a few helm references and added a complete example.
I think it is good to show in the main readme a quick walkthrough of helm, that way people don't have to click in the tree to find a quick start guide or examples...
