### PR TITLE
fix(helm): avoid a panic for sign

### DIFF
--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -153,7 +153,7 @@ func NewFromKeyring(keyringfile, id string) (*Signatory, error) {
 // The Signatory must have a valid Entity.PrivateKey for this to work. If it does
 // not, an error will be returned.
 func (s *Signatory) ClearSign(chartpath string) (string, error) {
-	if s.Entity.PrivateKey == nil {
+	if s.Entity == nil || s.Entity.PrivateKey == nil {
 		return "", errors.New("private key not found")
 	}
 


### PR DESCRIPTION
Before this fix:

```
 /Users/philips/src/k8s.io/helm/bin/helm package --sign mychart --key FC8A365E
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x13120a]

goroutine 1 [running]:
panic(0x10fed00, 0xc4200120d0)
        /usr/local/Cellar/go/1.7.1/libexec/src/runtime/panic.go:500 +0x1a1
k8s.io/helm/pkg/provenance.(*Signatory).ClearSign(0xc4205db100, 0xc42011ec20, 0x20, 0x8, 0xc4205db100, 0x0, 0x0)
        /Users/philips/src/k8s.io/helm/pkg/provenance/sign.go:156 +0x3a
main.(*packageCmd).clearsign(0xc420017720, 0xc42011ec20, 0x20, 0x0, 0x0)
        /Users/philips/src/k8s.io/helm/cmd/helm/package.go:143 +0xa5
main.(*packageCmd).run(0xc420017720, 0xc420390240, 0xc420120d00, 0x1, 0x4, 0x13639b0, 0x104dfe0)
        /Users/philips/src/k8s.io/helm/cmd/helm/package.go:130 +0x31b
main.newPackageCmd.func1(0xc420390240, 0xc420120d00, 0x1, 0x4, 0x0, 0x0)
        /Users/philips/src/k8s.io/helm/cmd/helm/package.go:77 +0xc4
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).execute(0xc420390240, 0xc420120c40, 0x4, 0x4, 0xc420390240, 0xc420120c40)
        /Users/philips/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:571 +0x234
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420405200, 0x0, 0x0, 0x0)
        /Users/philips/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:661 +0x367
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420405200, 0x1b52720, 0xc4200001a0)
        /Users/philips/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:620 +0x2b
main.main()
        /Users/philips/src/k8s.io/helm/cmd/helm/helm.go:110 +0x2d
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1164)

<!-- Reviewable:end -->
