### PR TITLE
Fix the clean task when directory not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ protoc:
 .PHONY: clean
 clean:
 	@rm -rf $(BINDIR)
-	@rm ./rootfs/tiller
+	@rm -f ./rootfs/tiller
 
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
The Makefile has clean task that was failing when the ./rootfs/tiller was not present.
