### PR TITLE
docs(README): remove the build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Think of it like apt/yum/homebrew for Kubernetes.
 - Charts can be stored on disk, or fetched from remote chart repositories
   (like Debian or RedHat packages)
 
+## Install
+
+Download a [release tarball of helm for your platform](https://github.com/kubernetes/helm/releases). Unpack the `helm` binary and add it to your PATH and you are good to go! OS X/[Cask](https://caskroom.github.io/) users can `brew cask install helm`.
+
 ## Docs
 
 - [Quick Start](docs/quickstart.md)
@@ -36,36 +40,3 @@ Think of it like apt/yum/homebrew for Kubernetes.
 	- [Chart Repository Guide](docs/chart_repository.md)
 	- [Syncing your Chart Repository](docs/chart_repository_sync_example.md)
 - [Developers](docs/developers.md)
-
-
-## Install
-
-Download a [release tarball of helm and tiller for your platform](https://github.com/kubernetes/helm/releases). Unpack the `helm` and `tiller` binaries and add them to your PATH and you are good to go! OS X/[Cask](https://caskroom.github.io/) users can `brew cask install helm`.
-
-### Install from source
-
-To install Helm from source, follow this process:
-
-Make sure you have the prerequisites:
-- Go 1.6
-- A running Kubernetes cluster
-- `kubectl` properly configured to talk to your cluster
-- [Glide](https://glide.sh/) 0.10 or greater with both git and mercurial installed.
-
-1. [Properly set your $GOPATH](https://golang.org/doc/code.html)
-2. Clone (or otherwise download) this repository into $GOPATH/src/k8s.io/helm
-3. Run `make bootstrap build`
-
-You will now have two binaries built:
-
-- `bin/helm` is the client
-- `bin/tiller` is the server
-
-From here, you can run `bin/helm` and use it to install a recent snapshot of
-Tiller. Helm will use your `kubectl` config to learn about your cluster.
-
-For development on Tiller, you can locally run Tiller, or you build a Docker
-image (`make docker-build`) and then deploy it (`helm init -i IMAGE_NAME`).
-
-The [documentation](docs) folder contains more information about the
-architecture and usage of Helm/Tiller.


### PR DESCRIPTION
docs/developers.md already has these instructions. And 80% of the time
someone looking at this project is interested in getting started not
hacking directly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1176)

<!-- Reviewable:end -->
