### PR TITLE
fix(tiller): fix install function

### DIFF
--- a/pkg/client/install.go
+++ b/pkg/client/install.go
@@ -40,17 +40,18 @@ func NewInstaller() *Installer {
 func (i *Installer) Install(verbose, createNS bool) error {
 
 	var b bytes.Buffer
-	t := template.New("manifest").Funcs(sprig.TxtFuncMap())
 
 	// Add namespace
 	if createNS {
-		if err := template.Must(t.Parse(NamespaceYAML)).Execute(&b, i); err != nil {
+		nstpl := template.New("namespace").Funcs(sprig.TxtFuncMap())
+		if err := template.Must(nstpl.Parse(NamespaceYAML)).Execute(&b, i); err != nil {
 			return err
 		}
 	}
 
 	// Add main install YAML
-	if err := template.Must(t.Parse(InstallYAML)).Execute(&b, i); err != nil {
+	istpl := template.New("install").Funcs(sprig.TxtFuncMap())
+	if err := template.Must(istpl.Parse(InstallYAML)).Execute(&b, i); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Because, occur the following error when `createNS` flag is true. (ex. run `helm init`
`panic: template: redefinition of template "manifest"`
