### PR TITLE
docs(helm): Fix broken link to glide project

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,7 @@ Here are links to the common builds:
 Building Helm from source is slightly more work, but is the best way to
 go if you want to test the latest (pre-release) Helm version.
 
-You must have a working Go environment with (https://github.com/Masterminds/glide)[glide]and Mercurial installed.
+You must have a working Go environment with [glide](https://github.com/Masterminds/glide) and Mercurial installed.
 
 ```console
 $ cd $GOPATH


### PR DESCRIPTION
Noticed this when updating glide recently

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1379)

<!-- Reviewable:end -->
