### PR TITLE
fix(tiller): stop printing <no value> when var is missing

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -46,6 +46,7 @@ func TestRender(t *testing.T) {
 		Templates: []*chart.Template{
 			{Name: "test1", Data: []byte("{{.outer | title }} {{.inner | title}}")},
 			{Name: "test2", Data: []byte("{{.global.callme | lower }}")},
+			{Name: "test3", Data: []byte("{{.noValue}}")},
 		},
 		Values: &chart.Config{
 			Raw: "outer: DEFAULT\ninner: DEFAULT",
@@ -81,6 +82,10 @@ func TestRender(t *testing.T) {
 	expect = "ishmael"
 	if out["test2"] != expect {
 		t.Errorf("Expected %q, got %q", expect, out["test2"])
+	}
+	expect = ""
+	if out["test3"] != expect {
+		t.Errorf("Expected %q, got %q", expect, out["test3"])
 	}
 
 	if _, err := e.Render(c, v); err != nil {


### PR DESCRIPTION
Instead of printing "no value", this prints an empty string by
default, but adds a Strict flag on the engine, which (if true)
will cause a template render to error out if a value is not supplied.

Strict is set to false so that developers can instead use `default` to
set default values.

Closes #887
