### PR TITLE
feat(helm): add --versions flag on search

### DIFF
--- a/cmd/helm/search/search_test.go
+++ b/cmd/helm/search/search_test.go
@@ -93,9 +93,9 @@ var indexfileEntries = map[string]repo.ChartVersions{
 	},
 }
 
-func loadTestIndex(t *testing.T) *Index {
+func loadTestIndex(t *testing.T, all bool) *Index {
 	i := NewIndex()
-	i.AddRepo("testing", &repo.IndexFile{Entries: indexfileEntries})
+	i.AddRepo("testing", &repo.IndexFile{Entries: indexfileEntries}, all)
 	i.AddRepo("ztesting", &repo.IndexFile{Entries: map[string]repo.ChartVersions{
 		"pinta": {
 			{
@@ -107,8 +107,22 @@ func loadTestIndex(t *testing.T) *Index {
 				},
 			},
 		},
-	}})
+	}}, all)
 	return i
+}
+
+func TestAll(t *testing.T) {
+	i := loadTestIndex(t, false)
+	all := i.All()
+	if len(all) != 4 {
+		t.Errorf("Expected 4 entries, got %d", len(all))
+	}
+
+	i = loadTestIndex(t, true)
+	all = i.All()
+	if len(all) != 5 {
+		t.Errorf("Expected 5 entries, got %d", len(all))
+	}
 }
 
 func TestSearchByName(t *testing.T) {
@@ -188,7 +202,7 @@ func TestSearchByName(t *testing.T) {
 		},
 	}
 
-	i := loadTestIndex(t)
+	i := loadTestIndex(t, false)
 
 	for _, tt := range tests {
 
@@ -221,6 +235,18 @@ func TestSearchByName(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestSearchByNameAll(t *testing.T) {
+	// Test with the All bit turned on.
+	i := loadTestIndex(t, true)
+	cs, err := i.Search("santa-maria", 100, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cs) != 2 {
+		t.Errorf("expected 2 charts, got %d", len(cs))
 	}
 }
 

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -42,6 +42,12 @@ func TestSearchCmd(t *testing.T) {
 			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.1.0  \tDeploy a basic Alpine Linux pod",
 		},
 		{
+			name:   "search for 'alpine' with versions, expect three matches",
+			args:   []string{"alpine"},
+			flags:  []string{"--versions"},
+			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod\ntesting/alpine\t0.1.0  \tDeploy a basic Alpine Linux pod",
+		},
+		{
 			name:   "search for 'syzygy', expect no matches",
 			args:   []string{"syzygy"},
 			expect: "NAME\tVERSION\tDESCRIPTION",


### PR DESCRIPTION
This causes search to index by name/version instead of just name, which
means you can get a list of versions of a chart. The '--versions' flag
enables this behavior.

Partially fixes #1199

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1284)

<!-- Reviewable:end -->
