### PR TITLE
fix(tiller): stop returning deleted releases for list

### DIFF
--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -70,15 +70,15 @@ func (m *Memory) Delete(name string) (*release.Release, error) {
 	return rel, nil
 }
 
-// List returns all releases.
+// List returns all releases whose status is not Status_DELETED.
 func (m *Memory) List() ([]*release.Release, error) {
 	m.RLock()
 	defer m.RUnlock()
-	buf := make([]*release.Release, len(m.releases))
-	i := 0
+	buf := []*release.Release{}
 	for _, v := range m.releases {
-		buf[i] = v
-		i++
+		if v.Info.Status.Code != release.Status_DELETED {
+			buf = append(buf, v)
+		}
 	}
 	return buf, nil
 }

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -72,7 +72,18 @@ func TestList(t *testing.T) {
 	rels := []string{"a", "b", "c"}
 
 	for _, k := range rels {
-		ms.Create(&release.Release{Name: k})
+		ms.Create(&release.Release{
+			Name: k,
+			Info: &release.Info{
+				Status: &release.Status{Code: release.Status_UNKNOWN},
+			},
+		})
+		ms.Create(&release.Release{
+			Name: "deleted-should-not-show-up",
+			Info: &release.Info{
+				Status: &release.Status{Code: release.Status_DELETED},
+			},
+		})
 	}
 
 	l, err := ms.List()


### PR DESCRIPTION
`helm list` was listing deleted releases. This was a bug in Tiller's storage retrieval, which errantly returned both deleted and non-deleted releases.
