### PR TITLE
fix(helm): fix linter test panic

### DIFF
--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -312,7 +312,7 @@ func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options ReleaseOp
 
 	vals, err := CoalesceValues(chrt, chrtVals, nil)
 	if err != nil {
-		return nil, err
+		return overrides, err
 	}
 
 	overrides["Values"] = vals

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -55,6 +55,12 @@ func Templates(linter *support.Linter) {
 
 	options := chartutil.ReleaseOptions{Name: "testRelease", Time: timeconv.Now(), Namespace: "testNamespace"}
 	valuesToRender, err := chartutil.ToRenderValues(chart, chart.Values, options)
+	if err != nil {
+		// FIXME: This seems to generate a duplicate, but I can't find where the first
+		// error is coming from.
+		//linter.RunLinterRule(support.ErrorSev, err)
+		return
+	}
 	renderedContentMap, err := engine.New().Render(chart, valuesToRender)
 
 	renderOk := linter.RunLinterRule(support.ErrorSev, validateNoError(err))


### PR DESCRIPTION
Handle a previously unhandled error in the linter. This simply bails out
if a chart's values files do not parse.

Also, changed the implementation of CoalesceValues to return a map even
on error.
