### PR TITLE
fix(helm): change helm repo list to return error when empty

### DIFF
--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -65,8 +65,7 @@ func runRepoList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(f.Repositories) == 0 {
-		fmt.Println("No repositories to show")
-		return nil
+		return errors.New("no repositories to show")
 	}
 	table := uitable.New()
 	table.MaxColWidth = 50


### PR DESCRIPTION
Following other commands, an empty list should return an error.
