### PR TITLE
fix(helm): add line feed between --values and --set data

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -207,6 +207,10 @@ func (i *installCmd) vals() ([]byte, error) {
 			return []byte{}, err
 		}
 		buffer.Write(bytes)
+
+		// Force a new line. An extra won't matter, but a missing one can
+		// break things. https://github.com/kubernetes/helm/issues/1430
+		buffer.WriteRune('\n')
 	}
 
 	// User specified value pairs via --set


### PR DESCRIPTION
Currently, --set simply appends data to the end of the existing values
YAML data. If a values file does not have a line feed at the end, the
set data is mis-appended. This fixes the issue by inserting a linefeed
between the --values data and --set data.

Closes #1430

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1434)

<!-- Reviewable:end -->
