### PR TITLE
feat(helm): make long listing default for helm list

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -58,7 +58,7 @@ flag with the '--offset' flag allows you to page through results.
 
 type listCmd struct {
 	filter     string
-	long       bool
+	short      bool
 	limit      int
 	offset     string
 	byDate     bool
@@ -94,7 +94,7 @@ func newListCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		},
 	}
 	f := cmd.Flags()
-	f.BoolVarP(&list.long, "long", "l", false, "output long listing format")
+	f.BoolVarP(&list.short, "short", "q", false, "output short (quiet) listing format")
 	f.BoolVarP(&list.byDate, "date", "d", false, "sort by release date")
 	f.BoolVarP(&list.sortDesc, "reverse", "r", false, "reverse the sort order")
 	f.IntVarP(&list.limit, "max", "m", 256, "maximum number of releases to fetch")
@@ -144,14 +144,13 @@ func (l *listCmd) run() error {
 
 	rels := res.Releases
 
-	if l.long {
-		fmt.Fprintln(l.out, formatList(rels))
+	if l.short {
+		for _, r := range rels {
+			fmt.Fprintln(l.out, r.Name)
+		}
 		return nil
 	}
-	for _, r := range rels {
-		fmt.Fprintln(l.out, r.Name)
-	}
-
+	fmt.Fprintln(l.out, formatList(rels))
 	return nil
 }
 

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -40,8 +40,8 @@ func TestListCmd(t *testing.T) {
 			expected: "thomas-guide",
 		},
 		{
-			name: "list --long",
-			args: []string{"--long"},
+			name: "list",
+			args: []string{},
 			resp: []*release.Release{
 				releaseMock(&releaseOptions{name: "atlas"}),
 			},
@@ -49,7 +49,7 @@ func TestListCmd(t *testing.T) {
 		},
 		{
 			name: "with a release, multiple flags",
-			args: []string{"--deleted", "--deployed", "--failed"},
+			args: []string{"--deleted", "--deployed", "--failed", "-q"},
 			resp: []*release.Release{
 				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_DELETED}),
 				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
@@ -60,7 +60,7 @@ func TestListCmd(t *testing.T) {
 		},
 		{
 			name: "with a release, multiple flags",
-			args: []string{"--all"},
+			args: []string{"--all", "-q"},
 			resp: []*release.Release{
 				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_DELETED}),
 				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),


### PR DESCRIPTION
This removes --long and adds --short,-q

The default listing is now the long listing, which matches the behavior
of all of the other listing commands.

Closes #1215

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1224)

<!-- Reviewable:end -->
