### PR TITLE
fix(tiller): improve deletion error messages

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -381,6 +381,12 @@ func (s *releaseServer) UninstallRelease(c ctx.Context, req *services.UninstallR
 		return nil, err
 	}
 
+	// TODO: Are there any cases where we want to force a delete even if it's
+	// already marked deleted?
+	if rel.Info.Status.Code == release.Status_DELETED {
+		return nil, fmt.Errorf("the release named %q is already deleted", req.Name)
+	}
+
 	log.Printf("uninstall: Deleting %s", req.Name)
 	rel.Info.Status.Code = release.Status_DELETED
 	rel.Info.Deleted = timeconv.Now()

--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -252,6 +252,13 @@ func TestUninstallRelease(t *testing.T) {
 	if res.Release.Info.Deleted.Seconds <= 0 {
 		t.Errorf("Expected valid UNIX date, got %d", res.Release.Info.Deleted.Seconds)
 	}
+
+	// Test that after deletion, we get an error that it is already deleted.
+	if _, err = rs.UninstallRelease(c, req); err == nil {
+		t.Error("Expected error when deleting already deleted resource.")
+	} else if err.Error() != "the release named \"angry-panda\" is already deleted" {
+		t.Errorf("Unexpected error message: %q", err)
+	}
 }
 
 func TestUninstallReleaseNoHooks(t *testing.T) {


### PR DESCRIPTION
This stops a repeat deletion from sending requests all the way to
Kubernetes, and gives a clear error message when a deletion is requested
on an already deleted resource.

Relates to #972
