### PR TITLE
fix(linter): add engine.FuncMap so linter can use real function list

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -52,6 +52,24 @@ func TestEngine(t *testing.T) {
 	}
 }
 
+func TestFuncMap(t *testing.T) {
+	fns := FuncMap()
+	forbidden := []string{"env", "expandenv"}
+	for _, f := range forbidden {
+		if _, ok := fns[f]; ok {
+			t.Errorf("Forbidden function %s exists in FuncMap.", f)
+		}
+	}
+
+	// Test for Engine-specific template functions.
+	expect := []string{"include", "toYaml"}
+	for _, f := range expect {
+		if _, ok := fns[f]; !ok {
+			t.Errorf("Expected add-on function %q", f)
+		}
+	}
+}
+
 func TestRender(t *testing.T) {
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 	"text/template"
 
-	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/engine"
@@ -138,7 +137,7 @@ func validateAllowedExtension(fileName string) error {
 func validateNoMissingValues(templatesPath string, chartValues chartutil.Values, templateContent []byte) error {
 	// 1 - Load Main and associated templates
 	// Main template that we will parse dynamically
-	tmpl := template.New("tpl").Funcs(sprig.TxtFuncMap())
+	tmpl := template.New("tpl").Funcs(engine.FuncMap())
 	// If the templatesPath includes any *.tpl files we will parse and import them as associated templates
 	associatedTemplates, err := filepath.Glob(filepath.Join(templatesPath, "*.tpl"))
 


### PR DESCRIPTION
This adds a function engine.FuncMap that returns a function mapping that
better represents the functions passed to a template. The linting logic
is reconfigured to use this function instead of the sprig.FuncMap
function.

Closes #1366

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1376)

<!-- Reviewable:end -->
