### PR TITLE
Add release version for the Helm CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ DOCKER_REGISTRY ?= gcr.io
 IMAGE_PREFIX    ?= kubernetes-helm
 SHORT_NAME      ?= tiller
 
+CLI_VERSION ?= devel
+
 # go option
 GO        ?= go
 PKG       := $(shell glide novendor)
 TAGS      :=
 TESTS     := .
 TESTFLAGS :=
-LDFLAGS   :=
+LDFLAGS   := "-X cmd.helm.cliVersion ${CLI_VERSION}"
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := helm tiller

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKG       := $(shell glide novendor)
 TAGS      :=
 TESTS     := .
 TESTFLAGS :=
-LDFLAGS   := "-X cmd.helm.cliVersion ${CLI_VERSION}"
+LDFLAGS   := -X cmd.helm.cliVersion=${CLI_VERSION}
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := helm tiller

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gosuri/uitable"
+	"github.com/kubernetes/helm/pkg/helm"
+	"github.com/kubernetes/helm/pkg/proto/hapi/release"
+	"github.com/kubernetes/helm/pkg/proto/hapi/services"
+	"github.com/kubernetes/helm/pkg/timeconv"
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionHelp = "This command prints out the current version of the Helm CLI."
+	// this variable is set by the Makefile, using the Go linker flags
+	cliVersion = "devel"
+)
+
+var versionCommand = &cobra.Command{
+	Use:     "version",
+	Short:   "Get the current version of Helm",
+	Long:    versionHelp,
+	RunE:    versionCmd,
+	Aliases: []string{"vsn"},
+}
+
+func init() {
+	RootCommand.AddCommand(versionCommand)
+}
+
+func versionCmd(cmd *cobra.Command, args []string) error {
+	fmt.Println("Helm CLI version", cliVersion)
+	return nil
+}

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -1,15 +1,8 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/gosuri/uitable"
-	"github.com/kubernetes/helm/pkg/helm"
-	"github.com/kubernetes/helm/pkg/proto/hapi/release"
-	"github.com/kubernetes/helm/pkg/proto/hapi/services"
-	"github.com/kubernetes/helm/pkg/timeconv"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
This is an in-progress patch to add a version command to the Helm CLI. Currently, it only prints out the version for the CLI, not the Tiller version.

TODO:
- [x] Build locally ~~(as of this writing, still waiting for dependencies to download)~~
- [ ] Depending on the answer to https://github.com/kubernetes/helm/issues/761#issuecomment-223055832, maybe implement the version RPC call on the Tiller server

Fixes https://github.com/kubernetes/helm/issues/761
