### PR TITLE
Add subcommands to inspect only chart or values

### DIFF
--- a/cmd/helm/inspect_test.go
+++ b/cmd/helm/inspect_test.go
@@ -28,6 +28,7 @@ func TestInspect(t *testing.T) {
 
 	insp := &inspectCmd{
 		chartpath: "testdata/testcharts/alpine",
+		output:    "both",
 		out:       b,
 	}
 	insp.run()


### PR DESCRIPTION
Adds #977 

This adds two subcommands to inspect:  `inspect values` and `inspect chart`. 

If neither subcommand is called both values and the yaml file will be printed, otherwise it will only print what was specified. 

For example, `helm inspect values`, or `helm inspect chart`, or just `helm inspect`

Signed-off-by: Grantseltzer grantseltzer@gmail.com
