### PR TITLE
fix(helm): add support for local version only

### DIFF
--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -29,11 +29,29 @@ import (
 	"k8s.io/helm/pkg/version"
 )
 
+const versionDesc = `
+Show the client and server versions for Helm and tiller.
+
+This will print a representation of the client and server versions of Helm and
+Tiller. The output will look something like this:
+
+Client: &version.Version{SemVer:"v2.0.0-beta.1", GitCommit:"ff52399e51bb880526e9cd0ed8386f6433b74da1", GitTreeState:"dirty"}
+Server: &version.Version{SemVer:"v2.0.0-beta.1", GitCommit:"b0c113dfb9f612a9add796549da66c0d294508a3", GitTreeState:"clean"}
+
+- SemVer is the semantic version of the release.
+- GitCommit is the SHA for the commit that this version was built from.
+- GitTreeState is "clean" if there are no local code changes when this binary was
+  built, and "dirty" if the binary was built from locally modified code.
+
+To print just the client version, use '--client'. To print just the server version,
+use '--server'.
+`
+
 type versionCmd struct {
 	out        io.Writer
 	client     helm.Interface
-	clientOnly bool
-	serverOnly bool
+	showClient bool
+	showServer bool
 }
 
 func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
@@ -45,8 +63,13 @@ func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "print the client/server version information",
+		Long:  versionDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !version.clientOnly {
+			// If neither is explicitly set, show both.
+			if !version.showClient && !version.showServer {
+				version.showClient, version.showServer = true, true
+			}
+			if version.showServer {
 				// We do this manually instead of in PreRun because we only
 				// need a tunnel if server version is requested.
 				setupConnection(cmd, args)
@@ -56,24 +79,20 @@ func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
 		},
 	}
 	f := cmd.Flags()
-	f.BoolVarP(&version.clientOnly, "client-only", "c", false, "if set does not query Tiller version")
-	f.BoolVarP(&version.serverOnly, "server-only", "s", false, "if set does not query Helm client version")
+	f.BoolVarP(&version.showClient, "client", "c", false, "if set, show the client version")
+	f.BoolVarP(&version.showServer, "server", "s", false, "if set, show the server version")
 
 	return cmd
 }
 
 func (v *versionCmd) run() error {
 
-	if v.clientOnly && v.serverOnly {
-		return errors.New("cannot set both client-only and server-only")
-	}
-
-	if !v.serverOnly {
+	if v.showClient {
 		cv := version.GetVersionProto()
 		fmt.Fprintf(v.out, "Client: %#v\n", cv)
 	}
 
-	if v.clientOnly {
+	if !v.showServer {
 		return nil
 	}
 

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/helm/pkg/version"
+)
+
+func TestVersion(t *testing.T) {
+
+	lver := version.GetVersionProto().SemVer
+	sver := "1.2.3-fakeclient+testonly"
+
+	tests := []struct {
+		name           string
+		client, server bool
+		args           []string
+		fail           bool
+	}{
+		{"default", true, true, []string{}, false},
+		{"client", true, false, []string{"-c"}, false},
+		{"server", false, true, []string{"-s"}, false},
+		{"neither", false, false, []string{"-c", "-s"}, true},
+	}
+
+	for _, tt := range tests {
+		b := new(bytes.Buffer)
+		c := &fakeReleaseClient{}
+
+		cmd := newVersionCmd(c, b)
+		cmd.ParseFlags(tt.args)
+		if err := cmd.RunE(cmd, tt.args); err != nil {
+			if tt.fail {
+				continue
+			}
+			t.Fatal(err)
+		}
+
+		if tt.client && !strings.Contains(b.String(), lver) {
+			t.Errorf("Expected %q to contain %q", b.String(), lver)
+		}
+		if tt.server && !strings.Contains(b.String(), sver) {
+			t.Errorf("Expected %q to contain %q", b.String(), sver)
+		}
+	}
+}

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -37,7 +37,6 @@ func TestVersion(t *testing.T) {
 		{"default", true, true, []string{}, false},
 		{"client", true, false, []string{"-c"}, false},
 		{"server", false, true, []string{"-s"}, false},
-		{"neither", false, false, []string{"-c", "-s"}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This modifies 'helm version' to allow for local-only or server-only
versions to avoid cases where calling 'helm version' was resulting in
errors.

Closes #1440

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1450)

<!-- Reviewable:end -->
