### PR TITLE
fix(helm): fix tests so that they do not write data into testdata

### DIFF
--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -62,19 +62,21 @@ func TestUpdateCmd(t *testing.T) {
 }
 
 func TestUpdateCharts(t *testing.T) {
-	srv := repotest.NewServer("testdata/testserver")
-	defer srv.Stop()
-
-	thome, err := tempHelmHome(t)
+	srv, thome, err := repotest.NewTempServer("testdata/testserver/*.*")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	oldhome := homePath()
 	helmHome = thome
 	defer func() {
+		srv.Stop()
 		helmHome = oldhome
 		os.Remove(thome)
 	}()
+	if err := ensureTestHome(helmpath.Home(thome), t); err != nil {
+		t.Fatal(err)
+	}
 
 	buf := bytes.NewBuffer(nil)
 	repos := []*repo.Entry{

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -27,6 +27,30 @@ import (
 	"k8s.io/helm/pkg/repo"
 )
 
+// NewTempServer creates a server inside of a temp dir.
+//
+// If the passed in string is not "", it will be treated as a shell glob, and files
+// will be copied from that path to the server's docroot.
+//
+// The caller is responsible for destroying the temp directory as well as stopping
+// the server.
+func NewTempServer(glob string) (*Server, string, error) {
+	tdir, err := ioutil.TempDir("", "helm-repotest-")
+	if err != nil {
+		return nil, tdir, err
+	}
+	srv := NewServer(tdir)
+
+	if glob != "" {
+		if _, err := srv.CopyCharts(glob); err != nil {
+			srv.Stop()
+			return srv, tdir, err
+		}
+	}
+
+	return srv, tdir, nil
+}
+
 // NewServer creates a repository server for testing.
 //
 // docroot should be a temp dir managed by the caller.

--- a/pkg/repo/repotest/server_test.go
+++ b/pkg/repo/repotest/server_test.go
@@ -102,3 +102,26 @@ func TestServer(t *testing.T) {
 		t.Errorf("Expected 404, got %d", res.StatusCode)
 	}
 }
+
+func TestNewTempServer(t *testing.T) {
+	srv, tdir, err := NewTempServer("testdata/examplechart-0.1.0.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		srv.Stop()
+		os.RemoveAll(tdir)
+	}()
+
+	if _, err := os.Stat(tdir); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.Head(srv.URL() + "/examplechart-0.1.0.tgz")
+	if err != nil {
+		t.Error(err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Expected 200, got %d", res.StatusCode)
+	}
+}


### PR DESCRIPTION
There was a bug in the repo tests that caused them to overwrite the
repositories.yaml file in that directory. Now, the entire tests (server
and client-side) run inside of a temp directory.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1275)

<!-- Reviewable:end -->
