### PR TITLE
fix(tiller): correct path to NOTES.txt template

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -79,7 +79,7 @@ func releaseMock(opts *releaseOptions) *release.Release {
 				Version: "0.1.0-beta.1",
 			},
 			Templates: []*chart.Template{
-				{Name: "foo.tpl", Data: []byte(mockManifest)},
+				{Name: "templates/foo.tpl", Data: []byte(mockManifest)},
 			},
 		}
 	}

--- a/cmd/tiller/release_server.go
+++ b/cmd/tiller/release_server.go
@@ -680,7 +680,7 @@ func (s *releaseServer) renderResources(ch *chart.Chart, values chartutil.Values
 	for k, v := range files {
 		if strings.HasSuffix(k, notesFileSuffix) {
 			// Only apply the notes if it belongs to the parent chart
-			if k == filepath.Join(ch.Metadata.Name, notesFileSuffix) {
+			if k == filepath.Join(ch.Metadata.Name, "templates", notesFileSuffix) {
 				notes = v
 			}
 			delete(files, k)

--- a/cmd/tiller/release_server_test.go
+++ b/cmd/tiller/release_server_test.go
@@ -85,12 +85,12 @@ func chartStub() *chart.Chart {
 		},
 		// This adds basic templates, partials, and hooks.
 		Templates: []*chart.Template{
-			{Name: "hello", Data: []byte("hello: world")},
-			{Name: "goodbye", Data: []byte("goodbye: world")},
-			{Name: "empty", Data: []byte("")},
-			{Name: "with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
-			{Name: "partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
-			{Name: "hooks", Data: []byte(manifestWithHook)},
+			{Name: "templates/hello", Data: []byte("hello: world")},
+			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
+			{Name: "templates/empty", Data: []byte("")},
+			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+			{Name: "templates/hooks", Data: []byte(manifestWithHook)},
 		},
 	}
 }
@@ -212,8 +212,8 @@ func TestInstallRelease(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithHook)},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithHook)},
 			},
 		},
 	}
@@ -257,7 +257,7 @@ func TestInstallRelease(t *testing.T) {
 		t.Errorf("Expected manifest in %v", res)
 	}
 
-	if !strings.Contains(rel.Manifest, "---\n# Source: hello/hello\nhello: world") {
+	if !strings.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world") {
 		t.Errorf("unexpected output: %s", rel.Manifest)
 	}
 }
@@ -272,9 +272,9 @@ func TestInstallReleaseWithNotes(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithHook)},
-				{Name: "NOTES.txt", Data: []byte(notesText)},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+				{Name: "templates/NOTES.txt", Data: []byte(notesText)},
 			},
 		},
 	}
@@ -322,7 +322,7 @@ func TestInstallReleaseWithNotes(t *testing.T) {
 		t.Errorf("Expected manifest in %v", res)
 	}
 
-	if !strings.Contains(rel.Manifest, "---\n# Source: hello/hello\nhello: world") {
+	if !strings.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world") {
 		t.Errorf("unexpected output: %s", rel.Manifest)
 	}
 }
@@ -337,9 +337,9 @@ func TestInstallReleaseWithNotesRendered(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithHook)},
-				{Name: "NOTES.txt", Data: []byte(notesText + " {{.Release.Name}}")},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+				{Name: "templates/NOTES.txt", Data: []byte(notesText + " {{.Release.Name}}")},
 			},
 		},
 	}
@@ -388,7 +388,7 @@ func TestInstallReleaseWithNotesRendered(t *testing.T) {
 		t.Errorf("Expected manifest in %v", res)
 	}
 
-	if !strings.Contains(rel.Manifest, "---\n# Source: hello/hello\nhello: world") {
+	if !strings.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world") {
 		t.Errorf("unexpected output: %s", rel.Manifest)
 	}
 }
