### PR TITLE
Fix(readme): Add more documentation on getting started.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Make sure you have the prerequisites:
 - Go 1.6
 - A running Kubernetes cluster
 - `kubectl` properly configured to talk to your cluster
-- Glide 0.10 or greater
+- [Glide](https://glide.sh/) 0.10 or greater
 
 1. Clone (or otherwise download) this repository
-2. Run `make boostrap build`
+2. Run `make bootstrap build`
 
 You will now have two binaries built:
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Make sure you have the prerequisites:
 - Go 1.6
 - A running Kubernetes cluster
 - `kubectl` properly configured to talk to your cluster
-- [Glide](https://glide.sh/) 0.10 or greater
+- [Glide](https://glide.sh/) 0.10 or greater with both git and mercurial installed.
 
-1. Clone (or otherwise download) this repository
-2. Run `make bootstrap build`
+1. [Properly set your $GOPATH](https://golang.org/doc/code.html)
+2. Clone (or otherwise download) this repository into $GOPATH/src/github.com/kubernetes/helm
+3. Run `make bootstrap build`
 
 You will now have two binaries built:
 


### PR DESCRIPTION
- Fixing the make target in the readme (misspelling)
- Adding link to Glide.
- Gopath, mercurial, and source location.
