### PR TITLE
docs(examples): unify the examples

### DIFF
--- a/docs/examples/alpine/README.md
+++ b/docs/examples/alpine/README.md
@@ -1,3 +1,7 @@
+#Alpine: A simple Helm chart
+
+Run a single pod of Alpine Linux.
+
 This example was generated using the command `helm create alpine`.
 
 The `templates/` directory contains a very simple pod resource with a

--- a/docs/examples/alpine/templates/alpine-pod.yaml
+++ b/docs/examples/alpine/templates/alpine-pod.yaml
@@ -3,13 +3,23 @@ kind: Pod
 metadata:
   name: {{.Release.Name}}-{{.Chart.Name}}
   labels:
+    # The "heritage" label is used to track which tool deployed a given chart.
+    # It is useful for admins who want to see what releases a particular tool
+    # is responsible for.
     heritage: {{.Release.Service}}
-    chartName: {{.Chart.Name}}
-    chartVersion: {{.Chart.Version | quote}}
+    # The "release" convention makes it easy to tie a release to all of the
+    # Kubernetes resources that were created as part of that release.
+    release: {{.Release.Name}}
+    # This makes it easy to audit chart usage.
+    chart: {{.Chart.Name}}-{{.Chart.Version}}
   annotations:
     "helm.sh/created": "{{.Release.Time.Seconds}}"
 spec:
-  restartPolicy: {{default "Never" .restart_policy}}
+  # This shows how to use a simple value. This will look for a passed-in value
+  # called restartPolicy. If it is not found, it will use the default value.
+  # {{default "Never" .restartPolicy}} is a slightly optimized version of the
+  # more conventional syntax: {{.restartPolicy | default "Never"}}
+  restartPolicy: {{default "Never" .restartPolicy}}
   containers:
   - name: waiter
     image: "alpine:3.3"

--- a/docs/examples/nginx/templates/configmap.yaml
+++ b/docs/examples/nginx/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     release: {{.Release.Name}}
     app: {{template "fullname" .}}
+    heritage: {{.Release.Service}}
 data:
   # When the config map is mounted as a volume, these will be created as
   # files.

--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   # multiple times into the same namespace.
   name: {{template "fullname" .}}
   labels:
-    # This is a convention. It makes it possible for an admin to query a cluster
-    # using Kubectl and find out what packages are managed by Helm. Helm itself
-    # does not depend on this label, though.
-    heritage: helm
+    # The "heritage" label is used to track which tool deployed a given chart.
+    # It is useful for admins who want to see what releases a particular tool
+    # is responsible for.
+    heritage: {{.Release.Service}}
     # This makes it easy to search for all components of a release using kubectl.
     release: {{.Release.Name}}
     # This makes it easy to audit chart usage.

--- a/docs/examples/nginx/templates/svc.yaml
+++ b/docs/examples/nginx/templates/svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: {{template "fullname" .}}
   labels:
-    heritage: helm
+    heritage: {{.Release.Service}}
     release: {{.Release.Name}}
     chart: {{.Chart.Name}}-{{.Chart.Version}}
 spec:


### PR DESCRIPTION
As noted in #860, there were a few places where the alpine and nginx
charts differed. This unifies the two, using common labels and
conventions.
