### PR TITLE
Fix/tiller helm flags

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -62,6 +62,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	cc := &createCmd{
 		out: out,
 	}
+
 	cmd := &cobra.Command{
 		Use:   "create NAME",
 		Short: "create a new chart with the given name",
@@ -74,6 +75,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 			return cc.run()
 		},
 	}
+
 	return cmd
 }
 

--- a/cmd/helm/delete.go
+++ b/cmd/helm/delete.go
@@ -71,6 +71,7 @@ func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			return nil
 		},
 	}
+
 	f := cmd.Flags()
 	f.BoolVar(&del.dryRun, "dry-run", false, "simulate a delete")
 	f.BoolVar(&del.disableHooks, "no-hooks", false, "prevent hooks from running during deletion")

--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -64,8 +64,8 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&dbc.verify, "verify", false, "Verify the packages against signatures.")
-	f.StringVar(&dbc.keyring, "keyring", defaultKeyring(), "The keyring containing public keys.")
+	f.BoolVar(&dbc.verify, "verify", false, "verify the packages against signatures")
+	f.StringVar(&dbc.keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 
 	return cmd
 }

--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -73,8 +73,8 @@ func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&duc.verify, "verify", false, "Verify the packages against signatures.")
-	f.StringVar(&duc.keyring, "keyring", defaultKeyring(), "The keyring containing public keys.")
+	f.BoolVar(&duc.verify, "verify", false, "verify the packages against signatures")
+	f.StringVar(&duc.keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 
 	return cmd
 }

--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -79,12 +79,12 @@ func newFetchCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&fch.untar, "untar", false, "If set to true, will untar the chart after downloading it.")
-	f.StringVar(&fch.untardir, "untardir", ".", "If untar is specified, this flag specifies the name of the directory into which the chart is expanded.")
-	f.BoolVar(&fch.verify, "verify", false, "Verify the package against its signature.")
-	f.StringVar(&fch.version, "version", "", "The specific version of a chart. Without this, the latest version is fetched.")
-	f.StringVar(&fch.keyring, "keyring", defaultKeyring(), "The keyring containing public keys.")
-	f.StringVarP(&fch.destdir, "destination", "d", ".", "The location to write the chart. If this and tardir are specified, tardir is appended to this.")
+	f.BoolVar(&fch.untar, "untar", false, "if set to true, will untar the chart after downloading it")
+	f.StringVar(&fch.untardir, "untardir", ".", "if untar is specified, this flag specifies the name of the directory into which the chart is expanded")
+	f.BoolVar(&fch.verify, "verify", false, "verify the package against its signature")
+	f.StringVar(&fch.version, "version", "", "specific version of a chart. Without this, the latest version is fetched")
+	f.StringVar(&fch.keyring, "keyring", defaultKeyring(), "keyring containing public keys")
+	f.StringVarP(&fch.destdir, "destination", "d", ".", "location to write the chart. If this and tardir are specified, tardir is appended to this")
 
 	return cmd
 }

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -56,6 +56,7 @@ func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		out:    out,
 		client: client,
 	}
