### PR TITLE
fix(proto): keep a local protoc Go plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,6 @@ ifndef HAS_GIT
 	$(error You must install Git)
 endif
 	glide install
+	go build -o bin/protoc-gen-go ./vendor/github.com/golang/protobuf/protoc-gen-go
 
 include versioning.mk

--- a/_proto/Makefile
+++ b/_proto/Makefile
@@ -22,16 +22,18 @@ services_pkg = services
 
 google_deps	 = Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp,Mgoogle/protobuf/any.proto=github.com/golang/protobuf/ptypes/any
 
+.PHONY: all
 all: chart release services
 
 chart:
-	protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias):$(dst) $(chart_pbs)
+	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias):$(dst) $(chart_pbs)
 
 release:
-	protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias):$(dst) $(release_pbs)
+	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias):$(dst) $(release_pbs)
 
 services:
-	protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias),$(release_ias):$(dst) $(services_pbs)
+	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias),$(release_ias):$(dst) $(services_pbs)
 
+.PHONY: clean
 clean:
 	@rm -rf $(dst)/hapi 2>/dev/null


### PR DESCRIPTION
This works around issues where $GOPATH/bin has a different version of
the protobuf Go plugin than the one Kubernetes uses.

To test:
- Move or rename whichever `protoc-gen-go` is on your `$PATH`
- Run `make bootstrap` to build `bin/protoc-gen-go`
- Run `make protoc`

The output should be identical to doing this on master.

Closes #845
