### PR TITLE
fix(tiller): ensure only the parent NOTES is used

### DIFF
--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -678,7 +679,10 @@ func (s *releaseServer) renderResources(ch *chart.Chart, values chartutil.Values
 	notes := ""
 	for k, v := range files {
 		if strings.HasSuffix(k, notesFileSuffix) {
-			notes = v
+			// Only apply the notes if it belongs to the parent chart
+			if k == filepath.Join(ch.Metadata.Name, notesFileSuffix) {
+				notes = v
+			}
 			delete(files, k)
 		}
 	}


### PR DESCRIPTION
fixes #1407

cc @vaikas-google @technosophos @adamreese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1409)

<!-- Reviewable:end -->
