### PR TITLE
ref(kube): delete skips IsNotFound errs

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -221,10 +221,16 @@ func (c *Client) Delete(namespace string, reader io.Reader) error {
 			if kubectl.IsNoSuchReaperError(err) {
 				return resource.NewHelper(info.Client, info.Mapping).Delete(info.Namespace, info.Name)
 			}
+
 			return err
 		}
 		log.Printf("Using reaper for deleting %s", info.Name)
-		return reaper.Stop(info.Namespace, info.Name, 0, nil)
+		err = reaper.Stop(info.Namespace, info.Name, 0, nil)
+		if err != nil && errors.IsNotFound(err) {
+			log.Printf("%v", err)
+			return nil
+		}
+		return err
 	})
 }
 


### PR DESCRIPTION
Currently, delete returns an error if a resource is not found.
That is a bit confusing because if you delete something that
is not found, the end state is not really an error. The end
state is what you wanted to do in the first place. This type
of error is not propogated from the kube client but it is logged
in tiller.  We could also change this to keep returning errors
(even the not found) and filter it out in the release server.

addresses #1101

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1102)

<!-- Reviewable:end -->
