### PR TITLE
feat(helm): add kubeconfig context switching to init command

### DIFF
--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestInstall(t *testing.T) {
+	image := "gcr.io/kubernetes-helm/tiller:v2.0.0"
+
+	fake := testclient.Fake{}
+	fake.AddReactor("create", "deployments", func(action testclient.Action) (bool, runtime.Object, error) {
+		obj := action.(testclient.CreateAction).GetObject().(*extensions.Deployment)
+		l := obj.GetLabels()
+		if reflect.DeepEqual(l, map[string]string{"app": "helm"}) {
+			t.Errorf("expected labels = '', got '%s'", l)
+		}
+		i := obj.Spec.Template.Spec.Containers[0].Image
+		if i != image {
+			t.Errorf("expected image = '%s', got '%s'", image, i)
+		}
+		return true, obj, nil
+	})
+
+	err := Install(fake.Extensions(), "default", image, false)
+	if err != nil {
+		t.Errorf("unexpected error: %#+v", err)
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0b56505a7d2b0bde1a8aba9c4ac52ef18ea1eae6d46157db598e5a1051b64cf5
-updated: 2016-10-11T12:54:05.869559929-06:00
+hash: e04a956fc7be01bd1a2450cdc0000ed25394da383f0c7a7e057a9377bd832c1e
+updated: 2016-10-13T12:28:13.380298639-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -434,7 +434,7 @@ imports:
   - 1.4/tools/metrics
   - 1.4/transport
 - name: k8s.io/kubernetes
-  version: ef16c3f8079df0654c8336741134ba142846ec13
+  version: fc3dab7de68c15de3421896dd051c2f127fb64ab
   subpackages:
   - federation/apis/federation
   - federation/apis/federation/install
@@ -446,7 +446,6 @@ imports:
   - pkg/api
   - pkg/api/annotations
   - pkg/api/endpoints
-  - pkg/api/error
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,25 +25,26 @@ import:
   version: ~1.4.1
   subpackages:
   - pkg/api
-  - pkg/api/meta
-  - pkg/api/error
+  - pkg/api/errors
   - pkg/api/unversioned
   - pkg/apimachinery/registered
+  - pkg/apis/batch
+  - pkg/apis/extensions
   - pkg/client/restclient
   - pkg/client/unversioned
-  - pkg/apis/batch
   - pkg/client/unversioned/clientcmd
-  - pkg/client/unversioned/fake
   - pkg/client/unversioned/portforward
   - pkg/client/unversioned/remotecommand
+  - pkg/client/unversioned/testclient
   - pkg/kubectl
   - pkg/kubectl/cmd/util
   - pkg/kubectl/resource
   - pkg/labels
   - pkg/runtime
-  - pkg/watch
+  - pkg/util/intstr
   - pkg/util/strategicpatch
   - pkg/util/yaml
+  - pkg/watch
 - package: github.com/gosuri/uitable
 - package: github.com/asaskevich/govalidator
   version: ^4.0.0

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube // import "k8s.io/helm/pkg/kube"
+
+import (
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+)
+
+// GetConfig returns a kubernetes client config for a given context.
+func GetConfig(context string) clientcmd.ClientConfig {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	overrides := &clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+}

--- a/pkg/kube/tunnel.go
+++ b/pkg/kube/tunnel.go
@@ -17,11 +17,13 @@ limitations under the License.
 package kube
 
 import (
-	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"strconv"
 
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/portforward"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 )
@@ -30,8 +32,27 @@ import (
 type Tunnel struct {
 	Local     int
 	Remote    int
+	Namespace string
+	PodName   string
+	Out       io.Writer
 	stopChan  chan struct{}
 	readyChan chan struct{}
+	config    *restclient.Config
+	client    *restclient.RESTClient
+}
+
+// NewTunnel creates a new tunnel
+func NewTunnel(client *restclient.RESTClient, config *restclient.Config, namespace, podName string, remote int) *Tunnel {
+	return &Tunnel{
+		config:    config,
+		client:    client,
+		Namespace: namespace,
+		PodName:   podName,
+		Remote:    remote,
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		Out:       ioutil.Discard,
+	}
 }
 
 // Close disconnects a tunnel connection
@@ -41,48 +62,31 @@ func (t *Tunnel) Close() {
 }
 
 // ForwardPort opens a tunnel to a kubernetes pod
-func (c *Client) ForwardPort(namespace, podName string, remote int) (*Tunnel, error) {
-	client, err := c.Client()
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := c.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// Build a url to the portforward endpoing
+func (t *Tunnel) ForwardPort() error {
+	// Build a url to the portforward endpoint
 	// example: http://localhost:8080/api/v1/namespaces/helm/pods/tiller-deploy-9itlq/portforward
-	u := client.RESTClient.Post().
+	u := t.client.Post().
 		Resource("pods").
-		Namespace(namespace).
-		Name(podName).
+		Namespace(t.Namespace).
+		Name(t.PodName).
 		SubResource("portforward").URL()
 
-	dialer, err := remotecommand.NewExecutor(config, "POST", u)
+	dialer, err := remotecommand.NewExecutor(t.config, "POST", u)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	local, err := getAvailablePort()
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("could not find an available port: %s", err)
 	}
+	t.Local = local
 
-	t := &Tunnel{
-		Local:     local,
-		Remote:    remote,
-		stopChan:  make(chan struct{}, 1),
-		readyChan: make(chan struct{}, 1),
-	}
+	ports := []string{fmt.Sprintf("%d:%d", t.Local, t.Remote)}
 
-	ports := []string{fmt.Sprintf("%d:%d", local, remote)}
-
-	var b bytes.Buffer
-	pf, err := portforward.New(dialer, ports, t.stopChan, t.readyChan, &b, &b)
+	pf, err := portforward.New(dialer, ports, t.stopChan, t.readyChan, t.Out, t.Out)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	errChan := make(chan error)
@@ -92,9 +96,9 @@ func (c *Client) ForwardPort(namespace, podName string, remote int) (*Tunnel, er
 
 	select {
 	case err = <-errChan:
-		return t, fmt.Errorf("Error forwarding ports: %v\n", err)
+		return fmt.Errorf("Error forwarding ports: %v\n", err)
 	case <-pf.Ready:
-		return t, nil
+		return nil
 	}
 }
 


### PR DESCRIPTION
- decouple tunnel from kube client
- add context switching for init cmd
- add unit tests for installer and init command
- refactor installer and remove unused code

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1359)

<!-- Reviewable:end -->
