### PR TITLE
fix(helm): skip overwriting the lock if it hasn't changed

### DIFF
--- a/cmd/helm/downloader/manager.go
+++ b/cmd/helm/downloader/manager.go
@@ -138,6 +138,12 @@ func (m *Manager) Update() error {
 		return err
 	}
 
+	// If the lock file hasn't changed, don't write a new one.
+	oldLock, err := chartutil.LoadRequirementsLock(c)
+	if err == nil && oldLock.Digest == lock.Digest {
+		return nil
+	}
+
 	// Finally, we need to write the lockfile.
 	return writeLock(m.ChartPath, lock)
 }


### PR DESCRIPTION
'helm dep up' will only overwrite the lock file if the digest has
changed (e.g. the source requirements.yaml is different).

Closes #1438

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1454)

<!-- Reviewable:end -->
