### PR TITLE
fix(ci): fix ci builds reporting dirty repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,8 +22,8 @@ dependencies:
 
   override:
     # install go
-    - wget "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
-    - sudo tar -C /usr/local -xzf "go${GOVERSION}.linux-amd64.tar.gz"
+    - wget "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" -O "${HOME}/go${GOVERSION}.tar.gz"
+    - sudo tar -C /usr/local -xzf "${HOME}/go${GOVERSION}.tar.gz"
 
     # move repository to the canonical import path
     - mkdir -p "$(dirname ${WORKDIR})"


### PR DESCRIPTION
```
% ./helm version
Client: &version.Version{SemVer:"v2.0.0-alpha.5", GitCommit:"4de...", GitTreeState:"dirty"}
Server: &version.Version{SemVer:"v2.0.0-alpha.5", GitCommit:"4de...", GitTreeState:"dirty"}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1307)

<!-- Reviewable:end -->
