### PR TITLE
fix(helm): change 'helm update' to 'helm repo update'

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -83,6 +83,9 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST.")
 	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
 
+	rup := newRepoUpdateCmd(out)
+	rup.Deprecated = "use 'helm repo update'\n"
+
 	cmd.AddCommand(
 		newCreateCmd(out),
 		newDeleteCmd(nil, out),
@@ -101,10 +104,11 @@ func newRootCmd(out io.Writer) *cobra.Command {
 		newSearchCmd(out),
 		newServeCmd(out),
 		newStatusCmd(nil, out),
-		newUpdateCmd(out),
 		newUpgradeCmd(nil, out),
 		newVerifyCmd(out),
 		newVersionCmd(nil, out),
+		// Deprecated
+		rup,
 	)
 	return cmd
 }

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -36,8 +36,8 @@ type repoCmd struct {
 
 func newRepoCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "repo [FLAGS] add|remove|list|index [ARGS]",
-		Short: "add, list, remove, index chart repositories",
+		Use:   "repo [FLAGS] add|remove|list|index|update [ARGS]",
+		Short: "add, list, remove, update, and index chart repositories",
 		Long:  repoHelm,
 	}
 
@@ -45,6 +45,7 @@ func newRepoCmd(out io.Writer) *cobra.Command {
 	cmd.AddCommand(newRepoListCmd(out))
 	cmd.AddCommand(newRepoRemoveCmd(out))
 	cmd.AddCommand(newRepoIndexCmd(out))
+	cmd.AddCommand(newRepoUpdateCmd(out))
 
 	return cmd
 }

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -30,16 +30,19 @@ import (
 const updateDesc = `
 Update gets the latest information about charts from the respective chart repositories.
 Information is cached locally, where it is used by commands like 'helm search'.
+
+'helm update' is the deprecated form of 'helm repo update'. It will be removed in
+future releases.
 `
 
-type updateCmd struct {
+type repoUpdateCmd struct {
 	repoFile string
 	update   func(map[string]string, bool, io.Writer)
 	out      io.Writer
 }
 
-func newUpdateCmd(out io.Writer) *cobra.Command {
-	u := &updateCmd{
+func newRepoUpdateCmd(out io.Writer) *cobra.Command {
+	u := &repoUpdateCmd{
 		out:      out,
 		update:   updateCharts,
 		repoFile: repositoriesFile(),
@@ -56,7 +59,7 @@ func newUpdateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (u *updateCmd) run() error {
+func (u *repoUpdateCmd) run() error {
 	f, err := repo.LoadRepositoriesFile(u.repoFile)
 	if err != nil {
 		return err

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -34,7 +34,7 @@ func TestUpdateCmd(t *testing.T) {
 			fmt.Fprintln(out, name)
 		}
 	}
-	uc := &updateCmd{
+	uc := &repoUpdateCmd{
 		out:      out,
 		update:   updater,
 		repoFile: "testdata/repositories.yaml",

--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -129,9 +129,9 @@ fantastic-charts    https://storage.googleapis.com/fantastic-charts
 
 *Note: A repository will not be added if it does not contain a valid index.yaml.*
 
-After that, they'll be able to search through your charts. After you've updated the repository, they can use the `helm update` command to get the latest chart information.
+After that, they'll be able to search through your charts. After you've updated the repository, they can use the `helm repo update` command to get the latest chart information.
 
-*Under the hood, the `helm repo add` and `helm update` commands are fetching the index.yaml file and storing them in the `$HELM_HOME/repository/cache/` directory. This is where the `helm search` function finds information about charts.*
+*Under the hood, the `helm repo add` and `helm repo update` commands are fetching the index.yaml file and storing them in the `$HELM_HOME/repository/cache/` directory. This is where the `helm search` function finds information about charts.*
 
 ## Contributing charts to the official helm chart repository
 *Coming Soon*

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -338,7 +338,7 @@ $ helm repo add dev https://example.com/dev-charts
 ```
 
 Because chart repositories change frequently, at any point you can make
-sure your Helm client is up to date by running `helm update`.
+sure your Helm client is up to date by running `helm repo update`.
 
 ## Creating Your Own Charts
 


### PR DESCRIPTION
The old form is marked deprecated.

This moves the `helm update` command to `helm repo update`. The old form is still there, but emits a deprecation warning on usage:

``` console
$ helm update
Command "update" is deprecated, use 'helm repo update'

Hang tight while we grab the latest from your chart repositories...
...Unable to get an update from the "local" chart repository
...Successfully got an update from the "mumoshu" chart repository
...Successfully got an update from the "kube-charts" chart repository
Update Complete. Happy Helming!
```

Relates to #1196

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1270)

<!-- Reviewable:end -->
