### PR TITLE
feat(tiller): limit the max len of Release.Name

### DIFF
--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -130,6 +130,7 @@ func TestUniqName(t *testing.T) {
 		{"angry-panda", "", false, true},
 		{"happy-panda", "", false, true},
 		{"happy-panda", "happy-panda", true, false},
+		{"hungry-hungry-hippos", "", true, true}, // Exceeds max name length
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This limits the number of characters in a release name to 14. This
preserves 10 characters for customizing the `name:` field in charts.

Relates to #1071

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1080)

<!-- Reviewable:end -->
