### PR TITLE
fix(helm): stop requiring a values.toml in a chart

### DIFF
--- a/pkg/helm/convert.go
+++ b/pkg/helm/convert.go
@@ -116,7 +116,8 @@ func ValuesToProto(ch *chartutil.Chart) (*chartpbs.Config, error) {
 
 	vals, err := ch.LoadValues()
 	if err != nil {
-		return nil, ErrMissingValues
+		//return nil, ErrMissingValues
+		vals = map[string]interface{}{}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Charts should not require a values.toml file -- some charts will just be
manifests with nothing configurable.
