### PR TITLE
feat(helm): `--no-update` flag for `helm repo add`

### DIFF
--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -92,4 +92,12 @@ func TestRepoAdd(t *testing.T) {
 	if !f.Has(testName) {
 		t.Errorf("%s was not successfully inserted into %s", testName, hh.RepositoryFile())
 	}
+
+	if err := updateRepository(testName, ts.URL(), hh); err != nil {
+		t.Errorf("Repository was not updated: %s", err)
+	}
+
+	if err := addRepository(testName, ts.URL(), hh); err == nil {
+		t.Errorf("Duplicate repository name was added")
+	}
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -109,6 +109,20 @@ func (r *RepoFile) Add(re ...*Entry) {
 	r.Repositories = append(r.Repositories, re...)
 }
 
+// Update attempts to replace one or more repo entries in a repo file. If an
+// entry with the same name doesn't exist in the repo file it will add it.
+func (r *RepoFile) Update(re ...*Entry) {
+	for _, target := range re {
+		for j, repo := range r.Repositories {
+			if repo.Name == target.Name {
+				r.Repositories[j] = target
+				break
+			}
+		}
+		r.Add(target)
+	}
+}
+
 // Has returns true if the given name is already a repository name.
 func (r *RepoFile) Has(name string) bool {
 	for _, rf := range r.Repositories {


### PR DESCRIPTION
When using `--update` new repositories will be added in the same way as
without  `--update` but if the repository has already been registered
then the endpoint will be updated.

Closes #1141

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1142)

<!-- Reviewable:end -->
