### PR TITLE
Add HTTP server for liveness and readiness probes

### DIFF
--- a/cmd/tiller/probes.go
+++ b/cmd/tiller/probes.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+)
+
+func readinessProbe(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func livenessProbe(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func runProbesServer(addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readiness", readinessProbe)
+	mux.HandleFunc("/liveness", livenessProbe)
+	return http.ListenAndServe(addr, mux)
+}

--- a/cmd/tiller/probes.go
+++ b/cmd/tiller/probes.go
@@ -12,9 +12,9 @@ func livenessProbe(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func runProbesServer(addr string) error {
+func newProbesMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/readiness", readinessProbe)
 	mux.HandleFunc("/liveness", livenessProbe)
-	return http.ListenAndServe(addr, mux)
+	return mux
 }

--- a/cmd/tiller/probes_test.go
+++ b/cmd/tiller/probes_test.go
@@ -10,7 +10,7 @@ func TestProbesServer(t *testing.T) {
 	mux := newProbesMux()
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	resp, err := http.Get("/readiness")
+	resp, err := http.Get(srv.URL + "/readiness")
 	if err != nil {
 		t.Fatalf("GET /readiness returned an error (%s)", err)
 	}
@@ -18,7 +18,7 @@ func TestProbesServer(t *testing.T) {
 		t.Fatalf("GET /readiness returned status code %d, expected %d", resp.StatusCode, http.StatusOK)
 	}
 
-	resp, err = http.Get("/liveness")
+	resp, err = http.Get(srv.URL + "/liveness")
 	if err != nil {
 		t.Fatalf("GET /liveness returned an error (%s)", err)
 	}

--- a/cmd/tiller/probes_test.go
+++ b/cmd/tiller/probes_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbesServer(t *testing.T) {
+	mux := newProbesMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	resp, err := http.Get("/readiness")
+	if err != nil {
+		t.Fatalf("GET /readiness returned an error (%s)", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /readiness returned status code %d, expected %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.Get("/liveness")
+	if err != nil {
+		t.Fatalf("GET /liveness returned an error (%s)", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /liveness returned status code %d, expected %d", resp.StatusCode, http.StatusOK)
+	}
+}

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/kubernetes/helm/cmd/tiller/environment"
@@ -65,7 +66,8 @@ func start(c *cobra.Command, args []string) {
 	}()
 
 	go func() {
-		if err := runProbesServer(probe); err != nil {
+		mux := newProbesMux()
+		if err := http.ListenAndServe(addr, mux); err != nil {
 			probeErrCh <- err
 		}
 	}()

--- a/pkg/client/install.go
+++ b/pkg/client/install.go
@@ -107,16 +107,16 @@ spec:
         - containerPort: 44134
           name: tiller
         imagePullPolicy: Always
-				livenessProbe:
-					httpGet:
-						path: /liveness
-						port: 44135
-					initialDelaySeconds: 1
-					timeoutSeconds: 1
-				readinessProbe:
-					httpGet:
-						path: /readiness
-						port: 44135
-					initialDelaySeconds: 1
-					timeoutSeconds:1
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
 `

--- a/pkg/client/install.go
+++ b/pkg/client/install.go
@@ -107,4 +107,16 @@ spec:
         - containerPort: 44134
           name: tiller
         imagePullPolicy: Always
+				livenessProbe:
+					httpGet:
+						path: /liveness
+						port: 44135
+					initialDelaySeconds: 1
+					timeoutSeconds: 1
+				readinessProbe:
+					httpGet:
+						path: /readiness
+						port: 44135
+					initialDelaySeconds: 1
+					timeoutSeconds:1
 `


### PR DESCRIPTION
Open questions:
- Where are the Kubernetes manifests in which the probe information should be added?
- What should the liveness and readiness probes check (respectively)? They currently just blindly respond with `200 OK`

Fixes https://github.com/kubernetes/helm/issues/756
