### PR TITLE
fix(helm): allow entries to be merged into index

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -191,6 +191,35 @@ func (r *ChartRepository) saveIndexFile() error {
 
 // Index generates an index for the chart repository and writes an index.yaml file.
 func (r *ChartRepository) Index() error {
+	err := r.generateIndex()
+	if err != nil {
+		return err
+	}
+	return r.saveIndexFile()
+}
+
+// MergeIndex merges the given index file into this index, and then writes the result.
+//
+// This provides a parallel function to the Index() method, but with the additional merge step.
+func (r *ChartRepository) MergeIndex(f *IndexFile) error {
+	err := r.generateIndex()
+	if err != nil {
+		return err
+	}
+
+	for _, cvs := range f.Entries {
+		for _, cv := range cvs {
+			if !r.IndexFile.Has(cv.Name, cv.Version) {
+				e := r.IndexFile.Entries[cv.Name]
+				r.IndexFile.Entries[cv.Name] = append(e, cv)
+			}
+		}
+	}
+
+	return r.saveIndexFile()
+}
+
+func (r *ChartRepository) generateIndex() error {
 	if r.IndexFile == nil {
 		r.IndexFile = NewIndexFile()
 	}
@@ -212,5 +241,5 @@ func (r *ChartRepository) Index() error {
 		// TODO: If a chart exists, but has a different Digest, should we error?
 	}
 	r.IndexFile.SortEntries()
-	return r.saveIndexFile()
+	return nil
 }


### PR DESCRIPTION
Between Alpha.4 and Alpha.5 there was a change in the indexing logic.
This prevent indices from being appended to (because those index files
were often broken). This change allows the user to explicitly merge an
existing index and a generated index.

Closes #1334

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1361)

<!-- Reviewable:end -->
