### PR TITLE
docs(helm): update grammar for upgrade command help

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -32,9 +32,9 @@ import (
 const upgradeDesc = `
 This command upgrades a release to a new version of a chart.
 
-The upgrade arguments must be a release and a chart. The chart
-argument can be a chart reference ('stable/mariadb'), a path to a chart directory
-or packaged chart, or a fully qualified URL. For chart references, the latest
+The upgrade arguments must be a release and chart. The chart
+argument can be either: a chart reference('stable/mariadb'), a path to a chart directory,
+a packaged chart, or a fully qualified URL. For chart references, the latest
 version will be specified unless the '--version' flag is set.
 
 To override values in a chart, use either the '--values' flag and pass in a file


### PR DESCRIPTION
Addresses: #1443

Notes
- This just modifies the grammar for the `upgrade` command's help

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1452)

<!-- Reviewable:end -->
