### PR TITLE
issue/1254

### DIFF
--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -215,7 +215,7 @@ and then pass that file during installation.
 
 ```console
 $ echo 'mariadbUser: user0` > config.yaml
-$ glide install -f config.yaml stable/mariadb
+$ helm install -f config.yaml stable/mariadb
 ```
 
 The above will set the default MariaDB user to `user0`, but accept all


### PR DESCRIPTION
Fix typo in docs/using_helm.md that refers to "glide install".  The
reference should be to "helm install".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1255)

<!-- Reviewable:end -->
