### PR TITLE
fix(tiller): fix nil pointers in error messages

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -100,7 +100,7 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 	for _, item := range list.Items {
 		rls, err := decodeRelease(item.Data["release"])
 		if err != nil {
-			logerrf(err, "list: failed to decode release: %s", rls)
+			logerrf(err, "list: failed to decode release: %v", item)
 			continue
 		}
 		if filter(rls) {
@@ -201,7 +201,7 @@ func (cfgmaps *ConfigMaps) Delete(key string) (rls *rspb.Release, err error) {
 			return nil, ErrReleaseNotFound
 		}
 
-		logerrf(err, "delete: failed to get release %q", rls.Name)
+		logerrf(err, "delete: failed to get release %q", key)
 		return nil, err
 	}
 	// delete the release


### PR DESCRIPTION
There were a few places where error messages were accessing properties
of objects that were nil because of the error.

Closes #1374

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1392)

<!-- Reviewable:end -->
