### PR TITLE
Fixed broken link from "chart.md" to "charts.md"

### DIFF
--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -344,7 +344,7 @@ sure your Helm client is up to date by running `helm repo update`.
 
 ## Creating Your Own Charts
 
-The [Chart Development Guide](chart.md) explains how to develop your own
+The [Chart Development Guide](charts.md) explains how to develop your own
 charts. But you can get started quickly by using the `helm create`
 command:
 


### PR DESCRIPTION
Found and fixed this broken link in the docs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1350)

<!-- Reviewable:end -->
