### PR TITLE
fix(cmd): s/supress/suppress/

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -75,7 +75,7 @@ func (i *initCmd) run() error {
 			if !strings.Contains(err.Error(), `"tiller-deploy" already exists`) {
 				return fmt.Errorf("error installing: %s", err)
 			}
-			fmt.Fprintln(i.out, "Warning: Tiller is already installed in the cluster. (Use --client-only to supress this message.)")
+			fmt.Fprintln(i.out, "Warning: Tiller is already installed in the cluster. (Use --client-only to suppress this message.)")
 		} else {
 			fmt.Fprintln(i.out, "\nTiller (the helm server side component) has been installed into your Kubernetes Cluster.")
 		}


### PR DESCRIPTION
Suppress is spelled wrong.

Matt did it.

/cc @technosophos 
