### PR TITLE
fix(Makefile): allow overriding the version for canary builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ dist:
 		cd _dist && \
 		$(DIST_DIRS) cp ../LICENSE {} \; && \
 		$(DIST_DIRS) cp ../README.md {} \; && \
-		$(DIST_DIRS) tar -zcf helm-${GIT_TAG}-{}.tar.gz {} \; && \
-		$(DIST_DIRS) zip -r helm-${GIT_TAG}-{}.zip {} \; \
+		$(DIST_DIRS) tar -zcf helm-${VERSION}-{}.tar.gz {} \; && \
+		$(DIST_DIRS) zip -r helm-${VERSION}-{}.zip {} \; \
 	)
 
 .PHONY: checksum


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1340)

<!-- Reviewable:end -->
