### PR TITLE
fix(deps): fix unvendored dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: c19bb16fcd70221817024b5443840f8beefadc89ee2398b7341594efb9b5bf08
-updated: 2016-06-21T13:29:28.273164339-06:00
+hash: 59c82bfdb7b051312ac8c32b511d4a4eca41cc2d5958122ab3da9f97873763ab
+updated: 2016-06-26T12:31:22.280004075-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
 - name: github.com/asaskevich/govalidator
@@ -22,6 +22,17 @@ imports:
   subpackages:
   - digest
   - reference
+- name: github.com/docker/docker
+  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
+  subpackages:
+  - pkg/jsonmessage
+  - pkg/mount
+  - pkg/stdcopy
+  - pkg/symlink
+  - pkg/term
+  - pkg/term/winconsole
+  - pkg/timeutils
+  - pkg/units
 - name: github.com/docker/engine-api
   version: 3d72d392d07bece8d7d7b2a3b6b2e57c2df376a2
   subpackages:
@@ -144,6 +155,8 @@ imports:
   - util/wordwrap
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/Masterminds/semver
@@ -156,6 +169,24 @@ imports:
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/opencontainers/runc
+  version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
+  subpackages:
+  - libcontainer
+  - libcontainer/apparmor
+  - libcontainer/cgroups
+  - libcontainer/cgroups/fs
+  - libcontainer/cgroups/systemd
+  - libcontainer/configs
+  - libcontainer/configs/validate
+  - libcontainer/criurpc
+  - libcontainer/label
+  - libcontainer/seccomp
+  - libcontainer/selinux
+  - libcontainer/stacktrace
+  - libcontainer/system
+  - libcontainer/user
+  - libcontainer/utils
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
@@ -203,6 +234,18 @@ imports:
   - internal
   - jws
   - jwt
+- name: google.golang.org/appengine
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - urlfetch
+  - internal/urlfetch
 - name: google.golang.org/cloud
   version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
   subpackages:
@@ -237,6 +280,7 @@ imports:
   - pkg/kubectl/cmd/util
   - pkg/kubectl/resource
   - pkg/labels
+  - pkg/api/errors
   - pkg/api/resource
   - pkg/api/unversioned
   - pkg/auth/user
@@ -250,6 +294,7 @@ imports:
   - pkg/util/rand
   - pkg/util/sets
   - pkg/util/validation
+  - pkg/util/validation/field
   - pkg/client/unversioned/auth
   - pkg/client/unversioned/clientcmd/api
   - pkg/client/unversioned/clientcmd/api/latest
@@ -261,7 +306,6 @@ imports:
   - pkg/client/transport
   - pkg/kubelet/server/remotecommand
   - pkg/util/httpstream/spdy
-  - pkg/api/errors
   - pkg/api/validation
   - pkg/apimachinery
   - pkg/apimachinery/registered
@@ -300,7 +344,6 @@ imports:
   - pkg/httplog
   - pkg/util/wsstream
   - third_party/golang/netutil
-  - pkg/util/validation/field
   - pkg/api/endpoints
   - pkg/api/pod
   - pkg/api/service


### PR DESCRIPTION
Fixes pulling a few dependencies from GOPATH

```
% glide -q list

...

GOPATH packages:
    github.com/inconshreveable/mousetrap
    github.com/opencontainers/runc/libcontainer/cgroups/fs
    github.com/opencontainers/runc/libcontainer/configs
    google.golang.org/appengine/urlfetch
    google.golang.org/appengine
```
