### PR TITLE
feat(helm): package to ignore all dotfiles by default

### DIFF
--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -208,6 +208,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 		}
 		rules = r
 	}
+	rules.AddDefaults()
 
 	files := []*afile{}
 	topdir += string(filepath.Separator)

--- a/pkg/ignore/rules.go
+++ b/pkg/ignore/rules.go
@@ -42,6 +42,13 @@ func Empty() *Rules {
 	return &Rules{patterns: []*pattern{}}
 }
 
+// AddDefaults adds default ignore patterns.
+//
+// Ignore all dotfiles in "templates/"
+func (r *Rules) AddDefaults() {
+	r.parseRule(`templates/.?*`)
+}
+
 // ParseFile parses a helmignore file and returns the *Rules.
 func ParseFile(file string) (*Rules, error) {
 	f, err := os.Open(file)

--- a/pkg/ignore/rules_test.go
+++ b/pkg/ignore/rules_test.go
@@ -63,7 +63,6 @@ func TestParseFail(t *testing.T) {
 			t.Errorf("Rule %q should have failed", fail)
 		}
 	}
-
 }
 
 func TestParseFile(t *testing.T) {
@@ -99,6 +98,7 @@ func TestIgnore(t *testing.T) {
 		{`cargo/*.*`, "cargo/a.txt", true},
 		{`cargo/*.txt`, "mast/a.txt", false},
 		{`ru[c-e]?er.txt`, "rudder.txt", true},
+		{`templates/.?*`, "templates/.dotfile", true},
 
 		// Directory tests
 		{`cargo/`, "cargo", true},
@@ -131,6 +131,15 @@ func TestIgnore(t *testing.T) {
 		if r.Ignore(test.name, fi) != test.expect {
 			t.Errorf("Expected %q to be %v for pattern %q", test.name, test.expect, test.pattern)
 		}
+	}
+}
+
+func TestAddDefaults(t *testing.T) {
+	r := Rules{}
+	r.AddDefaults()
+
+	if len(r.patterns) != 1 {
+		t.Errorf("Expected 1 default patterns, got %d", len(r.patterns))
 	}
 }
 


### PR DESCRIPTION
resolves: #1018
- ~~Adds default ignore rules, so that all dotfiles and dot directories in a chart are ignored~~
- ~~dotfiles are ignored in all of the chart directory, not just in templates as proposed in #1018~~
- ~~Will result in ".helmignore" files, not being packaged in the chart tgz~~
- Adds default ignore rules, so that all dot files in "templates/" are ignored

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1116)

<!-- Reviewable:end -->
