### PR TITLE
fix(repo): auto-update index file formats

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -138,7 +138,7 @@ func ensureHome(home helmpath.Home, out io.Writer) error {
 		}
 		cif := home.CacheIndex(stableRepository)
 		if err := repo.DownloadIndexFile(stableRepository, stableRepositoryURL, cif); err != nil {
-			fmt.Fprintf(out, "WARNING: Failed to download %s: %s (run 'helm update')\n", stableRepository, err)
+			fmt.Fprintf(out, "WARNING: Failed to download %s: %s (run 'helm repo update')\n", stableRepository, err)
 		}
 	} else if fi.IsDir() {
 		return fmt.Errorf("%s must be a file, not a directory", repoFile)

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -106,7 +106,7 @@ func (s *searchCmd) buildIndex() (*search.Index, error) {
 		f := s.helmhome.CacheIndex(n)
 		ind, err := repo.LoadIndexFile(f)
 		if err != nil {
-			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt or missing. Try 'helm update':\n\t%s\n", f, err)
+			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt or missing. Try 'helm repo update':\n\t%s\n", f, err)
 			continue
 		}
 

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -250,3 +250,23 @@ func TestIndexDirectory(t *testing.T) {
 		t.Errorf("Expected frobnitz, got %q", frob.Name)
 	}
 }
+
+func TestLoadUnversionedIndex(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/unversioned-index.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ind, err := loadUnversionedIndex(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(ind.Entries); l != 2 {
+		t.Fatalf("Expected 2 entries, got %d", l)
+	}
+
+	if l := len(ind.Entries["mysql"]); l != 3 {
+		t.Fatalf("Expected 3 mysql versions, got %d", l)
+	}
+}

--- a/pkg/repo/testdata/unversioned-index.yaml
+++ b/pkg/repo/testdata/unversioned-index.yaml
@@ -1,0 +1,64 @@
+memcached-0.1.0:
+  name: memcached
+  url: https://mumoshu.github.io/charts/memcached-0.1.0.tgz
+  created: 2016-08-04 02:05:02.259205055 +0000 UTC
+  checksum: ce9b76576c4b4eb74286fa30a978c56d69e7a522
+  chartfile:
+    name: memcached
+    home: http://https://hub.docker.com/_/memcached/
+    sources: []
+    version: 0.1.0
+    description: A simple Memcached cluster
+    keywords: []
+    maintainers:
+    - name: Matt Butcher
+      email: mbutcher@deis.com
+    engine: ""
+mysql-0.2.0:
+  name: mysql
+  url: https://mumoshu.github.io/charts/mysql-0.2.0.tgz
+  created: 2016-08-04 00:42:47.517342022 +0000 UTC
+  checksum: aa5edd2904d639b0b6295f1c7cf4c0a8e4f77dd3
+  chartfile:
+    name: mysql
+    home: https://www.mysql.com/
+    sources: []
+    version: 0.2.0
+    description: Chart running MySQL.
+    keywords: []
+    maintainers:
+    - name: Matt Fisher
+      email: mfisher@deis.com
+    engine: ""
+mysql-0.2.1:
+  name: mysql
+  url: https://mumoshu.github.io/charts/mysql-0.2.1.tgz
+  created: 2016-08-04 02:40:29.717829534 +0000 UTC
+  checksum: 9d9f056171beefaaa04db75680319ca4edb6336a
+  chartfile:
+    name: mysql
+    home: https://www.mysql.com/
+    sources: []
+    version: 0.2.1
+    description: Chart running MySQL.
+    keywords: []
+    maintainers:
+    - name: Matt Fisher
+      email: mfisher@deis.com
+    engine: ""
+mysql-0.2.2:
+  name: mysql
+  url: https://mumoshu.github.io/charts/mysql-0.2.2.tgz
+  created: 2016-08-04 02:40:29.71841952 +0000 UTC
+  checksum: 6d6810e76a5987943faf0040ec22990d9fb141c7
+  chartfile:
+    name: mysql
+    home: https://www.mysql.com/
+    sources: []
+    version: 0.2.2
+    description: Chart running MySQL.
+    keywords: []
+    maintainers:
+    - name: Matt Fisher
+      email: mfisher@deis.com
+    engine: ""


### PR DESCRIPTION
This performs a relatively weak in-memory translation of index file
data. It does not, in most cases, write the corrected data to disk, and
it emits a warning directly to STDERR each time it loads a deprecated
index.

Known limitations:
- It cannot recover certain bogus records that earlier alpha releases
  generated (notably, where all chartfile data is missing)
- In some cases, it has to parse a filename to get version info. This is
  lossy.
- Because it takes three passes through the YAML and JSON unmarshal, it
  is not performant.

This feature is transitional and should be removed during the Beta
cycle, prior to the release of 2.0.0.

Closes #1265

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1282)

<!-- Reviewable:end -->
