### PR TITLE
fix(sprig): update sprig library to 2.3.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c936008b9f7c5628e6c1bc442f64c7f858387eb2ce56337a33d6b5ef98a6b822
-updated: 2016-06-16T12:47:24.36415913-06:00
+hash: c19bb16fcd70221817024b5443840f8beefadc89ee2398b7341594efb9b5bf08
+updated: 2016-06-21T13:29:28.273164339-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -147,7 +147,7 @@ imports:
 - name: github.com/Masterminds/semver
   version: 808ed7761c233af2de3f9729a041d68c62527f3a
 - name: github.com/Masterminds/sprig
-  version: e6494bc7e81206ba6db404d2fd96500ffc453407
+  version: abe09979bcb1ec0a50b2d7bbf67e6aaa11787417
 - name: github.com/mattn/go-runewidth
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/matttproud/golang_protobuf_extensions

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   subpackages:
   - cobra
 - package: github.com/Masterminds/sprig
-  version: ^2.1
+  version: ^2.3
 - package: gopkg.in/yaml.v2
 - package: github.com/Masterminds/semver
   version: 1.1.0


### PR DESCRIPTION
New template functions like trunc will be really helpful for dealing
with Kubernetes naming limits.
