### PR TITLE
update kube client: Refactor Resource Printer arguments

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -117,7 +117,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 	// an object type changes, so we can just rely on that. Problem is it doesn't seem to keep
 	// track of tab widths
 	buf := new(bytes.Buffer)
-	p := kubectl.NewHumanReadablePrinter(false, false, false, false, false, false, []string{})
+	p := kubectl.NewHumanReadablePrinter(&kubectl.PrintOptions{})
 	for t, ot := range objs {
 		_, err = buf.WriteString("==> " + t + "\n")
 		if err != nil {


### PR DESCRIPTION
According kubernetes revision: 5ed881c6c4d27885faebbd7563f0e0a5c51202a4

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1211)

<!-- Reviewable:end -->
