### PR TITLE
Removing debugging line

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -71,7 +71,6 @@ func New() *Engine {
 func (e *Engine) Render(chrt *chart.Chart, values chartutil.Values) (map[string]string, error) {
 	// Render the charts
 	tmap := allTemplates(chrt, values)
-	fmt.Printf("%v", tmap)
 	return e.render(tmap)
 }
 


### PR DESCRIPTION
I am not sure if that line has been added on purpose for logging purposes but it was polluting the linter output so I decided to remove it.
