### PR TITLE
Fix docs regarding .Files.GetString and .Files.GetBytes

### DIFF
--- a/docs/charts.md
+++ b/docs/charts.md
@@ -287,8 +287,8 @@ sensitive_.
 - `Files`: A map-like object containing all non-special files in the chart. This
   will not give you access to templates, but will give you access to additional
   files that are present. Files can be accessed using `{{index .Files "file.name"}}`
-  or using the `{{.Files.Get name}}` or `{{.Files.GetString name}}` functions. Note that
-  file data is returned as a `[]byte` unless `{{.Files.GetString}}` is used.
+  or using the `{{.Files.Get name}}` or `{{.Files.GetString name}}` functions. You can
+  also access the contents of the file as `[]byte` using `{{.Files.GetBytes}}`
 
 **NOTE:** Any unknown Chart.yaml fields will be dropped. They will not
 be accessible inside of the `Chart` object. Thus, Chart.yaml cannot be


### PR DESCRIPTION
After #1021 `.Files.GetString` does not exist any more.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1299)

<!-- Reviewable:end -->
