### PR TITLE
chore(repo): Rename default charts repo to 'stable'

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -34,7 +34,7 @@ Kubernetes Cluster and sets up local configuration in $HELM_HOME (default: ~/.he
 `
 
 var (
-	defaultRepository    = "kubernetes-charts"
+	defaultRepository    = "stable"
 	defaultRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
 )
 


### PR DESCRIPTION
closes #1151

I think this is all that needs to be changed - I couldn't find any references to `kubernetes-charts/<name>` apart from the full URL which hasn't changed for now.

cc @technosophos @michelleN  @viglesiasce @jackfrancis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1234)

<!-- Reviewable:end -->
