### PR TITLE
feat(tiller): verify apiVersions before install

### DIFF
--- a/cmd/tiller/environment/environment.go
+++ b/cmd/tiller/environment/environment.go
@@ -23,7 +23,6 @@ These dependencies are expressed as interfaces so that alternate implementations
 package environment
 
 import (
-	"errors"
 	"io"
 
 	"k8s.io/helm/pkg/chartutil"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/helm/pkg/storage"
 	"k8s.io/helm/pkg/storage/driver"
 	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
 
 // TillerNamespace is the namespace tiller is running in.
@@ -150,7 +150,7 @@ type PrintingKubeClient struct {
 // The printing client does not have access to a Kubernetes client at all. So it
 // will always return an error if the client is accessed.
 func (p *PrintingKubeClient) APIClient() (unversioned.Interface, error) {
-	return nil, errors.New("no API client found")
+	return testclient.NewSimpleFake(), nil
 }
 
 // Create prints the values of what would be created with a real KubeClient.

--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -108,6 +108,20 @@ func releaseStub() *release.Release {
 	}
 }
 
+func TestGetVersionSet(t *testing.T) {
+	rs := rsFixture()
+	vs, err := rs.getVersionSet()
+	if err != nil {
+		t.Error(err)
+	}
+	if !vs.Has("v1") {
+		t.Errorf("Expected supported versions to at least include v1.")
+	}
+	if vs.Has("nosuchversion/v1") {
+		t.Error("Non-existent version is reported found.")
+	}
+}
+
 func TestUniqName(t *testing.T) {
 	rs := rsFixture()
 


### PR DESCRIPTION
This changes Tiller so that Tiller checks every Kubernetes resource against the apiVersions that are loaded on the server, and returns an error if the API version on the resources is not supported by the server.

Closes #1001

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1097)

<!-- Reviewable:end -->
