### PR TITLE
feat(tiller): allow specifying namespace on cli

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -11,6 +11,9 @@ import (
 var stdout = os.Stdout
 var helmHome string
 
+// flagVerbose is a signal that the user wants additional output.
+var flagVerbose bool
+
 var globalUsage = `The Kubernetes package manager
 
 To begin working with Helm, run the 'helm init' command:
@@ -41,6 +44,7 @@ var RootCommand = &cobra.Command{
 
 func init() {
 	RootCommand.PersistentFlags().StringVar(&helmHome, "home", "$HOME/.helm", "location of you Helm files [$HELM_HOME]")
+	RootCommand.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "enable verbose output")
 }
 
 func main() {

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -15,13 +15,15 @@ Kubernetes Cluster and sets up local configuration in $HELM_HOME (default: ~/.he
 `
 
 var (
-	tillerImg  string
-	clientOnly bool
+	tillerImg       string
+	clientOnly      bool
+	tillerNamespace string
 )
 
 func init() {
 	initCmd.Flags().StringVarP(&tillerImg, "tiller-image", "i", "", "override tiller image")
 	initCmd.Flags().BoolVarP(&clientOnly, "client-only", "c", false, "If set does not install tiller")
+	initCmd.Flags().StringVarP(&tillerNamespace, "namespace", "n", "helm", "set the tiller namespace")
 	RootCommand.AddCommand(initCmd)
 }
 
@@ -57,7 +59,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 func installTiller() error {
 	i := client.NewInstaller()
 	i.Tiller["Image"] = tillerImg
-	err := i.Install()
+	i.Tiller["Namespace"] = tillerNamespace
+	err := i.Install(flagVerbose)
 
 	if err != nil {
 		return fmt.Errorf("error installing: %s", err)

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -15,10 +15,13 @@ import (
 	ctx "golang.org/x/net/context"
 )
 
+var srv *releaseServer
+
 func init() {
-	srv := &releaseServer{
+	srv = &releaseServer{
 		env: env,
 	}
+	srv.env.Namespace = namespace
 	services.RegisterReleaseServiceServer(rootServer, srv)
 }
 

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -21,6 +21,7 @@ var rootServer = grpc.NewServer()
 var env = environment.New()
 
 var addr = ":44134"
+var namespace = ""
 
 const globalUsage = `The Kubernetes Helm server.
 
@@ -37,11 +38,14 @@ var rootCommand = &cobra.Command{
 }
 
 func main() {
-	rootCommand.PersistentFlags().StringVarP(&addr, "listen", "l", ":44134", "The address:port to listen on")
+	pf := rootCommand.PersistentFlags()
+	pf.StringVarP(&addr, "listen", "l", ":44134", "The address:port to listen on")
+	pf.StringVarP(&namespace, "namespace", "n", "", "The namespace Tiller calls home")
 	rootCommand.Execute()
 }
 
 func start(c *cobra.Command, args []string) {
+	setNamespace()
 	lstn, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Server died: %s\n", err)
@@ -53,5 +57,22 @@ func start(c *cobra.Command, args []string) {
 	if err := rootServer.Serve(lstn); err != nil {
 		fmt.Fprintf(os.Stderr, "Server died: %s\n", err)
 		os.Exit(1)
+	}
+}
+
+// setNamespace sets the namespace.
+//
+// It checks for the --namespace flag first, then checks the environment
+// (set by Downward API), then goes to default.
+func setNamespace() {
+	if len(namespace) != 0 {
+		fmt.Printf("Setting namespace to %q\n", namespace)
+		srv.env.Namespace = namespace
+	} else if ns := os.Getenv("DEFAULT_NAMESPACE"); len(ns) != 0 {
+		fmt.Printf("Inhereting namespace %q from Downward API\n", ns)
+		srv.env.Namespace = ns
+	} else {
+		fmt.Printf("Using default namespace %q", environment.DefaultNamespace)
+		srv.env.Namespace = environment.DefaultNamespace
 	}
 }

--- a/pkg/client/install.go
+++ b/pkg/client/install.go
@@ -77,7 +77,11 @@ spec:
         name: tiller
     spec:
       containers:
-      - env: []
+      - env:
+          - name: DEFAULT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         image: {{default "gcr.io/kubernetes-helm/tiller:canary" .Tiller.Image}}
         name: tiller
         ports:


### PR DESCRIPTION
This adds the ability to tell Tiller its default namespace in two new ways:
- If `tiller --namespace FOO` is set, this will set the default namespace to FOO
- Else it will search for the `DEFAULT_NAMESPACE` environment variable
  - The `helm init` command now uses a manifest that has `DEFAULT_NAMESPACE` configured to use the Downward API
- Otherwise, it will fall back to the `helm` namespace.
