### PR TITLE
feat(helm, tiller): add release listings

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -54,12 +54,13 @@ func runInstall(cmd *cobra.Command, args []string) error {
 // 		   Might be friendly to wrap our proto model with pretty-printers.
 //
 func printRelease(rel *release.Release) {
+	if rel == nil {
+		return
+	}
+	fmt.Printf("release.name:   %s\n", rel.Name)
 	if verbose {
-		if rel != nil {
-			fmt.Printf("release.name:   %s\n", rel.Name)
-			fmt.Printf("release.info:   %s\n", rel.GetInfo())
-			fmt.Printf("release.chart:  %s\n", rel.GetChart())
-		}
+		fmt.Printf("release.info:   %s\n", rel.GetInfo())
+		fmt.Printf("release.chart:  %s\n", rel.GetChart())
 	}
 }
 

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/kubernetes/helm/pkg/helm"
+	"github.com/kubernetes/helm/pkg/proto/hapi/release"
+	"github.com/spf13/cobra"
+)
+
+var listHelp = `
+This command lists all of the currently deployed releases.
+
+By default, items are sorted alphabetically.
+`
+
+var listCommand = &cobra.Command{
+	Use:   "list [flags] [FILTER]",
+	Short: "List releases",
+	Long:  listHelp,
+	RunE:  listCmd,
+}
+
+var listLong bool
+var listMax int
+
+func init() {
+	listCommand.LocalFlags().BoolVar(&listLong, "l", false, "output long listing format")
+	listCommand.LocalFlags().IntVar(&listMax, "m", 256, "maximum number of releases to fetch")
+	RootCommand.AddCommand(listCommand)
+}
+
+func listCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		fmt.Println("TODO: Implement filter.")
+	}
+
+	res, err := helm.ListReleases(listMax, 0)
+	if err != nil {
+		return err
+	}
+
+	rels := res.Releases
+	if res.Count+res.Offset < res.Total {
+		fmt.Println("Not all values were fetched.")
+	}
+
+	// TODO: Add sort here.
+
+	// Purty output, ya'll
+	if listLong {
+		return formatList(rels)
+	}
+	for _, r := range rels {
+		fmt.Println(r.Name)
+	}
+
+	return nil
+}
+
+func formatList(rels []*release.Release) error {
+	// TODO: Pretty it up
+	for _, r := range rels {
+		fmt.Println(r.Name)
+	}
+
+	return nil
+}

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -2,31 +2,42 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"time"
 
+	"github.com/gosuri/uitable"
 	"github.com/kubernetes/helm/pkg/helm"
 	"github.com/kubernetes/helm/pkg/proto/hapi/release"
+	"github.com/kubernetes/helm/pkg/timeconv"
 	"github.com/spf13/cobra"
 )
 
 var listHelp = `
 This command lists all of the currently deployed releases.
 
-By default, items are sorted alphabetically.
+By default, items are sorted alphabetically. Sorting is done client-side, so if
+the number of releases is less than the setting in '--max', some values will
+be omitted, and in no particular lexicographic order.
 `
 
 var listCommand = &cobra.Command{
-	Use:   "list [flags] [FILTER]",
-	Short: "List releases",
-	Long:  listHelp,
-	RunE:  listCmd,
+	Use:     "list [flags]",
+	Short:   "List releases",
+	Long:    listHelp,
+	RunE:    listCmd,
+	Aliases: []string{"ls"},
 }
 
 var listLong bool
 var listMax int
+var listOffset int
+var listByDate bool
 
 func init() {
-	listCommand.LocalFlags().BoolVar(&listLong, "l", false, "output long listing format")
-	listCommand.LocalFlags().IntVar(&listMax, "m", 256, "maximum number of releases to fetch")
+	listCommand.Flags().BoolVarP(&listLong, "long", "l", false, "output long listing format")
+	listCommand.Flags().BoolVarP(&listByDate, "date", "d", false, "sort by release date")
+	listCommand.Flags().IntVarP(&listMax, "max", "m", 256, "maximum number of releases to fetch")
+	listCommand.Flags().IntVarP(&listOffset, "offset", "o", 0, "offset from start value (zero-indexed)")
 	RootCommand.AddCommand(listCommand)
 }
 
@@ -35,7 +46,7 @@ func listCmd(cmd *cobra.Command, args []string) error {
 		fmt.Println("TODO: Implement filter.")
 	}
 
-	res, err := helm.ListReleases(listMax, 0)
+	res, err := helm.ListReleases(listMax, listOffset)
 	if err != nil {
 		return err
 	}
@@ -45,7 +56,11 @@ func listCmd(cmd *cobra.Command, args []string) error {
 		fmt.Println("Not all values were fetched.")
 	}
 
