### PR TITLE
Templates directory lint rules

### DIFF
--- a/docs/examples/alpine/templates/alpine-pod.yaml
+++ b/docs/examples/alpine/templates/alpine-pod.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{.Release.Name}}-{{.Chart.Name}}
+  name: "{{.Release.Name}}-{{.Chart.Name}}"
   labels:
     # The "heritage" label is used to track which tool deployed a given chart.
     # It is useful for admins who want to see what releases a particular tool
     # is responsible for.
-    heritage: {{.Release.Service}}
+    heritage: {{.Release.Service | quote }}
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.
-    release: {{.Release.Name}}
+    release: {{.Release.Name | quote }}
     # This makes it easy to audit chart usage.
-    chart: {{.Chart.Name}}-{{.Chart.Version}}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
-    "helm.sh/created": "{{.Release.Time.Seconds}}"
+    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   # This shows how to use a simple value. This will look for a passed-in value
   # called restartPolicy. If it is not found, it will use the default value.

--- a/docs/examples/nginx/templates/configmap.yaml
+++ b/docs/examples/nginx/templates/configmap.yaml
@@ -5,11 +5,11 @@ kind: ConfigMap
 metadata:
   name: {{template "fullname" .}}
   labels:
-    release: {{.Release.Name}}
+    release: {{ .Release.Name | quote }}
     app: {{template "fullname" .}}
-    heritage: {{.Release.Service}}
+    heritage: {{.Release.Service | quote }}
 data:
   # When the config map is mounted as a volume, these will be created as
   # files.
-  index.html: {{default "Hello" .index | squote}}
+  index.html: {{ default "Hello" .index | quote }}
   test.txt: test

--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -9,18 +9,18 @@ metadata:
     # The "heritage" label is used to track which tool deployed a given chart.
     # It is useful for admins who want to see what releases a particular tool
     # is responsible for.
-    heritage: {{.Release.Service}}
+    heritage: {{ .Release.Service | quote }}
     # This makes it easy to search for all components of a release using kubectl.
-    release: {{.Release.Name}}
+    release: {{ .Release.Name | quote }}
     # This makes it easy to audit chart usage.
-    chart: {{.Chart.Name}}-{{.Chart.Version}}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
 spec:
-  replicas: {{default 1 .replicaCount}}
+  replicas: {{ default 1 .replicaCount | quote }}
   template:
     metadata:
       labels:
         app: {{template "fullname" .}}
-        release: {{.Release.Name}}
+        release: {{.Release.Name | quote }}
     spec:
       containers:
       - name: {{template "fullname" .}}

--- a/docs/examples/nginx/templates/svc.yaml
+++ b/docs/examples/nginx/templates/svc.yaml
@@ -5,12 +5,12 @@ kind: Service
 metadata:
   name: {{template "fullname" .}}
   labels:
-    heritage: {{.Release.Service}}
-    release: {{.Release.Name}}
-    chart: {{.Chart.Name}}-{{.Chart.Version}}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
 spec:
   ports:
-  - port: {{default 80 .httpPort}}
+  - port: {{ default 80 .httpPort | quote }}
     targetPort: 80
     protocol: TCP
     name: http

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -211,6 +211,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 	files := []*afile{}
 	topdir += string(filepath.Separator)
