### PR TITLE
style(action/lint.go): silence golint warning

### DIFF
--- a/action/lint.go
+++ b/action/lint.go
@@ -20,7 +20,7 @@ const (
 	// Project is the default Charts repository name.
 	Project = "charts"
 
-	// Maximum length of Metadata.name allowed by kubernetes
+	// MaxMetadataNameLength is the longest Metadata.name allowed by kubernetes.
 	MaxMetadataNameLength = 24
 )
 


### PR DESCRIPTION
After correcting this documentation comment, `golint` runs quietly once again.