+
 	cmd := &cobra.Command{
 		Use:               "get [flags] RELEASE_NAME",
 		Short:             "download a named release",
@@ -78,6 +79,7 @@ func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	cmd.AddCommand(newGetValuesCmd(nil, out))
 	cmd.AddCommand(newGetManifestCmd(nil, out))
 	cmd.AddCommand(newGetHooksCmd(nil, out))
+
 	return cmd
 }
 

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -54,6 +54,7 @@ type historyCmd struct {
 
 func newHistoryCmd(c helm.Interface, w io.Writer) *cobra.Command {
 	his := &historyCmd{out: w, helmc: c}
+
 	cmd := &cobra.Command{
 		Use:               "history [flags] RELEASE_NAME",
 		Long:              historyHelp,
@@ -73,6 +74,7 @@ func newHistoryCmd(c helm.Interface, w io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().Int32Var(&his.max, "max", 256, "maximum number of revision to include in history")
+
 	return cmd
 }
 

--- a/cmd/helm/home.go
+++ b/cmd/helm/home.go
@@ -37,5 +37,6 @@ func newHomeCmd(out io.Writer) *cobra.Command {
 			fmt.Fprintf(out, homePath()+"\n")
 		},
 	}
+
 	return cmd
 }

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -56,6 +56,7 @@ func newInitCmd(out io.Writer) *cobra.Command {
 	i := &initCmd{
 		out: out,
 	}
+
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "initialize Helm on both client and server",
@@ -68,9 +69,12 @@ func newInitCmd(out io.Writer) *cobra.Command {
 			return i.run()
 		},
 	}
-	cmd.Flags().StringVarP(&i.image, "tiller-image", "i", "", "override tiller image")
-	cmd.Flags().BoolVar(&i.canary, "canary-image", false, "use the canary tiller image")
-	cmd.Flags().BoolVarP(&i.clientOnly, "client-only", "c", false, "if set does not install tiller")
+
+	f := cmd.Flags()
+	f.StringVarP(&i.image, "tiller-image", "i", "", "override tiller image")
+	f.BoolVar(&i.canary, "canary-image", false, "use the canary tiller image")
+	f.BoolVarP(&i.clientOnly, "client-only", "c", false, "if set does not install tiller")
+
 	return cmd
 }
 

--- a/cmd/helm/inspect.go
+++ b/cmd/helm/inspect.go
@@ -121,14 +121,14 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	chartSubCmd.Flags().BoolVar(&insp.verify, vflag, false, vdesc)
 
 	kflag := "keyring"
-	kdesc := "the path to the keyring containing public verification keys"
+	kdesc := "path to the keyring containing public verification keys"
 	kdefault := defaultKeyring()
 	inspectCommand.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
 	valuesSubCmd.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
 	chartSubCmd.Flags().StringVar(&insp.keyring, kflag, kdefault, kdesc)
 
 	verflag := "version"
-	verdesc := "the version of the chart. By default, the newest chart is shown."
+	verdesc := "version of the chart. By default, the newest chart is shown"
 	inspectCommand.Flags().StringVar(&insp.version, verflag, "", verdesc)
 	valuesSubCmd.Flags().StringVar(&insp.version, verflag, "", verdesc)
 	chartSubCmd.Flags().StringVar(&insp.version, verflag, "", verdesc)

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -126,9 +126,9 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&inst.valuesFile, "values", "f", "", "specify values in a YAML file")
-	f.StringVarP(&inst.name, "name", "n", "", "the release name. If unspecified, it will autogenerate one for you")
+	f.StringVarP(&inst.name, "name", "n", "", "release name. If unspecified, it will autogenerate one for you")
 	// TODO use kubeconfig default
-	f.StringVar(&inst.namespace, "namespace", "default", "the namespace to install the release into")
+	f.StringVar(&inst.namespace, "namespace", "default", "namespace to install the release into")
 	f.BoolVar(&inst.dryRun, "dry-run", false, "simulate an install")
 	f.BoolVar(&inst.disableHooks, "no-hooks", false, "prevent hooks from running during install")
 	f.BoolVar(&inst.replace, "replace", false, "re-use the given name, even if that name is already used. This is unsafe in production")
@@ -136,7 +136,8 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.nameTemplate, "name-template", "", "specify template used to name the release")
 	f.BoolVar(&inst.verify, "verify", false, "verify the package before installing it")
 	f.StringVar(&inst.keyring, "keyring", defaultKeyring(), "location of public keys used for verification")
-	f.StringVar(&inst.version, "version", "", "specify the exact chart version to install. If this is not specified, the latest version is installed.")
+	f.StringVar(&inst.version, "version", "", "specify the exact chart version to install. If this is not specified, the latest version is installed")
+
 	return cmd
 }
 

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -63,7 +63,9 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			return l.run()
 		},
 	}
+
 	cmd.Flags().BoolVar(&l.strict, "strict", false, "fail on lint warnings")
+
 	return cmd
 }
 

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -77,6 +77,7 @@ func newListCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		out:    out,
 		client: client,
 	}
