### PR TITLE
chore(helm): add test coverage to pkg/helm

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm // import "k8s.io/helm/pkg/helm"
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"k8s.io/helm/pkg/chartutil"
+	cpb "k8s.io/helm/pkg/proto/hapi/chart"
+	rls "k8s.io/helm/pkg/proto/hapi/release"
+	tpb "k8s.io/helm/pkg/proto/hapi/services"
+)
+
+// path to example charts relative to pkg/helm.
+const chartsDir = "../../docs/examples/"
+
+// sentinel error to indicate to the helm client to not send the request to tiller.
+var errSkip = errors.New("test: skip")
+
+// Verify ReleaseListOption's are applied to a ListReleasesRequest correctly.
+func TestListReleases_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var limit = 2
+	var offset = "offset"
+	var filter = "filter"
+	var sortBy = int32(2)
+	var sortOrd = int32(1)
+	var codes = []rls.Status_Code{
+		rls.Status_FAILED,
+		rls.Status_DELETED,
+		rls.Status_DEPLOYED,
+		rls.Status_SUPERSEDED,
+	}
+
+	// Expected ListReleasesRequest message
+	exp := &tpb.ListReleasesRequest{
+		Limit:       int64(limit),
+		Offset:      offset,
+		Filter:      filter,
+		SortBy:      tpb.ListSort_SortBy(sortBy),
+		SortOrder:   tpb.ListSort_SortOrder(sortOrd),
+		StatusCodes: codes,
+	}
+
+	// Options used in ListReleases
+	ops := []ReleaseListOption{
+		ReleaseListSort(sortBy),
+		ReleaseListOrder(sortOrd),
+		ReleaseListLimit(limit),
+		ReleaseListOffset(offset),
+		ReleaseListFilter(filter),
+		ReleaseListStatuses(codes),
+	}
+
+	// BeforeCall option to intercept helm client ListReleasesRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.ListReleasesRequest:
+			t.Logf("ListReleasesRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type ListReleasesRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).ListReleases(ops...)
+}
+
+// Verify InstallOption's are applied to an InstallReleaseRequest correctly.
+func TestInstallRelease_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var disableHooks = true
+	var releaseName = "test"
+	var namespace = "default"
+	var reuseName = true
+	var dryRun = true
+	var chartName = "alpine"
+	var overrides = []byte("key1=value1,key2=value2")
+
+	// Expected InstallReleaseRequest message
+	exp := &tpb.InstallReleaseRequest{
+		Chart:        loadChart(t, chartName),
+		Values:       &cpb.Config{Raw: string(overrides)},
+		DryRun:       dryRun,
+		Name:         releaseName,
+		DisableHooks: disableHooks,
+		Namespace:    namespace,
+		ReuseName:    reuseName,
+	}
+
+	// Options used in InstallRelease
+	ops := []InstallOption{
+		ValueOverrides(overrides),
+		InstallDryRun(dryRun),
+		ReleaseName(releaseName),
+		InstallReuseName(reuseName),
+		InstallDisableHooks(disableHooks),
+	}
+
+	// BeforeCall option to intercept helm client InstallReleaseRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.InstallReleaseRequest:
+			t.Logf("InstallReleaseRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type InstallReleaseRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).InstallRelease(chartName, namespace, ops...)
+}
+
+// Verify DeleteOptions's are applied to an UninstallReleaseRequest correctly.
+func TestDeleteRelease_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var releaseName = "test"
+	var disableHooks = true
+	var purgeFlag = true
+
+	// Expected DeleteReleaseRequest message
+	exp := &tpb.UninstallReleaseRequest{
+		Name:         releaseName,
+		Purge:        purgeFlag,
+		DisableHooks: disableHooks,
+	}
+
+	// Options used in DeleteRelease
+	ops := []DeleteOption{
+		DeletePurge(purgeFlag),
+		DeleteDisableHooks(disableHooks),
+	}
+
+	// BeforeCall option to intercept helm client DeleteReleaseRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.UninstallReleaseRequest:
+			t.Logf("UninstallReleaseRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type UninstallReleaseRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).DeleteRelease(releaseName, ops...)
+}
+
+// Verify UpdateOption's are applied to an UpdateReleaseRequest correctly.
+func TestUpdateRelease_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var chartName = "alpine"
+	var releaseName = "test"
+	var disableHooks = true
+	var overrides = []byte("key1=value1,key2=value2")
+	var dryRun = false
+
+	// Expected UpdateReleaseRequest message
+	exp := &tpb.UpdateReleaseRequest{
+		Name:         releaseName,
+		Chart:        loadChart(t, chartName),
+		Values:       &cpb.Config{Raw: string(overrides)},
+		DryRun:       dryRun,
+		DisableHooks: disableHooks,
+	}
+
+	// Options used in UpdateRelease
+	ops := []UpdateOption{
+		UpgradeDryRun(dryRun),
+		UpdateValueOverrides(overrides),
+		UpgradeDisableHooks(disableHooks),
+	}
+
+	// BeforeCall option to intercept helm client UpdateReleaseRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.UpdateReleaseRequest:
+			t.Logf("UpdateReleaseRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type UpdateReleaseRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).UpdateRelease(releaseName, chartName, ops...)
+}
+
+// Verify RollbackOption's are applied to a RollbackReleaseRequest correctly.
+func TestRollbackRelease_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var disableHooks = true
+	var releaseName = "test"
+	var revision = int32(2)
+	var dryRun = true
+
+	// Expected RollbackReleaseRequest message
+	exp := &tpb.RollbackReleaseRequest{
+		Name:         releaseName,
+		DryRun:       dryRun,
+		Version:      revision,
+		DisableHooks: disableHooks,
+	}
+
+	// Options used in RollbackRelease
+	ops := []RollbackOption{
+		RollbackDryRun(dryRun),
+		RollbackVersion(revision),
+		RollbackDisableHooks(disableHooks),
+	}
+
+	// BeforeCall option to intercept helm client RollbackReleaseRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.RollbackReleaseRequest:
+			t.Logf("RollbackReleaseRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type RollbackReleaseRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).RollbackRelease(releaseName, ops...)
+}
+
+// Verify StatusOption's are applied to a GetReleaseStatusRequest correctly.
+func TestReleaseStatus_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var releaseName = "test"
+	var revision = int32(2)
+
+	// Expected GetReleaseStatusRequest message
+	exp := &tpb.GetReleaseStatusRequest{
+		Name:    releaseName,
+		Version: revision,
+	}
+
+	// BeforeCall option to intercept helm client GetReleaseStatusRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.GetReleaseStatusRequest:
+			t.Logf("GetReleaseStatusRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type GetReleaseStatusRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).ReleaseStatus(releaseName, StatusReleaseVersion(revision))
+}
+
+// Verify ContentOption's are applied to a GetReleaseContentRequest correctly.
+func TestReleaseContent_VerifyOptions(t *testing.T) {
+	// Options testdata
+	var releaseName = "test"
+	var revision = int32(2)
+
+	// Expected GetReleaseContentRequest message
+	exp := &tpb.GetReleaseContentRequest{
+		Name:    releaseName,
+		Version: revision,
+	}
+
+	// BeforeCall option to intercept helm client GetReleaseContentRequest
+	b4c := BeforeCall(func(_ context.Context, msg proto.Message) error {
+		switch act := msg.(type) {
+		case *tpb.GetReleaseContentRequest:
+			t.Logf("GetReleaseContentRequest: %#+v\n", act)
+			assert(t, exp, act)
+		default:
+			t.Fatalf("expected message of type GetReleaseContentRequest, got %T\n", act)
+		}
+		return errSkip
+	})
+
+	NewClient(b4c).ReleaseContent(releaseName, ContentReleaseVersion(revision))
+}
+
+func assert(t *testing.T, expect, actual interface{}) {
+	if !reflect.DeepEqual(expect, actual) {
+		t.Fatalf("expected %#+v, actual %#+v\n", expect, actual)
+	}
+}
+
+func loadChart(t *testing.T, name string) *cpb.Chart {
+	c, err := chartutil.Load(filepath.Join(chartsDir, name))
+	if err != nil {
+		t.Fatalf("failed to load test chart (%q): %s\n", name, err)
+	}
+	return c
+}


### PR DESCRIPTION
closes: #1157
1. Organize grpc-specific code for helm apis.
2. Decouple options-to-request bulding code from grpc-specific code.
3. Add 'BeforeCall' option to support intercepting requests before sending to tiller.
4. Add tests to verify tiller requests are being constructed correctly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1253)

<!-- Reviewable:end -->
