### PR TITLE
feat(tiller): make configmaps the default storage

### DIFF
--- a/cmd/tiller/environment/environment_test.go
+++ b/cmd/tiller/environment/environment_test.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/storage"
 	"k8s.io/helm/pkg/storage/driver"
+	unversionedclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
 
 type mockEngine struct {
@@ -45,6 +47,10 @@ var _ driver.Driver = (*mockReleaseStorage)(nil)
 func (r *mockReleaseStorage) Create(v *release.Release) error {
 	r.rel = v
 	return nil
+}
+
+func (r *mockReleaseStorage) Name() string {
+	return "mockReleaseStorage"
 }
 
 func (r *mockReleaseStorage) Get(k string) (*release.Release, error) {
@@ -79,6 +85,10 @@ func (r *mockReleaseStorage) History(n string) ([]*release.Release, error) {
 }
 
 type mockKubeClient struct {
+}
+
+func (k *mockKubeClient) APIClient() (unversionedclient.Interface, error) {
+	return testclient.NewSimpleFake(), nil
 }
 
 func (k *mockKubeClient) Create(ns string, r io.Reader) error {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/batch"
+	unversionedclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -53,6 +54,16 @@ func New(config clientcmd.ClientConfig) *Client {
 
 // ResourceActorFunc performs an action on a single resource.
 type ResourceActorFunc func(*resource.Info) error
+
+// APIClient returns a Kubernetes API client.
+//
+// This is necessary because cmdutil.Client is a field, not a method, which
+// means it can't satisfy an interface's method requirement. In order to ensure
+// that an implementation of environment.KubeClient can access the raw API client,
+// it is necessary to add this method.
+func (c *Client) APIClient() (unversionedclient.Interface, error) {
+	return c.Client()
+}
 
 // Create creates kubernetes resources from an io.reader
 //

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -32,6 +32,9 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
+// ConfigMapsDriverName is the string name of the driver.
+const ConfigMapsDriverName = "ConfigMap"
+
 var b64 = base64.StdEncoding
 
 // labels is a map of key value pairs to be included as metadata in a configmap object.
@@ -52,6 +55,11 @@ type ConfigMaps struct {
 // the kubernetes ConfigMapsInterface.
 func NewConfigMaps(impl client.ConfigMapsInterface) *ConfigMaps {
 	return &ConfigMaps{impl: impl}
+}
+
+// Name returns the name of the driver.
+func (cfgmaps *ConfigMaps) Name() string {
+	return ConfigMapsDriverName
 }
 
 // Get fetches the release named by key. The corresponding release is returned

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -27,6 +27,15 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned"
 )
 
+var _ Driver = &ConfigMaps{}
+
+func TestConfigMapName(t *testing.T) {
+	c := newTestFixture(t)
+	if c.Name() != ConfigMapsDriverName {
+		t.Errorf("Expected name to be %q, got %q", ConfigMapsDriverName, c.Name())
+	}
+}
+
 func TestConfigMapGet(t *testing.T) {
 	key := "key-1"
 	rel := newTestRelease(key, 1, rspb.Status_DEPLOYED)

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -73,4 +73,5 @@ type Driver interface {
 	Updator
 	Deletor
 	Queryor
+	Name() string
 }

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -22,6 +22,9 @@ import (
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 )
 
+// MemoryDriverName is the string name of this driver.
+const MemoryDriverName = "Memory"
+
 // Memory is the in-memory storage driver implementation.
 type Memory struct {
 	sync.RWMutex
@@ -31,6 +34,11 @@ type Memory struct {
 // NewMemory initializes a new memory driver.
 func NewMemory() *Memory {
 	return &Memory{cache: map[string]*rspb.Release{}}
+}
+
+// Name returns the name of the driver.
+func (mem *Memory) Name() string {
+	return MemoryDriverName
 }
 
 // Get returns the release named by key or returns ErrReleaseNotFound.

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -23,6 +23,15 @@ import (
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 )
 
+var _ Driver = &Memory{}
+
+func TestMemoryName(t *testing.T) {
+	mem := NewMemory()
+	if mem.Name() != MemoryDriverName {
+		t.Errorf("Expected name to be %q, got %q", MemoryDriverName, mem.Name())
+	}
+}
+
 func TestMemoryGet(t *testing.T) {
 	key := "test-1"
 	rls := &rspb.Release{Name: key}


### PR DESCRIPTION
This adds a Tiller CLI flag to override the default, and tests to
make sure that the default comes up as expected.
