### PR TITLE
fix(tunnel): allow tunneling to non-default namespace

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -17,8 +17,11 @@ const (
 	hostEnvVar = "HELM_HOST"
 )
 
-var helmHome string
-var tillerHost string
+var (
+	helmHome        string
+	tillerHost      string
+	tillerNamespace string
+)
 
 // flagDebug is a signal that the user wants additional output.
 var flagDebug bool
@@ -61,6 +64,7 @@ func init() {
 	p := RootCommand.PersistentFlags()
 	p.StringVar(&helmHome, "home", home, "location of your Helm config. Overrides $HELM_HOME.")
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST.")
+	p.StringVarP(&tillerNamespace, "namespace", "n", "", "kubernetes namespace")
 	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
 }
 
@@ -72,8 +76,7 @@ func main() {
 
 func setupConnection(c *cobra.Command, args []string) error {
 	if tillerHost == "" {
-		// Should failure fall back to default host?
-		tunnel, err := newTillerPortForwarder()
+		tunnel, err := newTillerPortForwarder(tillerNamespace)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -64,7 +64,7 @@ func init() {
 	p := RootCommand.PersistentFlags()
 	p.StringVar(&helmHome, "home", home, "location of your Helm config. Overrides $HELM_HOME.")
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST.")
-	p.StringVarP(&tillerNamespace, "namespace", "n", "", "kubernetes namespace")
+	p.StringVarP(&tillerNamespace, "namespace", "", "", "kubernetes namespace")
 	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
 }
 

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -18,7 +18,6 @@ Kubernetes Cluster and sets up local configuration in $HELM_HOME (default: ~/.he
 var (
 	tillerImg            string
 	clientOnly           bool
-	initSkipNamespace    bool
 	defaultRepository    = "kubernetes-charts"
 	defaultRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
 )
@@ -27,7 +26,6 @@ func init() {
 	f := initCmd.Flags()
 	f.StringVarP(&tillerImg, "tiller-image", "i", "", "override tiller image")
 	f.BoolVarP(&clientOnly, "client-only", "c", false, "If set does not install tiller")
-	f.BoolVarP(&initSkipNamespace, "skip-namespace", "s", false, "Do not attempt to create a namespace. Assume the namespace is already there.")
 	RootCommand.AddCommand(initCmd)
 }
 
@@ -61,12 +59,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 }
 
 func installTiller() error {
-	i := client.NewInstaller()
-	i.Tiller["Image"] = tillerImg
-	i.Tiller["Namespace"] = tillerNamespace
-	err := i.Install(flagDebug, !initSkipNamespace)
-
-	if err != nil {
+	if err := client.Install(tillerNamespace, tillerImg, flagDebug); err != nil {
 		return fmt.Errorf("error installing: %s", err)
 	}
 	fmt.Println("\nTiller (the helm server side component) has been installed into your Kubernetes Cluster.")

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -17,7 +17,6 @@ Kubernetes Cluster and sets up local configuration in $HELM_HOME (default: ~/.he
 
 var (
 	tillerImg            string
-	tillerNamespace      string
 	clientOnly           bool
 	initSkipNamespace    bool
 	defaultRepository    = "kubernetes-charts"
@@ -29,7 +28,6 @@ func init() {
 	f.StringVarP(&tillerImg, "tiller-image", "i", "", "override tiller image")
 	f.BoolVarP(&clientOnly, "client-only", "c", false, "If set does not install tiller")
 	f.BoolVarP(&initSkipNamespace, "skip-namespace", "s", false, "Do not attempt to create a namespace. Assume the namespace is already there.")
-	f.StringVarP(&tillerNamespace, "namespace", "n", "helm", "set the tiller namespace")
 	RootCommand.AddCommand(initCmd)
 }
 

--- a/cmd/helm/tunnel.go
+++ b/cmd/helm/tunnel.go
@@ -12,14 +12,14 @@ import (
 // TODO refactor out this global var
 var tunnel *kube.Tunnel
 
-func newTillerPortForwarder() (*kube.Tunnel, error) {
-	podName, err := getTillerPodName("helm")
+func newTillerPortForwarder(namespace string) (*kube.Tunnel, error) {
+	podName, err := getTillerPodName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	// FIXME use a constain that is accessible on init
 	const tillerPort = 44134
-	return kube.New(nil).ForwardPort("helm", podName, tillerPort)
+	return kube.New(nil).ForwardPort(namespace, podName, tillerPort)
 }
 
 func getTillerPodName(namespace string) (string, error) {


### PR DESCRIPTION
- remove `helm` as the default namespace
- support kubeconfig default namespace
- refactor install client
