### PR TITLE
fix(helm): make 'helm repo index' generate the right index

### DIFF
--- a/cmd/helm/repo_index.go
+++ b/cmd/helm/repo_index.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 
@@ -80,18 +81,18 @@ func (i *repoIndexCmd) run() error {
 }
 
 func index(dir, url, mergeTo string) error {
-	chartRepo, err := repo.LoadChartRepository(dir, url)
+	out := filepath.Join(dir, "index.yaml")
+
+	i, err := repo.IndexDirectory(dir, url)
 	if err != nil {
 		return err
 	}
-
 	if mergeTo != "" {
-		old, err := repo.LoadIndexFile(mergeTo)
+		i2, err := repo.LoadIndexFile(mergeTo)
 		if err != nil {
-			return err
+			return fmt.Errorf("Merge failed: %s", err)
 		}
-		return chartRepo.MergeIndex(old)
+		i.Merge(i2)
 	}
-
-	return chartRepo.Index()
+	return i.WriteFile(out, 0755)
 }

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -170,6 +170,23 @@ func (i IndexFile) WriteFile(dest string, mode os.FileMode) error {
 	return ioutil.WriteFile(dest, b, mode)
 }
 
+// Merge merges the given index file into this index.
+//
+// This merges by name and version.
+//
+// If one of the entries in the given index does _not_ already exist, it is added.
+// In all other cases, the existing record is preserved.
+func (i *IndexFile) Merge(f *IndexFile) {
+	for _, cvs := range f.Entries {
+		for _, cv := range cvs {
+			if !i.Has(cv.Name, cv.Version) {
+				e := i.Entries[cv.Name]
+				i.Entries[cv.Name] = append(e, cv)
+			}
+		}
+	}
+}
+
 // Need both JSON and YAML annotations until we get rid of gopkg.in/yaml.v2
 
 // ChartVersion represents a chart entry in the IndexFile

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -82,27 +82,12 @@ func TestLoadIndexFile(t *testing.T) {
 	verifyLocalIndex(t, i)
 }
 
-func TestMergeIndex(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dirName)
-
-	ind := NewIndexFile()
-	ind.Add(&chart.Metadata{
+func TestMerge(t *testing.T) {
+	ind1 := NewIndexFile()
+	ind1.Add(&chart.Metadata{
 		Name:    "dreadnought",
 		Version: "0.1.0",
 	}, "dreadnought-0.1.0.tgz", "http://example.com", "aaaa")
-
-	cr := &ChartRepository{
-		IndexFile: ind,
-		RootPath:  dirName,
-	}
-
-	if err := cr.saveIndexFile(); err != nil {
-		t.Fatal(err)
-	}
 
 	ind2 := NewIndexFile()
 	ind2.Add(&chart.Metadata{
@@ -113,25 +98,12 @@ func TestMergeIndex(t *testing.T) {
 		Name:    "doughnut",
 		Version: "0.2.0",
 	}, "doughnut-0.2.0.tgz", "http://example.com", "ccccbbbb")
-	cr.IndexFile = ind2
 
-	ind3, err := LoadIndexFile(filepath.Join(dirName, "index.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	ind1.Merge(ind2)
 
-	if err := cr.MergeIndex(ind3); err != nil {
-		t.Fatal(err)
-	}
-
-	ind4, err := LoadIndexFile(filepath.Join(dirName, "index.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(ind4.Entries) != 2 {
-		t.Errorf("Expected 2 entries, got %d", len(ind4.Entries))
-		vs := ind4.Entries["dreadnaught"]
+	if len(ind1.Entries) != 2 {
+		t.Errorf("Expected 2 entries, got %d", len(ind1.Entries))
+		vs := ind1.Entries["dreadnaught"]
 		if len(vs) != 2 {
 			t.Errorf("Expected 2 versions, got %d", len(vs))
 		}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -198,27 +198,6 @@ func (r *ChartRepository) Index() error {
 	return r.saveIndexFile()
 }
 
-// MergeIndex merges the given index file into this index, and then writes the result.
-//
-// This provides a parallel function to the Index() method, but with the additional merge step.
-func (r *ChartRepository) MergeIndex(f *IndexFile) error {
-	err := r.generateIndex()
-	if err != nil {
-		return err
-	}
-
-	for _, cvs := range f.Entries {
-		for _, cv := range cvs {
-			if !r.IndexFile.Has(cv.Name, cv.Version) {
-				e := r.IndexFile.Entries[cv.Name]
-				r.IndexFile.Entries[cv.Name] = append(e, cv)
-			}
-		}
-	}
-
-	return r.saveIndexFile()
-}
-
 func (r *ChartRepository) generateIndex() error {
 	if r.IndexFile == nil {
 		r.IndexFile = NewIndexFile()


### PR DESCRIPTION
This prevents the index command from recursing through directories.
Behind the scenes, it swaps out the repository logic for the index file
logic.

Closes #1328

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1402)

<!-- Reviewable:end -->
