### PR TITLE
feat(helm): allow multiple args for fetch, package, delete

### DIFF
--- a/cmd/helm/delete.go
+++ b/cmd/helm/delete.go
@@ -50,7 +50,7 @@ func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:               "delete [flags] RELEASE_NAME",
+		Use:               "delete [flags] RELEASE_NAME [...]",
 		Aliases:           []string{"del"},
 		SuggestFor:        []string{"remove", "rm"},
 		Short:             "given a release name, delete the release from Kubernetes",
@@ -60,9 +60,15 @@ func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			if len(args) == 0 {
 				return errors.New("command 'delete' requires a release name")
 			}
-			del.name = args[0]
 			del.client = ensureHelmClient(del.client)
-			return del.run()
+
+			for i := 0; i < len(args); i++ {
+				del.name = args[i]
+				if err := del.run(); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 	f := cmd.Flags()

--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -64,15 +64,20 @@ func newFetchCmd(out io.Writer) *cobra.Command {
 	fch := &fetchCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:   "fetch [chart URL | repo/chartname]",
+		Use:   "fetch [flags] [chart URL | repo/chartname] [...]",
 		Short: "download a chart from a repository and (optionally) unpack it in local directory",
 		Long:  fetchDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("This command needs at least one argument, url or repo/name of the chart.")
 			}
-			fch.chartRef = args[0]
-			return fch.run()
+			for i := 0; i < len(args); i++ {
+				fch.chartRef = args[i]
+				if err := fch.run(); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -57,14 +57,13 @@ func newPackageCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		out: out,
 	}
 	cmd := &cobra.Command{
-		Use:   "package [CHART_PATH]",
+		Use:   "package [flags] [CHART_PATH] [...]",
 		Short: "package a chart directory into a chart archive",
 		Long:  packageDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("This command needs at least one argument, the path to the chart.")
 			}
-			pkg.path = args[0]
 			if pkg.sign {
 				if pkg.key == "" {
 					return errors.New("--key is required for signing a package")
@@ -73,7 +72,13 @@ func newPackageCmd(client helm.Interface, out io.Writer) *cobra.Command {
 					return errors.New("--keyring is required for signing a package")
 				}
 			}
-			return pkg.run(cmd, args)
+			for i := 0; i < len(args); i++ {
+				pkg.path = args[i]
+				if err := pkg.run(cmd, args); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
This allows the following commands to accept more than one argument on
the CLI:
- helm fetch
- helm package
- helm delete

Closes #1100

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1104)

<!-- Reviewable:end -->
