### PR TITLE
feat(helm): package to support linting a chart

### DIFF
--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -64,6 +64,13 @@ func TestPackage(t *testing.T) {
 			hasfile: "alpine-0.1.0.tgz",
 		},
 		{
+			name:    "package testdata/testcharts/alpine --no-lint",
+			args:    []string{"testdata/testcharts/alpine"},
+			flags:   map[string]string{"nolint": "1"},
+			expect:  "",
+			hasfile: "alpine-0.1.0.tgz",
+		},
+		{
 			name:    "package --sign --key=KEY --keyring=KEYRING testdata/testcharts/alpine",
 			args:    []string{"testdata/testcharts/alpine"},
 			flags:   map[string]string{"sign": "1", "keyring": "testdata/helm-test-key.secret", "key": "helm-test"},


### PR DESCRIPTION
resolves: #1119
- Adds support to package cmd for a "--lint " flag, which lints a chart before packaging
- If there are any error's, the chart is not packaged

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1121)

<!-- Reviewable:end -->
