### PR TITLE
fix(helm): add check for argument length for inspection subcommands

### DIFF
--- a/cmd/helm/inspect.go
+++ b/cmd/helm/inspect.go
@@ -90,6 +90,9 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		Long:  inspectValuesDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insp.output = valuesOnly
+			if err := checkArgsLength(len(args), "chart name"); err != nil {
+				return err
+			}
 			cp, err := locateChartPath(args[0], insp.version, insp.verify, insp.keyring)
 			if err != nil {
 				return err
@@ -105,6 +108,9 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		Long:  inspectChartDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insp.output = chartOnly
+			if err := checkArgsLength(len(args), "chart name"); err != nil {
+				return err
+			}
 			cp, err := locateChartPath(args[0], insp.version, insp.verify, insp.keyring)
 			if err != nil {
 				return err

--- a/cmd/helm/inspect.go
+++ b/cmd/helm/inspect.go
@@ -85,7 +85,7 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	}
 
 	valuesSubCmd := &cobra.Command{
-		Use:   "values",
+		Use:   "values [CHART]",
 		Short: "shows inspect values",
 		Long:  inspectValuesDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -103,7 +103,7 @@ func newInspectCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	}
 
 	chartSubCmd := &cobra.Command{
-		Use:   "chart",
+		Use:   "chart [CHART]",
 		Short: "shows inspect chart",
 		Long:  inspectChartDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Addresses: #1429

Notes
- [x]  Add checks for argument lengths for subcommands `chart` and `values`
- [x] Update help for command

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1433)

<!-- Reviewable:end -->