+
 	err = filepath.Walk(topdir, func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
 		if err != nil {

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -17,15 +17,214 @@ limitations under the License.
 package rules
 
 import (
-	"k8s.io/helm/pkg/lint/support"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/lint/support"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-const badchartfile = "testdata/badchartfile"
+const badChartDir = "testdata/badchartfile"
+const goodChartDir = "testdata/goodone"
+
+var badChartFilePath string = filepath.Join(badChartDir, "Chart.yaml")
+var goodChartFilePath string = filepath.Join(goodChartDir, "Chart.yaml")
+var nonExistingChartFilePath string = filepath.Join(os.TempDir(), "Chart.yaml")
+
+var badChart, chatLoadRrr = chartutil.LoadChartfile(badChartFilePath)
+var goodChart, _ = chartutil.LoadChartfile(goodChartFilePath)
+
+// Validation functions Test
+func TestValidateChartYamlFileExistence(t *testing.T) {
+	err := validateChartYamlFileExistence(nonExistingChartFilePath)
+	if err == nil {
+		t.Errorf("validateChartYamlFileExistence to return a linter error, got no error")
+	}
+
+	err = validateChartYamlFileExistence(badChartFilePath)
+	if err != nil {
+		t.Errorf("validateChartYamlFileExistence to return no error, got a linter error")
+	}
+}
+
+func TestValidateChartYamlNotDirectory(t *testing.T) {
+	_ = os.Mkdir(nonExistingChartFilePath, os.ModePerm)
+	defer os.Remove(nonExistingChartFilePath)
+
+	err := validateChartYamlNotDirectory(nonExistingChartFilePath)
+	if err == nil {
+		t.Errorf("validateChartYamlNotDirectory to return a linter error, got no error")
+	}
+}
+
+func TestValidateChartYamlFormat(t *testing.T) {
+	err := validateChartYamlFormat(errors.New("Read error"))
+	if err == nil {
+		t.Errorf("validateChartYamlFormat to return a linter error, got no error")
+	}
+
+	err = validateChartYamlFormat(nil)
+	if err != nil {
+		t.Errorf("validateChartYamlFormat to return no error, got a linter error")
+	}
+}
+
+func TestValidateChartName(t *testing.T) {
+	err := validateChartName(badChart)
+	if err == nil {
+		t.Errorf("validateChartName to return a linter error, got no error")
+	}
+}
+
+func TestValidateChartNameDirMatch(t *testing.T) {
+	err := validateChartNameDirMatch(goodChartDir, goodChart)
+	if err != nil {
+		t.Errorf("validateChartNameDirMatch to return no error, gor a linter error")
+	}
+	// It has not name
+	err = validateChartNameDirMatch(badChartDir, badChart)
+	if err == nil {
+		t.Errorf("validatechartnamedirmatch to return a linter error, got no error")
+	}
+
+	// Wrong path
+	err = validateChartNameDirMatch(badChartDir, goodChart)
+	if err == nil {
+		t.Errorf("validatechartnamedirmatch to return a linter error, got no error")
+	}
+}
+
+func TestValidateChartVersion(t *testing.T) {
+	var failTest = []struct {
+		Version  string
+		ErrorMsg string
+	}{
+		{"", "'version' value is required"},
+		{"0", "0 is less than or equal to 0"},
+		{"waps", "is not a valid SemVer"},
+		{"-3", "is not a valid SemVer"},
+	}
+
+	var successTest = []string{"0.0.1", "0.0.1+build", "0.0.1-beta"}
+
+	for _, test := range failTest {
+		badChart.Version = test.Version
+		err := validateChartVersion(badChart)
+		if err == nil || !strings.Contains(err.Error(), test.ErrorMsg) {
+			t.Errorf("validateChartVersion(%s) to return \"%s\", got no error", test.Version, test.ErrorMsg)
+		}
+	}
+
+	for _, version := range successTest {
+		badChart.Version = version
+		err := validateChartVersion(badChart)
+		if err != nil {
+			t.Errorf("validateChartVersion(%s) to return no error, got a linter error", version)
+		}
+	}
+}
+
+func TestValidateChartEngine(t *testing.T) {
+	var successTest = []string{"", "gotpl"}
+
+	for _, engine := range successTest {
+		badChart.Engine = engine
+		err := validateChartEngine(badChart)
+		if err != nil {
+			t.Errorf("validateChartEngine(%s) to return no error, got a linter error %s", engine, err.Error())
+		}
+	}
+
+	badChart.Engine = "foobar"
+	err := validateChartEngine(badChart)
+	if err == nil || !strings.Contains(err.Error(), "not valid. Valid options are [gotpl") {
+		t.Errorf("validateChartEngine(%s) to return an error, got no error", badChart.Engine)
+	}
+}
+
+func TestValidateChartMaintainer(t *testing.T) {
+	var failTest = []struct {
+		Name     string
+		Email    string
+		ErrorMsg string
+	}{
+		{"", "", "maintainer requires a name"},
+		{"", "test@test.com", "maintainer requires a name"},
+		{"John Snow", "wrongFormatEmail.com", "maintainer invalid email"},
+	}
+
+	var successTest = []struct {
+		Name  string
+		Email string
+	}{
+		{"John Snow", ""},
+		{"John Snow", "john@winterfell.com"},
+	}
+
+	for _, test := range failTest {
+		badChart.Maintainers = []*chart.Maintainer{{Name: test.Name, Email: test.Email}}
+		err := validateChartMaintainer(badChart)
+		if err == nil || !strings.Contains(err.Error(), test.ErrorMsg) {
+			t.Errorf("validateChartMaintainer(%s, %s) to return \"%s\", got no error", test.Name, test.Email, test.ErrorMsg)
+		}
+	}
+
+	for _, test := range successTest {
+		badChart.Maintainers = []*chart.Maintainer{{Name: test.Name, Email: test.Email}}
+		err := validateChartMaintainer(badChart)
+		if err != nil {
+			t.Errorf("validateChartMaintainer(%s, %s) to return no error, got %s", test.Name, test.Email, err.Error())
+		}
+	}
+}
+
+func TestValidateChartSources(t *testing.T) {
+	var failTest = []string{"", "RiverRun", "john@winterfell", "riverrun.io"}
+	var successTest = []string{"http://riverrun.io", "https://riverrun.io", "https://riverrun.io/blackfish"}
+	for _, test := range failTest {
+		badChart.Sources = []string{test}
+		err := validateChartSources(badChart)
+		if err == nil || !strings.Contains(err.Error(), "invalid URL") {
+			t.Errorf("validateChartSources(%s) to return \"invalid URL\", got no error", test)
+		}
+	}
+
+	for _, test := range successTest {
+		badChart.Sources = []string{test}
+		err := validateChartSources(badChart)
+		if err != nil {
+			t.Errorf("validateChartSources(%s) to return no error, got %s", test, err.Error())
+		}
+	}
+}
+
+func TestValidateChartHome(t *testing.T) {
+	var failTest = []string{"RiverRun", "john@winterfell", "riverrun.io"}
+	var successTest = []string{"", "http://riverrun.io", "https://riverrun.io", "https://riverrun.io/blackfish"}
+
+	for _, test := range failTest {
+		badChart.Home = test
+		err := validateChartHome(badChart)
+		if err == nil || !strings.Contains(err.Error(), "invalid URL") {
+			t.Errorf("validateChartHome(%s) to return \"invalid URL\", got no error", test)
+		}
+	}
+
+	for _, test := range successTest {
+		badChart.Home = test
+		err := validateChartHome(badChart)
+		if err != nil {
+			t.Errorf("validateChartHome(%s) to return no error, got %s", test, err.Error())
+		}
+	}
+}
 
 func TestChartfile(t *testing.T) {
-	linter := support.Linter{ChartDir: badchartfile}
+	linter := support.Linter{ChartDir: badChartDir}
 	Chartfile(&linter)
 	msgs := linter.Messages
 

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -17,70 +17,200 @@ limitations under the License.
 package rules
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/Masterminds/sprig"
-	"io/ioutil"
+	"gopkg.in/yaml.v2"
+	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/engine"
 	"k8s.io/helm/pkg/lint/support"
+	"k8s.io/helm/pkg/timeconv"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"text/template"
 )
 
-// Templates lints a chart's templates.
 func Templates(linter *support.Linter) {
-	templatespath := filepath.Join(linter.ChartDir, "templates")
+	templatesPath := filepath.Join(linter.ChartDir, "templates")
 
-	templatesExist := linter.RunLinterRule(support.WarningSev, validateTemplatesExistence(linter, templatespath))
+	templatesDirExist := linter.RunLinterRule(support.WarningSev, validateTemplatesDir(linter, templatesPath))
 
 	// Templates directory is optional for now
-	if !templatesExist {
+	if !templatesDirExist {
 		return
 	}
 
-	linter.RunLinterRule(support.ErrorSev, validateTemplatesDir(linter, templatespath))
-	linter.RunLinterRule(support.ErrorSev, validateTemplatesParseable(linter, templatespath))
-}
+	// Load chart and parse templates, based on tiller/release_server
+	chart, err := chartutil.Load(linter.ChartDir)
 
-func validateTemplatesExistence(linter *support.Linter, templatesPath string) (lintError support.LintError) {
-	if _, err := os.Stat(templatesPath); err != nil {
-		lintError = fmt.Errorf("Templates directory not found")
+	chartLoaded := linter.RunLinterRule(support.ErrorSev, validateNoError(err))
+
+	if !chartLoaded {
+		return
 	}
-	return
+
+	// Based on cmd/tiller/release_server.go
+	overrides := map[string]interface{}{
+		"Release": map[string]interface{}{
+			"Name":    "testRelease",
+			"Service": "Tiller",
+			"Time":    timeconv.Now(),
+		},
+		"Chart": chart.Metadata,
+	}
+
+	chartValues, _ := chartutil.CoalesceValues(chart, chart.Values, overrides)
+	renderedContentMap, err := engine.New().Render(chart, chartValues)
+
+	renderOk := linter.RunLinterRule(support.ErrorSev, validateNoError(err))
+
+	if !renderOk {
+		return
+	}
+
+	/* Iterate over all the templates to check:
+	   - It is a .yaml file
+		 - All the values in the template file is defined
+		 - {{}} include | quote
+		 - Generated content is a valid Yaml file
+		 - Metadata.Namespace is not set
+	*/
+	for _, template := range chart.Templates {
+		fileName, preExecutedTemplate := template.Name, template.Data
+
+		yamlFile := linter.RunLinterRule(support.ErrorSev, validateYamlExtension(linter, fileName))
+
+		if !yamlFile {
+			return
+		}
+
+		// Check that all the templates have a matching value
+		linter.RunLinterRule(support.WarningSev, validateNonMissingValues(fileName, chartValues, preExecutedTemplate))
+
+		linter.RunLinterRule(support.WarningSev, validateQuotes(fileName, string(preExecutedTemplate)))
+
+		renderedContent := renderedContentMap[fileName]
+		var yamlStruct K8sYamlStruct
+		// Even though K8sYamlStruct only defines Metadata namespace, an error in any other
+		// key will be raised as well
+		err := yaml.Unmarshal([]byte(renderedContent), &yamlStruct)
+
+		validYaml := linter.RunLinterRule(support.ErrorSev, validateYamlContent(fileName, err))
+
+		if !validYaml {
+			return
+		}
+
+		linter.RunLinterRule(support.ErrorSev, validateNoNamespace(fileName, yamlStruct))
+	}
 }
 
+// Validation functions
 func validateTemplatesDir(linter *support.Linter, templatesPath string) (lintError support.LintError) {
-	fi, err := os.Stat(templatesPath)
-	if err == nil && !fi.IsDir() {
+	if fi, err := os.Stat(templatesPath); err != nil {
+		lintError = fmt.Errorf("Templates directory not found")
+	} else if err == nil && !fi.IsDir() {
 		lintError = fmt.Errorf("'templates' is not a directory")
 	}
 	return
 }
 
-func validateTemplatesParseable(linter *support.Linter, templatesPath string) (lintError support.LintError) {
-	tpl := template.New("tpl").Funcs(sprig.TxtFuncMap())
+// Validates that go template tags include the quote pipelined function
+// i.e {{ .Foo.bar }} -> {{ .Foo.bar | quote }}
+// {{ .Foo.bar }}-{{ .Foo.baz }} -> "{{ .Foo.bar }}-{{ .Foo.baz }}"
+func validateQuotes(templateName string, templateContent string) (lintError support.LintError) {
+	// {{ .Foo.bar }}
+	r, _ := regexp.Compile(`(?m)(:|-)\s+{{[\w|\.|\s|\']+}}\s*$`)
+	functions := r.FindAllString(templateContent, -1)
 
-	lintError = filepath.Walk(templatesPath, func(name string, fi os.FileInfo, e error) error {
-		if e != nil {
-			return e
+	for _, str := range functions {
+		if match, _ := regexp.MatchString("quote", str); !match {
+			result := strings.Replace(str, "}}", " | quote }}", -1)
+			lintError = fmt.Errorf("templates: \"%s\". add \"| quote\" to your substitution functions: %s -> %s", templateName, str, result)
+			return
 		}
-		if fi.IsDir() {
-			return nil
-		}
+	}
 
-		data, err := ioutil.ReadFile(name)
-		if err != nil {
-			lintError = fmt.Errorf("cannot read %s: %s", name, err)
-			return lintError
-		}
+	// {{ .Foo.bar }}-{{ .Foo.baz }} -> "{{ .Foo.bar }}-{{ .Foo.baz }}"
+	r, _ = regexp.Compile(`(?m)({{(\w|\.|\s|\')+}}(\s|-)*)+\s*$`)
+	functions = r.FindAllString(templateContent, -1)
 
-		newtpl, err := tpl.Parse(string(data))
-		if err != nil {
-			lintError = fmt.Errorf("error processing %s: %s", name, err)
-			return lintError
-		}
-		tpl = newtpl
-		return nil
-	})
-
+	for _, str := range functions {
+		result := strings.Replace(str, str, fmt.Sprintf("\"%s\"", str), -1)
+		lintError = fmt.Errorf("templates: \"%s\". wrap your substitution functions in double quotes: %s -> %s", templateName, str, result)
+		return
+	}
 	return
+}
+
+func validateYamlExtension(linter *support.Linter, fileName string) (lintError support.LintError) {
+	if filepath.Ext(fileName) != ".yaml" {
+		lintError = fmt.Errorf("templates: \"%s\" needs to use the .yaml extension", fileName)
+	}
+	return
+}
+
+// validateNonMissingValues checks that all the {{}} functions returns a non empty value (<no value> or "")
+// and return an error otherwise.
+func validateNonMissingValues(fileName string, chartValues chartutil.Values, templateContent []byte) (lintError support.LintError) {
+	tmpl := template.New("tpl").Funcs(sprig.TxtFuncMap())
+	var buf bytes.Buffer
+	var emptyValues []string
+
+	// Supported {{ .Chart.Name }}, {{ .Chart.Name | quote }}
+	r, _ := regexp.Compile(`{{([\w]|\.*|\s|\|)+}}`)
+	functions := r.FindAllString(string(templateContent), -1)
+
+	// Iterate over the {{ FOO }} templates, executing them against the chartValues
+	// We do individual templates parsing so we keep the reference for the key (str) that we want it to be interpolated.
+	for _, str := range functions {
+		newtmpl, err := tmpl.Parse(str)
+		if err != nil {
+			lintError = fmt.Errorf("templates: %s", err.Error())
+			return
+		}
+
+		err = newtmpl.Execute(&buf, chartValues)
+		renderedValue := buf.String()
+
+		if renderedValue == "<no value>" || renderedValue == "" {
+			emptyValues = append(emptyValues, str)
+		}
+		buf.Reset()
+	}
+
+	if len(emptyValues) > 0 {
+		lintError = fmt.Errorf("templates: %s: The following functions are not returning eny value %v", fileName, emptyValues)
+	}
+	return
+}
+
+func validateNoError(readError error) (lintError support.LintError) {
+	if readError != nil {
+		lintError = fmt.Errorf("templates: %s", readError.Error())
+	}
+	return
+}
+
+func validateYamlContent(filePath string, err error) (lintError support.LintError) {
+	if err != nil {
+		lintError = fmt.Errorf("templates: \"%s\". Wrong YAML content.", filePath)
+	}
+	return
+}
+
+func validateNoNamespace(filePath string, yamlStruct K8sYamlStruct) (lintError support.LintError) {
+	if yamlStruct.Metadata.Namespace != "" {
+		lintError = fmt.Errorf("templates: \"%s\". namespace option is currently NOT supported.", filePath)
+	}
+	return
+}
+
+// Need to access for now to Namespace only
+type K8sYamlStruct struct {
+	Metadata struct {
+		Namespace string
+	}
 }

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -24,6 +24,38 @@ import (
 
 const templateTestBasedir = "./testdata/albatross"
 
+func TestValidateQuotes(t *testing.T) {
+	// add `| quote` lint error
+	var failTest = []string{"foo: {{.Release.Service }}", "foo:  {{.Release.Service }}", "- {{.Release.Service }}", "foo: {{default 'Never' .restart_policy}}", "-  {{.Release.Service }} "}
+
+	for _, test := range failTest {
+		err := validateQuotes("testTemplate.yaml", test)
+		if err == nil || !strings.Contains(err.Error(), "add \"| quote\" to your substitution functions") {
+			t.Errorf("validateQuotes('%s') to return \"add | quote error\", got no error", test)
+		}
+	}
+
+	var successTest = []string{"foo: {{.Release.Service | quote }}", "foo:  {{.Release.Service | quote }}", "- {{.Release.Service | quote }}", "foo: {{default 'Never' .restart_policy | quote }}", "foo: \"{{ .Release.Service }}\"", "foo: \"{{ .Release.Service }} {{ .Foo.Bar }}\"", "foo: \"{{ default 'Never' .Release.Service }} {{ .Foo.Bar }}\""}
+
+	for _, test := range successTest {
+		err := validateQuotes("testTemplate.yaml", test)
+		if err != nil {
+			t.Errorf("validateQuotes('%s') to return not error and got \"%s\"", test, err.Error())
+		}
+	}
+
+	// Surrounding quotes
+	failTest = []string{"foo: {{.Release.Service }}-{{ .Release.Bar }}", "foo: {{.Release.Service }} {{ .Release.Bar }}", "- {{.Release.Service }}-{{ .Release.Bar }}", "- {{.Release.Service }}-{{ .Release.Bar }} {{ .Release.Baz }}", "foo: {{.Release.Service | default }}-{{ .Release.Bar }}"}
+
+	for _, test := range failTest {
+		err := validateQuotes("testTemplate.yaml", test)
+		if err == nil || !strings.Contains(err.Error(), "wrap your substitution functions in double quotes") {
+			t.Errorf("validateQuotes('%s') to return \"wrap your substitution functions in double quotes\", got no error %s", test, err.Error())
+		}
+	}
+
+}
+
 func TestTemplate(t *testing.T) {
 	linter := support.Linter{ChartDir: templateTestBasedir}
 	Templates(&linter)

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -24,6 +24,23 @@ import (
 
 const templateTestBasedir = "./testdata/albatross"
 
+func TestValidateAllowedExtension(t *testing.T) {
+	var failTest = []string{"/foo", "/test.yml", "/test.toml", "test.yml"}
+	for _, test := range failTest {
+		err := validateAllowedExtension(test)
+		if err == nil || !strings.Contains(err.Error(), "needs to use .yaml or .tpl extension") {
+			t.Errorf("validateAllowedExtension('%s') to return \"needs to use .yaml or .tpl extension\", got no error", test)
+		}
+	}
+	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml"}
+	for _, test := range successTest {
+		err := validateAllowedExtension(test)
+		if err != nil {
+			t.Errorf("validateAllowedExtension('%s') to return no error but got \"%s\"", test, err.Error())
+		}
+	}
+}
+
 func TestValidateQuotes(t *testing.T) {
 	// add `| quote` lint error
 	var failTest = []string{"foo: {{.Release.Service }}", "foo:  {{.Release.Service }}", "- {{.Release.Service }}", "foo: {{default 'Never' .restart_policy}}", "-  {{.Release.Service }} "}

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -19,8 +19,6 @@ package support
 import "fmt"
 
 // Severity indicatest the severity of a Message.
-type Severity int
-
 const (
 	// UnknownSev indicates that the severity of the error is unknown, and should not stop processing.
 	UnknownSev = iota
@@ -38,7 +36,7 @@ var sev = []string{"UNKNOWN", "INFO", "WARNING", "ERROR"}
 // Message is a linting output message
 type Message struct {
 	// Severity is one of the *Sev constants
-	Severity Severity
+	Severity int
 	// Text contains the message text
 	Text string
 }
@@ -60,9 +58,9 @@ func (m Message) String() string {
 }
 
 // Returns true if the validation passed
-func (l *Linter) RunLinterRule(severity Severity, lintError LintError) bool {
+func (l *Linter) RunLinterRule(severity int, lintError LintError) bool {
 	// severity is out of bound
-	if severity < 0 || int(severity) >= len(sev) {
+	if severity < 0 || severity >= len(sev) {
 		return false
 	}
 

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -52,8 +52,6 @@ type LintError interface {
 	error
 }
 
-type ValidationFunc func(*Linter) LintError
-
 // String prints a string representation of this Message.
 //
 // Implements fmt.Stringer.
@@ -63,6 +61,11 @@ func (m Message) String() string {
 
 // Returns true if the validation passed
 func (l *Linter) RunLinterRule(severity Severity, lintError LintError) bool {
+	// severity is out of bound
+	if severity < 0 || int(severity) >= len(sev) {
+		return false
+	}
+
 	if lintError != nil {
 		l.Messages = append(l.Messages, Message{Text: lintError.Error(), Severity: severity})
 	}

--- a/pkg/lint/support/message_test.go
+++ b/pkg/lint/support/message_test.go
@@ -26,7 +26,7 @@ var lintError LintError = fmt.Errorf("Foobar")
 
 func TestRunLinterRule(t *testing.T) {
 	var tests = []struct {
-		Severity         Severity
+		Severity         int
 		LintError        error
 		ExpectedMessages int
 		ExpectedReturn   bool

--- a/pkg/lint/support/message_test.go
+++ b/pkg/lint/support/message_test.go
@@ -21,7 +21,38 @@ import (
 	"testing"
 )
 
-var _ fmt.Stringer = Message{}
+var linter Linter = Linter{}
+var lintError LintError = fmt.Errorf("Foobar")
+
+func TestRunLinterRule(t *testing.T) {
+	var tests = []struct {
+		Severity         Severity
+		LintError        error
+		ExpectedMessages int
+		ExpectedReturn   bool
+	}{
+		{ErrorSev, lintError, 1, false},
+		{WarningSev, lintError, 2, false},
+		{InfoSev, lintError, 3, false},
+		// No error so it returns true
+		{ErrorSev, nil, 3, true},
+		// Invalid severity values
+		{4, lintError, 3, false},
+		{22, lintError, 3, false},
+		{-1, lintError, 3, false},
+	}
+
+	for _, test := range tests {
+		isValid := linter.RunLinterRule(test.Severity, test.LintError)
+		if len(linter.Messages) != test.ExpectedMessages {
+			t.Errorf("RunLinterRule(%d, %v), linter.Messages should have now %d message, we got %d", test.Severity, test.LintError, test.ExpectedMessages, len(linter.Messages))
+		}
+
+		if isValid != test.ExpectedReturn {
+			t.Errorf("RunLinterRule(%d, %v), should have returned %t but returned %t", test.Severity, test.LintError, test.ExpectedReturn, isValid)
+		}
+	}
+}
 
 func TestMessage(t *testing.T) {
 	m := Message{ErrorSev, "Foo"}


### PR DESCRIPTION
This is a second PR related to the issue https://github.com/kubernetes/helm/issues/689

It includes a set of new lint rules like:
- [x] Detect if the user has set the namespace value https://github.com/kubernetes/helm/issues/814
- [x] Add warning telling the user to add `| quote` to template functions.
- [x] Add warning telling the user to add double quotes on expressions `{{}}-{{}}` 
- [x] The templates directory does not have any non yaml file
- [x] Check that generated file is valid after rendering
- [x] Let the user know if some of the template `{{}}` are being interpolated as an empty value.
- [x] Added tests for chartfile and support
- [x] Support for partial templates rendering https://github.com/kubernetes/helm/pull/811

Please note that I am using `chart = chartutil.Load(linter.ChartDir)` and `chart.Templates` instead of walking on the directory. That way I can take advantage of template rendering. Is this something that you are ok with?
- [x] Added tests for chartfile validation functions, the support package and some for the templates ones.
