### PR TITLE
fix(cmd): rename verbose flag to debug

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -19,8 +20,8 @@ const (
 var helmHome string
 var tillerHost string
 
-// flagVerbose is a signal that the user wants additional output.
-var flagVerbose bool
+// flagDebug is a signal that the user wants additional output.
+var flagDebug bool
 
 var globalUsage = `The Kubernetes package manager
 
@@ -60,7 +61,8 @@ func init() {
 	p := RootCommand.PersistentFlags()
 	p.StringVar(&helmHome, "home", home, "location of your Helm config. Overrides $HELM_HOME.")
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST.")
-	p.BoolVarP(&flagVerbose, "verbose", "v", false, "enable verbose output")
+	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
+	p.AddGoFlagSet(flag.CommandLine)
 }
 
 func main() {
@@ -78,14 +80,14 @@ func setupConnection(c *cobra.Command, args []string) error {
 		}
 
 		tillerHost = fmt.Sprintf(":%d", tunnel.Local)
-		if flagVerbose {
+		if flagDebug {
 			fmt.Printf("Created tunnel using local port: '%d'\n", tunnel.Local)
 		}
 	}
 
 	// Set up the gRPC config.
 	helm.Config.ServAddr = tillerHost
-	if flagVerbose {
+	if flagDebug {
 		fmt.Printf("Server: %q\n", helm.Config.ServAddr)
 	}
 	return nil

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -65,7 +65,7 @@ func installTiller() error {
 	i := client.NewInstaller()
 	i.Tiller["Image"] = tillerImg
 	i.Tiller["Namespace"] = tillerNamespace
-	err := i.Install(flagVerbose, !initSkipNamespace)
+	err := i.Install(flagDebug, !initSkipNamespace)
 
 	if err != nil {
 		return fmt.Errorf("error installing: %s", err)

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -57,7 +57,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if flagVerbose {
+	if flagDebug {
 		fmt.Printf("Chart path: %s\n", chartpath)
 	}
 
@@ -87,7 +87,7 @@ func printRelease(rel *release.Release) {
 	if rel == nil {
 		return
 	}
-	if flagVerbose {
+	if flagDebug {
 		fmt.Printf("NAME:   %s\n", rel.Name)
 		fmt.Printf("INFO:   %s %s\n", timeconv.String(rel.Info.LastDeployed), rel.Info.Status)
 		fmt.Printf("CHART:  %s %s\n", rel.Chart.Metadata.Name, rel.Chart.Metadata.Version)

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -60,7 +60,7 @@ func runPackage(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	name, err := chart.Save(ch, cwd)
-	if err == nil && flagVerbose {
+	if err == nil && flagDebug {
 		cmd.Printf("Saved %s to current directory\n", name)
 	}
 
@@ -69,7 +69,7 @@ func runPackage(cmd *cobra.Command, args []string) error {
 	if save {
 		if err := repo.AddChartToLocalRepo(ch, localRepoDirectory()); err != nil {
 			return err
-		} else if flagVerbose {
+		} else if flagDebug {
 			cmd.Printf("Saved %s to %s\n", name, localRepoDirectory())
 		}
 	}


### PR DESCRIPTION
Remove a naming conflict with glog which allows for debugging kubernetes
requests.
