### PR TITLE
fix(tiller): return status for deleted release

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -83,7 +83,9 @@ func PrintStatus(out io.Writer, res *services.GetReleaseStatusResponse) {
 		fmt.Fprintf(out, "Details: %s\n", res.Info.Status.Details)
 	}
 	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "Resources:\n%s\n", res.Info.Status.Resources)
+	if len(res.Info.Status.Resources) > 0 {
+		fmt.Fprintf(out, "Resources:\n%s\n", res.Info.Status.Resources)
+	}
 	if len(res.Info.Status.Notes) > 0 {
 		fmt.Fprintf(out, "Notes:\n%s\n", res.Info.Status.Notes)
 	}

--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -711,6 +711,25 @@ func TestGetReleaseStatus(t *testing.T) {
 	}
 }
 
+func TestGetReleaseStatusDeleted(t *testing.T) {
+	c := context.Background()
+	rs := rsFixture()
+	rel := releaseStub()
+	rel.Info.Status.Code = release.Status_DELETED
+	if err := rs.env.Releases.Create(rel); err != nil {
+		t.Fatalf("Could not store mock release: %s", err)
+	}
+
+	res, err := rs.GetReleaseStatus(c, &services.GetReleaseStatusRequest{Name: rel.Name})
+	if err != nil {
+		t.Errorf("Error getting release content: %s", err)
+	}
+
+	if res.Info.Status.Code != release.Status_DELETED {
+		t.Errorf("Expected %d, got %d", release.Status_DELETED, res.Info.Status.Code)
+	}
+}
+
 func TestListReleases(t *testing.T) {
 	rs := rsFixture()
 	num := 7


### PR DESCRIPTION
This modifies `helm status` to return info about deleted and failed
releases. We do our best to retrieve info for releases that were
partially deployed.

Closes #1095

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1124)

<!-- Reviewable:end -->
