### PR TITLE
feat(kube): add update logic to kube client

### DIFF
--- a/cmd/tiller/environment/environment.go
+++ b/cmd/tiller/environment/environment.go
@@ -161,6 +161,15 @@ type KubeClient interface {
 	// For all other kinds, it means the kind was created or modified without
 	// error.
 	WatchUntilReady(namespace string, reader io.Reader) error
+
+	// Update updates one or more resources or creates the resource
+	// if it doesn't exist
+	//
+	// namespace must contain a valid existing namespace
+	//
+	// reader must contain a YAML stream (one or more YAML documents separated
+	// by "\n---\n").
+	Update(namespace string, originalReader, modifiedReader io.Reader) error
 }
 
 // PrintingKubeClient implements KubeClient, but simply prints the reader to
@@ -186,6 +195,12 @@ func (p *PrintingKubeClient) Delete(ns string, r io.Reader) error {
 // WatchUntilReady implements KubeClient WatchUntilReady.
 func (p *PrintingKubeClient) WatchUntilReady(ns string, r io.Reader) error {
 	_, err := io.Copy(p.Out, r)
+	return err
+}
+
+// Update implements KubeClient Update.
+func (p *PrintingKubeClient) Update(ns string, currentReader, modifiedReader io.Reader) error {
+	_, err := io.Copy(p.Out, modifiedReader)
 	return err
 }
 

--- a/cmd/tiller/environment/environment_test.go
+++ b/cmd/tiller/environment/environment_test.go
@@ -83,6 +83,9 @@ func (k *mockKubeClient) Create(ns string, r io.Reader) error {
 func (k *mockKubeClient) Delete(ns string, r io.Reader) error {
 	return nil
 }
+func (k *mockKubeClient) Update(ns string, currentReader, modifiedReader io.Reader) error {
+	return nil
+}
 func (k *mockKubeClient) WatchUntilReady(ns string, r io.Reader) error {
 	return nil
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,8 @@ import:
   - pkg/api
   - pkg/api/meta
   - pkg/api/error
+  - pkg/api/unversioned
+  - pkg/apimachinery/registered
   - pkg/client/restclient
   - pkg/client/unversioned
   - pkg/apis/batch
@@ -40,6 +42,8 @@ import:
   - pkg/labels
   - pkg/runtime
   - pkg/watch
+  - pkg/util/strategicpatch
+  - pkg/util/yaml
 - package: github.com/gosuri/uitable
 - package: speter.net/go/exp/math/dec/inf
   version: ^0.9.0

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -251,8 +251,7 @@ func updateResource(modified *resource.Info, currentObj runtime.Object) error {
 
 	// send patch to server
 	helper := resource.NewHelper(modified.Client, modified.Mapping)
-	_, err = helper.Patch(modified.Namespace, modified.Name, api.StrategicMergePatchType, patch)
-	if err != nil {
+	if _, err = helper.Patch(modified.Namespace, modified.Name, api.StrategicMergePatchType, patch); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit adds an Update function to the client.
The Update function takes in the modified manifests and
the original manifests. It then iterates through the modified
objects, creates objects not found in kubernetes, and updates
objects that exists but have been modified. Finally, it
iterates through the original resources and checks to see if
they have been deleted in the modified configuration and then
proceeds to delete them. #690
