### PR TITLE
Support Linter for Values namespace

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -220,33 +220,20 @@ func (s *releaseServer) InstallRelease(c ctx.Context, req *services.InstallRelea
 		return nil, errMissingChart
 	}
 
-	ts := timeconv.Now()
 	name, err := s.uniqName(req.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	overrides := map[string]interface{}{
-		"Release": map[string]interface{}{
-			"Name":      name,
-			"Time":      ts,
-			"Namespace": s.env.Namespace,
-			"Service":   "Tiller",
-		},
-		"Chart": req.Chart.Metadata,
-	}
-
-	// Render the templates
-	// TODO: Fix based on whether chart has `engine: SOMETHING` set.
-	vals, err := chartutil.CoalesceValues(req.Chart, req.Values, nil)
+	ts := timeconv.Now()
+	options := map[string]interface{}{"namespace": s.env.Namespace, "releaseName": name, "releaseTime": ts}
+	valuesToRender, err := chartutil.ToRenderValues(req.Chart, req.Values, options)
 	if err != nil {
 		return nil, err
 	}
 
-	overrides["Values"] = vals
-
 	renderer := s.engine(req.Chart)
-	files, err := renderer.Render(req.Chart, overrides)
+	files, err := renderer.Render(req.Chart, valuesToRender)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -226,7 +226,7 @@ func (s *releaseServer) InstallRelease(c ctx.Context, req *services.InstallRelea
 	}
 
 	ts := timeconv.Now()
-	options := map[string]interface{}{"namespace": s.env.Namespace, "releaseName": name, "releaseTime": ts}
+	options := chartutil.ReleaseOptions{Name: name, Time: ts, Namespace: s.env.Namespace}
 	valuesToRender, err := chartutil.ToRenderValues(req.Chart, req.Values, options)
 	if err != nil {
 		return nil, err

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -288,6 +288,27 @@ func coalesceTables(dst, src map[string]interface{}) map[string]interface{} {
 	return dst
 }
 
+// ToRenderValues composes the struct from the data coming from the Releases, Charts and Values files
+func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options map[string]interface{}) (Values, error) {
+	overrides := map[string]interface{}{
+		"Release": map[string]interface{}{
+			"Name":      options["releaseName"],
+			"Time":      options["releaseTime"],
+			"Namespace": options["namespace"],
+			"Service":   "Tiller",
+		},
+		"Chart": chrt.Metadata,
+	}
+
+	vals, err := CoalesceValues(chrt, chrtVals, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	overrides["Values"] = vals
+	return overrides, nil
+}
+
 // istable is a special-purpose function to see if the present thing matches the definition of a YAML table.
 func istable(v interface{}) bool {
 	_, ok := v.(map[string]interface{})

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
@@ -288,13 +289,21 @@ func coalesceTables(dst, src map[string]interface{}) map[string]interface{} {
 	return dst
 }
 
+// ReleaseOptions represents the additional release options needed
+// for the composition of the final values struct
+type ReleaseOptions struct {
+	Name      string
+	Time      *timestamp.Timestamp
+	Namespace string
+}
+
 // ToRenderValues composes the struct from the data coming from the Releases, Charts and Values files
-func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options map[string]interface{}) (Values, error) {
+func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options ReleaseOptions) (Values, error) {
 	overrides := map[string]interface{}{
 		"Release": map[string]interface{}{
-			"Name":      options["releaseName"],
-			"Time":      options["releaseTime"],
-			"Namespace": options["namespace"],
+			"Name":      options.Name,
+			"Time":      options.Time,
+			"Namespace": options.Namespace,
 			"Service":   "Tiller",
 		},
 		"Chart": chrt.Metadata,

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -52,7 +52,7 @@ func Templates(linter *support.Linter) {
 		return
 	}
 
-	options := map[string]interface{}{"namespace": "testNamespace", "releaseName": "testRelease", "releaseTime": timeconv.Now()}
+	options := chartutil.ReleaseOptions{Name: "testRelease", Time: timeconv.Now(), Namespace: "testNamespace"}
 	valuesToRender, err := chartutil.ToRenderValues(chart, chart.Values, options)
 	renderedContentMap, err := engine.New().Render(chart, valuesToRender)
 

--- a/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
+++ b/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 }}{{end}}
+
+{{/*
+Create a default fully qualified app name.
+
+We truncate at 24 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{define "fullname"}}
+{{- $name := default "nginx" .Values.nameOverride -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{end}}

--- a/pkg/lint/rules/testdata/albatross/templates/albatross.yaml
+++ b/pkg/lint/rules/testdata/albatross/templates/albatross.yaml
@@ -1,2 +1,0 @@
-metadata:
-  name: {{.name | default "foo" | title}}

--- a/pkg/lint/rules/testdata/albatross/templates/svc.yaml
+++ b/pkg/lint/rules/testdata/albatross/templates/svc.yaml
@@ -1,0 +1,18 @@
+# This is a service gateway to the replica set created by the deployment.
+# Take a look at the deployment.yaml for general notes about this chart.
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Values.name }}"
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+spec:
+  ports:
+  - port: {{default 80 .Values.httpPort | quote}}
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: {{template "fullname" .}}


### PR DESCRIPTION
The linter stopped working when we added the Values namespace.  Refs #897

Cause: I was duplicating the code that generated the `overrides` struct that container the final namespaced values. So the code was changed in releaseServer but no in the linter. 
Why we did not catch it in tests: The linter test was using non namespaced values plus the  `| default`  functions which was hiding the problem.

Changes:

1 - Extract the struct generated to a function in chartutils (please let me know if you know a better place), so the linter and release_server uses it.
2 - Add a smoke test in the linter using the nginx template which includes all the new features (Values namespace, partial templates, etc)
