### PR TITLE
fix(chartutil): Ensure ReadValues doesn't return a nil map

### DIFF
--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -110,9 +110,9 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	vals = make(map[string]interface{})
-	if len(data) > 0 {
-		err = yaml.Unmarshal(data, &vals)
+	err = yaml.Unmarshal(data, &vals)
+	if len(vals) == 0 {
+		vals = Values{}
 	}
 	return
 }

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -53,6 +53,18 @@ water:
 		t.Fatalf("Error parsing bytes: %s", err)
 	}
 	matchValues(t, data)
+
+	tests := []string{`poet: "Coleridge"`, "# Just a comment", ""}
+
+	for _, tt := range tests {
+		data, err = ReadValues([]byte(tt))
+		if err != nil {
+			t.Fatalf("Error parsing bytes: %s", err)
+		}
+		if data == nil {
+			t.Errorf(`YAML string "%s" gave a nil map`, tt)
+		}
+	}
 }
 
 func TestReadValuesFile(t *testing.T) {


### PR DESCRIPTION
closes #912 

Not sure if this is necessary anymore @technosophos, as you mentioned in #912, but it seems safer to me nonetheless.
