### PR TITLE
fix(helm): fix for issue #680r

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -73,16 +73,14 @@ func printRelease(rel *release.Release) {
 }
 
 func setupInstallEnv() {
-	// note: TILLER_HOST envvar is
-	// acknowledged iff the host flag
-	// does not override the default.
-	//
-	// bug: except that if the host flag happens to set the host to the same
-	// value as the defaultHost, the env var will be used instead.
-	if tillerHost == defaultHost {
-		host := os.Getenv(hostEnvVar)
-		if host != "" {
-			tillerHost = host
+	// The 'host' flag takes precendence uber alles.
+	// If set, proceed with install using provided host
+	// address. If unset, the 'TILLER_HOST' environment
+	// variable (if set) is used, otherwise defaults to ":44134".
+	if tillerHost == "" {
+		tillerHost = os.Getenv(hostEnvVar)
+		if tillerHost == "" {
+			tillerHost = defaultHost
 		}
 	}
 
@@ -90,7 +88,7 @@ func setupInstallEnv() {
 }
 
 func init() {
-	installCmd.Flags().StringVar(&tillerHost, "host", defaultHost, "address of tiller server")
+	installCmd.Flags().StringVar(&tillerHost, "host", "", "address of tiller server (default \":44134\")")
 	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "simulate an install")
 
 	RootCommand.AddCommand(installCmd)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 998d87445fec0bd715fa5ccbcc227cb4997e56ceff58dc8eb53ea2e0cc84abfd
-updated: 2016-04-27T16:11:47.531200165-06:00
+hash: 206ac8a0bde06c910b7100ca5de782dc96728e29693af6671cf5a52d1942b9c9
+updated: 2016-05-11T16:15:47.057456197-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -352,4 +352,6 @@ imports:
   - pkg/controller/podautoscaler/metrics
 - name: speter.net/go/exp/math/dec/inf
   version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
+  repo: git@github.com:go-inf/inf.git
+  vcs: git
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,3 +30,6 @@ import:
   - pkg/kubectl/cmd/util
   - pkg/kubectl/resource
 - package: github.com/gosuri/uitable
+- package: speter.net/go/exp/math/dec/inf
+  vcs: git
+  repo: git@github.com:go-inf/inf.git


### PR DESCRIPTION
details: the host flag for install overrides the
TILLER_HOST env var. If neither are set,
host defaults to ":44134".
