### PR TITLE
fix(tiller): correct sort manifests by type

### DIFF
--- a/cmd/tiller/hooks.go
+++ b/cmd/tiller/hooks.go
@@ -165,5 +165,5 @@ func sortManifests(files map[string]string, apis versionSet, sort SortOrder) ([]
 		}
 		hs = append(hs, h)
 	}
-	return hs, generic, nil
+	return hs, sortByKind(generic, sort), nil
 }


### PR DESCRIPTION
Closes #1313

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1315)

<!-- Reviewable:end -->
