### PR TITLE
fix(cmd/hist): print revision history with unix synergy

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -38,10 +38,10 @@ The historical release set is printed as a formatted table, e.g:
 
     $ helm history angry-bird --max=4
     REVISION   UPDATED                      STATUS           CHART
-    4           Mon Oct 3 10:15:13 2016     DEPLOYED        alpine-0.1.0
-    3           Mon Oct 3 10:15:13 2016     SUPERSEDED      alpine-0.1.0
-    2           Mon Oct 3 10:15:13 2016     SUPERSEDED      alpine-0.1.0
     1           Mon Oct 3 10:15:13 2016     SUPERSEDED      alpine-0.1.0
+    2           Mon Oct 3 10:15:13 2016     SUPERSEDED      alpine-0.1.0
+    3           Mon Oct 3 10:15:13 2016     SUPERSEDED      alpine-0.1.0
+    4           Mon Oct 3 10:15:13 2016     DEPLOYED        alpine-0.1.0
 `
 
 type historyCmd struct {
@@ -96,7 +96,8 @@ func formatHistory(rls []*release.Release) string {
 	tbl := uitable.New()
 	tbl.MaxColWidth = 30
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART")
-	for _, r := range rls {
+	for i := len(rls) - 1; i >= 0; i-- {
+		r := rls[i]
 		c := fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
 		t := timeconv.String(r.Info.LastDeployed)
 		s := r.Info.Status.Code.String()

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -50,7 +50,7 @@ func TestHistoryCmd(t *testing.T) {
 				mk("angry-bird", 2, rpb.Status_SUPERSEDED),
 				mk("angry-bird", 1, rpb.Status_SUPERSEDED),
 			},
-			xout: "REVISION\tUPDATED                 \tSTATUS    \tCHART           \n4       \t(.*)\tDEPLOYED  \tfoo-0.1.0-beta.1\n3       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n2       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n1       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n",
+			xout: "REVISION\tUPDATED                 \tSTATUS    \tCHART           \n1       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n2       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n3       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n4       \t(.*)\tDEPLOYED  \tfoo-0.1.0-beta.1\n",
 		},
 		{
 			cmds: "helm history --max=MAX RELEASE_NAME",
@@ -60,7 +60,7 @@ func TestHistoryCmd(t *testing.T) {
 				mk("angry-bird", 4, rpb.Status_DEPLOYED),
 				mk("angry-bird", 3, rpb.Status_SUPERSEDED),
 			},
-			xout: "REVISION\tUPDATED                 \tSTATUS    \tCHART           \n4       \t(.*)\tDEPLOYED  \tfoo-0.1.0-beta.1\n3       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n",
+			xout: "REVISION\tUPDATED                 \tSTATUS    \tCHART           \n3       \t(.*)\tSUPERSEDED\tfoo-0.1.0-beta.1\n4       \t(.*)\tDEPLOYED  \tfoo-0.1.0-beta.1\n",
 		},
 	}
 


### PR DESCRIPTION
This fix reverses the ordering of a release's revision history during output (current is descending order) to remain consistent with other commands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1289)

<!-- Reviewable:end -->