@@ -403,17 +403,17 @@ func TestInstallReleaseWithChartAndDependencyNotes(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithHook)},
-				{Name: "NOTES.txt", Data: []byte(notesText)},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+				{Name: "templates/NOTES.txt", Data: []byte(notesText)},
 			},
 			Dependencies: []*chart.Chart{
 				{
 					Metadata: &chart.Metadata{Name: "hello"},
 					Templates: []*chart.Template{
-						{Name: "hello", Data: []byte("hello: world")},
-						{Name: "hooks", Data: []byte(manifestWithHook)},
-						{Name: "NOTES.txt", Data: []byte(notesText + " child")},
+						{Name: "templates/hello", Data: []byte("hello: world")},
+						{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+						{Name: "templates/NOTES.txt", Data: []byte(notesText + " child")},
 					},
 				},
 			},
@@ -456,11 +456,11 @@ func TestInstallReleaseDryRun(t *testing.T) {
 		t.Errorf("Expected release name.")
 	}
 
-	if !strings.Contains(res.Release.Manifest, "---\n# Source: hello/hello\nhello: world") {
+	if !strings.Contains(res.Release.Manifest, "---\n# Source: hello/templates/hello\nhello: world") {
 		t.Errorf("unexpected output: %s", res.Release.Manifest)
 	}
 
-	if !strings.Contains(res.Release.Manifest, "---\n# Source: hello/goodbye\ngoodbye: world") {
+	if !strings.Contains(res.Release.Manifest, "---\n# Source: hello/templates/goodbye\ngoodbye: world") {
 		t.Errorf("unexpected output: %s", res.Release.Manifest)
 	}
 
@@ -569,8 +569,8 @@ func TestUpdateRelease(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithUpgradeHooks)},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithUpgradeHooks)},
 			},
 		},
 	}
@@ -625,7 +625,7 @@ func TestUpdateRelease(t *testing.T) {
 		t.Errorf("Expected manifest in %v", res)
 	}
 
-	if !strings.Contains(updated.Manifest, "---\n# Source: hello/hello\nhello: world") {
+	if !strings.Contains(updated.Manifest, "---\n# Source: hello/templates/hello\nhello: world") {
 		t.Errorf("unexpected output: %s", rel.Manifest)
 	}
 
@@ -647,7 +647,7 @@ func TestUpdateReleaseFailure(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "something", Data: []byte("hello: world")},
+				{Name: "templates/something", Data: []byte("hello: world")},
 			},
 		},
 	}
@@ -715,8 +715,8 @@ func TestUpdateReleaseNoHooks(t *testing.T) {
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},
 			Templates: []*chart.Template{
-				{Name: "hello", Data: []byte("hello: world")},
-				{Name: "hooks", Data: []byte(manifestWithUpgradeHooks)},
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithUpgradeHooks)},
 			},
 		},
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -77,9 +77,9 @@ func TestRender(t *testing.T) {
 			Version: "1.2.3",
 		},
 		Templates: []*chart.Template{
-			{Name: "test1", Data: []byte("{{.outer | title }} {{.inner | title}}")},
-			{Name: "test2", Data: []byte("{{.global.callme | lower }}")},
-			{Name: "test3", Data: []byte("{{.noValue}}")},
+			{Name: "templates/test1", Data: []byte("{{.outer | title }} {{.inner | title}}")},
+			{Name: "templates/test2", Data: []byte("{{.global.callme | lower }}")},
+			{Name: "templates/test3", Data: []byte("{{.noValue}}")},
 		},
 		Values: &chart.Config{
 			Raw: "outer: DEFAULT\ninner: DEFAULT",
@@ -105,16 +105,16 @@ global:
 	}
 
 	expect := "Spouter Inn"