+
 	cmd := &cobra.Command{
 		Use:               "list [flags] [FILTER]",
 		Short:             "list releases",
@@ -93,18 +94,20 @@ func newListCmd(client helm.Interface, out io.Writer) *cobra.Command {
 			return list.run()
 		},
 	}
+
 	f := cmd.Flags()
 	f.BoolVarP(&list.short, "short", "q", false, "output short (quiet) listing format")
 	f.BoolVarP(&list.byDate, "date", "d", false, "sort by release date")
 	f.BoolVarP(&list.sortDesc, "reverse", "r", false, "reverse the sort order")
 	f.IntVarP(&list.limit, "max", "m", 256, "maximum number of releases to fetch")
-	f.StringVarP(&list.offset, "offset", "o", "", "the next release name in the list, used to offset from start value")
+	f.StringVarP(&list.offset, "offset", "o", "", "next release name in the list, used to offset from start value")
 	f.BoolVar(&list.all, "all", false, "show all releases, not just the ones marked DEPLOYED")
 	f.BoolVar(&list.deleted, "deleted", false, "show deleted releases")
 	f.BoolVar(&list.deployed, "deployed", false, "show deployed releases. If no other is specified, this will be automatically enabled")
 	f.BoolVar(&list.failed, "failed", false, "show failed releases")
 	// TODO: Do we want this as a feature of 'helm list'?
 	//f.BoolVar(&list.superseded, "history", true, "show historical releases")
+
 	return cmd
 }
 

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -58,6 +58,7 @@ func newPackageCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	pkg := &packageCmd{
 		out: out,
 	}
+
 	cmd := &cobra.Command{
 		Use:   "package [flags] [CHART_PATH] [...]",
 		Short: "package a chart directory into a chart archive",
@@ -88,8 +89,8 @@ func newPackageCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&pkg.save, "save", true, "save packaged chart to local chart repository")
 	f.BoolVar(&pkg.sign, "sign", false, "use a PGP private key to sign this package")
-	f.StringVar(&pkg.key, "key", "", "the name of the key to use when signing. Used if --sign is true.")
-	f.StringVar(&pkg.keyring, "keyring", defaultKeyring(), "the location of a public keyring")
+	f.StringVar(&pkg.key, "key", "", "name of the key to use when signing. Used if --sign is true")
+	f.StringVar(&pkg.keyring, "keyring", defaultKeyring(), "location of a public keyring")
 
 	return cmd
 }

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -64,6 +64,7 @@ func newRollbackCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	f.Int32Var(&rollback.version, "revision", 0, "revision to deploy")
 	f.BoolVar(&rollback.dryRun, "dry-run", false, "simulate a rollback")
 	f.BoolVar(&rollback.disableHooks, "no-hooks", false, "prevent hooks from running during rollback")
+
 	return cmd
 }
 

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -61,7 +61,7 @@ func newSearchCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVarP(&sc.regexp, "regexp", "r", false, "use regular expressions for searching")
-	f.BoolVarP(&sc.versions, "versions", "l", false, "show the long listing, with each version of each chart on its own line.")
+	f.BoolVarP(&sc.versions, "versions", "l", false, "show the long listing, with each version of each chart on its own line")
 
 	return cmd
 }

--- a/cmd/helm/serve.go
+++ b/cmd/helm/serve.go
@@ -48,8 +48,10 @@ func newServeCmd(out io.Writer) *cobra.Command {
 			return srv.run()
 		},
 	}
-	cmd.Flags().StringVar(&srv.repoPath, "repo-path", helmpath.Home(homePath()).LocalRepository(), "The local directory path from which to serve charts.")
-	cmd.Flags().StringVar(&srv.address, "address", "localhost:8879", "The address to listen on.")
+
+	f := cmd.Flags()
+	f.StringVar(&srv.repoPath, "repo-path", helmpath.Home(homePath()).LocalRepository(), "local directory path from which to serve charts")
+	f.StringVar(&srv.address, "address", "localhost:8879", "address to listen on")
 
 	return cmd
 }

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -43,6 +43,7 @@ func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		out:    out,
 		client: client,
 	}