-	// TODO: Add sort here.
+	if listByDate {
+		sort.Sort(byDate(rels))
+	} else {
+		sort.Sort(byName(rels))
+	}
 
 	// Purty output, ya'll
 	if listLong {
@@ -59,10 +74,38 @@ func listCmd(cmd *cobra.Command, args []string) error {
 }
 
 func formatList(rels []*release.Release) error {
-	// TODO: Pretty it up
+	table := uitable.New()
+	table.MaxColWidth = 30
+	table.AddRow("NAME", "UPDATED", "CHART")
 	for _, r := range rels {
-		fmt.Println(r.Name)
+		c := fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
+		t := timeconv.Format(r.Info.LastDeployed, time.ANSIC)
+		table.AddRow(r.Name, t, c)
 	}
+	fmt.Println(table)
 
 	return nil
+}
+
+// byName implements the sort.Interface for []*release.Release.
+type byName []*release.Release
+
+func (r byName) Len() int {
+	return len(r)
+}
+func (r byName) Swap(p, q int) {
+	r[p], r[q] = r[q], r[p]
+}
+func (r byName) Less(i, j int) bool {
+	return r[i].Name < r[j].Name
+}
+
+type byDate []*release.Release
+
+func (r byDate) Len() int { return len(r) }
+func (r byDate) Swap(p, q int) {
+	r[p], r[q] = r[q], r[p]
+}
+func (r byDate) Less(p, q int) bool {
+	return r[p].Info.LastDeployed.Seconds < r[q].Info.LastDeployed.Seconds
 }

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/kubernetes/helm/cmd/tiller/environment"
@@ -33,18 +34,39 @@ var (
 	errMissingRelease = errors.New("no release provided")
 )
 
+// ListDefaultLimit is the default limit for number of items returned in a list.
+var ListDefaultLimit int64 = 512
+
 func (s *releaseServer) ListReleases(req *services.ListReleasesRequest, stream services.ReleaseService_ListReleasesServer) error {
 	rels, err := s.env.Releases.List()
 	if err != nil {
 		return err
 	}
 
+	total := int64(len(rels))
+
 	l := int64(len(rels))
+	if req.Offset > 0 {
+		if req.Offset >= l {
+			return fmt.Errorf("offset %d is outside of range %d", req.Offset, l)
+		}
+		rels = rels[req.Offset:]
+		l = int64(len(rels))
+	}
+
+	if req.Limit == 0 {
+		req.Limit = ListDefaultLimit
+	}
+
+	if l > req.Limit {
+		rels = rels[0:req.Limit]
+		l = int64(len(rels))
+	}
 
 	res := &services.ListReleasesResponse{
 		Offset:   0,
 		Count:    l,
-		Total:    l,
+		Total:    total,
 		Releases: rels,
 	}
 	stream.Send(res)

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -34,7 +34,21 @@ var (
 )
 
 func (s *releaseServer) ListReleases(req *services.ListReleasesRequest, stream services.ReleaseService_ListReleasesServer) error {
-	return errNotImplemented
+	rels, err := s.env.Releases.List()
+	if err != nil {
+		return err
+	}
+
+	l := int64(len(rels))
+
+	res := &services.ListReleasesResponse{
+		Offset:   0,
+		Count:    l,
+		Total:    l,
+		Releases: rels,
+	}
+	stream.Send(res)
+	return nil
 }
 
 func (s *releaseServer) GetReleaseStatus(c ctx.Context, req *services.GetReleaseStatusRequest) (*services.GetReleaseStatusResponse, error) {

--- a/docs/examples/alpine/Chart.yaml
+++ b/docs/examples/alpine/Chart.yaml
@@ -1,4 +1,4 @@
 name: alpine
 description: Deploy a basic Alpine Linux pod
 version: 0.1.0
-home: "https://github.com/kubernetes/helm"
+home: https://github.com/kubernetes/helm

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -13,8 +13,20 @@ var Config = &config{
 }
 
 // ListReleases lists the current releases.
-func ListReleases(limit, offset int) (<-chan *services.ListReleasesResponse, error) {
-	return nil, ErrNotImplemented
+func ListReleases(limit, offset int) (*services.ListReleasesResponse, error) {
+	c := Config.client()
+	if err := c.dial(); err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	req := &services.ListReleasesRequest{}
+	cli, err := c.impl.ListReleases(context.TODO(), req, c.cfg.CallOpts()...)
+	if err != nil {
+		return nil, err
+	}
+
+	return cli.Recv()
 }
 
 // GetReleaseStatus returns the given release's status.

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -20,7 +20,10 @@ func ListReleases(limit, offset int) (*services.ListReleasesResponse, error) {
 	}
 	defer c.Close()
 
-	req := &services.ListReleasesRequest{}
+	req := &services.ListReleasesRequest{
+		Limit:  int64(limit),
+		Offset: int64(offset),
+	}
 	cli, err := c.impl.ListReleases(context.TODO(), req, c.cfg.CallOpts()...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds client and server support for 'helm list'.
