### PR TITLE
feat(tiller): stub in release history

### DIFF
--- a/cmd/tiller/environment/environment.go
+++ b/cmd/tiller/environment/environment.go
@@ -116,6 +116,9 @@ type ReleaseStorage interface {
 	// Query will search all releases, including deleted and superseded ones.
 	// The provided map will be used to filter results.
 	Query(map[string]string) ([]*release.Release, error)
+
+	// History takes a release name and returns the history of releases.
+	History(name string) ([]*release.Release, error)
 }
 
 // KubeClient represents a client capable of communicating with the Kubernetes API.

--- a/cmd/tiller/environment/environment_test.go
+++ b/cmd/tiller/environment/environment_test.go
@@ -47,6 +47,16 @@ func (r *mockReleaseStorage) Query(labels map[string]string) ([]*release.Release
 	return []*release.Release{}, nil
 }
 
+func (r *mockReleaseStorage) History(n string) ([]*release.Release, error) {
+	res := []*release.Release{}
+	rel, err := r.Read(n)
+	if err != nil {
+		return res, err
+	}
+	res = append(res, rel)
+	return res, nil
+}
+
 type mockKubeClient struct {
 }
 

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -87,5 +87,16 @@ func (m *Memory) List() ([]*release.Release, error) {
 func (m *Memory) Query(labels map[string]string) ([]*release.Release, error) {
 	m.RLock()
 	defer m.RUnlock()
-	return []*release.Release{}, errors.New("Cannot implement until release.Release is defined.")
+	return []*release.Release{}, errors.New("not implemented")
+}
+
+// History returns the history of this release, in the form of a series of releases.
+func (m *Memory) History(name string) ([]*release.Release, error) {
+	// TODO: This _should_ return all of the releases with the given name, sorted
+	// by LastDeployed, regardless of status.
+	r, err := m.Read(name)
+	if err != nil {
+		return []*release.Release{}, err
+	}
+	return []*release.Release{r}, nil
 }

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -34,6 +34,22 @@ func TestRead(t *testing.T) {
 	}
 }
 
+func TestHistory(t *testing.T) {
+	k := "test-1"
+	r := &release.Release{Name: k}
+
+	ms := NewMemory()
+	ms.Create(r)
+
+	if out, err := ms.History(k); err != nil {
+		t.Errorf("Could not get %s: %s", k, err)
+	} else if len(out) != 1 {
+		t.Fatalf("Expected 1 release, got %d", len(out))
+	} else if out[0].Name != k {
+		t.Errorf("Expected %s, got %s", k, out[0].Name)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	k := "test-1"
 	r := &release.Release{Name: k}


### PR DESCRIPTION
This provides the basics for the release history feature that
ReleaseStorage needs to support. The implementation for Memory storage
is only partial.
