### PR TITLE
fix(Makefile): Fix error in dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@ check-docker:
 # Allow developers to step into the containerized development environment
 dev: check-docker
 	${DEV_ENV_CMD_INT} bash
-	ifndef GOPATH
-	$(error No GOPATH set)
-	endif
+
 # Containerized dependency resolution
 bootstrap: check-docker
 	${DEV_ENV_CMD} glide install


### PR DESCRIPTION
This error somehow made it past code reviews for #445.

This snippet of code, once upon a time was at the very top of the Makefile.  #445 initially meant to remove that.  @mboersma said it should stay and @chaitanyaenr agreed to that, but somehow, it _moved_ down to here where it broke the `dev` target (which allows contributors to step interactively into the containerized development environment).

As for where this snippet actually belongs... the whole point of the containerized development environment is that no one should _need_ Go installed and set up on their local machine-- and this would include not needing to have the `GOPATH` env var defined.

What I have done in this PR is _moved_ this check to the `native-build` target, which is the target that contributors can _optionally_ invoke to build helm for their native OS/architecture if they really want to.  This is a more appropriate place for this check.