### PR TITLE
fix(kube): find current resource by name and kind

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -176,6 +176,7 @@ func (c *Client) Update(namespace string, currentReader, targetReader io.Reader)
 			return err
 		}
 		resourceName := info.Name
+		resourceKind := info.Mapping.GroupVersionKind.Kind
 
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		if _, err := helper.Get(info.Namespace, resourceName, info.Export); err != nil {
@@ -193,7 +194,7 @@ func (c *Client) Update(namespace string, currentReader, targetReader io.Reader)
 			return nil
 		}
 
-		currentObj, err := getCurrentObject(resourceName, currentInfos)
+		currentObj, err := getCurrentObject(resourceName, resourceKind, currentInfos)
 		if err != nil {
 			return err
 		}
@@ -453,10 +454,11 @@ func deleteUnwantedResources(currentInfos, targetInfos []*resource.Info) {
 	}
 }
 
-func getCurrentObject(targetName string, infos []*resource.Info) (runtime.Object, error) {
+func getCurrentObject(targetName, targetKind string, infos []*resource.Info) (runtime.Object, error) {
 	var curr *resource.Info
 	for _, currInfo := range infos {
-		if currInfo.Name == targetName {
+		currKind := currInfo.Mapping.GroupVersionKind.Kind
+		if currInfo.Name == targetName && currKind == targetKind {
 			curr = currInfo
 		}
 	}


### PR DESCRIPTION
This resolves #1210. Update will find current resource
by name and kind for comparison purposes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1385)

<!-- Reviewable:end -->
