### PR TITLE
fix(ci): move docker-build out of parallel step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,4 +41,5 @@ deployment:
     commands:
       - echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json
       - docker login -e 1234@5678.com -u _json_key -p "$(cat ${HOME}/gcloud-service-key.json)" https://gcr.io
+      - make docker-build
       - docker push gcr.io/kubernetes-helm/tiller:canary

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -31,8 +31,4 @@ case "${CIRCLE_NODE_INDEX-0}" in
     echo "Running 'make test-style'"
     make test-style
     ;;
-  2)
-    echo "Running 'make docker-build'"
-    make docker-build
-    ;;
 esac


### PR DESCRIPTION
circle ci can't seem to find the image when it is build in a parallel
container.
