### PR TITLE
feat(tiller): add toYaml template function

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -24,6 +24,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+	"github.com/ghodss/yaml"
+
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
@@ -49,9 +51,21 @@ func New() *Engine {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")
 	delete(f, "expandenv")
+
+	// Add a function to convert to YAML:
+	f["toYaml"] = toYaml
 	return &Engine{
 		FuncMap: f,
 	}
+}
+
+func toYaml(v interface{}) string {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return string(data)
 }
 
 // Render takes a chart, optional values, and value overrides, and attempts to render the Go templates.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -27,6 +27,19 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 )
 
+func TestToYaml(t *testing.T) {
+	expect := "foo: bar\n"
+	v := struct {
+		Foo string `json:"foo"`
+	}{
+		Foo: "bar",
+	}
+
+	if got := toYaml(v); got != expect {
+		t.Errorf("Expected %q, got %q", expect, got)
+	}
+}
+
 func TestEngine(t *testing.T) {
 	e := New()
 


### PR DESCRIPTION
This adds the function toYaml to the Engine template functions.

Closes #1225

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1230)

<!-- Reviewable:end -->
