### PR TITLE
docs(install): Add reference to glide in install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,7 @@ Here are links to the common builds:
 Building Helm from source is slightly more work, but is the best way to
 go if you want to test the latest (pre-release) Helm version.
 
-You must have a working Go environment.
+You must have a working Go environment with (https://github.com/Masterminds/glide)[glide] installed.
 
 ```console
 $ cd $GOPATH

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,7 @@ Here are links to the common builds:
 Building Helm from source is slightly more work, but is the best way to
 go if you want to test the latest (pre-release) Helm version.
 
-You must have a working Go environment with (https://github.com/Masterminds/glide)[glide] installed.
+You must have a working Go environment with (https://github.com/Masterminds/glide)[glide]and Mercurial installed.
 
 ```console
 $ cd $GOPATH


### PR DESCRIPTION
The user needs to get all of the way down to developers docs to realize they need glide, but if you follow a user who doesn't necessarily want to develop but wants to build from source, you'd follow this path:
README -> Quick Start -> Releases -> . o O (Binary doesn't work) -> Install
And then you'd realize that you need Glide.

This one-liner patch fixes that. :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1308)

<!-- Reviewable:end -->
