### PR TITLE
feat(helm): add optional version flag to helm{get,status}

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -48,6 +48,7 @@ type getCmd struct {
 	release string
 	out     io.Writer
 	client  helm.Interface
+	version int32
 }
 
 func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
@@ -71,6 +72,9 @@ func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 			return get.run()
 		},
 	}
+
+	cmd.PersistentFlags().Int32Var(&get.version, "version", 0, "version of release")
+
 	cmd.AddCommand(newGetValuesCmd(nil, out))
 	cmd.AddCommand(newGetManifestCmd(nil, out))
 	cmd.AddCommand(newGetHooksCmd(nil, out))
@@ -96,7 +100,7 @@ MANIFEST:
 
 // getCmd is the command that implements 'helm get'
 func (g *getCmd) run() error {
-	res, err := g.client.ReleaseContent(g.release)
+	res, err := g.client.ReleaseContent(g.release, helm.ContentReleaseVersion(g.version))
 	if err != nil {
 		return prettyError(err)
 	}

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -73,7 +73,7 @@ func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().Int32Var(&get.version, "version", 0, "version of release")
+	cmd.PersistentFlags().Int32Var(&get.version, "version", 0, "get the named release with version")
 
 	cmd.AddCommand(newGetValuesCmd(nil, out))
 	cmd.AddCommand(newGetManifestCmd(nil, out))

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -35,6 +35,7 @@ type statusCmd struct {
 	release string
 	out     io.Writer
 	client  helm.Interface
+	version int32
 }
 
 func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
@@ -58,11 +59,14 @@ func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
 			return status.run()
 		},
 	}
+
+	cmd.PersistentFlags().Int32Var(&status.version, "version", 0, "version of release")
+
 	return cmd
 }
 
 func (s *statusCmd) run() error {
-	res, err := s.client.ReleaseStatus(s.release)
+	res, err := s.client.ReleaseStatus(s.release, helm.StatusReleaseVersion(s.version))
 	if err != nil {
 		return prettyError(err)
 	}

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -60,7 +60,7 @@ func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().Int32Var(&status.version, "version", 0, "version of release")
+	cmd.PersistentFlags().Int32Var(&status.version, "version", 0, "If set, display the status of the named release with version")
 
 	return cmd
 }


### PR DESCRIPTION
This adds a `--version` flag to `helm get` and `helm status` to refine querying for release information by (release_name, release_version) tuple.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1154)

<!-- Reviewable:end -->
