### PR TITLE
fix(helm): use 127.0.0.1 instead of localhost

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -40,7 +40,9 @@ const (
 	stableRepository    = "stable"
 	localRepository     = "local"
 	stableRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
-	localRepositoryURL  = "http://localhost:8879/charts"
+	// This is the IPv4 loopback, not localhost, because we have to force IPv4
+	// for Dockerized Helm: https://github.com/kubernetes/helm/issues/1410
+	localRepositoryURL = "http://127.0.0.1:8879/charts"
 )
 
 type initCmd struct {

--- a/cmd/helm/serve.go
+++ b/cmd/helm/serve.go
@@ -51,7 +51,7 @@ func newServeCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVar(&srv.repoPath, "repo-path", helmpath.Home(homePath()).LocalRepository(), "local directory path from which to serve charts")
-	f.StringVar(&srv.address, "address", "localhost:8879", "address to listen on")
+	f.StringVar(&srv.address, "address", "127.0.0.1:8879", "address to listen on")
 
 	return cmd
 }

--- a/pkg/repo/local.go
+++ b/pkg/repo/local.go
@@ -51,10 +51,6 @@ const indexHTMLTemplate = `
 </html>
 `
 
-const indexFile = `
-Welcome to the Kubernetes Package manager!\nBrowse charts on localhost:8879/charts!
-`
-
 // RepositoryServer is an HTTP handler for serving a chart repository.
 type RepositoryServer struct {
 	RepoPath string
@@ -64,10 +60,8 @@ type RepositoryServer struct {
 func (s *RepositoryServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	uri := r.URL.Path
 	switch uri {
-	case "/":
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		fmt.Fprintf(w, indexFile)
-	case "/charts/", "/charts/index.html", "/charts/index":
+	case "/", "/charts/", "/charts/index.html", "/charts/index":
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		s.htmlIndex(w, r)
 	default:
 		file := strings.TrimPrefix(uri, "/charts/")
@@ -78,7 +72,7 @@ func (s *RepositoryServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // StartLocalRepo starts a web server and serves files from the given path
 func StartLocalRepo(path, address string) error {
 	if address == "" {
-		address = ":8879"
+		address = "127.0.0.1:8879"
 	}
 	s := &RepositoryServer{RepoPath: path}
 	return http.ListenAndServe(address, s)
@@ -130,7 +124,7 @@ func Reindex(ch *chart.Chart, path string) error {
 			return err
 		}
 
-		y.Add(ch.Metadata, name+".tgz", "http://localhost:8879/charts", "sha256:"+dig)
+		y.Add(ch.Metadata, name+".tgz", "http://127.0.0.1:8879/charts", "sha256:"+dig)
 
 		out, err := yaml.Marshal(y)
 		if err != nil {

--- a/pkg/repo/local_test.go
+++ b/pkg/repo/local_test.go
@@ -25,16 +25,20 @@ import (
 )
 
 func TestRepositoryServer(t *testing.T) {
+	expectedIndexYAML, err := ioutil.ReadFile("testdata/server/index.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name   string
 		path   string
 		expect string
 	}{
-		{"index YAML", "/charts/index.yaml", "apiVersion: v1"},
+		{"index YAML", "/charts/index.yaml", string(expectedIndexYAML)},
 		{"index HTML", "/charts/index.html", "<html>"},
 		{"charts root", "/charts/", "<html>"},
-		{"root", "/", "Welcome"},
+		{"root", "/", "<html>"},
 		{"file", "/test.txt", "Hello World"},
 	}
 


### PR DESCRIPTION
This switches the local chart repo to use 127.0.0.1 instead of localhost
so that the net library does not negotiate localhost to an IPv6 address,
which is known to cause issues in some Docker containers.

Breaking Change: When testing on a system that does NOT have IPv4
configured, this will break 'helm serve'. We estimate this will impact
none of the current user base.

Closes #1410
