### PR TITLE
docs(*): Minor corrections kebuctl commands in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -154,7 +154,7 @@ configuration in ConfigMaps inside of Kubernetes.
 Because Tiller stores its data in Kubernetes ConfigMaps, you can safely
 delete and re-install Tiller without worrying about losing any data. The
 recommended way of deleting Tiller is with `kubectl delete deployment
-tiller-deployment -n kube-system`
+tiller-deployment --namespace kube-system`
 
 ## Conclusion
 


### PR DESCRIPTION
Addresses: #1393

Notes
- The flag `-n` was introduced in kubectl 1.4 and is not available  <1.4
- Switching to `--namespace` keeps consistency within the docs and hopefully will produce less install issues

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1421)

<!-- Reviewable:end -->
