### PR TITLE
ref(pkg/client): move pkg/client to cmd/helm/installer

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/helm/pkg/client"
+	"k8s.io/helm/cmd/helm/installer"
 )
 
 const initDesc = `
@@ -71,7 +71,7 @@ func (i *initCmd) run() error {
 	}
 
 	if !i.clientOnly {
-		if err := client.Install(tillerNamespace, i.image, flagDebug); err != nil {
+		if err := installer.Install(tillerNamespace, i.image, flagDebug); err != nil {
 			if !strings.Contains(err.Error(), `"tiller-deploy" already exists`) {
 				return fmt.Errorf("error installing: %s", err)
 			}

--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client // import "k8s.io/helm/pkg/client"
+package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
 	"bytes"


### PR DESCRIPTION
This is a minor refactor to move a leftover from Ancient Helm into the
current design. Specifically, the code to install Tiller from the Helm
client is now in `cmd/helm/installer`.

Closes #1033

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1105)

<!-- Reviewable:end -->
