### PR TITLE
Check for the tgz extension while collecting chart paths

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -98,8 +98,7 @@ func LoadChartRepository(dir, url string) (*ChartRepository, error) {
 					return nil
 				}
 				r.IndexFile = i
-			} else {
-				// TODO: check for tgz extension
+			} else if strings.HasSuffix(f.Name(), ".tgz") {
 				r.ChartPaths = append(r.ChartPaths, path)
 			}
 		}


### PR DESCRIPTION
Finished a commented TODO which caught me while I was trying to publish my charts to GitHub Pages 😄 

Without this patch, `helm repo index <DIR> <URL>` ends up with a confusing error `Error: gzip: invalid header` when `<DIR>` contains files other than `.tgz`:

```
$ git worktree add pages gh-pages

$ ls pages/
.git             .helmignore      mysql-0.2.0.tgz

$ cat pages/.helmignore
.git

$ helm repo index pages/ https://mumoshu.github.io/charts
Error: gzip: invalid header
```
