### PR TITLE
fix(*): correct numerous golint errors

### DIFF
--- a/cmd/tiller/environment/environment.go
+++ b/cmd/tiller/environment/environment.go
@@ -150,6 +150,10 @@ func (p *PrintingKubeClient) Create(ns string, r io.Reader) error {
 	_, err := io.Copy(p.Out, r)
 	return err
 }
+
+// Delete implements KubeClient delete.
+//
+// It only prints out the content to be deleted.
 func (p *PrintingKubeClient) Delete(ns string, r io.Reader) error {
 	_, err := io.Copy(p.Out, r)
 	return err

--- a/pkg/chart/values.go
+++ b/pkg/chart/values.go
@@ -41,6 +41,7 @@ func (v Values) Table(name string) (Values, error) {
 	return table, err
 }
 
+// Encode writes serialized Values information to the given io.Writer.
 func (v Values) Encode(w io.Writer) error {
 	return toml.NewEncoder(w).Encode(v)
 }

--- a/pkg/helm/convert.go
+++ b/pkg/helm/convert.go
@@ -7,6 +7,7 @@ import (
 	chartpbs "github.com/kubernetes/helm/pkg/proto/hapi/chart"
 )
 
+// ChartToProto converts a chart to its Protobuf struct representation.
 func ChartToProto(ch *chartutil.Chart) (chpb *chartpbs.Chart, err error) {
 	chpb = new(chartpbs.Chart)
 
@@ -42,6 +43,7 @@ func ChartToProto(ch *chartutil.Chart) (chpb *chartpbs.Chart, err error) {
 	return
 }
 
+// MetadataToProto converts Chart.yaml data into  protocol buffere Metadata.
 func MetadataToProto(ch *chartutil.Chart) (*chartpbs.Metadata, error) {
 	if ch == nil {
 		return nil, ErrMissingChart
@@ -72,6 +74,7 @@ func MetadataToProto(ch *chartutil.Chart) (*chartpbs.Metadata, error) {
 	return md, nil
 }
 
+// TemplatesToProto converts chart templates to their protobuf representation.
 func TemplatesToProto(ch *chartutil.Chart) (tpls []*chartpbs.Template, err error) {
 	if ch == nil {
 		return nil, ErrMissingChart
@@ -98,6 +101,7 @@ func TemplatesToProto(ch *chartutil.Chart) (tpls []*chartpbs.Template, err error
 	return
 }
 
+// ValuesToProto converts a chart's values.toml data to protobuf.
 func ValuesToProto(ch *chartutil.Chart) (*chartpbs.Config, error) {
 	if ch == nil {
 		return nil, ErrMissingChart

--- a/pkg/helm/error.go
+++ b/pkg/helm/error.go
@@ -1,16 +1,22 @@
 package helm
 
 const (
+	// ErrNotImplemented indicates that this API is not implemented.
 	ErrNotImplemented = Error("helm api not implemented")
+	// ErrInvalidSrvAddr indicates an invalid address to the Tiller server.
 	ErrInvalidSrvAddr = Error("invalid tiller address")
-	ErrMissingTpls    = Error("missing chart templates")
-	ErrMissingChart   = Error("missing chart metadata")
-	ErrMissingValues  = Error("missing chart values")
+	// ErrMissingTpls indicates that the templates are missing from a chart.
+	ErrMissingTpls = Error("missing chart templates")
+	// ErrMissingChart indicates that the Chart.yaml data is missing.
+	ErrMissingChart = Error("missing chart metadata")
+	// ErrMissingValues indicates that the config values.toml data is missing.
+	ErrMissingValues = Error("missing chart values")
 )
 
 // Error represents a Helm client error.
 type Error string
 
+// Error returns a string representation of this error.
 func (e Error) Error() string {
 	return string(e)
 }

--- a/pkg/helm/traverse.go
+++ b/pkg/helm/traverse.go
@@ -50,6 +50,10 @@ import (
 //
 //
 
+// WalkChartFile walks a chart and returns a *chartObj.
+//
+// FIXME: Why does an exported function return an unexported struct whose only
+// exported method is to return the object passed into this method?
 func WalkChartFile(chfi *chartutil.Chart) (*chartObj, error) {
 	root := &chartObj{file: chfi}
 	err := root.walkChartDeps(chfi)
@@ -62,6 +66,7 @@ type chartObj struct {
 	deps []*chartObj
 }
 
+// File returns the *chartutil.Chart associated with this *chartObj.
 func (chd *chartObj) File() *chartutil.Chart {
 	return chd.file
 }

--- a/pkg/lint/chartfile.go
+++ b/pkg/lint/chartfile.go
@@ -7,6 +7,7 @@ import (
 	chartutil "github.com/kubernetes/helm/pkg/chart"
 )
 
+// Chartfile checks the Chart.yaml file for errors and warnings.
 func Chartfile(basepath string) (m []Message) {
 	m = []Message{}
 


### PR DESCRIPTION
Original output of `make test-style`:

```
⇒  make test-style
==> Running golint...
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/cmd/tiller/environment/environment.go:153:1: exported method PrintingKubeClient.Delete should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/chart/values.go:44:1: exported method Values.Encode should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/convert.go:10:1: exported function ChartToProto should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/convert.go:45:1: exported function MetadataToProto should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/convert.go:75:1: exported function TemplatesToProto should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/convert.go:101:1: exported function ValuesToProto should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/error.go:4:2: exported const ErrNotImplemented should have comment (or a comment on this block) or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/traverse.go:53:1: exported function WalkChartFile should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/traverse.go:53:44: exported func WalkChartFile returns unexported type *helm.chartObj, which can be annoying to use
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/traverse.go:69:1: receiver name chs should be consistent with previous receiver name chd for chartObj
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/lint/chartfile.go:10:1: exported function Chartfile should have comment or be unexported
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/repo/repo.go:10:6: type name will be used as repo.RepoFile by other packages, and that stutters; consider calling this File
==> Running go vet...
==> Running gofmt...
```

New output:

```
⇒  make test-style
==> Running golint...
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/traverse.go:57:44: exported func WalkChartFile returns unexported type *helm.chartObj, which can be annoying to use
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/helm/traverse.go:74:1: receiver name chs should be consistent with previous receiver name chd for chartObj
/Users/mattbutcher/Code/Go/src/github.com/kubernetes/helm/pkg/repo/repo.go:10:6: type name will be used as repo.RepoFile by other packages, and that stutters; consider calling this File
==> Running go vet...
==> Running gofmt...
```
