### PR TITLE
fix(helm): show failed releases by default

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -33,8 +33,9 @@ import (
 var listHelp = `
 This command lists all of the releases.
 
-By default, it lists only releases that are deployed. Flags like '--delete' and
-'--all' will alter this behavior. Such flags can be combined: '--deleted --failed'.
+By default, it lists only releases that are deployed or failed. Flags like
+'--delete' and '--all' will alter this behavior. Such flags can be combined:
+'--deleted --failed'.
 
 By default, items are sorted alphabetically. Use the '-d' flag to sort by
 release date.
@@ -186,7 +187,7 @@ func (l *listCmd) statusCodes() []release.Status_Code {
 
 	// Default case.
 	if len(status) == 0 {
-		status = append(status, release.Status_DEPLOYED)
+		status = append(status, release.Status_DEPLOYED, release.Status_FAILED)
 	}
 	return status
 }

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -48,6 +48,15 @@ func TestListCmd(t *testing.T) {
 			expected: "NAME \tREVISION\tUPDATED                 \tSTATUS  \tCHART           \natlas\t1       \t(.*)\tDEPLOYED\tfoo-0.1.0-beta.1\n",
 		},
 		{
+			name: "list, one deployed, one failed",
+			args: []string{"-q"},
+			resp: []*release.Release{
+				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_FAILED}),
+				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+			},
+			expected: "thomas-guide\natlas-guide",
+		},
+		{
 			name: "with a release, multiple flags",
 			args: []string{"--deleted", "--deployed", "--failed", "-q"},
 			resp: []*release.Release{
@@ -83,7 +92,7 @@ func TestListCmd(t *testing.T) {
 		}
 		re := regexp.MustCompile(tt.expected)
 		if !re.Match(buf.Bytes()) {
-			t.Errorf("%q. expected %q, got %q", tt.name, tt.expected, buf.String())
+			t.Errorf("%q. expected\n%q\ngot\n%q", tt.name, tt.expected, buf.String())
 		}
 		buf.Reset()
 	}


### PR DESCRIPTION
For 'helm list', this now shows both deployed and failed releases by
default.

Closes #1387

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1389)

<!-- Reviewable:end -->
