### PR TITLE
feat(pkg): add a timeconv.String function

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -64,7 +63,7 @@ func printRelease(rel *release.Release) {
 	}
 	if flagVerbose {
 		fmt.Printf("NAME:   %s\n", rel.Name)
-		fmt.Printf("INFO:   %s %s\n", timeconv.Format(rel.Info.LastDeployed, time.ANSIC), rel.Info.Status)
+		fmt.Printf("INFO:   %s %s\n", timeconv.String(rel.Info.LastDeployed), rel.Info.Status)
 		fmt.Printf("CHART:  %s %s\n", rel.Chart.Metadata.Name, rel.Chart.Metadata.Version)
 		fmt.Printf("MANIFEST: %s\n", rel.Manifest)
 	} else {

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/gosuri/uitable"
 	"github.com/kubernetes/helm/pkg/helm"
@@ -79,7 +78,7 @@ func formatList(rels []*release.Release) error {
 	table.AddRow("NAME", "UPDATED", "CHART")
 	for _, r := range rels {
 		c := fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
-		t := timeconv.Format(r.Info.LastDeployed, time.ANSIC)
+		t := timeconv.String(r.Info.LastDeployed)
 		table.AddRow(r.Name, t, c)
 	}
 	fmt.Println(table)

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/kubernetes/helm/pkg/helm"
 	"github.com/kubernetes/helm/pkg/timeconv"
@@ -34,7 +33,7 @@ func status(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Last Deployed: %s\n", timeconv.Format(res.Info.LastDeployed, time.ANSIC))
+	fmt.Printf("Last Deployed: %s\n", timeconv.String(res.Info.LastDeployed))
 	fmt.Printf("Status: %s\n", res.Info.Status.Code)
 	if res.Info.Status.Details != nil {
 		fmt.Printf("Details: %s\n", res.Info.Status.Details)

--- a/pkg/timeconv/timeconv.go
+++ b/pkg/timeconv/timeconv.go
@@ -30,3 +30,13 @@ func Time(ts *timestamp.Timestamp) time.Time {
 func Format(ts *timestamp.Timestamp, layout string) string {
 	return Time(ts).Format(layout)
 }
+
+// String formats the timestamp into a user-friendly string.
+//
+// Currently, this uses the 'time.ANSIC' format string, but there is no guarantee
+// that this will not change.
+//
+// This is a convenience function for formatting timestamps for user display.
+func String(ts *timestamp.Timestamp) string {
+	return Format(ts, time.ANSIC)
+}


### PR DESCRIPTION
Rather than do the same formatting repeatedly, we can just call a
convenience function to format to a specific format.
