### PR TITLE
feat(helm): add canary option to init command

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -46,6 +46,7 @@ const (
 type initCmd struct {
 	image      string
 	clientOnly bool
+	canary     bool
 	out        io.Writer
 	home       helmpath.Home
 	kubeClient unversioned.DeploymentsNamespacer
@@ -68,7 +69,8 @@ func newInitCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&i.image, "tiller-image", "i", "", "override tiller image")
-	cmd.Flags().BoolVarP(&i.clientOnly, "client-only", "c", false, "If set does not install tiller")
+	cmd.Flags().BoolVar(&i.canary, "canary-image", false, "use the canary tiller image")
+	cmd.Flags().BoolVarP(&i.clientOnly, "client-only", "c", false, "if set does not install tiller")
 	return cmd
 }
 
@@ -86,7 +88,7 @@ func (i *initCmd) run() error {
 			}
 			i.kubeClient = c
 		}
-		if err := installer.Install(i.kubeClient, tillerNamespace, i.image, flagDebug); err != nil {
+		if err := installer.Install(i.kubeClient, tillerNamespace, i.image, i.canary, flagDebug); err != nil {
 			if !kerrors.IsAlreadyExists(err) {
 				return fmt.Errorf("error installing: %s", err)
 			}

--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -35,8 +35,11 @@ const defaultImage = "gcr.io/kubernetes-helm/tiller"
 // command failed.
 //
 // If verbose is true, this will print the manifest to stdout.
-func Install(client unversioned.DeploymentsNamespacer, namespace, image string, verbose bool) error {
-	if image == "" {
+func Install(client unversioned.DeploymentsNamespacer, namespace, image string, canary, verbose bool) error {
+	switch {
+	case canary:
+		image = defaultImage + ":canary"
+	case image == "":
 		image = fmt.Sprintf("%s:%s", defaultImage, version.Version)
 	}
 	obj := generateDeployment(image)

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -42,7 +42,24 @@ func TestInstall(t *testing.T) {
 		return true, obj, nil
 	})
 
-	err := Install(fake.Extensions(), "default", image, false)
+	err := Install(fake.Extensions(), "default", image, false, false)
+	if err != nil {
+		t.Errorf("unexpected error: %#+v", err)
+	}
+}
+
+func TestInstall_canary(t *testing.T) {
+	fake := testclient.Fake{}
+	fake.AddReactor("create", "deployments", func(action testclient.Action) (bool, runtime.Object, error) {
+		obj := action.(testclient.CreateAction).GetObject().(*extensions.Deployment)
+		i := obj.Spec.Template.Spec.Containers[0].Image
+		if i != "gcr.io/kubernetes-helm/tiller:canary" {
+			t.Errorf("expected canary image, got '%s'", i)
+		}
+		return true, obj, nil
+	})
+
+	err := Install(fake.Extensions(), "default", "", true, false)
 	if err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}


### PR DESCRIPTION
To install the tiller canary `helm init --canary`
