### PR TITLE
Add a strict flag to helm lint

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -47,7 +47,10 @@ var lintCommand = &cobra.Command{
 	RunE:  lintCmd,
 }
 
+var flagStrict bool
+
 func init() {
+	lintCommand.Flags().BoolVarP(&flagStrict, "strict", "", false, "fail on lint warnings")
 	RootCommand.AddCommand(lintCommand)
 }
 
@@ -57,6 +60,13 @@ func lintCmd(cmd *cobra.Command, args []string) error {
 	paths := []string{"."}
 	if len(args) > 0 {
 		paths = args
+	}
+
+	var lowestTolerance int
+	if flagStrict {
+		lowestTolerance = support.WarningSev
+	} else {
+		lowestTolerance = support.ErrorSev
 	}
 
 	var total int
@@ -77,7 +87,7 @@ func lintCmd(cmd *cobra.Command, args []string) error {
 			}
 
 			total = total + 1
-			if linter.HighestSeverity >= support.ErrorSev {
+			if linter.HighestSeverity >= lowestTolerance {
 				failures = failures + 1
 			}
 		}


### PR DESCRIPTION
being total novice on both helm and golang, for having more effective use of helm lint on our charts repo CI I've added a flag, --strict, which makes "helm lint" command to treat warnings as errors. I am not completely sure if this is possible with some other way currently but I've found this useful for our project so just wanted to share it with others. Thank you
