### PR TITLE
ref(helm): add new line after repo remove msg

### DIFF
--- a/cmd/helm/repo_remove.go
+++ b/cmd/helm/repo_remove.go
@@ -78,7 +78,7 @@ func removeRepoLine(out io.Writer, name string, home helmpath.Home) error {
 		return err
 	}
 
-	fmt.Fprintf(out, "%q has been removed from your repositories", name)
+	fmt.Fprintf(out, "%q has been removed from your repositories\n", name)
 
 	return nil
 }


### PR DESCRIPTION
I think this got lost in a refactor. Was just bothering me.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1324)

<!-- Reviewable:end -->
