### PR TITLE
feat(helm): implement new index format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit:
-	$(GO) test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
+	HELM_HOME=/no/such/dir $(GO) test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
 
 .PHONY: test-style
 test-style:

--- a/cmd/helm/dependency_build_test.go
+++ b/cmd/helm/dependency_build_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestDependencyBuildCmd(t *testing.T) {
 	oldhome := helmHome
-	hh, err := tempHelmHome()
+	hh, err := tempHelmHome(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,8 +108,12 @@ func TestDependencyBuildCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if h := i.Entries["reqtest-0.1.0"].Digest; h != hash {
+	reqver := i.Entries["reqtest"][0]
+	if h := reqver.Digest; h != hash {
 		t.Errorf("Failed hash match: expected %s, got %s", hash, h)
+	}
+	if v := reqver.Version; v != "0.1.0" {
+		t.Errorf("mismatched versions. Expected %q, got %q", "0.1.0", v)
 	}
 
 }

--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -36,7 +36,7 @@ import (
 func TestDependencyUpdateCmd(t *testing.T) {
 	// Set up a testing helm home
 	oldhome := helmHome
-	hh, err := tempHelmHome()
+	hh, err := tempHelmHome(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,8 @@ func TestDependencyUpdateCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if h := i.Entries["reqtest-0.1.0"].Digest; h != hash {
+	reqver := i.Entries["reqtest"][0]
+	if h := reqver.Digest; h != hash {
 		t.Errorf("Failed hash match: expected %s, got %s", hash, h)
 	}
 

--- a/cmd/helm/downloader/chart_downloader_test.go
+++ b/cmd/helm/downloader/chart_downloader_test.go
@@ -47,7 +47,7 @@ func TestResolveChartRef(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		u, err := c.ResolveChartRef(tt.ref)
+		u, err := c.ResolveChartVersion(tt.ref)
 		if err != nil {
 			if tt.fail {
 				continue

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
@@ -1,38 +1,46 @@
-alpine-0.1.0:
-  name: alpine
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
-  created: 2016-09-06 21:58:44.211261566 +0000 UTC
-  checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
-  chartfile:
-    name: alpine
-    home: https://k8s.io/helm
-    sources:
-    - https://github.com/kubernetes/helm
-    version: 0.1.0
-    description: Deploy a basic Alpine Linux pod
-    keywords: []
-    maintainers: []
-    engine: ""
-    icon: ""
-mariadb-0.3.0:
-  name: mariadb
-  url: http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
-  created: 2016-09-06 21:58:44.211870222 +0000 UTC
-  checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
-  chartfile:
-    name: mariadb
-    home: https://mariadb.org
-    sources:
-    - https://github.com/bitnami/bitnami-docker-mariadb
-    version: 0.3.0
-    description: Chart for MariaDB
-    keywords:
-    - mariadb
-    - mysql
-    - database
-    - sql
-    maintainers:
-    - name: Bitnami
-      email: containers@bitnami.com
-    engine: gotpl
-    icon: ""
+apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 0.1.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""
+    - name: alpine
+      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 0.2.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""
+  mariadb:
+    - name: mariadb
+      url: http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
+      checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
+      home: https://mariadb.org
+      sources:
+      - https://github.com/bitnami/bitnami-docker-mariadb
+      version: 0.3.0
+      description: Chart for MariaDB
+      keywords:
+      - mariadb
+      - mysql
+      - database
+      - sql
+      maintainers:
+      - name: Bitnami
+        email: containers@bitnami.com
+      engine: gotpl
+      icon: ""

--- a/cmd/helm/downloader/testdata/helmhome/repository/repositories.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/repositories.yaml
@@ -1,1 +1,4 @@
-testing: "http://example.com"
+apiVersion: v1
+repositories:
+  - name: testing
+    url: "http://example.com"

--- a/cmd/helm/fetch_test.go
+++ b/cmd/helm/fetch_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFetchCmd(t *testing.T) {
-	hh, err := tempHelmHome()
+	hh, err := tempHelmHome(t)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/helm/helmpath/helmhome.go
+++ b/cmd/helm/helmpath/helmhome.go
@@ -56,6 +56,9 @@ func (h Home) CacheIndex(name string) string {
 // LocalRepository returns the location to the local repo.
 //
 // The local repo is the one used by 'helm serve'
-func (h Home) LocalRepository() string {
-	return filepath.Join(string(h), "repository/local")
+//
+// If additional path elements are passed, they are appended to the returned path.
+func (h Home) LocalRepository(paths ...string) string {
+	frag := append([]string{string(h), "repository/local"}, paths...)
+	return filepath.Join(frag...)
 }

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -25,7 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/helm/cmd/helm/helmpath"
 	"k8s.io/helm/cmd/helm/installer"
+	"k8s.io/helm/pkg/repo"
 )
 
 const initDesc = `
@@ -33,15 +35,18 @@ This command installs Tiller (the helm server side component) onto your
 Kubernetes Cluster and sets up local configuration in $HELM_HOME (default: ~/.helm/)
 `
 
-var (
-	defaultRepository    = "stable"
-	defaultRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
+const (
+	stableRepository    = "stable"
+	localRepository     = "local"
+	stableRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
+	localRepositoryURL  = "http://localhost:8879/charts"
 )
 
 type initCmd struct {
 	image      string
 	clientOnly bool
 	out        io.Writer
+	home       helmpath.Home
 }
 
 func newInitCmd(out io.Writer) *cobra.Command {
@@ -56,6 +61,7 @@ func newInitCmd(out io.Writer) *cobra.Command {
 			if len(args) != 0 {
 				return errors.New("This command does not accept arguments")
 			}
+			i.home = helmpath.Home(homePath())
 			return i.run()
 		},
 	}
@@ -66,7 +72,7 @@ func newInitCmd(out io.Writer) *cobra.Command {
 
 // runInit initializes local config and installs tiller to Kubernetes Cluster
 func (i *initCmd) run() error {
-	if err := ensureHome(); err != nil {
+	if err := ensureHome(i.home, i.out); err != nil {
 		return err
 	}
 
@@ -101,12 +107,11 @@ func requireHome() error {
 // ensureHome checks to see if $HELM_HOME exists
 //
 // If $HELM_HOME does not exist, this function will create it.
-func ensureHome() error {
-	configDirectories := []string{homePath(), repositoryDirectory(), cacheDirectory(), localRepoDirectory()}
-
+func ensureHome(home helmpath.Home, out io.Writer) error {
+	configDirectories := []string{home.String(), home.Repository(), home.Cache(), home.LocalRepository()}
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {
-			fmt.Printf("Creating %s \n", p)
+			fmt.Fprintf(out, "Creating %s \n", p)
 			if err := os.MkdirAll(p, 0755); err != nil {
 				return fmt.Errorf("Could not create %s: %s", p, err)
 			}
@@ -115,24 +120,41 @@ func ensureHome() error {
 		}
 	}
 
-	repoFile := repositoriesFile()
+	repoFile := home.RepositoryFile()
 	if fi, err := os.Stat(repoFile); err != nil {
-		fmt.Printf("Creating %s \n", repoFile)
-		if _, err := os.Create(repoFile); err != nil {
+		fmt.Fprintf(out, "Creating %s \n", repoFile)
+		r := repo.NewRepoFile()
+		r.Add(&repo.Entry{
+			Name:  stableRepository,
+			URL:   stableRepositoryURL,
+			Cache: "stable-index.yaml",
+		}, &repo.Entry{
+			Name:  localRepository,
+			URL:   localRepositoryURL,
+			Cache: "local-index.yaml",
+		})
+		if err := r.WriteFile(repoFile, 0644); err != nil {
 			return err
 		}
-		if err := addRepository(defaultRepository, defaultRepositoryURL); err != nil {
-			return err
+		cif := home.CacheIndex(stableRepository)
+		if err := repo.DownloadIndexFile(stableRepository, stableRepositoryURL, cif); err != nil {
+			fmt.Fprintf(out, "WARNING: Failed to download %s: %s (run 'helm update')\n", stableRepository, err)
 		}
 	} else if fi.IsDir() {
 		return fmt.Errorf("%s must be a file, not a directory", repoFile)
 	}
+	if r, err := repo.LoadRepositoriesFile(repoFile); err == repo.ErrRepoOutOfDate {
+		fmt.Fprintln(out, "Updating repository file format...")
+		if err := r.WriteFile(repoFile, 0644); err != nil {
+			return err
+		}
+	}
 
 	localRepoIndexFile := localRepoDirectory(localRepoIndexFilePath)
 	if fi, err := os.Stat(localRepoIndexFile); err != nil {
-		fmt.Printf("Creating %s \n", localRepoIndexFile)
-		_, err := os.Create(localRepoIndexFile)
-		if err != nil {
+		fmt.Fprintf(out, "Creating %s \n", localRepoIndexFile)
+		i := repo.NewIndexFile()
+		if err := i.WriteFile(localRepoIndexFile, 0644); err != nil {
 			return err
 		}
 
@@ -142,6 +164,6 @@ func ensureHome() error {
 		return fmt.Errorf("%s must be a file, not a directory", localRepoIndexFile)
 	}
 
-	fmt.Printf("$HELM_HOME has been configured at %s.\n", helmHome)
+	fmt.Fprintf(out, "$HELM_HOME has been configured at %s.\n", helmHome)
 	return nil
 }

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/cmd/helm/helmpath"
 )
 
 func TestPackage(t *testing.T) {
@@ -58,6 +60,13 @@ func TestPackage(t *testing.T) {
 			err:    true,
 		},
 		{
+			name:    "package testdata/testcharts/alpine, no save",
+			args:    []string{"testdata/testcharts/alpine"},
+			flags:   map[string]string{"save": "0"},
+			expect:  "",
+			hasfile: "alpine-0.1.0.tgz",
+		},
+		{
 			name:    "package testdata/testcharts/alpine",
 			args:    []string{"testdata/testcharts/alpine"},
 			expect:  "",
@@ -87,7 +96,11 @@ func TestPackage(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ensureTestHome(helmpath.Home(tmp), t)
+	oldhome := homePath()
+	helmHome = tmp
 	defer func() {
+		helmHome = oldhome
 		os.Chdir(origDir)
 		os.RemoveAll(tmp)
 	}()

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -17,45 +17,52 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 
+	"k8s.io/helm/cmd/helm/helmpath"
 	"k8s.io/helm/pkg/repo"
 )
 
 func TestRepoRemove(t *testing.T) {
 	testURL := "https://test-url.com"
-	home := createTmpHome()
-	helmHome = home
-	if err := ensureHome(); err != nil {
-		t.Errorf("%s", err)
-	}
 
-	if err := removeRepoLine(testName); err == nil {
+	b := bytes.NewBuffer(nil)
+
+	home, err := tempHelmHome(t)
+	defer os.Remove(home)
+	hh := helmpath.Home(home)
+
+	if err := removeRepoLine(b, testName, hh); err == nil {
 		t.Errorf("Expected error removing %s, but did not get one.", testName)
 	}
-
-	if err := insertRepoLine(testName, testURL); err != nil {
-		t.Errorf("%s", err)
+	if err := insertRepoLine(testName, testURL, hh); err != nil {
+		t.Error(err)
 	}
 
-	mf, _ := os.Create(cacheIndexFile(testName))
+	mf, _ := os.Create(hh.CacheIndex(testName))
 	mf.Close()
 
-	if err := removeRepoLine(testName); err != nil {
+	b.Reset()
+	if err := removeRepoLine(b, testName, hh); err != nil {
 		t.Errorf("Error removing %s from repositories", testName)
 	}
+	if !strings.Contains(b.String(), "has been removed") {
+		t.Errorf("Unexpected output: %s", b.String())
+	}
 
-	if _, err := os.Stat(cacheIndexFile(testName)); err == nil {
+	if _, err := os.Stat(hh.CacheIndex(testName)); err == nil {
 		t.Errorf("Error cache file was not removed for repository %s", testName)
 	}
 
-	f, err := repo.LoadRepositoriesFile(repositoriesFile())
+	f, err := repo.LoadRepositoriesFile(hh.RepositoryFile())
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Error(err)
 	}
 
-	if _, ok := f.Repositories[testName]; ok {
+	if f.Has(testName) {
 		t.Errorf("%s was not successfully removed from repositories list", testName)
 	}
 }

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -101,11 +101,12 @@ func (s *searchCmd) buildIndex() (*search.Index, error) {
 	}
 
 	i := search.NewIndex()
-	for n := range rf.Repositories {
+	for _, re := range rf.Repositories {
+		n := re.Name
 		f := s.helmhome.CacheIndex(n)
 		ind, err := repo.LoadIndexFile(f)
 		if err != nil {
-			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt. Try 'helm update': %s", f, err)
+			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt or missing. Try 'helm update':\n\t%s\n", f, err)
 			continue
 		}
 

--- a/cmd/helm/search/search_test.go
+++ b/cmd/helm/search/search_test.go
@@ -52,32 +52,43 @@ func TestSortScore(t *testing.T) {
 
 var testCacheDir = "../testdata/"
 
-var indexfileEntries = map[string]*repo.ChartRef{
-	"niña-0.1.0": {
-		Name: "niña",
-		URL:  "http://example.com/charts/nina-0.1.0.tgz",
-		Chartfile: &chart.Metadata{
-			Name:        "niña",
-			Version:     "0.1.0",
-			Description: "One boat",
+var indexfileEntries = map[string]repo.ChartVersions{
+	"niña": {
+		{
+			URLs: []string{"http://example.com/charts/nina-0.1.0.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "niña",
+				Version:     "0.1.0",
+				Description: "One boat",
+			},
 		},
 	},
-	"pinta-0.1.0": {
-		Name: "pinta",
-		URL:  "http://example.com/charts/pinta-0.1.0.tgz",
-		Chartfile: &chart.Metadata{
-			Name:        "pinta",
-			Version:     "0.1.0",
-			Description: "Two ship",
+	"pinta": {
+		{
+			URLs: []string{"http://example.com/charts/pinta-0.1.0.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "pinta",
+				Version:     "0.1.0",
+				Description: "Two ship",
+			},
 		},
 	},
-	"santa-maria-1.2.3": {
-		Name: "santa-maria",
-		URL:  "http://example.com/charts/santa-maria-1.2.3.tgz",
-		Chartfile: &chart.Metadata{
-			Name:        "santa-maria",
-			Version:     "1.2.3",
-			Description: "Three boat",
+	"santa-maria": {
+		{
+			URLs: []string{"http://example.com/charts/santa-maria-1.2.3.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "santa-maria",
+				Version:     "1.2.3",
+				Description: "Three boat",
+			},
+		},
+		{
+			URLs: []string{"http://example.com/charts/santa-maria-1.2.2.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "santa-maria",
+				Version:     "1.2.2",
+				Description: "Three boat",
+			},
 		},
 	},
 }
@@ -85,14 +96,15 @@ var indexfileEntries = map[string]*repo.ChartRef{
 func loadTestIndex(t *testing.T) *Index {
 	i := NewIndex()
 	i.AddRepo("testing", &repo.IndexFile{Entries: indexfileEntries})
-	i.AddRepo("ztesting", &repo.IndexFile{Entries: map[string]*repo.ChartRef{
-		"pinta-2.0.0": {
-			Name: "pinta",
-			URL:  "http://example.com/charts/pinta-2.0.0.tgz",
-			Chartfile: &chart.Metadata{
-				Name:        "pinta",
-				Version:     "2.0.0",
-				Description: "Two ship, version two",
+	i.AddRepo("ztesting", &repo.IndexFile{Entries: map[string]repo.ChartVersions{
+		"pinta": {
+			{
+				URLs: []string{"http://example.com/charts/pinta-2.0.0.tgz"},
+				Metadata: &chart.Metadata{
+					Name:        "pinta",
+					Version:     "2.0.0",
+					Description: "Two ship, version two",
+				},
 			},
 		},
 	}})
@@ -113,44 +125,44 @@ func TestSearchByName(t *testing.T) {
 			name:  "basic search for one result",
 			query: "santa-maria",
 			expect: []*Result{
-				{Name: "testing/santa-maria-1.2.3"},
+				{Name: "testing/santa-maria"},
 			},
 		},
 		{
 			name:  "basic search for two results",
 			query: "pinta",
 			expect: []*Result{
-				{Name: "testing/pinta-0.1.0"},
-				{Name: "ztesting/pinta-2.0.0"},
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
 			},
 		},
 		{
 			name:  "repo-specific search for one result",
 			query: "ztesting/pinta",
 			expect: []*Result{
-				{Name: "ztesting/pinta-2.0.0"},
+				{Name: "ztesting/pinta"},
 			},
 		},
 		{
 			name:  "partial name search",
 			query: "santa",
 			expect: []*Result{
-				{Name: "testing/santa-maria-1.2.3"},
+				{Name: "testing/santa-maria"},
 			},
 		},
 		{
 			name:  "description search, one result",
 			query: "Three",
 			expect: []*Result{
-				{Name: "testing/santa-maria-1.2.3"},
+				{Name: "testing/santa-maria"},
 			},
 		},
 		{
 			name:  "description search, two results",
 			query: "two",
 			expect: []*Result{
-				{Name: "testing/pinta-0.1.0"},
-				{Name: "ztesting/pinta-2.0.0"},
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
 			},
 		},
 		{
@@ -162,7 +174,7 @@ func TestSearchByName(t *testing.T) {
 			name:  "regexp, one result",
 			query: "th[ref]*",
 			expect: []*Result{
-				{Name: "testing/santa-maria-1.2.3"},
+				{Name: "testing/santa-maria"},
 			},
 			regexp: true,
 		},

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -34,12 +34,12 @@ func TestSearchCmd(t *testing.T) {
 		{
 			name:   "search for 'maria', expect one match",
 			args:   []string{"maria"},
-			expect: "testing/mariadb-0.3.0",
+			expect: "testing/mariadb",
 		},
 		{
 			name:   "search for 'alpine', expect two matches",
 			args:   []string{"alpine"},
-			expect: "testing/alpine-0.1.0\ntesting/alpine-0.2.0",
+			expect: "testing/alpine",
 		},
 		{
 			name:   "search for 'syzygy', expect no matches",
@@ -50,7 +50,7 @@ func TestSearchCmd(t *testing.T) {
 			name:   "search for 'alp[a-z]+', expect two matches",
 			args:   []string{"alp[a-z]+"},
 			flags:  []string{"--regexp"},
-			expect: "testing/alpine-0.1.0\ntesting/alpine-0.2.0",
+			expect: "testing/alpine",
 			regexp: true,
 		},
 		{

--- a/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
@@ -1,54 +1,46 @@
-alpine-0.1.0:
-  name: alpine
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
-  created: 2016-09-06 21:58:44.211261566 +0000 UTC
-  checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
-  chartfile:
-    name: alpine
-    home: https://k8s.io/helm
-    sources:
-    - https://github.com/kubernetes/helm
-    version: 0.1.0
-    description: Deploy a basic Alpine Linux pod
-    keywords: []
-    maintainers: []
-    engine: ""
-    icon: ""
-alpine-0.2.0:
-  name: alpine
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
-  created: 2016-09-06 21:58:44.211261566 +0000 UTC
-  checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
-  chartfile:
-    name: alpine
-    home: https://k8s.io/helm
-    sources:
-    - https://github.com/kubernetes/helm
-    version: 0.2.0
-    description: Deploy a basic Alpine Linux pod
-    keywords: []
-    maintainers: []
-    engine: ""
-    icon: ""
-mariadb-0.3.0:
-  name: mariadb
-  url: http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
-  created: 2016-09-06 21:58:44.211870222 +0000 UTC
-  checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
-  chartfile:
-    name: mariadb
-    home: https://mariadb.org
-    sources:
-    - https://github.com/bitnami/bitnami-docker-mariadb
-    version: 0.3.0
-    description: Chart for MariaDB
-    keywords:
-    - mariadb
-    - mysql
-    - database
-    - sql
-    maintainers:
-    - name: Bitnami
-      email: containers@bitnami.com
-    engine: gotpl
-    icon: ""
+apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 0.1.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""
+    - name: alpine
+      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 0.2.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""
+  mariadb:
+    - name: mariadb
+      url: http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
+      checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
+      home: https://mariadb.org
+      sources:
+      - https://github.com/bitnami/bitnami-docker-mariadb
+      version: 0.3.0
+      description: Chart for MariaDB
+      keywords:
+      - mariadb
+      - mysql
+      - database
+      - sql
+      maintainers:
+      - name: Bitnami
+        email: containers@bitnami.com
+      engine: gotpl
+      icon: ""

--- a/cmd/helm/testdata/helmhome/repository/repositories.yaml
+++ b/cmd/helm/testdata/helmhome/repository/repositories.yaml
@@ -1,1 +1,6 @@
-testing: http://example.com/charts
+apiVersion: v1
+generated: 2016-10-03T16:03:10.640376913-06:00
+repositories:
+- cache: testing-index.yaml
+  name: testing
+  url: http://example.com/charts

--- a/cmd/helm/testdata/repositories.yaml
+++ b/cmd/helm/testdata/repositories.yaml
@@ -1,2 +1,6 @@
-charts: http://storage.googleapis.com/kubernetes-charts
-local: http://localhost:8879/charts
+apiVersion: v1
+repositories:
+  - name: charts
+    url: "http://storage.googleapis.com/kubernetes-charts"
+  - name: local
+    url: "http://localhost:8879/charts"

--- a/cmd/helm/testdata/testserver/index.yaml
+++ b/cmd/helm/testdata/testserver/index.yaml
@@ -1,0 +1,1 @@
+apiVersion: v1

--- a/cmd/helm/testdata/testserver/repository/repositories.yaml
+++ b/cmd/helm/testdata/testserver/repository/repositories.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+generated: 2016-10-04T13:50:02.87649685-06:00
+repositories:
+- cache: ""
+  name: test
+  url: http://127.0.0.1:49216

--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -19,26 +19,45 @@ The index file is a yaml file called `index.yaml`. It contains some metadata abo
 
 This is an example of an index file:
 ```
-alpine-0.1.0:
-  name: alpine
-  url: https://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
-  created: 2016-05-26 11:23:44.086354411 +0000 UTC
-  digest: sha256:78e9a4282295184e8ce1496d23987993673f38e33e203c8bc18bc838a73e5864
-  chartfile:
-    name: alpine
-    description: Deploy a basic Alpine Linux pod
-    version: 0.1.0
-    home: https://github.com/example-charts/alpine
-redis-2.0.0:
-  name: redis
-  url: https://storage.googleapis.com/kubernetes-charts/redis-2.0.0.tgz
-  created: 2016-05-26 11:23:44.087939192 +0000 UTC
-  digest: sha256:bde9c2949e64d059c18d8f93566a64dafc6d2e8e259a70322fb804831dfd0b5b
-  chartfile:
-    name: redis
-    description: Port of the replicatedservice template from kubernetes/charts
-    version: 2.0.0
-    home: https://github.com/example-charts/redis
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+      name: nginx
+      description: string
+      version: 0.1.0
+      home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+  alpine:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+      name: alpine
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      keywords:
+        - linux
+        - alpine
+        - small
+        - sumtin
+      digest: "sha256:1234567890abcdef"
 ```
 
 We will go through detailed GCS and Github Pages examples here, but feel free to skip to the next section if you've already created a chart repository.

--- a/pkg/repo/doc.go
+++ b/pkg/repo/doc.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*Package repo implements the Helm Chart Repository.
+
+A chart repository is an HTTP server that provides information on charts. A local
+repository cache is an on-disk representation of a chart repository.
+
+There are two important file formats for chart repositories.
+
+The first is the 'index.yaml' format, which is expressed like this:
+
+	apiVersion: v1
+	entries:
+	  frobnitz:
+	  - created: 2016-09-29T12:14:34.830161306-06:00
+		description: This is a frobniz.
+		digest: 587bd19a9bd9d2bc4a6d25ab91c8c8e7042c47b4ac246e37bf8e1e74386190f4
+		home: http://example.com
+		keywords:
+		- frobnitz
+		- sprocket
+		- dodad
+		maintainers:
+		- email: helm@example.com
+		  name: The Helm Team
+		- email: nobody@example.com
+		  name: Someone Else
+		name: frobnitz
+		urls:
+		- http://example-charts.com/testdata/repository/frobnitz-1.2.3.tgz
+		version: 1.2.3
+	  sprocket:
+	  - created: 2016-09-29T12:14:34.830507606-06:00
+		description: This is a sprocket"
+		digest: 8505ff813c39502cc849a38e1e4a8ac24b8e6e1dcea88f4c34ad9b7439685ae6
+		home: http://example.com
+		keywords:
+		- frobnitz
+		- sprocket
+		- dodad
+		maintainers:
+		- email: helm@example.com
+		  name: The Helm Team
+		- email: nobody@example.com
+		  name: Someone Else
+		name: sprocket
+		urls:
+		- http://example-charts.com/testdata/repository/sprocket-1.2.0.tgz
+		version: 1.2.0
+	generated: 2016-09-29T12:14:34.829721375-06:00
+
+An index.yaml file contains the necessary descriptive information about what
+charts are available in a repository, and how to get them.
+
+The second file format is the repositories.yaml file format. This file is for
+facilitating local cached copies of one or more chart repositories.
+
+The format of a repository.yaml file is:
+
+	apiVersion: v1
+	generated: TIMESTAMP
+	repositories:
+	  - name: stable
+	    url: http://example.com/charts
+		cache: stable-index.yaml
+	  - name: incubator
+	    url: http://example.com/incubator
+		cache: incubator-index.yaml
+
+This file maps three bits of information about a repository:
+
+	- The name the user uses to refer to it
+	- The fully qualified URL to the repository (index.yaml will be appended)
+    - The name of the local cachefile
+
+The format for both files was changed after Helm v2.0.0-Alpha.4. Helm is not
+backwards compatible with those earlier versions.
+*/
+package repo

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -22,11 +22,110 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 const testRepositoriesFile = "testdata/repositories.yaml"
 const testRepository = "testdata/repository"
 const testURL = "http://example-charts.com"
+
+func TestRepoFile(t *testing.T) {
+	rf := NewRepoFile()
+	rf.Add(
+		&Entry{
+			Name:  "stable",
+			URL:   "https://example.com/stable/charts",
+			Cache: "stable-index.yaml",
+		},
+		&Entry{
+			Name:  "incubator",
+			URL:   "https://example.com/incubator",
+			Cache: "incubator-index.yaml",
+		},
+	)
+
+	if len(rf.Repositories) != 2 {
+		t.Fatal("Expected 2 repositories")
+	}
+
+	if rf.Has("nosuchrepo") {
+		t.Error("Found nonexistent repo")
+	}
+	if !rf.Has("incubator") {
+		t.Error("incubator repo is missing")
+	}
+
+	stable := rf.Repositories[0]
+	if stable.Name != "stable" {
+		t.Error("stable is not named stable")
+	}
+	if stable.URL != "https://example.com/stable/charts" {
+		t.Error("Wrong URL for stable")
+	}
+	if stable.Cache != "stable-index.yaml" {
+		t.Error("Wrong cache name for stable")
+	}
+}
+
+func TestLoadRepositoriesFile(t *testing.T) {
+	expects := NewRepoFile()
+	expects.Add(
+		&Entry{
+			Name:  "stable",
+			URL:   "https://example.com/stable/charts",
+			Cache: "stable-index.yaml",
+		},
+		&Entry{
+			Name:  "incubator",
+			URL:   "https://example.com/incubator",
+			Cache: "incubator-index.yaml",
+		},
+	)
+
+	repofile, err := LoadRepositoriesFile(testRepositoriesFile)
+	if err != nil {
+		t.Errorf("%q could not be loaded: %s", testRepositoriesFile, err)
+	}
+
+	if len(expects.Repositories) != len(repofile.Repositories) {
+		t.Fatalf("Unexpected repo data: %#v", repofile.Repositories)
+	}
+
+	for i, expect := range expects.Repositories {
+		got := repofile.Repositories[i]
+		if expect.Name != got.Name {
+			t.Errorf("Expected name %q, got %q", expect.Name, got.Name)
+		}
+		if expect.URL != got.URL {
+			t.Errorf("Expected url %q, got %q", expect.URL, got.URL)
+		}
+		if expect.Cache != got.Cache {
+			t.Errorf("Expected cache %q, got %q", expect.Cache, got.Cache)
+		}
+	}
+}
+
+func TestLoadPreV1RepositoriesFile(t *testing.T) {
+	r, err := LoadRepositoriesFile("testdata/old-repositories.yaml")
+	if err != nil && err != ErrRepoOutOfDate {
+		t.Fatal(err)
+	}
+	if len(r.Repositories) != 3 {
+		t.Fatalf("Expected 3 repos: %#v", r)
+	}
+
+	// Because they are parsed as a map, we lose ordering.
+	found := false
+	for _, rr := range r.Repositories {
+		if rr.Name == "best-charts-ever" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected the best charts ever. Got %#v", r.Repositories)
+	}
+}
 
 func TestLoadChartRepository(t *testing.T) {
 	cr, err := LoadChartRepository(testRepository, testURL)
@@ -66,76 +165,94 @@ func TestIndex(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error loading index file %v", err)
 	}
+	verifyIndex(t, actual)
 
-	entries := actual.Entries
-	numEntries := len(entries)
-	if numEntries != 2 {
-		t.Errorf("Expected 2 charts to be listed in index file but got %v", numEntries)
-	}
-
-	timestamps := make(map[string]string)
-	var empty time.Time
-	for chartName, details := range entries {
-		if details == nil {
-			t.Errorf("Chart Entry is not filled out for %s", chartName)
-		}
-
-		if details.Created == empty.String() {
-			t.Errorf("Created timestamp under %s chart entry is nil", chartName)
-		}
-		timestamps[chartName] = details.Created
-
-		if details.Digest == "" {
-			t.Errorf("Digest was not set for %s", chartName)
-		}
-	}
-
-	if err = cr.Index(); err != nil {
-		t.Errorf("Error performing index the second time: %v\n", err)
+	// Re-index and test again.
+	err = cr.Index()
+	if err != nil {
+		t.Errorf("Error performing re-index: %s\n", err)
 	}
 	second, err := LoadIndexFile(tempIndexPath)
 	if err != nil {
-		t.Errorf("Error loading index file second time: %#v\n", err)
+		t.Errorf("Error re-loading index file %v", err)
 	}
-
-	for chart, created := range timestamps {
-		v, ok := second.Entries[chart]
-		if !ok {
-			t.Errorf("Expected %s chart entry in index file but did not find it", chart)
-		}
-		if v.Created != created {
-			t.Errorf("Expected Created timestamp to be %s, but got %s for chart %s", created, v.Created, chart)
-		}
-		// Created manually since we control the input of the test
-		expectedURL := testURL + "/" + chart + ".tgz"
-		if v.URL != expectedURL {
-			t.Errorf("Expected url in entry to be %s but got %s for chart: %s", expectedURL, v.URL, chart)
-		}
-	}
+	verifyIndex(t, second)
 }
 
-func TestLoadRepositoriesFile(t *testing.T) {
-	rf, err := LoadRepositoriesFile(testRepositoriesFile)
-	if err != nil {
-		t.Errorf(testRepositoriesFile + " could not be loaded: " + err.Error())
-	}
-	expected := map[string]string{"best-charts-ever": "http://best-charts-ever.com",
-		"okay-charts": "http://okay-charts.org", "example123": "http://examplecharts.net/charts/123"}
+func verifyIndex(t *testing.T, actual *IndexFile) {
 
-	numOfRepositories := len(rf.Repositories)
-	expectedNumOfRepositories := 3
-	if numOfRepositories != expectedNumOfRepositories {
-		t.Errorf("Expected %v repositories but only got %v", expectedNumOfRepositories, numOfRepositories)
+	var empty time.Time
+	if actual.Generated == empty {
+		t.Errorf("Generated should be greater than 0: %s", actual.Generated)
 	}
 
-	for expectedRepo, expectedURL := range expected {
-		actual, ok := rf.Repositories[expectedRepo]
+	if actual.APIVersion != APIVersionV1 {
+		t.Error("Expected v1 API")
+	}
+
+	entries := actual.Entries
+	if numEntries := len(entries); numEntries != 2 {
+		t.Errorf("Expected 2 charts to be listed in index file but got %v", numEntries)
+	}
+
+	expects := map[string]ChartVersions{
+		"frobnitz": {
+			{
+				Metadata: &chart.Metadata{
+					Name:    "frobnitz",
+					Version: "1.2.3",
+				},
+			},
+		},
+		"sprocket": {
+			{
+				Metadata: &chart.Metadata{
+					Name:    "sprocket",
+					Version: "1.2.0",
+				},
+			},
+		},
+	}
+
+	for name, versions := range expects {
+		got, ok := entries[name]
 		if !ok {
-			t.Errorf("Expected repository: %v but was not found", expectedRepo)
+			t.Errorf("Could not find %q entry", name)
+			continue
 		}
-
-		if expectedURL != actual {
-			t.Errorf("Expected url %s for the %s repository but got %s ", expectedURL, expectedRepo, actual)
+		if len(versions) != len(got) {
+			t.Errorf("Expected %d versions, got %d", len(versions), len(got))
+			continue
+		}
+		for i, e := range versions {
+			g := got[i]
+			if e.Name != g.Name {
+				t.Errorf("Expected %q, got %q", e.Name, g.Name)
+			}
+			if e.Version != g.Version {
+				t.Errorf("Expected %q, got %q", e.Version, g.Version)
+			}
+			if len(g.Keywords) != 3 {
+				t.Error("Expected 3 keyrwords.")
+			}
+			if len(g.Maintainers) != 2 {
+				t.Error("Expected 2 maintainers.")
+			}
+			if g.Created == empty {
+				t.Error("Expected created to be non-empty")
+			}
+			if g.Description == "" {
+				t.Error("Expected description to be non-empty")
+			}
+			if g.Home == "" {
+				t.Error("Expected home to be non-empty")
+			}
+			if g.Digest == "" {
+				t.Error("Expected digest to be non-empty")
+			}
+			if len(g.URLs) != 1 {
+				t.Error("Expected exactly 1 URL")
+			}
 		}
 	}
 }

--- a/pkg/repo/repotest/server_test.go
+++ b/pkg/repo/repotest/server_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	"k8s.io/helm/pkg/repo"
 )
@@ -77,23 +77,20 @@ func TestServer(t *testing.T) {
 		return
 	}
 
-	var m map[string]*repo.ChartRef
-	if err := yaml.Unmarshal(data, &m); err != nil {
+	m := repo.NewIndexFile()
+	if err := yaml.Unmarshal(data, m); err != nil {
 		t.Error(err)
 		return
 	}
 
-	if l := len(m); l != 1 {
+	if l := len(m.Entries); l != 1 {
 		t.Errorf("Expected 1 entry, got %d", l)
 		return
 	}
 
-	expect := "examplechart-0.1.0"
-	if m[expect].Name != "examplechart-0.1.0" {
-		t.Errorf("Unexpected chart: %s", m[expect].Name)
-	}
-	if m[expect].Chartfile.Name != "examplechart" {
-		t.Errorf("Unexpected chart: %s", m[expect].Chartfile.Name)
+	expect := "examplechart"
+	if !m.Has(expect, "0.1.0") {
+		t.Errorf("missing %q", expect)
 	}
 
 	res, err = http.Get(srv.URL() + "/index.yaml-nosuchthing")

--- a/pkg/repo/testdata/local-index.yaml
+++ b/pkg/repo/testdata/local-index.yaml
@@ -1,19 +1,32 @@
-nginx-0.1.0:
-  url: http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
-  name: nginx
-  chartfile:
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
       name: nginx
       description: string
       version: 0.1.0
       home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
       keywords:
         - popular
         - web server
         - proxy
-alpine-1.0.0:
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
-  name: alpine
-  chartfile:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+  alpine:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
       name: alpine
       description: string
       version: 1.0.0
@@ -23,4 +36,5 @@ alpine-1.0.0:
         - alpine
         - small
         - sumtin
+      digest: "sha256:1234567890abcdef"
 

--- a/pkg/repo/testdata/old-repositories.yaml
+++ b/pkg/repo/testdata/old-repositories.yaml
@@ -1,0 +1,3 @@
+best-charts-ever: http://best-charts-ever.com
+okay-charts: http://okay-charts.org
+example123: http://examplecharts.net/charts/123

--- a/pkg/repo/testdata/repositories.yaml
+++ b/pkg/repo/testdata/repositories.yaml
@@ -1,3 +1,8 @@
-best-charts-ever: http://best-charts-ever.com
-okay-charts: http://okay-charts.org
-example123: http://examplecharts.net/charts/123
+apiVersion: v1
+repositories:
+  - name: stable
+    url: https://example.com/stable/charts
+    cache: stable-index.yaml
+  - name: incubator
+    url: https://example.com/incubator
+    cache: incubator-index.yaml


### PR DESCRIPTION
This implements a new index file format for repository indices. It also
implements a new format for requirements.yaml.

**Breaking change:** This will break all previous versions of Helm, and will
impact helm search, repo, serve, and fetch functions. Old chart indices will also be broken, since the `index.yaml` format is different.

Closes #1197

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1257)

<!-- Reviewable:end -->
