### PR TITLE
feat(helm): add 'helm upgrade --install' support

### DIFF
--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -69,6 +69,13 @@ func TestUpgradeCmd(t *testing.T) {
 			resp:     releaseMock(&releaseOptions{name: "funny-bunny", version: 2, chart: ch}),
 			expected: "funny-bunny has been upgraded. Happy Helming!\n",
 		},
+		{
+			name:     "install a release with 'upgrade --install'",
+			args:     []string{"zany-bunny", chartPath},
+			flags:    []string{"-i"},
+			resp:     releaseMock(&releaseOptions{name: "zany-bunny", version: 1, chart: ch}),
+			expected: "zany-bunny has been upgraded. Happy Helming!\n",
+		},
 	}
 
 	cmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {


### PR DESCRIPTION
This makes it possible to run an upgrade that will install a release if
it doesn't already exist.

Closes #1042

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1232)

<!-- Reviewable:end -->
