### PR TITLE
feat(repo): use OCI style digest identifiers

### DIFF
--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -23,7 +23,7 @@ alpine-0.1.0:
   name: alpine
   url: https://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
   created: 2016-05-26 11:23:44.086354411 +0000 UTC
-  checksum: a61575c2d3160e5e39abf2a5ec984d6119404b18
+  digest: sha256:78e9a4282295184e8ce1496d23987993673f38e33e203c8bc18bc838a73e5864
   chartfile:
     name: alpine
     description: Deploy a basic Alpine Linux pod
@@ -33,7 +33,7 @@ redis-2.0.0:
   name: redis
   url: https://storage.googleapis.com/kubernetes-charts/redis-2.0.0.tgz
   created: 2016-05-26 11:23:44.087939192 +0000 UTC
-  checksum: 2cea3048cf85d588204e1b1cc0674472b4517919
+  digest: sha256:bde9c2949e64d059c18d8f93566a64dafc6d2e8e259a70322fb804831dfd0b5b
   chartfile:
     name: redis
     description: Port of the replicatedservice template from kubernetes/charts

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -39,7 +39,7 @@ type ChartRef struct {
 	URL       string          `yaml:"url"`
 	Created   string          `yaml:"created,omitempty"`
 	Removed   bool            `yaml:"removed,omitempty"`
-	Checksum  string          `yaml:"checksum,omitempty"`
+	Digest    string          `yaml:"digest,omitempty"`
 	Chartfile *chart.Metadata `yaml:"chartfile"`
 }
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -85,8 +85,8 @@ func TestIndex(t *testing.T) {
 		}
 		timestamps[chartName] = details.Created
 
-		if details.Checksum == "" {
-			t.Errorf("Checksum was not set for %s", chartName)
+		if details.Digest == "" {
+			t.Errorf("Digest was not set for %s", chartName)
 		}
 	}
 


### PR DESCRIPTION
Use the same format as the Open Container Initiative for a digest
string. https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests-and-verification

Fixes #1166

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1202)

<!-- Reviewable:end -->
