### PR TITLE
feat(kube): use env variable to control kube logging

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -62,7 +61,6 @@ func init() {
 	p.StringVar(&helmHome, "home", home, "location of your Helm config. Overrides $HELM_HOME.")
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST.")
 	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
-	p.AddGoFlagSet(flag.CommandLine)
 }
 
 func main() {

--- a/pkg/kube/log.go
+++ b/pkg/kube/log.go
@@ -1,0 +1,14 @@
+package kube
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func init() {
+	if level := os.Getenv("KUBE_LOG_LEVEL"); level != "" {
+		flag.Set("vmodule", fmt.Sprintf("loader=%s,round_trippers=%s,request=%s", level, level, level))
+		flag.Set("logtostderr", "true")
+	}
+}


### PR DESCRIPTION
Removes command line flags and adds the environment variable
`KUBE_LOG_LEVEL`
