### PR TITLE
Add deployment, service and NOTES to create

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -36,12 +36,29 @@ const (
 	ChartsDir = "charts"
 	// IgnorefileName is the name of the Helm ignore file.
 	IgnorefileName = ".helmignore"
+	// DeploymentName is the name of the example deployment file.
+	DeploymentName = "deployment.yaml"
+	// ServiceName is the name of the example service file.
+	ServiceName = "service.yaml"
+	// NotesName is the name of the example NOTES.txt file.
+	NotesName = "NOTES.txt"
+	// HelpersName is the name of the example NOTES.txt file.
+	HelpersName = "_helpers.tpl"
 )
 
 const defaultValues = `# Default values for %s.
 # This is a YAML-formatted file.
-# Declare name/value pairs to be passed into your templates.
-# name: value
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+service:
+  name: nginx
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 80
 `
 
 const defaultIgnore = `# Patterns to ignore when building packages.
@@ -65,6 +82,79 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 .project
 .idea/
 *.tmproj
+`
+
+const defaultDeployment = `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: nginx
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+`
+
+const defaultService = `apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}
+`
+
+const defaultNotes = `1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
+****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:{{ .Values.service.externalPort }}
+  kubectl port-forward $POD_NAME {{ .Values.service.externalPort }}:{{ .Values.service.externalPort }}
+{{- end }}
+`
+
+const defaultHelpers = `{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
 `
 
 // Create creates a new chart in a directory.
@@ -119,6 +209,30 @@ func Create(chartfile *chart.Metadata, dir string) (string, error) {
 		if err := os.MkdirAll(filepath.Join(cdir, d), 0755); err != nil {
 			return cdir, err
 		}
+	}
+
+	// Write out deployment.yaml
+	val = []byte(defaultDeployment)
+	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, DeploymentName), val, 0644); err != nil {
+			return cdir, err
+	}
+
+	// Write out service.yaml
+	val = []byte(defaultService)
+	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, ServiceName), val, 0644); err != nil {
+			return cdir, err
+	}
+
+	// Write out NOTES.txt
+	val = []byte(defaultNotes)
+	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, NotesName), val, 0644); err != nil {
+			return cdir, err
+	}
+
+	// Write out _helpers.tpl
+	val = []byte(defaultHelpers)
+	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, HelpersName), val, 0644); err != nil {
+			return cdir, err
 	}
 	return cdir, nil
 }

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -146,8 +146,8 @@ const defaultNotes = `1. Get the application URL by running these commands:
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/login
 {{- else if contains "LoadBalancer" .Values.service.type }}
-**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
-****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -249,8 +249,5 @@ func Create(chartfile *chart.Metadata, dir string) (string, error) {
 
 	// Write out _helpers.tpl
 	val = []byte(defaultHelpers)
-	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, HelpersName), val, 0644); err != nil {
-		return cdir, err
-	}
-	return cdir, nil
+	return cdir, ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, HelpersName), val, 0644)
 }

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -59,6 +59,14 @@ service:
   type: ClusterIP
   externalPort: 80
   internalPort: 80
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
 `
 
 const defaultIgnore = `# Patterns to ignore when building packages.
@@ -103,6 +111,16 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
 `
 
 const defaultService = `apiVersion: v1

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -232,25 +232,25 @@ func Create(chartfile *chart.Metadata, dir string) (string, error) {
 	// Write out deployment.yaml
 	val = []byte(defaultDeployment)
 	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, DeploymentName), val, 0644); err != nil {
-			return cdir, err
+		return cdir, err
 	}
 
 	// Write out service.yaml
 	val = []byte(defaultService)
 	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, ServiceName), val, 0644); err != nil {
-			return cdir, err
+		return cdir, err
 	}
 
 	// Write out NOTES.txt
 	val = []byte(defaultNotes)
 	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, NotesName), val, 0644); err != nil {
-			return cdir, err
+		return cdir, err
 	}
 
 	// Write out _helpers.tpl
 	val = []byte(defaultHelpers)
 	if err := ioutil.WriteFile(filepath.Join(cdir, TemplatesDir, HelpersName), val, 0644); err != nil {
-			return cdir, err
+		return cdir, err
 	}
 	return cdir, nil
 }

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -62,7 +62,15 @@ func TestCreate(t *testing.T) {
 		if fi, err := os.Stat(filepath.Join(dir, f)); err != nil {
 			t.Errorf("Expected %s file: %s", f, err)
 		} else if fi.IsDir() {
-			t.Errorf("Expected %s to be a fle.", f)
+			t.Errorf("Expected %s to be a file.", f)
+		}
+	}
+
+	for _, f := range []string{NotesName, DeploymentName, ServiceName, HelpersName} {
+		if fi, err := os.Stat(filepath.Join(dir, TemplatesDir, f)); err != nil {
+			t.Errorf("Expected %s file: %s", f, err)
+		} else if fi.IsDir() {
+			t.Errorf("Expected %s to be a file.", f)
 		}
 	}
 


### PR DESCRIPTION
This brings the `helm create` command templates up to date with what we expect to see in the Charts repo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1461)

<!-- Reviewable:end -->
