### PR TITLE
Include values from both --set and --values when specified on install

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -147,13 +147,28 @@ func (i *installCmd) run() error {
 }
 
 func (i *installCmd) vals() ([]byte, error) {
+	var buffer bytes.Buffer
+
+	// User specified a values file via -f/--values
+	if i.valuesFile != "" {
+		bytes, err := ioutil.ReadFile(i.valuesFile)
+		if err != nil {
+			return []byte{}, err
+		}
+		buffer.Write(bytes)
+	}
+
+	// User specified value pairs via --set
+	// These override any values in the specified file
 	if len(i.values.pairs) > 0 {
-		return i.values.yaml()
+		bytes, err := i.values.yaml()
+		if err != nil {
+			return []byte{}, err
+		}
+		buffer.Write(bytes)
 	}
-	if i.valuesFile == "" {
-		return []byte{}, nil
-	}
-	return ioutil.ReadFile(i.valuesFile)
+
+	return buffer.Bytes(), nil
 }
 
 func (i *installCmd) printRelease(rel *release.Release) {

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -121,6 +121,23 @@ sailor: sinbad
 	if vobj.String() != y {
 		t.Errorf("Expected String() to be \n%s\nGot\n%s\n", y, out)
 	}
+
+	// Combined case, overriding a property
+	vals["sailor"] = "pisti"
+	updated_yaml := `good: true
+port:
+  destination: basrah
+  source: baghdad
+sailor: pisti
+`
+	new_out, err := vobj.yaml()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(new_out) != updated_yaml {
+		t.Errorf("Expected YAML to be \n%s\nGot\n%s\n", updated_yaml, new_out)
+	}
+
 }
 
 type nameTemplateTestCase struct {


### PR DESCRIPTION
Hey @technosophos, here is the beginning of merging values like we talked about on Slack.

Appending them to the byte buffer was enough. Later, when YAML parses it, it merges. Latter fields override earlier, so I moved `--set` handling after `--values` handling.
1. Is this an ok approach?
2. Should I add it to `helm upgrade` too?
3. Anything else?