-	if out["moby/test1"] != expect {
+	if out["moby/templates/test1"] != expect {
 		t.Errorf("Expected %q, got %q", expect, out["test1"])
 	}
 
 	expect = "ishmael"
-	if out["moby/test2"] != expect {
+	if out["moby/templates/test2"] != expect {
 		t.Errorf("Expected %q, got %q", expect, out["test2"])
 	}
 	expect = ""
-	if out["moby/test3"] != expect {
+	if out["moby/templates/test3"] != expect {
 		t.Errorf("Expected %q, got %q", expect, out["test3"])
 	}
 
@@ -186,20 +186,20 @@ func TestAllTemplates(t *testing.T) {
 	ch1 := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "ch1"},
 		Templates: []*chart.Template{
-			{Name: "foo", Data: []byte("foo")},
-			{Name: "bar", Data: []byte("bar")},
+			{Name: "templates/foo", Data: []byte("foo")},
+			{Name: "templates/bar", Data: []byte("bar")},
 		},
 		Dependencies: []*chart.Chart{
 			{
 				Metadata: &chart.Metadata{Name: "laboratory mice"},
 				Templates: []*chart.Template{
-					{Name: "pinky", Data: []byte("pinky")},
-					{Name: "brain", Data: []byte("brain")},
+					{Name: "templates/pinky", Data: []byte("pinky")},
+					{Name: "templates/brain", Data: []byte("brain")},
 				},
 				Dependencies: []*chart.Chart{{
 					Metadata: &chart.Metadata{Name: "same thing we do every night"},
 					Templates: []*chart.Template{
-						{Name: "innermost", Data: []byte("innermost")},
+						{Name: "templates/innermost", Data: []byte("innermost")},
 					}},
 				},
 			},
@@ -220,13 +220,13 @@ func TestRenderDependency(t *testing.T) {
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "outerchart"},
 		Templates: []*chart.Template{
-			{Name: "outer", Data: []byte(toptpl)},
+			{Name: "templates/outer", Data: []byte(toptpl)},
 		},
 		Dependencies: []*chart.Chart{
 			{
 				Metadata: &chart.Metadata{Name: "innerchart"},
 				Templates: []*chart.Template{
-					{Name: "inner", Data: []byte(deptpl)},
+					{Name: "templates/inner", Data: []byte(deptpl)},
 				},
 			},
 		},
@@ -243,7 +243,7 @@ func TestRenderDependency(t *testing.T) {
 	}
 
 	expect := "Hello World"
-	if out["outerchart/outer"] != expect {
+	if out["outerchart/templates/outer"] != expect {
 		t.Errorf("Expected %q, got %q", expect, out["outer"])
 	}
 
@@ -346,8 +346,8 @@ func TestRenderBuiltinValues(t *testing.T) {
 	inner := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "Latium"},
 		Templates: []*chart.Template{
-			{Name: "Lavinia", Data: []byte(`{{.Template.Name}}{{.Chart.Name}}{{.Release.Name}}`)},
-			{Name: "From", Data: []byte(`{{.Files.author | printf "%s"}} {{.Files.Get "book/title.txt"}}`)},
+			{Name: "templates/Lavinia", Data: []byte(`{{.Template.Name}}{{.Chart.Name}}{{.Release.Name}}`)},
+			{Name: "templates/From", Data: []byte(`{{.Files.author | printf "%s"}} {{.Files.Get "book/title.txt"}}`)},
 		},
 		Values:       &chart.Config{Raw: ``},
 		Dependencies: []*chart.Chart{},
@@ -360,7 +360,7 @@ func TestRenderBuiltinValues(t *testing.T) {
 	outer := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "Troy"},
 		Templates: []*chart.Template{
-			{Name: "Aeneas", Data: []byte(`{{.Template.Name}}{{.Chart.Name}}{{.Release.Name}}`)},
+			{Name: "templates/Aeneas", Data: []byte(`{{.Template.Name}}{{.Chart.Name}}{{.Release.Name}}`)},
 		},
 		Values:       &chart.Config{Raw: ``},
 		Dependencies: []*chart.Chart{inner},
@@ -382,9 +382,9 @@ func TestRenderBuiltinValues(t *testing.T) {
 	}
 
 	expects := map[string]string{
-		"Troy/charts/Latium/Lavinia": "Troy/charts/Latium/LaviniaLatiumAeneid",
-		"Troy/Aeneas":                "Troy/AeneasTroyAeneid",
-		"Troy/charts/Latium/From":    "Virgil Aeneid",
+		"Troy/charts/Latium/templates/Lavinia": "Troy/charts/Latium/templates/LaviniaLatiumAeneid",
+		"Troy/templates/Aeneas":                "Troy/templates/AeneasTroyAeneid",
+		"Troy/charts/Latium/templates/From":    "Virgil Aeneid",
 	}
 	for file, expect := range expects {
 		if out[file] != expect {
@@ -398,8 +398,8 @@ func TestAlterFuncMap(t *testing.T) {
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "conrad"},
 		Templates: []*chart.Template{
-			{Name: "quote", Data: []byte(`{{include "conrad/_partial" . | indent 2}} dead.`)},
-			{Name: "_partial", Data: []byte(`{{.Release.Name}} - he`)},
+			{Name: "templates/quote", Data: []byte(`{{include "conrad/templates/_partial" . | indent 2}} dead.`)},
+			{Name: "templates/_partial", Data: []byte(`{{.Release.Name}} - he`)},
 		},
 		Values:       &chart.Config{Raw: ``},
 		Dependencies: []*chart.Chart{},
@@ -419,7 +419,7 @@ func TestAlterFuncMap(t *testing.T) {
 	}
 
 	expect := "  Mistah Kurtz - he dead."
-	if got := out["conrad/quote"]; got != expect {
+	if got := out["conrad/templates/quote"]; got != expect {
 		t.Errorf("Expected %q, got %q (%v)", expect, got, out)
 	}
 }


### PR DESCRIPTION
See https://github.com/kubernetes/helm/pull/1409#discussion_r84535055, the tests use a different path `$NAME/NOTES.txt` instead of `$NAME/templates/NOTES.txt`. Will try to dig into why that's the case.

closes #1431

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1435)

<!-- Reviewable:end -->
