### PR TITLE
Disable validateQuotes linter rule

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -92,7 +92,8 @@ func Templates(linter *support.Linter) {
 		// Check that all the templates have a matching value
 		linter.RunLinterRule(support.WarningSev, path, validateNoMissingValues(templatesPath, valuesToRender, preExecutedTemplate))
 
-		linter.RunLinterRule(support.WarningSev, path, validateQuotes(string(preExecutedTemplate)))
+		// NOTE, disabled for now, Refs https://github.com/kubernetes/helm/issues/1037
+		// linter.RunLinterRule(support.WarningSev, path, validateQuotes(string(preExecutedTemplate)))
 
 		renderedContent := renderedContentMap[fileName]
 		var yamlStruct K8sYamlStruct


### PR DESCRIPTION
Refs https://github.com/kubernetes/helm/issues/1037#issuecomment-240800636

I am usually pro-remove code instead of commenting it out. But in this case I think that having the code commented and a ref to the GH issue could help developers to understand why the behavior has changed and that it is WIP to be improved/changed.

If you prefer me to remove all the code `validateQuotes`, its tests, etc, please let me know and I will remove it instead.
