### PR TITLE
docs(developers): recommend minikube

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,9 +75,8 @@ The Go files generated from the `proto` definitions are stored in
 Docker images are built by cross-compiling Linux binaries and then
 building a Docker image from the files in `rootfs`.
 
-The `scripts/` directory contains a number of utility scripts, including
-`local-cluster.sh`, which can start a full Kubernetes instance inside of
-a Docker container.
+The `scripts/` directory contains a number of utility scripts. Most of these
+are used by the CI/CD pipeline.
 
 Go dependencies are managed with
 [Glide](https://github.com/Masterminds/glide) and stored in the

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -66,11 +66,31 @@ GCR registry.
 
 ## Running a Local Cluster
 
-You can run tests locally using the `scripts/local-cluster.sh` script to
-start Kubernetes inside of a Docker container. For OS X, you will need
-to be running `docker-machine`.
+For development, we highly recommend using the
+[Kubernetes Minikube](https://github.com/kubernetes/minikube)
+developer-oriented distribution. Once this is installed, you can use 
+`helm init` to install into the cluster.
 
-Tiller should run on any >= 1.2 Kubernetes cluster with beta extensions.
+For developing on Tiller, it is sometimes more expedient to run Tiller locally
+instead of packaging it into an image and running it in-cluster. You can do
+this by telling the Helm client to us a local instance.
+
+```console
+$ make build
+$ bin/tiller
+```
+
+And to configure the Helm client, use the `--host` flag or export the `HELM_HOST`
+environment variable:
+
+```console
+$ export HELM_HOST=localhost:44134
+$ helm install foo
+```
+
+(Note that you do not need to use `helm init` when you are running Tiller directly)
+
+Tiller should run on any >= 1.3 Kubernetes cluster.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
This reflects our internal decision to suggest minikube rather than
commit resources to maintaining scripts/local-cluster.sh

Closes #889
