### PR TITLE
fix(1357): print help text if revision is not specified

### DIFF
--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -28,14 +28,13 @@ func TestRollbackCmd(t *testing.T) {
 	tests := []releaseCase{
 		{
 			name:     "rollback a release",
-			args:     []string{"funny-honey"},
-			flags:    []string{"revision", "1"},
+			args:     []string{"funny-honey", "1"},
 			expected: "Rollback was a success! Happy Helming!",
 		},
 		{
-			name:     "rollback a release without version",
-			args:     []string{"funny-honey"},
-			expected: "Rollback was a success! Happy Helming!",
+			name: "rollback a release without revision",
+			args: []string{"funny-honey"},
+			err:  true,
 		},
 	}
 


### PR DESCRIPTION
Require revision number for helm rollback. Drop '--revision flag'.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1394)

<!-- Reviewable:end -->
