### PR TITLE
feat(helm): remove the requirement that fetch/install need version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Think of it like apt/yum/homebrew for Kubernetes.
 
 Download a [release tarball of helm for your platform](https://github.com/kubernetes/helm/releases). Unpack the `helm` binary and add it to your PATH and you are good to go! OS X/[Cask](https://caskroom.github.io/) users can `brew cask install helm`.
 
+To rapidly get Helm up and running, start with the [Quick Start Guide](docs/quickstart.md).
+
 See the [installation guide](docs/install.md) for more options,
 including installing pre-releases.
 

--- a/cmd/helm/downloader/manager_test.go
+++ b/cmd/helm/downloader/manager_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/helm/cmd/helm/helmpath"
-	//"k8s.io/helm/pkg/repo"
 )
 
 func TestVersionEquals(t *testing.T) {

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
@@ -1,1 +1,30 @@
 apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      urls:
+        - http://example.com/alpine-1.2.3.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 1.2.3
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""
+    - name: alpine
+      urls:
+        - http://example.com/alpine-0.2.0.tgz
+        - http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 0.2.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""

--- a/cmd/helm/fetch_test.go
+++ b/cmd/helm/fetch_test.go
@@ -49,38 +49,51 @@ func TestFetchCmd(t *testing.T) {
 	}{
 		{
 			name:       "Basic chart fetch",
-			chart:      "test/signtest-0.1.0",
+			chart:      "test/signtest",
 			expectFile: "./signtest-0.1.0.tgz",
 		},
 		{
+			name:       "Chart fetch with version",
+			chart:      "test/signtest",
+			flags:      []string{"--version", "0.1.0"},
+			expectFile: "./signtest-0.1.0.tgz",
+		},
+		{
+			name:       "Fail chart fetch with non-existent version",
+			chart:      "test/signtest",
+			flags:      []string{"--version", "99.1.0"},
+			fail:       true,
+			failExpect: "no such chart",
+		},
+		{
 			name:       "Fail fetching non-existent chart",
-			chart:      "test/nosuchthing-0.1.0",
+			chart:      "test/nosuchthing",
 			failExpect: "Failed to fetch",
 			fail:       true,
 		},
 		{
 			name:       "Fetch and verify",
-			chart:      "test/signtest-0.1.0",
+			chart:      "test/signtest",
 			flags:      []string{"--verify", "--keyring", "testdata/helm-test-key.pub"},
 			expectFile: "./signtest-0.1.0.tgz",
 		},
 		{
 			name:       "Fetch and fail verify",
-			chart:      "test/reqtest-0.1.0",
+			chart:      "test/reqtest",
 			flags:      []string{"--verify", "--keyring", "testdata/helm-test-key.pub"},
 			failExpect: "Failed to fetch provenance",
 			fail:       true,
 		},
 		{
 			name:       "Fetch and untar",
-			chart:      "test/signtest-0.1.0",
+			chart:      "test/signtest",
 			flags:      []string{"--verify", "--keyring", "testdata/helm-test-key.pub", "--untar", "--untardir", "signtest"},
 			expectFile: "./signtest",
 			expectDir:  true,
 		},
 		{
 			name:       "Fetch, verify, untar",
-			chart:      "test/signtest-0.1.0",
+			chart:      "test/signtest",
 			flags:      []string{"--verify", "--keyring", "testdata/helm-test-key.pub", "--untar", "--untardir", "signtest"},
 			expectFile: "./signtest",
 			expectDir:  true,
@@ -93,8 +106,9 @@ func TestFetchCmd(t *testing.T) {
 	if _, err := srv.CopyCharts("testdata/testcharts/*.tgz*"); err != nil {
 		t.Fatal(err)
 	}
-
-	t.Logf("HELM_HOME=%s", homePath())
+	if err := srv.LinkIndices(); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tt := range tests {
 		outdir := filepath.Join(hh, "testout")

--- a/cmd/helm/inspect.go
+++ b/cmd/helm/inspect.go
@@ -28,7 +28,8 @@ import (
 )
 
 const inspectDesc = `
-This command inspects a chart (directory, file, or URL) and displays information.
+This command inspects a chart and displays information. It takes a chart reference
+('stable/drupal'), a full path to a directory or packaged chart, or a URL.
 
 Inspect prints the contents of the Chart.yaml file and the values.yaml file.
 `
@@ -50,6 +51,7 @@ type inspectCmd struct {
 	keyring   string
 	out       io.Writer
 	client    helm.Interface
+	version   string
 }
 
 const (
@@ -73,7 +75,7 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			if err := checkArgsLength(len(args), "chart name"); err != nil {
 				return err
 			}
-			cp, err := locateChartPath(args[0], insp.verify, insp.keyring)
+			cp, err := locateChartPath(args[0], insp.version, insp.verify, insp.keyring)
 			if err != nil {
 				return err
 			}
@@ -88,7 +90,7 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		Long:  inspectValuesDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insp.output = valuesOnly
-			cp, err := locateChartPath(args[0], insp.verify, insp.keyring)
+			cp, err := locateChartPath(args[0], insp.version, insp.verify, insp.keyring)
 			if err != nil {
 				return err
 			}
@@ -103,7 +105,7 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		Long:  inspectChartDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insp.output = chartOnly
-			cp, err := locateChartPath(args[0], insp.verify, insp.keyring)
+			cp, err := locateChartPath(args[0], insp.version, insp.verify, insp.keyring)
 			if err != nil {
 				return err
 			}
@@ -124,6 +126,12 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	inspectCommand.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
 	valuesSubCmd.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
 	chartSubCmd.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
+
+	verflag := "version"
+	verdesc := "the version of the chart. By default, the newest chart is shown."
+	inspectCommand.Flags().StringVar(&insp.version, verflag, "", verdesc)
+	valuesSubCmd.Flags().StringVar(&insp.version, verflag, "", verdesc)
+	chartSubCmd.Flags().StringVar(&insp.version, verflag, "", verdesc)
 
 	inspectCommand.AddCommand(valuesSubCmd)
 	inspectCommand.AddCommand(chartSubCmd)

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -97,6 +97,9 @@ func (s *searchCmd) showAllCharts(i *search.Index) {
 }
 
 func (s *searchCmd) formatSearchResults(res []*search.Result) string {
+	if len(res) == 0 {
+		return "No results found"
+	}
 	table := uitable.New()
 	table.MaxColWidth = 50
 	table.AddRow("NAME", "VERSION", "DESCRIPTION")
@@ -119,7 +122,7 @@ func (s *searchCmd) buildIndex() (*search.Index, error) {
 		f := s.helmhome.CacheIndex(n)
 		ind, err := repo.LoadIndexFile(f)
 		if err != nil {
-			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt or missing. Try 'helm repo update':\n\t%s\n", f, err)
+			fmt.Fprintf(s.out, "WARNING: Repo %q is corrupt or missing. Try 'helm repo update'.", n)
 			continue
 		}
 

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -50,7 +50,7 @@ func TestSearchCmd(t *testing.T) {
 		{
 			name:   "search for 'syzygy', expect no matches",
 			args:   []string{"syzygy"},
-			expect: "NAME\tVERSION\tDESCRIPTION",
+			expect: "No results found",
 		},
 		{
 			name:   "search for 'alp[a-z]+', expect two matches",

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -33,7 +33,9 @@ const upgradeDesc = `
 This command upgrades a release to a new version of a chart.
 
 The upgrade arguments must be a release and a chart. The chart
-argument can be a relative path to a packaged or unpackaged chart.
+argument can a chart reference ('stable/mariadb'), a path to a chart directory
+or packaged chart, or a fully qualified URL. For chart references, the latest
+version will be specified unless the '--version' flag is set.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line.
@@ -52,6 +54,7 @@ type upgradeCmd struct {
 	keyring      string
 	install      bool
 	namespace    string
+	version      string
 }
 
 func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
@@ -89,12 +92,13 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f.StringVar(&upgrade.keyring, "keyring", defaultKeyring(), "the path to the keyring that contains public singing keys")
 	f.BoolVarP(&upgrade.install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.StringVar(&upgrade.namespace, "namespace", "default", "the namespace to install the release into (only used if --install is set)")
+	f.StringVar(&upgrade.version, "version", "", "specify the exact chart version to use. If this is not specified, the latest version is used.")
 
 	return cmd
 }
 
 func (u *upgradeCmd) run() error {
-	chartPath, err := locateChartPath(u.chart, u.verify, u.keyring)
+	chartPath, err := locateChartPath(u.chart, u.version, u.verify, u.keyring)
 	if err != nil {
 		return err
 	}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,6 +7,11 @@ This guide covers how you can quickly get started using Helm.
 - You must have Kubernetes installed, and have a local configured copy
   of `kubectl`.
 
+Helm will figure out where to install Tiller by reading your Kubernetes
+configuration file (usually `$HOME/.kube/config`). This is the same file
+that `kubectl` uses, so to find out which cluster Tiller would install
+to, you can run `kubectl cluster-info`.
+
 ## Install Helm
 
 Download a binary release of the Helm client from 
@@ -27,20 +32,19 @@ $ helm init
 
 ## Install an Example Chart
 
-To install a chart, you can run the `helm install` command. 
-Let's use an example chart from this repository. 
+To install a chart, you can run the `helm install` command.
+Let's use an example chart from this repository.
 Make sure you are in the root directory of this repo.
 
 
 ```console
-$ helm install docs/examples/alpine
+$ helm install stable/mysql
 Released smiling-penguin
 ```
 
-In the example above, the `alpine` chart was released, and the name of
-our new release is `smiling-penguin`. You can view the details of the chart we just 
-installed by taking a look at the nginx chart in 
-[docs/examples/alpine/Chart.yaml](examples/alpine/Chart.yaml).
+In the example above, the `stable/mysql` chart was released, and the name of
+our new release is `smiling-penguin`. You get a simple idea of this
+MySQL chart by running `helm inspect stable/mysql`.
 
 ## Change a Default Chart Value
 
@@ -48,7 +52,7 @@ A nice feature of helm is the ability to change certain values of the package fo
 Let's install the `nginx` example from this repository but change the `replicaCount` to 7.
 
 ```console
-$ helm install --set replicaCount=7 docs/examples/nginx
+$ helm install --set replicaCount=7 ./docs/examples/nginx
 happy-panda
 ```
 
@@ -64,6 +68,9 @@ To find out about our release, run `helm status`:
 $ helm status smiling-penguin
 Status: DEPLOYED
 ```
+
+The `status` command will display information about a release in your
+cluster.
 
 ## Uninstall a Release
 

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -181,7 +181,7 @@ To see what options are configurable on a chart, use `helm inspect
 values`:
 
 ```console
-helm inspect values stable/mariadb-0.3.0.tgz
+helm inspect values stable/mariadb
 Fetched stable/mariadb-0.3.0.tgz to /Users/mattbutcher/Code/Go/src/k8s.io/helm/mariadb-0.3.0.tgz
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
@@ -235,7 +235,7 @@ complex, Helm tries to perform the least invasive upgrade. It will only
 update things that have changed since the last release.
 
 ```console
-$ helm upgrade -f panda.yaml happy-panda stable/mariadb-0.3.0.tgz                                                                                        1 ↵
+$ helm upgrade -f panda.yaml happy-panda stable/mariadb
 Fetched stable/mariadb-0.3.0.tgz to /Users/mattbutcher/Code/Go/src/k8s.io/helm/mariadb-0.3.0.tgz
 happy-panda has been upgraded. Happy Helming!
 Last Deployed: Wed Sep 28 12:47:54 2016

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -60,6 +60,8 @@ type Verification struct {
 	SignedBy *openpgp.Entity
 	// FileHash is the hash, prepended with the scheme, for the file that was verified.
 	FileHash string
+	// FileName is the name of the file that FileHash verifies.
+	FileName string
 }
 
 // Signatory signs things.
@@ -221,6 +223,7 @@ func (s *Signatory) Verify(chartpath, sigpath string) (*Verification, error) {
 		return ver, fmt.Errorf("sha256 sum does not match for %s: %q != %q", basename, sha, sum)
 	}
 	ver.FileHash = sum
+	ver.FileName = basename
 
 	// TODO: when image signing is added, verify that here.
 

--- a/pkg/provenance/sign_test.go
+++ b/pkg/provenance/sign_test.go
@@ -18,6 +18,7 @@ package provenance
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -246,6 +247,8 @@ func TestVerify(t *testing.T) {
 		t.Error("Verification is missing hash.")
 	} else if ver.SignedBy == nil {
 		t.Error("No SignedBy field")
+	} else if ver.FileName != filepath.Base(testChartfile) {
+		t.Errorf("FileName is unexpectedly %q", ver.FileName)
 	}
 
 	if _, err = signer.Verify(testChartfile, testTamperedSigBlock); err == nil {

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -138,7 +138,10 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 	if !ok {
 		return nil, ErrNoChartName
 	}
-	if version == "" && len(vs) > 0 {
+	if len(vs) == 0 {
+		return nil, ErrNoChartVersion
+	}
+	if len(version) == 0 {
 		return vs[0], nil
 	}
 	for _, ver := range vs {
@@ -147,7 +150,7 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 			return ver, nil
 		}
 	}
-	return nil, ErrNoChartVersion
+	return nil, fmt.Errorf("No chart version found for %s-%s", name, version)
 }
 
 // WriteFile writes an index file to the given destination path.

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -123,8 +123,6 @@ func (s *Server) CreateIndex() error {
 		return err
 	}
 
-	println(string(d))
-
 	ifile := filepath.Join(s.docroot, "index.yaml")
 	return ioutil.WriteFile(ifile, d, 0755)
 }
@@ -148,11 +146,23 @@ func (s *Server) URL() string {
 	return s.srv.URL
 }
 
+// LinkIndices links the index created with CreateIndex and makes a symboic link to the repositories/cache directory.
+//
+// This makes it possible to simulate a local cache of a repository.
+func (s *Server) LinkIndices() error {
+	destfile := "test-index.yaml"
+	// Link the index.yaml file to the
+	lstart := filepath.Join(s.docroot, "index.yaml")
+	ldest := filepath.Join(s.docroot, "repository/cache", destfile)
+	return os.Symlink(lstart, ldest)
+}
+
 // setTestingRepository sets up a testing repository.yaml with only the given name/URL.
 func setTestingRepository(helmhome, name, url string) error {
 	rf := repo.NewRepoFile()
 	rf.Add(&repo.Entry{Name: name, URL: url})
 	os.MkdirAll(filepath.Join(helmhome, "repository", name), 0755)
 	dest := filepath.Join(helmhome, "repository/repositories.yaml")
+
 	return rf.WriteFile(dest, 0644)
 }


### PR DESCRIPTION
This removes the requirement that a fetch or install command must
explicitly state the version number to install. Instead, this goes to
the strategy used by OS package managers: Install the latest until told
to do otherwise.

Closes #1198

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1293)

<!-- Reviewable:end -->
