### PR TITLE
feat(tiller): re-use values during upgrade

### DIFF
--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -110,7 +110,7 @@ func namedReleaseStub(name string, status release.Status_Code) *release.Release 
 			Status:        &release.Status{Code: status},
 		},
 		Chart:   chartStub(),
-		Config:  &chart.Config{Raw: `name = "value"`},
+		Config:  &chart.Config{Raw: `name: value`},
 		Version: 1,
 		Hooks: []*release.Hook{
 			{
@@ -566,6 +566,12 @@ func TestUpdateRelease(t *testing.T) {
 
 	if len(res.Release.Manifest) == 0 {
 		t.Errorf("No manifest returned: %v", res.Release)
+	}
+
+	if res.Release.Config == nil {
+		t.Errorf("Got release without config: %#v", res.Release)
+	} else if res.Release.Config.Raw != rel.Config.Raw {
+		t.Errorf("Expected release values %q, got %q", rel.Config.Raw, res.Release.Config.Raw)
 	}
 
 	if len(updated.Manifest) == 0 {

--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -24,7 +24,9 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-// APIVersionV1 is the API version number for version 1.
+// ApiVersionV1 is the API version number for version 1.
+//
+// This is ApiVersionV1 instead of APIVersionV1 to match the protobuf-generated name.
 const ApiVersionV1 = "v1"
 
 // UnmarshalChartfile takes raw Chart.yaml data and unmarshals it.


### PR DESCRIPTION
When `helm install -f foo.yaml bar` is called, and then the release is
upgraded with `helm upgrade happy-panda bar`, this will now re-use the
values that were submitted with `-f foo.yaml`. The same is true for
values specified with `--set`.

Closes #1227

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1278)

<!-- Reviewable:end -->
