### PR TITLE
fix(tiller): truncate release name returned from moniker

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -333,8 +333,7 @@ func (s *releaseServer) uniqName(start string, reuse bool) (string, error) {
 		namer := moniker.New()
 		name := namer.NameSep("-")
 		if len(name) > releaseNameMaxLen {
-			log.Printf("info: Candidate name %q exceeds maximum length %d. Skipping.", name, releaseNameMaxLen)
-			continue
+			name = name[:releaseNameMaxLen]
 		}
 		if _, err := s.env.Releases.Get(name); err == driver.ErrReleaseNotFound {
 			return name, nil


### PR DESCRIPTION
fixes #1113 
- Truncate release name candidate provided by moniker to 14 characters
- Ensures tiller unit tests / install will not periodically fail, when moniker returns 5 "greater then 14 char" names

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1114)

<!-- Reviewable:end -->
