### PR TITLE
feat(helm): install directly from repo

### DIFF
--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -39,6 +39,11 @@ func fetch(cmd *cobra.Command, args []string) error {
 	if filepath.Ext(pname) != ".tgz" {
 		pname += ".tgz"
 	}
+	return fetchChart(pname)
+
+}
+
+func fetchChart(pname string) error {
 
 	f, err := repo.LoadRepositoriesFile(repositoriesFile())
 	if err != nil {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -117,5 +117,19 @@ func locateChartPath(name string) (string, error) {
 	if _, err := os.Stat(crepo); err == nil {
 		return filepath.Abs(crepo)
 	}
+
+	// Try fetching the chart from a remote repo into a tmpdir
+	if filepath.Ext(name) != ".tgz" {
+		name += ".tgz"
+	}
+	if err := fetchChart(name); err == nil {
+		lname, err := filepath.Abs(filepath.Base(name))
+		if err != nil {
+			return lname, err
+		}
+		fmt.Printf("Fetched %s to %s\n", name, lname)
+		return lname, nil
+	}
+
 	return name, fmt.Errorf("file %q not found", name)
 }


### PR DESCRIPTION
A helm install command will try to load a chart from a local file first.
But if a local file is not found, it will try to fetch a file from a
matching repo request. The file will be downloaded to the client,
and then sent to Tiller for installation.
