### PR TITLE
Fix #872: index function should handle deleted charts correctly

### DIFF
--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -60,7 +60,7 @@ func search(cmd *cobra.Command, args []string) error {
 func searchChartRefsForPattern(search string, chartRefs map[string]*repo.ChartRef) []string {
 	matches := []string{}
 	for k, c := range chartRefs {
-		if strings.Contains(c.Name, search) {
+		if strings.Contains(c.Name, search) && !c.Removed {
 			matches = append(matches, k)
 			continue
 		}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -105,7 +105,6 @@ func LoadChartRepository(dir, url string) (*ChartRepository, error) {
 		}
 		return nil
 	})
-
 	return r, nil
 }
 
@@ -123,6 +122,8 @@ func (r *ChartRepository) Index() error {
 	if r.IndexFile == nil {
 		r.IndexFile = &IndexFile{Entries: make(map[string]*ChartRef)}
 	}
+
+	var existCharts map[string]bool = make(map[string]bool)
 
 	for _, path := range r.ChartPaths {
 		ch, err := chartutil.Load(path)
@@ -156,6 +157,15 @@ func (r *ChartRepository) Index() error {
 
 		r.IndexFile.Entries[key] = entry
 
+		// chart is existing
+		existCharts[key] = true
+	}
+
+	// update deleted charts with Removed = true
+	for k, _ := range r.IndexFile.Entries {
+		if _, ok := existCharts[k]; !ok {
+			r.IndexFile.Entries[k].Removed = true
+		}
 	}
 
 	return r.saveIndexFile()

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -123,8 +123,7 @@ func (r *ChartRepository) Index() error {
 		r.IndexFile = &IndexFile{Entries: make(map[string]*ChartRef)}
 	}
 
-	var existCharts map[string]bool
-	existCharts = make(map[string]bool)
+	existCharts := map[string]bool{}
 
 	for _, path := range r.ChartPaths {
 		ch, err := chartutil.Load(path)

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -123,7 +123,8 @@ func (r *ChartRepository) Index() error {
 		r.IndexFile = &IndexFile{Entries: make(map[string]*ChartRef)}
 	}
 
-	var existCharts map[string]bool = make(map[string]bool)
+	var existCharts map[string]bool
+	existCharts = make(map[string]bool)
 
 	for _, path := range r.ChartPaths {
 		ch, err := chartutil.Load(path)
@@ -162,7 +163,7 @@ func (r *ChartRepository) Index() error {
 	}
 
 	// update deleted charts with Removed = true
-	for k, _ := range r.IndexFile.Entries {
+	for k := range r.IndexFile.Entries {
 		if _, ok := existCharts[k]; !ok {
 			r.IndexFile.Entries[k].Removed = true
 		}


### PR DESCRIPTION
- Mark removed=true for deleted charts when doing `helm repo index`
- Only display charts with removed=false with `helm search`
- `helm update` already replaced index.yaml file in the $HELM_HOME/repository/cache