+
 	cmd := &cobra.Command{
 		Use:               "status [flags] RELEASE_NAME",
 		Short:             "displays the status of the named release",
@@ -60,7 +61,7 @@ func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().Int32Var(&status.version, "revision", 0, "If set, display the status of the named release with revision")
+	cmd.PersistentFlags().Int32Var(&status.version, "revision", 0, "if set, display the status of the named release with revision")
 
 	return cmd
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -89,10 +89,10 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f.Var(upgrade.values, "set", "set values on the command line. Separate values with commas: key1=val1,key2=val2")
 	f.BoolVar(&upgrade.disableHooks, "disable-hooks", false, "disable pre/post upgrade hooks")
 	f.BoolVar(&upgrade.verify, "verify", false, "verify the provenance of the chart before upgrading")
-	f.StringVar(&upgrade.keyring, "keyring", defaultKeyring(), "the path to the keyring that contains public singing keys")
+	f.StringVar(&upgrade.keyring, "keyring", defaultKeyring(), "path to the keyring that contains public singing keys")
 	f.BoolVarP(&upgrade.install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
-	f.StringVar(&upgrade.namespace, "namespace", "default", "the namespace to install the release into (only used if --install is set)")
-	f.StringVar(&upgrade.version, "version", "", "specify the exact chart version to use. If this is not specified, the latest version is used.")
+	f.StringVar(&upgrade.namespace, "namespace", "default", "namespace to install the release into (only used if --install is set)")
+	f.StringVar(&upgrade.version, "version", "", "specify the exact chart version to use. If this is not specified, the latest version is used")
 
 	return cmd
 }

--- a/cmd/helm/verify.go
+++ b/cmd/helm/verify.go
@@ -59,7 +59,7 @@ func newVerifyCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&vc.keyring, "keyring", defaultKeyring(), "the keyring containing public keys.")
+	f.StringVar(&vc.keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 
 	return cmd
 }

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -39,6 +39,7 @@ func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		client: c,
 		out:    out,
 	}
+
 	cmd := &cobra.Command{
 		Use:               "version",
 		Short:             "print the client/server version information",
@@ -48,6 +49,7 @@ func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			return version.run()
 		},
 	}
+
 	return cmd
 }
 

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -69,9 +69,9 @@ var rootCommand = &cobra.Command{
 
 func main() {
 	pf := rootCommand.PersistentFlags()
-	pf.StringVarP(&grpcAddr, "listen", "l", ":44134", "The address:port to listen on")
-	pf.StringVar(&store, "storage", storageConfigMap, "The storage driver to use. One of 'configmap' or 'memory'")
-	pf.BoolVar(&enableTracing, "trace", false, "Enable rpc tracing")
+	pf.StringVarP(&grpcAddr, "listen", "l", ":44134", "address:port to listen on")
+	pf.StringVar(&store, "storage", storageConfigMap, "storage driver to use. One of 'configmap' or 'memory'")
+	pf.BoolVar(&enableTracing, "trace", false, "enable rpc tracing")
 	rootCommand.Execute()
 }
 

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -68,10 +68,10 @@ var rootCommand = &cobra.Command{
 }
 
 func main() {
-	pf := rootCommand.PersistentFlags()
-	pf.StringVarP(&grpcAddr, "listen", "l", ":44134", "address:port to listen on")
-	pf.StringVar(&store, "storage", storageConfigMap, "storage driver to use. One of 'configmap' or 'memory'")
-	pf.BoolVar(&enableTracing, "trace", false, "enable rpc tracing")
+	p := rootCommand.PersistentFlags()
+	p.StringVarP(&grpcAddr, "listen", "l", ":44134", "address:port to listen on")
+	p.StringVar(&store, "storage", storageConfigMap, "storage driver to use. One of 'configmap' or 'memory'")
+	p.BoolVar(&enableTracing, "trace", false, "enable rpc tracing")
 	rootCommand.Execute()
 }
 


### PR DESCRIPTION
Addresses: #1072 

Notes
- Did a run through of the help flags and commands. Lowercasing first letter and removing ending punctuation.
- Added extra spaces for consistency with programming style.
- Added `f := cmd.Flags()` where missing for consistency.
- Removed `the` from the beginning of messages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1377)

<!-- Reviewable:end -->
