### PR TITLE
ref(templates): change GetString to Get

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -32,11 +32,14 @@ func NewFiles(from []*any.Any) Files {
 	return files
 }
 
-// Get a file by path.
+// GetBytes gets a file by path.
+//
+// The returned data is raw. In a template context, this is identical to calling
+// {{index .Files $path}}.
 //
 // This is intended to be accessed from within a template, so a missed key returns
 // an empty []byte.
-func (f Files) Get(name string) []byte {
+func (f Files) GetBytes(name string) []byte {
 	v, ok := f[name]
 	if !ok {
 		return []byte{}
@@ -44,10 +47,12 @@ func (f Files) Get(name string) []byte {
 	return v
 }
 
-// GetString returns a string representation of the given file.
+// Get returns a string representation of the given file.
 //
-// This is a convenience for the otherwise cumbersome template logic
-// for '{{.Files.Get "foo" | printf "%s"}}'.
-func (f Files) GetString(name string) string {
-	return string(f.Get(name))
+// Fetch the contents of a file as a string. It is designed to be called in a
+// template.
+//
+//	{{.Files.Get "foo"}}
+func (f Files) Get(name string) string {
+	return string(f.GetBytes(name))
 }

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -43,10 +43,10 @@ func TestNewFiles(t *testing.T) {
 	}
 
 	for i, f := range cases {
-		if got := string(files.Get(f.path)); got != f.data {
+		if got := string(files.GetBytes(f.path)); got != f.data {
 			t.Errorf("%d: expected %q, got %q", i, f.data, got)
 		}
-		if got := files.GetString(f.path); got != f.data {
+		if got := files.Get(f.path); got != f.data {
 			t.Errorf("%d: expected %q, got %q", i, f.data, got)
 		}
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -312,7 +312,7 @@ func TestRenderBuiltinValues(t *testing.T) {
 		Metadata: &chart.Metadata{Name: "Latium"},
 		Templates: []*chart.Template{
 			{Name: "Lavinia", Data: []byte(`{{.Template.Name}}{{.Chart.Name}}{{.Release.Name}}`)},
-			{Name: "From", Data: []byte(`{{.Files.author | printf "%s"}} {{.Files.GetString "book/title.txt"}}`)},
+			{Name: "From", Data: []byte(`{{.Files.author | printf "%s"}} {{.Files.Get "book/title.txt"}}`)},
 		},
 		Values:       &chart.Config{Raw: ``},
 		Dependencies: []*chart.Chart{},


### PR DESCRIPTION
This changes "pkg/chartutil".Files.Get to return a string, removes
"pkg/chartutil".Files.GetString, and adds
"pkg/chartutil".Files.GetBytes.

Closes #1020
