### PR TITLE
fix(docs): fix nginx example chart name

### DIFF
--- a/docs/examples/nginx/templates/_helpers.tpl
+++ b/docs/examples/nginx/templates/_helpers.tpl
@@ -10,4 +10,7 @@ Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec).
 */}}
-{{define "fullname"}}{{.Release.Name}}-{{default "nginx" .Values.nameOverride | trunc 24 }}{{end}}
+{{define "fullname"}}
+{{- $name := default "nginx" .Values.nameOverride -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{end}}


### PR DESCRIPTION
The name was not correctly truncating, which occasionally resulted
in naming errors, since Kubernetes restricts names to 24 characters.
