### PR TITLE
doc(*): Update docs for helm-classic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,32 @@
 # How to Contribute
 
-We love getting Pull Requests (PRs). To make sure we keep code quality
+|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Helm Classic (the `helm/helm` repository) is **no longer actively developed** but will remain available until `kubernetes/helm` has stabilized.
+|---|---|
+
+Helm and [Deployment Manager](https://github.com/kubernetes/deployment-manager)
+have recently joined forces to make deploying and managing software on
+Kubernetes as simple as possible. The combined effort now lives in the Kubernetes GitHub organization at
+[kubernetes/helm](https://github.com/kubernetes/helm).
+
+We love getting Pull Requests (PRs) _for bug fixes only_. To make sure we keep code quality
 and consistency high, we do have some process in place. In a nutshell:
 
 - Code should follow Go coding standards and pass `go lint` and `go
   vet`. (These tools are automatically run on every pull request.)
-- PRs should contain a single feature or fix, and follow the conventions
+- PRs should contain a single ~~feature or~~ fix, and follow the conventions
   linked below.
 - Contributors must agree to the DCO
 - Every patch must be signed off by two core contributors (and this is
   made easier when the community at large weighs in on PRs, too).
 
-Helm follows the contribution guidelines established by the Deis
+Helm Classic follows the contribution guidelines established by the Deis
 project. Please take a look at them.
 
 - [Deis Contribution Guidelines](https://github.com/deis/deis/blob/master/CONTRIBUTING.md)
 - [Details on commit messages](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)
 
 Again, thanks for taking the time to contribute. We know the process
-isn't trivial, and we really appreciate your helping ensure that Helm
+isn't trivial, and we really appreciate your helping ensure that Helm Classic
 develops into a high quality tool.
 
 ## Interpreting the Labels in GitHub

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,15 @@
-# Helm Maintainers
+# Helm Classic Maintainers
 
-This document serves to describe the leadership structure of the Helm project, and to list the current
-project maintainers.
+|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Helm Classic (the `helm/helm` repository) is **no longer actively developed** but will remain available until `kubernetes/helm` has stabilized.
+|---|---|
+
+Helm and [Deployment Manager](https://github.com/kubernetes/deployment-manager)
+have recently joined forces to make deploying and managing software on
+Kubernetes as simple as possible. The combined effort now lives in the Kubernetes GitHub organization at
+[kubernetes/helm](https://github.com/kubernetes/helm).
+
+This document serves to describe the leadership structure of the Helm Classic project, and to list the current
+project maintainers. _Maintainers of Helm Classic currently perform bug fixes and critical maintenance only._
 
 # What is a maintainer?
 
@@ -21,26 +29,27 @@ to appreciate the absence of bugs, the slow but steady improvement in stability,
 or the reliability of a release process. But those things distinguish a good
 project from a great one.
 
-# Helm maintainers
+# Helm Classic maintainers
 
-Helm has two groups of maintainers: core and contributing.
+Helm Classic has two groups of maintainers: core and contributing.
 
 ## Core maintainers
 
-Core maintainers are knowledgeable about all areas of Helm. Some maintainers work on Helm
+Core maintainers are knowledgeable about all areas of Helm Classic. Some maintainers work on Helm Classic (and Helm)
 full-time, although this is not a requirement.
 
 The duties of a core maintainer include:
 * Classify and respond to GitHub issues and review pull requests
-* Help to shape the Helm roadmap and lead efforts to accomplish roadmap milestones
-* Participate actively in feature development and bug fixing
-* Answer questions and help users in IRC
+* ~~Help to shape the Helm Classic roadmap and lead efforts to accomplish roadmap milestones~~
+* Participate actively in ~~feature development~~ and bug fixing
+* Answer questions and help users in Slack
 
-The current core maintainers of Helm:
-* Matt Butcher - <mbutcher@engineyard.com> ([@technosophos](https://github.com/technosophos))
-* Gabe Monroy - <gmonroy@engineyard.com> ([@gabrtv](https://github.com/gabrtv))
-* Chris Armstrong - <carmstrong@engineyard.com> ([@carmstrong](https://github.com/carmstrong))
-* Matt Boersma - <mboersma@engineyard.com> ([@mboersma](https://github.com/mboersma))
+The current core maintainers of Helm Classic:
+* Matt Butcher - <mbutcher@deis.com> ([@technosophos](https://github.com/technosophos))
+* Gabe Monroy - <gabe@deis.com> ([@gabrtv](https://github.com/gabrtv))
+* Kent Rancourt - <kent@deis.com> ([@krancour](https://github.com/krancour))
+* Keerthan Reddy Mala - <kmala@deis.com> ([@kmala](https://github.com/kmala))
+
 
 ### Pull requests
 
@@ -50,27 +59,27 @@ creates a pull request should also be the one to merge it, after two LGTMs.
 
 ## Contributing maintainers
 
-Contributing maintainers may have deep knowledge about some but not necessarily all areas of Helm.
+Contributing maintainers may have deep knowledge about some but not necessarily all areas of Helm Classic.
 Core maintainers will enlist contributing maintainers to weigh in on issues, review pull
 requests, or join conversations as needed in their areas of expertise.
 
 The duties of a contributing maintainer are similar to those of a core maintainer, but may be
-scoped to relevant areas of the Helm project.
+scoped to relevant areas of the Helm Classic project.
 
-Contributing maintainers are defined in practice as those who have write access to the Helm
+Contributing maintainers are defined in practice as those who have write access to the Helm Classic
 repository. All maintainers can review pull requests and add LGTM labels as appropriate.
 
 ## Becoming a maintainer
 
-The Helm project will succeed exactly as its community thrives. It is essential that the breadth
-of potential Kubernetes users find Helm useful enough to help it grow. If you use Helm every day,
+The Helm Classic project will succeed exactly as its community thrives. It is essential that the breadth
+of potential Kubernetes users find Helm Classic useful enough to help it grow. If you use Helm Classic every day,
 we want you to help determine where the ship is steered.
 
-Generally, potential contributing maintainers are selected by the Helm core maintainers based in
+Generally, potential contributing maintainers are selected by the Helm Classic core maintainers based in
 part on the following criteria:
 * Sustained contributions to the project over a period of time
-* A willingness to help Helm users on GitHub and in IRC
+* A willingness to help Helm Classic users on GitHub and in Slack
 * A friendly attitude!
 
-The Helm core maintainers must agree in unison before inviting a community member to join as a
+The Helm Classic core maintainers must agree in unison before inviting a community member to join as a
 contributing maintainer.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Helm - The Kubernetes Package Manager
+# Helm Classic - The Original Kubernetes Package Manager
 
-|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | This `helm/helm` (Helm Classic) repository is **no longer actively developed** but will remain available until `kubernetes/helm` has stabilized.  |
+|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Helm Classic (the `helm/helm` repository) is **no longer actively developed** but will remain available until `kubernetes/helm` has stabilized.
 |---|---|
 
-[Helm](https://github.com/helm/helm) and [Deployment Manager](https://github.com/kubernetes/deployment-manager)
+Helm and [Deployment Manager](https://github.com/kubernetes/deployment-manager)
 have recently joined forces to make deploying and managing software on
 Kubernetes as simple as possible. The combined effort now lives in the Kubernetes GitHub organization at
 [kubernetes/helm](https://github.com/kubernetes/helm).
@@ -12,31 +12,18 @@ For more information about the architecture of `kubernetes/helm` read the **[arc
 
 ## Overview
 
-[![Build Status](https://travis-ci.org/helm/helm.svg?branch=master)](https://travis-ci.org/helm/helm) [![Go Report Card](http://goreportcard.com/badge/helm/helm)](http://goreportcard.com/report/helm/helm)
+[![Build Status](https://travis-ci.org/helm/helm-classic.svg?branch=master)](https://travis-ci.org/helm/helm-classic) [![Go Report Card](http://goreportcard.com/badge/helm/helm-classic)](http://goreportcard.com/report/helm/helm-classic)
 
-[Helm](https://helm.sh) bootstraps your Kubernetes cluster with **Charts** that provide ready-to-use workloads like:
+[Helm Classic](https://helm.sh) bootstraps your Kubernetes cluster with **Charts** that provide ready-to-use workloads like:
 
 - A Redis cluster
 - A Postgres database
 - An HAProxy edge load balancer
 
-A Chart is a unit of Kubernetes manifests that reflect best practices as determined by the Helm community.  Helm's [architecture](docs/architecture.md) is heavily influenced by [Homebrew](https://github.com/Homebrew/homebrew).
+A Chart is a unit of Kubernetes manifests that reflect best practices as determined by the Helm Classic community.  Helm Classic's [architecture](docs/architecture.md) is heavily influenced by [Homebrew](https://github.com/Homebrew/homebrew).
 
-### Updating from Helm 0.1
 
-**If you are a Helm 0.1 user** you will need to do an extra step when
-you upgrade to Helm 0.2 or later. We changed our GitHub org from `deis` to
-`helm`, which means the new default charts repository is now
-`github.com/helm/charts`.
-
-To fix quickly, simply run a couple helm commands:
-
-```
-$ helm repo rm
-$ helm repo add charts https://github.com/helm/charts
-```
-
-## Installing Helm
+## Installing Helm Classic
 
 From a Linux or Mac OS X client:
 ```
@@ -46,35 +33,35 @@ curl -s https://get.helm.sh | bash
 *or*:
 
 1. Grab a prebuilt binary from:
-  - the latest release: [ ![Download](https://api.bintray.com/packages/deis/helm/helm/images/download.svg) ](https://bintray.com/deis/helm/helm/_latestVersion#files)
-  - the CI build pipeline: [ ![Download](https://api.bintray.com/packages/deis/helm-ci/helm/images/download.svg) ](https://bintray.com/deis/helm-ci/helm/_latestVersion#files)
-2. Unzip the package and make sure `helm` is available on the PATH.
+  - the latest release: [ ![Download](https://api.bintray.com/packages/deis/helm/helm-classic/images/download.svg) ](https://bintray.com/deis/helm/helm-classic/_latestVersion#files)
+  - the CI build pipeline: [ ![Download](https://api.bintray.com/packages/deis/helm-ci/helm-classic/images/download.svg) ](https://bintray.com/deis/helm-ci/helm-classic/_latestVersion#files)
+2. Unzip the package and make sure `helmc` is available on the PATH.
 
 ### Prerequisite
 
-Helm requires an appropriately wired `kubectl` client to speak with a running Kubernetes cluster.
+Helm Classic requires an appropriately wired `kubectl` client to speak with a running Kubernetes cluster.
 
-## Using Helm
+## Using Helm Classic
 
 To quickly install a redis cluster:
 
 ```
-$ helm update
----> Cloning into '$HOME/.helm/cache/charts'...
----> Updating cache from https://github.com/helm/charts
+$ helmc update
+---> Cloning into '$HOME/.helmc/cache/charts'...
+---> Updating cache from https://github.com/helmc/charts
 ---> Done
-$ helm search redis
+$ helmc search redis
 ---> 	redis-cluster (redis-cluster 0.0.5) - Highly available Redis cluster with multiple sentinels and standbys.
 ---> 	redis-standalone (redis-standalone 0.0.1) - Standalone Redis Master
-$ helm info redis-cluster
+$ helmc info redis-cluster
 Name: redis-cluster
 Home: http://github.com/deis/redis-cluster
 Version: 0.0.5
 Description: Highly available Redis cluster with multiple sentinels and standbys.
 Details: This package provides a highly available Redis cluster with multiple sentinels and standbys. Note the `redis-master` pod is used for bootstrapping only and can be deleted once the cluster is up and running.
-$ helm install redis-cluster
+$ helmc install redis-cluster
 ---> No chart named "redis-cluster" in your workspace. Fetching now.
----> Fetched chart into workspace $HOME/.helm/workspace/charts/redis-cluster
+---> Fetched chart into workspace $HOME/.helmc/workspace/charts/redis-cluster
 ---> Running `kubectl create -f` ...
 services/redis-sentinel
 pods/redis-master
@@ -86,42 +73,40 @@ replicationcontrollers/redis-sentinel
 To fetch, modify and install a chart out of your local workspace:
 
 ```
-$ helm update
+$ helmc update
 ---> Updating cache from https://github.com/helm/charts
 ---> Done
-$ helm fetch redis-standalone redis
----> Fetched chart into workspace $HOME/.helm/workspace/charts/redis
+$ helmc fetch redis-standalone redis
+---> Fetched chart into workspace $HOME/.helmc/workspace/charts/redis
 ---> Done
-$ helm edit redis
-$ helm install redis
+$ helmc edit redis
+$ helmc install redis
 ---> Running `kubectl create -f` ...
 replicationcontrollers/redis-standalone
 ---> Done
 ```
 
-## Building the Helm CLI
+## Building the Helm Classic CLI
 
 - Make sure you have a `kubectl` client installed and configured to speak with a running Kubernetes cluster.
-- Helm requires Go 1.5
-- Install [glide](https://github.com/Masterminds/glide) >= 0.8.2
-- Run the following commands:
+- Helm Classic utilizes a containerized build and test process. Making use of the containerized development environment only requires `make` and a _local_ Docker daemon _or_ `docker-machine`.
 
 ```console
-git clone https://github.com/helm/helm.git $GOPATH/src/github.com/helm/helm
+git clone https://github.com/helm/helm-classic.git
 
-cd $GOPATH/src/github.com/helm/helm
+cd helm-classic
 
-make bootstrap # installs all of helm's dependencies
+make bootstrap # installs all of helm classic's dependencies
 
-make build # generates bin/helm binary
+make build # generates bin/helmc binary
 
-./bin/helm # prints usage
+./bin/helmc # prints usage
 
 # optional
 
-make install # installs helm system-wide
+make install # installs helmc system-wide
 
-helm # prints usage
+helmc # prints usage
 
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-# Helm: Kubernetes Package Manager
+# Helm Classic: The Original Kubernetes Package Manager
 
-Helm provides package management for Kubernetes. This directory provides
-a number of documents explaining how to build Helm packages (called
+Helm Classic provides package management for Kubernetes. This directory provides
+a number of documents explaining how to build Helm Classic packages (called
 Charts).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Helm, Version 1
+# Helm Classic Architecture
 
 **TL;DR:** Homebrew for Kubernetes, with packages called "Charts"
 
@@ -30,33 +30,33 @@ In this document, we refer to a Kubernetes package as a Chart. The package forma
 
 Right now, the Kubernetes community largely hand-crafts their manifest files. There is no accepted distribution schema, and the only commonly referenced set of files are the ones in the core Kubernetes GitHub repository, which are examples.
 
-The Helm project will provide a GitHub repository to store and collaborate on Charts.  Users will fetch information about available packages from this archive.  Charts in the archive will be usable as-is, but will also serve as a basis for customization.
+The Helm Classic project will provide a GitHub repository to store and collaborate on Charts.  Users will fetch information about available packages from this archive.  Charts in the archive will be usable as-is, but will also serve as a basis for customization.
 
 ## The Workflows
 
-This section describes a few different workflows for Helm users.
+This section describes a few different workflows for Helm Classic users.
 
 ### User Workflow (Simple)
 
 Use case: User is looking for a redis cluster. User wants it immediately installed on Kubernetes.
 
 ```
-$ helm update
----> Cloning into '$HOME/.helm/cache/charts'...
+$ helmc update
+---> Cloning into '$HOME/.helmc/cache/charts'...
 ---> Updating cache from https://github.com/helm/charts
 ---> Done
-$ helm search redis
+$ helmc search redis
 ---> 	redis-cluster (redis-cluster 0.0.5) - Highly available Redis cluster with multiple sentinels and standbys.
 ---> 	redis-standalone (redis-standalone 0.0.1) - Standalone Redis Master
-$ helm info redis-cluster
+$ helmc info redis-cluster
 Name: redis-cluster
 Home: http://github.com/deis/redis-cluster
 Version: 0.0.5
 Description: Highly available Redis cluster with multiple sentinels and standbys.
 Details: This package provides a highly available Redis cluster with multiple sentinels and standbys. Note the `redis-master` pod is used for bootstrapping only and can be deleted once the cluster is up and running.
-$ helm install redis-cluster
+$ helmc install redis-cluster
 ---> No chart named "redis-cluster" in your workspace. Fetching now.
----> Fetched chart into workspace $HOME/.helm/workspace/charts/redis-cluster
+---> Fetched chart into workspace $HOME/.helmc/workspace/charts/redis-cluster
 ---> Running `kubectl create -f` ...
 services/redis-sentinel
 pods/redis-master
@@ -70,22 +70,22 @@ replicationcontrollers/redis-sentinel
 Use Case: User wants to get an NGINX chart, modify it, and then install the modified version into a running Kubernetes cluster.
 
 ```
-$ helm update
+$ helmc update
 ---> Updating cache from https://github.com/helm/charts
 ---> Done
-$ helm fetch redis-standalone redis
----> Fetched chart into workspace $HOME/.helm/workspace/charts/redis
+$ helmc fetch redis-standalone redis
+---> Fetched chart into workspace $HOME/.helmc/workspace/charts/redis
 ---> Done
-$ helm edit redis
-$ helm install redis
+$ helmc edit redis
+$ helmc install redis
 ---> Running `kubectl create -f` ...
 replicationcontrollers/redis-standalone
 ---> Done
 ```
 
-## Helm Repository Design
+## Helm Classic Repository Design
 
-This section describes the design of the Helm package repository.
+This section describes the design of the Helm Classic package repository.
 
 The goals for designing an archive backend are as follows:
 
@@ -118,7 +118,7 @@ Contributing packages to the archive is done by submitting GitHub Pull Requests.
 
 ## A Command Line Client
 
-The command line client is the primary way that users interact with the Helm repository. The client is used for getting and installing packages.
+The `helmc` command line client is the primary way that users interact with the Helm repository. The client is used for getting and installing packages.
 
 The command line will support (at least) the following commands:
 
@@ -144,21 +144,21 @@ The client will locally track the following three things:
 The tree looks something like this:
 
 ```
-- $HELM_HOME
+- $HELMC_HOME
       |
-      |- cache/       # Where `helm update` data goes
+      |- cache/       # Where `helmc update` data goes
       |
-      |- workspace/     # Working directory, where `helm fetch` copies to
+      |- workspace/     # Working directory, where `helmc fetch` copies to
       |
       |- config.yaml  # configuration info
 ```
 
-The default location for `$HELM_HOME` will be `$HOME/.helm`. This reflects the fact that package management by this method is scoped to the developer, not to the system. However, we will make this flexible because we have the following target use cases in mind:
+The default location for `$HELMC_HOME` will be `$HOME/.helmc`. This reflects the fact that package management by this method is scoped to the developer, not to the system. However, we will make this flexible because we have the following target use cases in mind:
 
-- Individual Helm developer/user
+- Individual Helm Classic developer/user
 - CI/CD system
 - Workspace shared by `git` repo among several developers
-- Dockerized Helm that runs in a container
+- Dockerized Helm Classic that runs in a container
 
 ### Client Config
 
@@ -168,7 +168,7 @@ Clients will track minimal configuration about remote hosts, local state, and po
 
 The initial web interface will focus exclusively on education:
 
-- Introduction to Helm
+- Introduction to Helm Classic
 - Instructions for installing
 - Instructions for package submission
 
@@ -226,17 +226,17 @@ details:
 
 #### Dependency Resolution
 
-If dependencies are declared, `helm` will...
+If dependencies are declared, `helmc` will...
 
 - Check to see if the named dependency is locally present
 - If it is, check to see if the version is within the supplied parameters
 
-If either check fails, `helm` will _emit a warning_, but will not prevent the installation. Under normal operation, it will prompt to continue. If the `--force` flag is set, it will simply continue.
+If either check fails, `helmc` will _emit a warning_, but will not prevent the installation. Under normal operation, it will prompt to continue. If the `--force` flag is set, it will simply continue.
 
 Example:
 
 ```
-$ helm install ponycorn
+$ helmc install ponycorn
 !!-> WARNING: Dependency nginx (1.9 < x <= 1.10) does not seem to be satisfied.
 !!-> This package may not function correctly.
 Continue? yes

--- a/docs/authoring_charts.md
+++ b/docs/authoring_charts.md
@@ -1,14 +1,14 @@
-# Authoring Helm Charts
+# Authoring Helm Classic Charts
 
-It is important for chart authors to understand Helm fundamentals.  Before you begin, make sure you are familiar with:
+It is important for chart authors to understand Helm Classic fundamentals.  Before you begin, make sure you are familiar with:
 
-- How to [model Services in Helm](modeling_services.md)
-- How Helm [uses Kubernetes Labels](using_labels.md)
-- How the [Helm workspace](workspace.md) is laid out
+- How to [model Services in Helm Classic](modeling_services.md)
+- How Helm Classic [uses Kubernetes Labels](using_labels.md)
+- How the [Helm Classic workspace](workspace.md) is laid out
 
 ## Background
 
-Helm Charts consist of three items:
+Helm Classic Charts consist of three items:
 
 1. A `manifests` directory for Kubernetes resources
 2. A `Chart.yaml` file
@@ -32,21 +32,21 @@ The directory structure of a chart is as follows:
 
 ### Step 1: Create the Chart in your Workspace
 
-Use `helm create <chart-name>` to create a new chart in your workspace.
-This will copy the default "skeleton" chart into `~/.helm/workspace/charts/<chart-name>`.
+Use `helmc create <chart-name>` to create a new chart in your workspace.
+This will copy the default "skeleton" chart into `~/.helmc/workspace/charts/<chart-name>`.
 
 ### Step 2: Edit the Chart
 
-Use helm edit <chart-name> to open all files in the chart in a single editor.  
+Use `helmc edit <chart-name>` to open all files in the chart in a single editor.  
 
-For convenience, this will present all the chart files inside a single editor, with `--- : <filepath>` delimiters.  This makes it easy to modify a chart, add files, and remove files all within a single `helm edit` command.
+For convenience, this will present all the chart files inside a single editor, with `--- : <filepath>` delimiters.  This makes it easy to modify a chart, add files, and remove files all within a single `helmc edit` command.
 
 If you prefer to edit files manually, you can use an IDE or any other file-based editor.
 
 ### Step 3: Test the Chart
 
-Use `helm test <chart-name>` to test installing the chart and validating that the proper Kubernetes resources are created, as evidenced by the `helm test` output and return code.
+Use `helmc test <chart-name>` to test installing the chart and validating that the proper Kubernetes resources are created, as evidenced by the `helmc test` output and return code.
 
 ### Step 4: Publish the Chart
 
-Use `helm publish <chart-name>` to copy a chart from your local workspace into the Git checkout that lives under `~/.helm/cache`.  From here you can submit a pull request.
+Use `helmc publish <chart-name>` to copy a chart from your local workspace into the Git checkout that lives under `~/.helmc/cache`.  From here you can submit a pull request.

--- a/docs/awesome.md
+++ b/docs/awesome.md
@@ -1,10 +1,10 @@
-# The Helm Guide to Writing Awesome Charts
+# The Helm Classic Guide to Writing Awesome Charts
 
-A Helm Chart provides a recipe for installing and running a containerized application inside of Kubernetes. This guide explains how to write an outstanding Chart.
+A Helm Classic Chart provides a recipe for installing and running a containerized application inside of Kubernetes. This guide explains how to write an outstanding Chart.
 
 ## Creating a New Chart
 
-You can create a new chart using the `helm create` command. This will put the chart in your workspace, which is the perfect place for trying it out. You may choose to use the `helm edit` command to edit your chart, or you may be more comfortable editing directly with your favorite editor.
+You can create a new chart using the `helmc create` command. This will put the chart in your workspace, which is the perfect place for trying it out. You may choose to use the `helmc edit` command to edit your chart, or you may be more comfortable editing directly with your favorite editor.
 
 ## A Brief Anatomy of a Chart
 
@@ -24,7 +24,7 @@ If your chart displays some more advanced features, or creates a cluster of serv
 
 Please take a look at the existing charts before naming your own.
 
-_A Note on example charts:_ As Helm was getting started, we created a few example charts, whose purpose was to illustrate how to write a chart. We are trying to only add new _example_ charts when they illustrate something new and helpful for chart developers.
+_A Note on example charts:_ As Helm Classic was getting started, we created a few example charts, whose purpose was to illustrate how to write a chart. We are trying to only add new _example_ charts when they illustrate something new and helpful for chart developers.
 
 ## The Chart.yaml File
 
@@ -63,19 +63,19 @@ Except for `dependencies`, all fields are required.
 
 ### Dependency Resolution
 
-When a chart fetched or installed, Helm will perform dependency
+When a chart is fetched or installed, Helm Classic will perform dependency
 resolution and alert the user if the chart dependencies are not
 satisfied.
 
-When just a `name` is provided, Helm will verify that a chart by that
+When just a `name` is provided, Helm Classic will verify that a chart by that
 name exists in the same Git repo, and that it is fetched into the
 workspace.
 
-When `name` and `repo` is provided, Helm will verify that a chart by
+When `name` and `repo` is provided, Helm Classic will verify that a chart by
 that name exists in the given repo, and is fetched into the current
 workspace.
 
-When `version` is added (in either case), Helm will additionally verify
+When `version` is added (in either case), Helm Classic will additionally verify
 that the chart in the workspace has a version within the bounds of the
 specified version. Remember that the `version` section can us version
 ranges, fuzzy versions, and [so on](https://github.com/Masterminds/semver#hyphen-range-comparisons).
@@ -100,7 +100,7 @@ In a nutshell, the README is intended as help text for your user: It gets the us
 
 ## Manifest Files
 
-All Kubernetes manifest files should be in YAML format. We know some people prefer JSON, but we've decided for a number of reasons to adopt YAML as the single format for Helm manifests.
+All Kubernetes manifest files should be in YAML format. We know some people prefer JSON, but we've decided for a number of reasons to adopt YAML as the single format for Helm Classic manifests.
 
 A good simple manifest typically includes:
 
@@ -110,7 +110,7 @@ A good simple manifest typically includes:
 
 ### Labels
 
-All Helm charts should have an `app` label and a `heritage: helm` label in their metadata sections. These provide a base-level consistency across all Helm charts. (`heritage: helm` makes it easy to search a Kubernetes cluster for all components installed via Helm.)
+All Helm Classic charts should have an `app` label and a `heritage: helm` label in their metadata sections. These provide a base-level consistency across all Helm Classic charts. (`heritage: helm` makes it easy to search a Kubernetes cluster for all components installed via Helm Classic.)
 
 We suggest using the following labels where appropriate:
 
@@ -154,23 +154,23 @@ details:
 
 ## Testing
 
-The Helm chart reviewers expect that you have tested your chart, both for compatibility with Helm, and also with Kubernetes. We run some basic tests on your charts on submission, but these perform only rudimentary checks. So please test before submitting.
+The Helm Classic chart reviewers expect that you have tested your chart, both for compatibility with Helm, and also with Kubernetes. We run some basic tests on your charts on submission, but these perform only rudimentary checks. So please test before submitting.
 
 ## Publishing a Pull Request
 
 The suggested workflow for publishing a pull request goes like this:
 
 1. From GitHub, clone the `github.com/helm/charts` repository
-2. Add your fork to Helm: `helm repo add technosophos git@github.com:technosophos/charts.git`
-3. Copy your chart from your workspace to your new charts repo (see `helm publish`)
+2. Add your fork to Helm Classic: `helm repo add technosophos git@github.com:technosophos/charts.git`
+3. Copy your chart from your workspace to your new charts repo (see `helmc publish`)
 4. Commit and push to your charts repo
 5. Using GitHub, file a PR (Pull Request) against the `helm/charts` repository
 6. Follow along in the `helm/charts` issue queue
 
 ## Review
 
-The core Helm charts team reviews all charts to see if they comply with our chart best practices. **All charts must be reviewed and marked LGTM by two members of the Helm charts team.** Once that is done, your chart will be merged into the repository.
+The core Helm Classic charts team reviews all charts to see if they comply with our chart best practices. **All charts must be reviewed and marked LGTM by two members of the Helm Classic charts team.** Once that is done, your chart will be merged into the repository.
 
-We absolutely _love_ contributions, so don't fret about this part of the process. When we ask for additional changes, it's only because we (like you) want the Helm community to have the best experience possible.
+We absolutely _love_ contributions, so don't fret about this part of the process. When we ask for additional changes, it's only because we (like you) want the Helm Classic community to have the best experience possible.
 
 See you in the issue queue!

--- a/docs/chart_tables.md
+++ b/docs/chart_tables.md
@@ -1,24 +1,24 @@
 # Using Other Repositories
 
-Helm allows for the use of additional (potentially private) repositories of charts via the `helm repo` command.
+Helm Classic allows for the use of additional (potentially private) repositories of charts via the `helmc repo` command.
 
 ## Adding a repository
 
-`$ helm repo add mycharts https://github.com/dev/mycharts` will add a chart table with the name `mycharts` pointing to the `dev/mycharts` git repository (any valid git protocol with regular git authentication).
+`$ helmc repo add mycharts https://github.com/dev/mycharts` will add a chart table with the name `mycharts` pointing to the `dev/mycharts` git repository (any valid git protocol with regular git authentication).
 
 ## Listing repositories
 
 ```
-$ helm repo list
+$ helmc repo list
     charts*    https://github.com/helm/charts
     mycharts    https://github.com/dev/mycharts
 ```
-Note the `*` indicates the default repository. This is configured in a `config.yaml` file in `$HELM_HOME`.
+Note the `*` indicates the default repository. This is configured in a `config.yaml` file in `$HELMC_HOME`.
 
 ## Using a different repository
 
-`$ helm fetch mycharts/app` will fetch the `app` chart from the `mycharts` repo. I can then `helm install` as normal.
+`$ helmc fetch mycharts/app` will fetch the `app` chart from the `mycharts` repo. I can then `helmc install` as normal.
 
 ## Removing repositories
 
-`$ helm repo rm mycharts` Note: there is no confirmation requested.
+`$ helmc repo rm mycharts` Note: there is no confirmation requested.

--- a/docs/generate-and-template.md
+++ b/docs/generate-and-template.md
@@ -1,11 +1,11 @@
-# Helm Generate and Template
+# Helm Classic Generate and Template
 
-Introduced in Helm 0.3.0, Helm has the ability to embed and run
+Introduced in Helm Classic 0.3.0, Helm Classic has the ability to embed and run
 generators that can perform arbitrary modifications on charts. The
 intent of this feature is to provide chart developers with the ability
 to modify charts using strategies like parameterization.
 
-Along with the generation feature, Helm includes a templating command
+Along with the generation feature, Helm Classic includes a templating command
 that simply provides Go template support.
 
 This document describes how to use this pair of tools, and how to extend
@@ -13,8 +13,8 @@ generation to use other tools.
 
 ## Templates
 
-Helm includes a simple templating solution based on Go templates.
-Running `helm template example.yaml` will compile and execute
+Helm Classic includes a simple templating solution based on Go templates.
+Running `helmc template example.yaml` will compile and execute
 the template `example.yaml`.
 
 As a simple example, here is a basic template:
@@ -23,21 +23,21 @@ As a simple example, here is a basic template:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{lower "Helm"}}
+  name: {{lower "Foo"}}
   labels:
     heritage: deis
 ```
 
 The above is a Kubernetes namespace YAML file with one template
-directive: `{{lower "Helm"}}` will lowercase the string "helm" and
-insert it into the template. Here is the result of running `helm
+directive: `{{lower "Foo"}}` will lowercase the string "Foo" to "foo" and
+insert it into the template. Here is the result of running `helmc
 template example.yaml`:
 
 ```
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: helm
+  name: foo
   labels:
     heritage: deis
 ```
@@ -46,13 +46,13 @@ metadata:
 
 Templates become more powerful when we parameterize them. For example,
 we can modify the above template to say "If there is a parameter named
-`.Namespace`, use that. Otherwise set the default namespace to 'helm'":
+`.Namespace`, use that. Otherwise set the default namespace to 'foobar'":
 
 ```
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{default "helm" .Namespace}}
+  name: {{default "foobar" .Namespace}}
   labels:
     heritage: deis
 ```
@@ -63,13 +63,13 @@ Once again, if we render that template, we'll see the same results:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: helm
+  name: foobar
   labels:
 ```
 
 ### Template Functions
 
-Helm's template tool includes an array of built-in functions. A few
+Helm Classic's template tool includes an array of built-in functions. A few
 particularly useful ones are:
 
 - `default <default> <other>`: This function allows you to set a default value. We saw it
@@ -84,7 +84,7 @@ library](https://github.com/Masterminds/sprig).
 
 ### The Values File
 
-To pass parameters into the `helm template` rendering process, we need
+To pass parameters into the `helmc template` rendering process, we need
 to supply a file of values. Above we used the `.Namespace` placeholder,
 but no value was ever supplied to it, and so it is always empty.
 
@@ -94,22 +94,22 @@ We can now supply a value in a file called `values.toml`.
 Namespace = "goldie"
 ```
 
-Helm templates support three file formats for values files, and it uses
+Helm Classic templates support three file formats for values files, and it uses
 the file extensions to determine which type of data is in a value file.
 
 - [TOML](https://github.com/toml-lang/toml) is a clear and concise
   configuration file format (`.toml`).
-- YAML is the same format Helm uses (`.yaml` or `.yml`).
+- YAML is the same format Helm Classic uses (`.yaml` or `.yml`).
 - JSON is the Javascript-like syntax (`.json`).
 
 We prefer TOML because it is clear and concise, and because the
 different format makes it easy to visually distinguish values files from
 manifest files. But you can use whichever you like.
 
-Once we have a values file, we can tell `helm template` about it:
+Once we have a values file, we can tell `helmc template` about it:
 
 ```
-$ helm template -d values.toml example.yaml
+$ helmc template -d values.toml example.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -119,20 +119,20 @@ metadata:
 ```
 
 Note that `name` is now `goldie` (the value in `values.toml`) instead of
-the default `helm`.
+the default `foobar`.
 
-Finally, by default `helm template` writes to STDOUT. You can redirect
+Finally, by default `helmc template` writes to STDOUT. You can redirect
 output to a file with the `-o` or `--out` flags:
 
 ```
-$ helm template -o out.yaml -d values.toml example.yaml
+$ helmc template -o out.yaml -d values.toml example.yaml
 ```
 
 This final form is the one used most frequently by generators.
 
 ## Generators
 
-Helm provides a command called `helm generate`. This function operates
+Helm Classic provides a command called `helmc generate`. This function operates
 on charts within your workspace (e.g. charts that you have fetched or
 installed).
 
@@ -157,7 +157,7 @@ The generate header is space-sensitive and case-sensitive. Lines MUST
 begin with one of the above comment sequences, and MUST have a lowercase
 `helm:generate` string.
 
-`CMD` is the command that Helm will run, and the optional `[ARGS]` are
+`CMD` is the command that Helm Classic will run, and the optional `[ARGS]` are
 arguments passed to the `CMD`.
 
 For example, we could embed a simple `sed` script inside of a generate
@@ -173,10 +173,11 @@ However, environment variables are expanded.
 Along with any existing environment variables, the following variables
 are specially defined:
 
-- HELM_HOME: The Helm home directory
-- HELM_DEFAULT_REPO: The repository alias for the default repository.
-- HELM_GENERATE_FILE: The present file's name
-- HELM_GENERATE_DIR: The absolute path to the chart directory of the present chart
+- `HELM_HOME`: The Helm Classic home directory
+    - Although the value of the `HELMC_HOME` environment variable, if defined, may play a role in defining the specially expanded `HELM_HOME` variable, the two are not equivalent. To produce charts that remain compatible with the _original_ Helm tool, which has now become Helm Classic, only the `HELM_HOME` variable should be used within `helm:generate` headers.
+- `HELM_DEFAULT_REPO`: The repository alias for the default repository.
+- `HELM_GENERATE_FILE`: The present file's name
+- `HELM_GENERATE_DIR`: The absolute path to the chart directory of the present chart
 
 These are available both from the invocation of the `CMD`, and from
 inside any generator command itself.
@@ -193,7 +194,7 @@ This will be expanded to the command `echo /path/to/example.json`.
 ### Writing A Custom Generator
 
 A generator is any tool that is executable within your environment. When
-`helm generate` runs, it looks for the generator in two places:
+`helmc generate` runs, it looks for the generator in two places:
 
 - First, if the generator is an absolute path (any path that begins with
   `/`), it will execute it on that path.
@@ -207,9 +208,9 @@ the `$HELM_GENERATE_DIR` variable:
 ```
 
 Note that the above variable is the absolute path to the chart
-directory, not to the file that `helm generate` found.
+directory, not to the file that `helmc generate` found.
 
-The following guidelines should be kept in mind when writing Helm
+The following guidelines should be kept in mind when writing Helm Classic
 generator plugins:
 
 - All of the named environment variables are available to the plugin.
@@ -219,19 +220,19 @@ generator plugins:
   - It is advised, therefore, that you not write generated output to
    STDOUT, but provide a flag for writing to a file.
   - User-facing output like progress meters _should_ be written to
-  STDOUT. `helm generate` will pass this information on to the user
+  STDOUT. `helmc generate` will pass this information on to the user
   during execution.
-  - Errors should be written to STDERR so that `helm generate` can
+  - Errors should be written to STDERR so that `helmc generate` can
    capture them and redirect them to the user.
 - Plugins should return the exit code 0 on success. Any other exit code
   will be treated as an error and will stop execution of further
   generators.
-- No recovery action is performed by `helm generate`. So if your script
+- No recovery action is performed by `helmc generate`. So if your script
   dirties the environment, it must also clean the environment.
 
 In addition to these, it is important to remember that the plugins you
 write may not be used in isolation. Other plugins may operate on the
-same chart, even during the course of the same `helm generate` run.
+same chart, even during the course of the same `helmc generate` run.
 
 It is considered a best practice to _not_ embed generator headers inside
 of `Chart.yaml` or inside of `manifests/` files. Conversely, it is
@@ -242,7 +243,7 @@ tool place their tool-specific files within `$CHART/secgenerate/`.
 
 ## Combining Generate and Template
 
-The `helm template` command is an example of a generator plugin. It is
+The `helmc template` command is an example of a generator plugin. It is
 designed to be invoked within a generator. Here is an example of using
 the two in conjunction:
 
@@ -259,14 +260,16 @@ metadata:
     heritage: deis
 ```
 
-To run the generators, we first install the chart, and then run the
+__IMPORTANT NOTE:__ To produce charts that remain compatible with the _original_ Helm tool, which has now become Helm Classic, the `helmc` binary should not be invoked _directly_ from within a `helm:generator` header. Using `helm` instead will allow older versions of the tool to execute your generators successfully. Meanwhile, Helm Classic intelligently invokes `helmc` wherever `helm` is invoked within a `helm:generator` header.
+
+To run the generators, we first fetch the chart, and then run the
 generator:
 
 ```
-⇒  helm fetch deis/namespace                                                                                                                                                                          1 ↵
----> Fetched chart into workspace /Users/mattbutcher/Code/helm_home/workspace/charts/namespace
+$ helmc fetch deis/namespace
+---> Fetched chart into workspace /Users/mattbutcher/.helmc/workspace/charts/namespace
 ---> Done
-⇒  helm generate namespace
+$  helmc generate namespace
 ---> Ran 2 generators.
 ```
 
@@ -274,7 +277,7 @@ At this point, if we look inside of the generated `namespace.yaml` file,
 we will see the result:
 
 ```
-⇒  cat $(helm home)/workspace/charts/namespace/manifests/namespace.yaml
+$ cat $(helmc home)/workspace/charts/namespace/manifests/namespace.yaml
 #helm:generate helm tpl -d tpl/values.toml -o manifests/namespace.yaml $HELM_GENERATE_FILE
 apiVersion: v1
 kind: Namespace
@@ -290,6 +293,6 @@ and we will be able to substitute.
 
 ## Conclusion
 
-Generators are a powerful way of extending Helms generative
+Generators are a powerful way of extending Helm Classic's generative
 capabilities. While we have provided the template generator, the system
 can be extended to your needs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,22 @@
-# Helm: The Kubernetes Package Manager
+# Helm Classic: The Original Kubernetes Package Manager
 
-[Helm](https://helm.sh) helps you find and use software built for Kubernetes. The Helm CLI uses Charts which not only contain metadata about software packages but also Pod, ReplicationController and Service manifests for Kubernetes. With a few Helm commands you can quickly and easily deploy software packages like:
+[Helm Classic](https://helm.sh) helps you find and use software built for Kubernetes. The Helm Classic CLI uses Charts which not only contain metadata about software packages but also Pod, ReplicationController and Service manifests for Kubernetes. With a few Helm Classic commands you can quickly and easily deploy software packages like:
 
 - Postgres
 - etcd
 - HAProxy
 - redis
 
-All of the Helm charts live at [github.com/helm/charts](https://github.com/helm/charts). If you want to make your own charts we have a guide for [authoring charts](authoring_charts.md) as well.
+All of the Helm Classic charts live at [github.com/helm/charts](https://github.com/helm/charts). If you want to make your own charts we have a guide for [authoring charts](authoring_charts.md) as well.
 
 ## Additional Information
 
-Learn more about Helm's [architecture](architecture.md).
+Learn more about Helm Classic's [architecture](architecture.md).
 
-Find out how Helm uses [Kubernetes labels](using_labels.md).
+Find out how Helm Classic uses [Kubernetes labels](using_labels.md).
 
-If you are authoring a chart that will be used by other apps, check out how Helm [models services](modeling_services.md).
+If you are authoring a chart that will be used by other apps, check out how Helm Classic [models services](modeling_services.md).
 
 ## Thanks
 
-Helm was inspired by [Homebrew](https://github.com/Homebrew/homebrew).
+Helm Classic was inspired by [Homebrew](https://github.com/Homebrew/homebrew).

--- a/docs/modeling_services.md
+++ b/docs/modeling_services.md
@@ -9,7 +9,7 @@ With the first option, service consumers must constantly track the service provi
 
 With the second option, consumers defines the services they require with label selectors.  Once pods are launched that fulfill the label selectors, the consumer can begin accessing the service.  This facilitates looser coupling between service consumers and providers.
 
-While the first option is more common in traditional orchestration systems, the second is a more natural fit for Kubernetes.  As a result, #2 is how we model services in Helm.  See the documentation on [using labels](using_labels.md) for more details.
+While the first option is more common in traditional orchestration systems, the second is a more natural fit for Kubernetes.  As a result, #2 is how we model services in Helm Classic.  See the documentation on [using labels](using_labels.md) for more details.
 
 ## Example: Ponycorn, a Redis-backed Application
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,15 +1,15 @@
-# Helm Plugins
+# Helm Classic Plugins
 
-Helm supports a basic plugin mechanism not unlike the one found in Git
+Helm Classic supports a basic plugin mechanism not unlike the one found in Git
 or similar CLI projects. This feature is still considered experimental.
 
-The basic model: When `helm` receives a subcommand that it does not know
-(e.g. `helm foo`), it will look on `$PATH` for an executable named
+The basic model: When `helmc` receives a subcommand that it does not know
+(e.g. `helmc foo`), it will look on `$PATH` for an executable named
 `helm-foo`. If it finds one, it will set several environment variables
 and then execute the named command, returning the results directly to
 STDOUT and STDERR. Any flags passed after `foo` are passed on to the
-`helm-foo` command. (Flags before foo, such as `helm -v foo`, are
-interpreted by Helm. They may influence the environment, but are not
+`helm-foo` command. (Flags before foo, such as `helmc -v foo`, are
+interpreted by Helm Classic. They may influence the environment, but are not
 passed on.)
 
 The plugin `plugins/sec/helm-sec` provides an example of how plugins can

--- a/docs/using_labels.md
+++ b/docs/using_labels.md
@@ -1,6 +1,6 @@
-# Helm Labels
+# Helm Classic Labels
 
-Helm is designed to take full advantage of [Kubernetes labels](http://kubernetes.io/v1.0/docs/user-guide/labels.html).
+Helm Classic is designed to take full advantage of [Kubernetes labels](http://kubernetes.io/v1.0/docs/user-guide/labels.html).
 
 ## What are Labels?
 
@@ -13,11 +13,11 @@ From the Kubernetes documentation on the [motivation for labels](http://kubernet
 To learn more about how labels work, check out [label selectors](http://kubernetes.io/v1.0/docs/user-guide/labels.html#label-selectors)
 in the Kubernetes documentation.
 
-## Helm Labels
+## Helm Classic Labels
 
 ### Group Label
 
-Helm uses the `group` label as a convention for organizing Charts.  Services which share the same `group` are able to find each other and communicate automatically.  Examples include:
+Helm Classic uses the `group` label as a convention for organizing Charts.  Services which share the same `group` are able to find each other and communicate automatically.  Examples include:
 
  * frontend
  * api
@@ -27,7 +27,7 @@ Groups are user-defined and not included in the Chart repository.
 
 ### Provider Label
 
-Helm uses the `provider` label as a convention specifying the type of Service provided by a Chart. Examples include:
+Helm Classic uses the `provider` label as a convention specifying the type of Service provided by a Chart. Examples include:
 
 * etcd
 * postgres
@@ -37,7 +37,7 @@ A Chart may have dependencies on specific `provider`(s).  Chart authors are resp
 
 ### Mode Label
 
-Helm uses the `mode` label as a convention for specifying the operating mode of the service.  Examples include:
+Helm Classic uses the `mode` label as a convention for specifying the operating mode of the service.  Examples include:
 
 * standalone
 * clustered
@@ -47,34 +47,34 @@ Charts may have dependencies on the operating `mode` of another Chart.
 
 ### Heritage Label
 
-All Helm Charts include the label `heritage: helm`. This provides a
+All Helm Classic Charts include the label `heritage: helm`. This provides a
 convenient and standard way to query which components in a Kubernetes
-cluster trace to Helm.
+cluster trace to Helm Classic.
 
 ## Using Labels
 
-In Kubernetes, labels are typically edited by hand and stored with manifests in a version control system.  Helm makes it easier to use labels effectively using the `helm` CLI.
+In Kubernetes, labels are typically edited by hand and stored with manifests in a version control system.  Helm Classic makes it easier to use labels effectively using the `helmc` CLI.
 
 ### Label Workflow (Simple)
 
-If you want to place a package into a `group` while installing it, pass the group as an argument to `helm install`.
+If you want to place a package into a `group` while installing it, pass the group as an argument to `helmc install`.
 
 ```
-helm install nginx --group=frontend
-helm install python --group=frontend
+helmc install nginx --group=frontend
+helmc install python --group=frontend
 ```
 
 ### Label Workflow (Advanced)
 
-Use the `helm label` command to apply arbitrary labels to Charts in your workspace.
+Use the `helmc label` command to apply arbitrary labels to Charts in your workspace.
 
 ```
-helm fetch nginx
-helm fetch python
-helm label nginx group=frontend other=label
-helm label python group=frontend other=label
-helm install nginx
-helm install python
+helmc fetch nginx
+helmc fetch python
+helmc label nginx group=frontend other=label
+helmc label python group=frontend other=label
+helmc install nginx
+helmc install python
 ```
 
-Of course, you can always use `helm edit` or your own editor to customize labels and other manifest data in your local workspace.
+Of course, you can always use `helmc edit` or your own editor to customize labels and other manifest data in your local workspace.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,20 +1,26 @@
 # Using the Workspace
 
-Your local Helm directory looks like this:
+Your local Helm Classic home directory looks like this:
 
 ```
-$HELM_HOME
-├── cache
-│   ├── .git            # Cache is a git repo
-│   ├── charts          # The cache of all existing charts
-|   |   ├── alpine
-│   │   └── ...
-│   ├── docs
-│   └── helm            # The Helm client source
+$HELMC_HOME
+├── cache               # The cache of all existing chart repositories
+│   ├── charts          # The cache of the helm/charts repository
+│   │   ├── .git        # Each cached repository is a git repository
+│   │   ├── ...
+│   │   ├── mysql
+│   │   ├── redis
+│   │   └── ...
+│   ├── deis            # An example of another cached chart repository
+│   │   ├── .git        # Each cached repository is a git repository
+│   │   ├── ...
+│   │   ├── workflow-dev
+│   │   └── ...
+│   └── ...
 └── workspace
-    └── charts
-        ├── alpine
-        ├── myserver
+    └── charts          # Charts that have been fetched from the cache
+        ├── redis
+        ├── workflow-dev
         └── ...
 ```
 
@@ -22,24 +28,24 @@ In this document, we focus on the `workspace` directory. We suggest some ways to
 
 ## The Cache Directory
 
-The `cache` directory is your local copy of the Helm repository. If you compare it to [github.com/helm/helm](https://github.com/helm/helm) they should look the same. And when you run a `helm update`, it will sync your local `cache` directory to the upstream.
+The `cache` contains local clones of remote chart repositories, such as [github.com/helm/charts](https://github.com/helm/charts).  Anytime you run a `helmc update`, Helm Classic will re-sync each of these clone to their respective upstreams.
 
-When you are developing Charts to be contributed upstream, you will interact with the `cache` directory directly. But in normal day-to-day usage, you do not need to worry about it.
+When you are developing Charts to be contributed upstream, you will interact with the cloned repositories in the `cache` directory directly. But in normal day-to-day usage, you do not need to worry about it.
 
 ## The Workspace
 
-"Infrastructure is code." One of the giant benefits of Kubernetes is that we can use a simple declarative model to describe microservice infrastructure. Helm is designed to make it easier to manage your Kubernetes manifest files.
+"Infrastructure is code." One of the giant benefits of Kubernetes is that we can use a simple declarative model to describe microservice infrastructure. Helm Classic is designed to make it easier to manage your Kubernetes manifest files.
 
-At its simplest, the workspace is the place where your Charts go. When you run the command `helm fetch nginx`, it copies the `nginx` chart to your workspace. There, you can modify it to your heart's content, customizing the manifests for your particular needs.
+At its simplest, the workspace is the place where your Charts go. When you run the command `helmc fetch nginx`, it copies the `nginx` chart from the cache to your workspace. There, you can modify it to your heart's content, customizing the manifests for your particular needs.
 
-The `helm install` command also copies a chart into your workspace (if you don't already have it there) so that even your quick builds are reproducible. And the mention of reproducibility leads us to the main topic at hand: _the workspace describes your infrastructure_.
+The `helmc install` command also copies a chart into your workspace (only if you don't already have it there) so that even your quick builds are reproducible. And the mention of reproducibility leads us to the main topic at hand: _the workspace describes your infrastructure_.
 
 ### Dependencies, Naming, and Copying
 
-When `helm fetch` or `helm install` fetches a chart into the workspace,
+When `helmc fetch` or `helmc install` fetches a chart into the workspace,
 it automatically adds the `from:` section to a chart. For example,
-running `helm fetch alpine myalpine` will create a `Chart.yaml` in
-`$HELM_HOME/workspace/charts/myalpine`. That chart will look like this:
+running `helmc fetch alpine myalpine` will create a `Chart.yaml` in
+`$HELMC_HOME/workspace/charts/myalpine`. That chart will look like this:
 
 ```
 name: myalpine
@@ -63,20 +69,20 @@ the `dependency` section of a chart.
 
 ## Best Practice for your Workspace
 
-Most Helm users spend at least a little bit of time experimenting with Helm. They run a few installs, edit a few charts, and see what they can do. But we hope that at some point users transition from experimentation to real-world usage.
+Most Helm Classic users spend at least a little bit of time experimenting. They run a few installs, edit a few charts, and see what they can do. But we hope that at some point users transition from experimentation to real-world usage.
 
-Here's where the Helm team has decided to be hands-off so that you can institute practices that are best for you.
+Here's where the Helm Classic team has decided to be hands-off so that you can institute practices that are best for you.
 
 ### Scenario 1: The Workspace Team Repo
 
-A small team uses several charts to deploy Kubernetes objects with Helm. Some of these charts are unmodified, but many more are tailored specifically to the team's needs.
+A small team uses several charts to deploy Kubernetes objects with Helm Classic. Some of these charts are unmodified, but many more are tailored specifically to the team's needs.
 
 How should the team keep track of these?
 
 Our suggestion is to create a source code repository (using a tool like Git or Mercurial) mapped to your workspace.
 
 ```
-$ cd $HELM_HOME/workspace
+$ cd $HELMC_HOME/workspace
 $ git init
 $ git remote add...
 $ git push -u origin master
@@ -88,29 +94,29 @@ Now the workspace is tracked by a version control system, and the team can begin
 2. Since your local copy of the charts is stored, if you accidentally overwrite or break a chart, you can restore a previous version.
 3. Your CI/CD pipeline can take advantage of version control hooks, using charts to deploy to testing, staging, or production.
 
-With all of these advantages, why didn't we (the Helm authors) just create this repository for you? We thought long and hard about it, but we decided that teams are better equipped to decide how to set up this tooling for their own environment.
+With all of these advantages, why didn't we (the Helm Classic authors) just create this repository for you? We thought long and hard about it, but we decided that teams are better equipped to decide how to set up this tooling for their own environment.
 
 ### Scenario 2: The Chart Developer
 
-Helm comes with tooling to make chart development easy. If you want to create a new chart, it is as easy as this:
+Helm Classic comes with tooling to make chart development easy. If you want to create a new chart, it is as easy as this:
 
 ```
-$ helm create mychart
+$ helmc create mychart
 ```
 
-This will scaffold out a new chart named `mychart` will be created in `$HELM_HOME/workspace/charts/mychart`. This directory will have a basic `Chart.yaml` and a `manifests` directory.
+This will scaffold out a new chart named `mychart` will be created in `$HELMC_HOME/workspace/charts/mychart`. This directory will have a basic `Chart.yaml` and a `manifests` directory.
 
-You can easily get started editing with the `helm edit mychart` command.
+You can easily get started editing with the `helmc edit mychart` command.
 
 Charts are edited in the workspace, giving you a place to edit, test, and tune without having to dirty your `cache` copy (a lesson we learned from corrupting our own Homebrew repos).
 
 Once your chart is ready for submission, you can set up your `cache` directory and submit upstream:
 
-1. Fork the `github.com/helm/helm` repository
-2. Set up your local cache to track the fork: `cd $HELM_HOME/cache && git remote add ...`
-3. Run `helm publish` to push your chart into your cache
+1. Fork the `github.com/helm/charts` repository
+2. Set up your local cache to track the fork: `cd $HELMC_HOME/cache && git remote add ...`
+3. Run `helmc publish` to push your chart into your cache
 4. Commit, push, and issue your pull request.
 
 ## Conclusion
 
-The workspace is designated as a location that Helm does not explicitly manage. Helm does not manage it so that you can pick the tools best for you and your team, and also tailor the environment to your use case.
+The workspace is designated as a location that Helm Classic does not explicitly manage. Helm Classic does not manage it so that you can pick the tools best for you and your team, and also tailor the environment to your use case.

--- a/plugins/example/README.md
+++ b/plugins/example/README.md
@@ -1,6 +1,6 @@
-# Helm Example Plugin
+# Helm Classic Example Plugin
 
-This plugin highlights a few of the features of the Helm plugin system.
+This example plugic highlights a few of the features of the Helm Classic plugin system.
 
 ## Usage
 
@@ -10,16 +10,16 @@ In this directory, build the example plugin:
 $ go build -o helm-example helm-example.go
 ```
 
-Helm will search the path for plugins. So assuming you have Helm
+Helm Classic will search the path for plugins. So assuming you have Helm
 installed, you can test your plugin like this:
 
 ```
-$ PATH=$PATH:. helm example -a foo -b bar baz
+$ PATH=$PATH:. helmc example -a foo -b bar baz
 Args are: [helm-example -a foo -b bar baz]
-Helm home is: /Users/mattbutcher/Code/helm_home
-Helm command is: example
-Helm default repo is: charts
+Helm Classic home is: /Users/mattbutcher/.helmc
+Helm Classic command is: example
+Helm Classic default repo is: charts
 ```
 
 The output of `helm-example` shows the contents of the arguments and
-environment variables that Helm passes to plugins.
+environment variables that Helm Classic passes to plugins.

--- a/plugins/sec/README.md
+++ b/plugins/sec/README.md
@@ -1,4 +1,4 @@
-# Helm Sec: Work On Secrets
+# Helm Classic Sec: Work On Secrets
 
 The `helm-sec` plugin provides a tool for working with Kubernetes
 secrets.
@@ -11,7 +11,7 @@ It can:
 
 ## Examples
 
-The simplest invocation of `helm sec` generates a secret file and sends
+The simplest invocation of `helmc sec` generates a secret file and sends
 it to stdout:
 
 ```
@@ -33,10 +33,10 @@ You can send the output to a file by specifying the file name with the
 $ helm-sec -f secret.yaml name value
 ```
 
-And `helm sec` can generate passwords or tokens for you:
+And `helmc sec` can generate passwords or tokens for you:
 
 ```
-$ helm sec --password mysecret
+$ helmc sec --password mysecret
 ---> Password: jb@OTr}k|dG<jc,m
 kind: Secret
 apiVersion: v1
@@ -50,7 +50,7 @@ Use the `--length,-l` flag to specify how long of a password or token
 you'd like. You can also use `--alphanum` and `--alpha` to generate
 alphanumeric or alphabetic phrases (no special characters).
 
-`helm sec` can also generate keypairs. To generate a NaCl Box pair, use
+`helmc sec` can also generate keypairs. To generate a NaCl Box pair, use
 the `--box` flag:
 
 ```


### PR DESCRIPTION
Fixes #452 

This reflects many changes that have not been implemented yet, but I'd prefer to not be submitting a mammoth PR.  If this means the docs at the head of the master branch are temporarily incorrect, I believe that is acceptable.  I have removed the readthedocs webhook from this repository that so that these changes will _not_ propagate to the _original_ (not to be conflated with "classic") helm docs at http://helm.readthedocs.io/en/latest/

The existing docs were also a bit stale, so some corrections were also made for accuracy.  For instance, the documented layout of the `helmc home` dir was all wrong.