### PR TITLE
fix(lint): use correct hash key for rendered tmpl

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -94,7 +94,7 @@ func Templates(linter *support.Linter) {
 		// NOTE, disabled for now, Refs https://github.com/kubernetes/helm/issues/1037
 		// linter.RunLinterRule(support.WarningSev, path, validateQuotes(string(preExecutedTemplate)))
 
-		renderedContent := renderedContentMap[fileName]
+		renderedContent := renderedContentMap[filepath.Join(chart.GetMetadata().Name, fileName)]
 		var yamlStruct K8sYamlStruct
 		// Even though K8sYamlStruct only defines Metadata namespace, an error in any other
 		// key will be raised as well


### PR DESCRIPTION
The YAML validation was broken because the renderedContentMap has keys
with the path to the template including the chart directory, whereas the
linter was trying to access it relative from the chart directory.

For example, the hash key was `drupal/templates/deployment.yaml` but the
linter was trying to access `templates/deployment.yaml`. This commit
fixes the key used to access the rendered content.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1370)

<!-- Reviewable:end -->
