### PR TITLE
fix(manager,resourcifier): use kubectl 1.2.0

### DIFF
--- a/rootfs/include.mk
+++ b/rootfs/include.mk
@@ -85,6 +85,6 @@ binary:
 kubectl:
 ifeq ("$(wildcard bin/$(KUBE_VERSION))", "")
 	touch bin/$(KUBE_VERSION)
-	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/386/kubectl
+	curl -fsSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
 	chmod +x bin/kubectl
 endif

--- a/rootfs/manager/Makefile
+++ b/rootfs/manager/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE ?= manager
-KUBE_VERSION ?= v1.1.7
+KUBE_VERSION ?= v1.2.0
 
 include ../include.mk
 

--- a/rootfs/resourcifier/Makefile
+++ b/rootfs/resourcifier/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE ?= resourcifier
-KUBE_VERSION ?= v1.1.7
+KUBE_VERSION ?= v1.2.0
 
 include ../include.mk
 


### PR DESCRIPTION
Closes #547

To verify the fix:

`make push` and then run the appropriate `helm server install` command to use your newly pushed images.

Then log into resourcifier or manager and manually run kubectl.

``` console
⇒  kubectl exec --namespace=dm -it manager-rc-5xnck sh 
/ # kubectl version
Client Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"5cb86ee022267586db386f62781338b0483733b3", GitTreeState:"clean"}
Error from server: the server has asked for the client to provide credentials
/ #
```

If the file is not appropriately compiled, instead of version information, you will get:

``` console
$  kubectl exec resourcifier-rc-ilrxj --namespace=dm -it sh
/ # kubectl
sh: kubectl: not found
```
