### PR TITLE
docs(repo): update repo index docs to show new flags

### DIFF
--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -124,7 +124,7 @@ $ mv alpine-0.1.0.tgz fantastic-charts/
 Outside of your directory, run the `helm repo index [DIR] [URL]` command. This command takes the path of the local directory that you just created and the URL of your remote chart repository and composes an index.yaml file inside the given directory path.
 
 ```console
-$ helm repo index fantastic-charts https://storage.googleapis.com/fantastic-charts
+$ helm repo index fantastic-charts --url https://storage.googleapis.com/fantastic-charts
 ```
 
 Now, you can upload the chart and the index file to your chart repository using a sync tool or manually. If you're using Google Cloud Storage, check out this [example workflow](chart_repository_sync_example.md) using the gsutil client.

--- a/docs/chart_repository_sync_example.md
+++ b/docs/chart_repository_sync_example.md
@@ -19,7 +19,7 @@ $ mv alpine-0.1.0.tgz fantastic-charts/
 Use helm to generate an updated index.yaml file by passing in the directory path and the url of the remote repository to the `helm repo index` command like this:
 
 ```console
-$ helm repo index fantastic-charts/ https://storage.googleapis.com/fantastic-charts
+$ helm repo index fantastic-charts/ --url https://storage.googleapis.com/fantastic-charts
 ```
 This will generate an updated index.yaml file and place in the `fantastic-charts/` directory.
 


### PR DESCRIPTION
This adds the `--url` flag to examples.

Closes #1343

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1344)

<!-- Reviewable:end -->
