### PR TITLE
Avoid use of -f for docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker-binary:
 .PHONY: docker-build
 docker-build: check-docker docker-binary
 	docker build --rm -t ${IMAGE} rootfs
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 .PHONY: test
 test: build


### PR DESCRIPTION
As of docker 1.10, `-f` has been removed as an option for `docker tag`

https://docs.docker.com/engine/deprecated/
