### PR TITLE
fix(helm-list): filter configmaps by owner=TILLER

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -84,7 +84,10 @@ func (cfgmaps *ConfigMaps) Get(key string) (*rspb.Release, error) {
 // that filter(release) == true. An error is returned if the
 // configmap fails to retrieve the releases.
 func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
-	list, err := cfgmaps.impl.List(api.ListOptions{})
+	lsel := kblabels.Set{"OWNER": "TILLER"}.AsSelector()
+	opts := api.ListOptions{LabelSelector: lsel}
+
+	list, err := cfgmaps.impl.List(opts)
 	if err != nil {
 		logerrf(err, "list: failed to list")
 		return nil, err

--- a/pkg/storage/driver/records.go
+++ b/pkg/storage/driver/records.go
@@ -125,6 +125,7 @@ func newRecord(key string, rls *rspb.Release) *record {
 
 	lbs.init()
 	lbs.set("NAME", rls.Name)
+	lbs.set("OWNER", "TILLER")
 	lbs.set("STATUS", rspb.Status_Code_name[int32(rls.Info.Status.Code)])
 	lbs.set("VERSION", strconv.Itoa(int(rls.Version)))
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -113,6 +113,7 @@ func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 
 	ls, err := s.Driver.Query(map[string]string{
 		"NAME":   name,
+		"OWNER":  "TILLER",
 		"STATUS": "DEPLOYED",
 	})
 	switch {


### PR DESCRIPTION
Credit to @adamreese for finding the cause of this bug (see issues #1173, #1195).

When storage is ConfigMaps, a label selector (`"OWNER=TILLER"`) is now applied to filter the configmaps within the kube-system namespace owned by tiller. The panic was caused by trying to decode release data that did not exist within a configmap not owned by tiller.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1207)

<!-- Reviewable:end -->
