### PR TITLE
fix(1333): cannot delete release in failed state

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -813,11 +813,17 @@ func (s *releaseServer) UninstallRelease(c ctx.Context, req *services.UninstallR
 		return nil, errMissingRelease
 	}
 
-	rel, err := s.env.Releases.Deployed(req.Name)
+	rels, err := s.env.Releases.History(req.Name)
 	if err != nil {
 		log.Printf("uninstall: Release not loaded: %s", req.Name)
 		return nil, err
 	}
+	if len(rels) < 1 {
+		return nil, errMissingRelease
+	}
+
+	relutil.SortByRevision(rels)
+	rel := rels[len(rels)-1]
 
 	// TODO: Are there any cases where we want to force a delete even if it's
 	// already marked deleted?


### PR DESCRIPTION
closes issue #1333.

Now fetches release to delete from its history instead of assuming the release to delete is deployed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1380)

<!-- Reviewable:end -->
