### PR TITLE
Add -f flag to docker tag to prevent push failure

### DIFF
--- a/rootfs/include.mk
+++ b/rootfs/include.mk
@@ -63,7 +63,7 @@ endif
 .PHONY: container
 container: .project .docker binary extras
 	docker build -t $(FULL_IMAGE):$(TAG) -f Dockerfile .
-	docker tag $(FULL_IMAGE):$(TAG) $(FULL_IMAGE):latest
+	docker tag -f $(FULL_IMAGE):$(TAG) $(FULL_IMAGE):latest
 
 .project:
 ifeq ($(DOCKER_REGISTRY), gcr.io)


### PR DESCRIPTION
Somehow the -f flag was dropped from the `docker tag` command in rootfs/install.mk. Dropping it causes the push to fail. This PR restores it.

/cc @sparkprime, @adamreese 
