### PR TITLE
fix(tiller): store failed release on post-inst failure

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -588,7 +588,7 @@ func (s *releaseServer) execHook(hs []*release.Hook, name, namespace, hook strin
 
 		b := bytes.NewBufferString(h.Manifest)
 		if err := kubeCli.Create(namespace, b); err != nil {
-			log.Printf("wrning: Release %q pre-install %s failed: %s", name, h.Path, err)
+			log.Printf("warning: Release %q pre-install %s failed: %s", name, h.Path, err)
 			return err
 		}
 		// No way to rewind a bytes.Buffer()?

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -538,8 +538,8 @@ func (s *releaseServer) performRelease(r *release.Release, req *services.Install
 	kubeCli := s.env.KubeClient
 	b := bytes.NewBufferString(r.Manifest)
 	if err := kubeCli.Create(r.Namespace, b); err != nil {
-		r.Info.Status.Code = release.Status_FAILED
 		log.Printf("warning: Release %q failed: %s", r.Name, err)
+		r.Info.Status.Code = release.Status_FAILED
 		s.recordRelease(r, req.ReuseName)
 		return res, fmt.Errorf("release %s failed: %s", r.Name, err)
 	}
@@ -547,6 +547,9 @@ func (s *releaseServer) performRelease(r *release.Release, req *services.Install
 	// post-install hooks
 	if !req.DisableHooks {
 		if err := s.execHook(r.Hooks, r.Name, r.Namespace, postInstall); err != nil {
+			log.Printf("warning: Release %q failed post-install: %s", r.Name, err)
+			r.Info.Status.Code = release.Status_FAILED
+			s.recordRelease(r, req.ReuseName)
 			return res, err
 		}
 	}


### PR DESCRIPTION
This fixes a bug where post-install hooks did not result in recording a
failure.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1139)

<!-- Reviewable:end -->
