### PR TITLE
Fixed URL parse

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,9 +132,10 @@ func (r *ChartRepository) Index() error {
 			created = time.Now().UTC().String()
 		}
 
-		url := filepath.Join(r.URL, key+".tgz")
+		url, _ := url.Parse(r.URL)
+		url.Path = filepath.Join(url.Path, key+".tgz")
 
-		entry := &ChartRef{Chartfile: *chartfile, Name: chartfile.Name, URL: url, Created: created, Checksum: hash, Removed: false}
+		entry := &ChartRef{Chartfile: *chartfile, Name: chartfile.Name, URL: url.String(), Created: created, Checksum: hash, Removed: false}
 
 		r.IndexFile.Entries[key] = entry
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -90,7 +90,8 @@ func TestIndex(t *testing.T) {
 		if v.Created != created {
 			t.Errorf("Expected Created timestamp to be %s, but got %s for chart %s", created, v.Created, chart)
 		}
-		expectedURL := filepath.Join(cr.URL, chart+".tgz")
+		// Created manually since we control the input of the test
+		expectedURL := testURL + "/" + chart + ".tgz"
 		if v.URL != expectedURL {
 			t.Errorf("Expected url in entry to be %s but got %s for chart: %s", expectedURL, v.URL, chart)
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/784

It supports URLs and local paths (since url.Parse() will return it as the path component)

The change in the test is hardcoding the output so it does not use the same transformation mechanism than the tested method.

I wanted to extend the test suite to test local and remote urls, but being honest I have not been able to figure out a way to do it without changing/adding a lot of code and because I am new in Go I think I should walk in small steps at the time.

Feedback is more than welcome :) 
