### PR TITLE
fix(tiller): merge -f values correctly

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -101,7 +101,7 @@ func (g *getCmd) run() error {
 		return prettyError(err)
 	}
 
-	cfg, err := chartutil.CoalesceValues(res.Release.Chart, res.Release.Config, nil)
+	cfg, err := chartutil.CoalesceValues(res.Release.Chart, res.Release.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -68,7 +68,7 @@ func (g *getValuesCmd) run() error {
 
 	// If the user wants all values, compute the values and return.
 	if g.allValues {
-		cfg, err := chartutil.CoalesceValues(res.Release.Chart, res.Release.Config, nil)
+		cfg, err := chartutil.CoalesceValues(res.Release.Chart, res.Release.Config)
 		if err != nil {
 			return err
 		}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -54,18 +54,15 @@ func TestRender(t *testing.T) {
 	}
 
 	vals := &chart.Config{
-		Raw: "outer: BAD\ninner: inn",
-	}
-
-	overrides := map[string]interface{}{
-		"outer": "spouter",
-		"global": map[string]interface{}{
-			"callme": "Ishmael",
-		},
-	}
+		Raw: `
+outer: spouter
+inner: inn
+global:
+  callme: Ishmael
+`}
 
 	e := New()
-	v, err := chartutil.CoalesceValues(c, vals, overrides)
+	v, err := chartutil.CoalesceValues(c, vals)
 	if err != nil {
 		t.Fatalf("Failed to coalesce values: %s", err)
 	}
@@ -271,7 +268,7 @@ global:
   when: to-day`,
 	}
 
-	tmp, err := chartutil.CoalesceValues(outer, &injValues, map[string]interface{}{})
+	tmp, err := chartutil.CoalesceValues(outer, &injValues)
 	if err != nil {
 		t.Fatalf("Failed to coalesce values: %s", err)
 	}


### PR DESCRIPTION
This fixes a bug in which passed-in values files were not correctly
merged into the chart's default values YAML data. I believe it also
fixes some other prioritization bugs in values merging.

The existing unit test was wrong (see TestCoalesceValues). It is
fixed now. Also added more tests to simulate issue #971.

In the course of writing this, I removed some vestigial code as
mentioned in #920.

Closes #971
Closes #920
