### PR TITLE
fix(helm): return correct version on dep up

### DIFF
--- a/cmd/helm/downloader/manager.go
+++ b/cmd/helm/downloader/manager.go
@@ -333,8 +333,6 @@ func findVersionedEntry(version string, vers repo.ChartVersions) (*repo.ChartVer
 		if version == "" || versionEquals(version, verEntry.Version) {
 			return verEntry, nil
 		}
-
-		return verEntry, nil
 	}
 	return nil, errors.New("no matching version")
 }


### PR DESCRIPTION
There was an extra return statement in a helper that was causing
the download manager to get a false positive on a release version.

Closes #1383

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1384)

<!-- Reviewable:end -->
