### PR TITLE
Fix typo in chart docs

### DIFF
--- a/docs/charts.md
+++ b/docs/charts.md
@@ -255,7 +255,7 @@ spec:
 
 The above example, based loosely on [https://github.com/deis/charts](https://github.com/deis/charts), is a template for a Kubernetes replication controller.
 It can use the following four template values (usually defined in a
-`.values.yaml` file):
+`values.yaml` file):
 
 - `imageRegistry`: The source registry for the Docker image.
 - `dockerTag`: The tag for the docker image.


### PR DESCRIPTION
The name for the default values file is `values.yaml` and not `.values.yaml`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1296)

<!-- Reviewable:end -->
