### PR TITLE
fix(tiller): remove partials and empty manifests

### DIFF
--- a/cmd/tiller/hooks.go
+++ b/cmd/tiller/hooks.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"path"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -79,6 +80,17 @@ func sortHooks(files map[string]string) ([]*release.Hook, map[string]string, err
 	generic := map[string]string{}
 
 	for n, c := range files {
+		// Skip partials. We could return these as a separate map, but there doesn't
+		// seem to be any need for that at this time.
+		if strings.HasPrefix(path.Base(n), "_") {
+			continue
+		}
+		// Skip empty files, and log this.
+		if len(strings.TrimSpace(c)) == 0 {
+			log.Printf("info: manifest %q is empty. Skipping.", n)
+			continue
+		}
+
 		var sh simpleHead
 		err := yaml.Unmarshal([]byte(c), &sh)
 

--- a/cmd/tiller/hooks_test.go
+++ b/cmd/tiller/hooks_test.go
@@ -90,6 +90,20 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete, post-install
 `,
+		}, {
+			// Regression test: files with an underscore in the base name should be skipped.
+			name:     "sixth",
+			path:     "six/_six",
+			kind:     "ReplicaSet",
+			hooks:    []release.Hook_Event{},
+			manifest: `invalid manifest`, // This will fail if partial is not skipped.
+		}, {
+			// Regression test: files with no content should be skipped.
+			name:     "seventh",
+			path:     "seven",
+			kind:     "ReplicaSet",
+			hooks:    []release.Hook_Event{},
+			manifest: "",
 		},
 	}
 
@@ -103,6 +117,7 @@ metadata:
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
+	// This test will fail if 'six' or 'seven' was added.
 	if len(generic) != 1 {
 		t.Errorf("Expected 1 generic manifest, got %d", len(generic))
 	}


### PR DESCRIPTION
This removes partials and empty manifests during the sortHooks
operation. Doing so makes sortHooks the defacto place for sorting
manifests, hooks, and partials.

Closes #991
