### PR TITLE
fix(helm): finish repo index.html

### DIFF
--- a/pkg/repo/local_test.go
+++ b/pkg/repo/local_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRepositoryServer(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		path   string
+		expect string
+	}{
+		{"index YAML", "/charts/index.yaml", "apiVersion: v1"},
+		{"index HTML", "/charts/index.html", "<html>"},
+		{"charts root", "/charts/", "<html>"},
+		{"root", "/", "Welcome"},
+		{"file", "/test.txt", "Hello World"},
+	}
+
+	s := &RepositoryServer{RepoPath: "testdata/server"}
+	srv := httptest.NewServer(s)
+	defer srv.Close()
+
+	for _, tt := range tests {
+		res, err := http.Get(srv.URL + tt.path)
+		if err != nil {
+			t.Errorf("%s: error getting %s: %s", tt.name, tt.path, err)
+			continue
+		}
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Errorf("%s: error reading %s: %s", tt.name, tt.path, err)
+		}
+		res.Body.Close()
+		if !strings.Contains(string(body), tt.expect) {
+			t.Errorf("%s: expected to find %q in %q", tt.name, tt.expect, string(body))
+		}
+	}
+
+}

--- a/pkg/repo/testdata/server/index.yaml
+++ b/pkg/repo/testdata/server/index.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+      name: nginx
+      description: string
+      version: 0.1.0
+      home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+  alpine:
+    - urls:
+        - http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+      name: alpine
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      keywords:
+        - linux
+        - alpine
+        - small
+        - sumtin
+      digest: "sha256:1234567890abcdef"
+

--- a/pkg/repo/testdata/server/test.txt
+++ b/pkg/repo/testdata/server/test.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
Previous versions of Helm had placeholder text in the index.yaml file.
This generates an HTML index for 'helm serve'. It also has a
refactoring of the server so that the server can be tested.

Closes #1397
Closes #1416

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1406)

<!-- Reviewable:end -->
