### PR TITLE
fix(helm): fail when helm deps are not fetched

### DIFF
--- a/cmd/helm/downloader/manager.go
+++ b/cmd/helm/downloader/manager.go
@@ -194,15 +194,15 @@ func (m *Manager) downloadAll(deps []*chartutil.Dependency) error {
 	for _, dep := range deps {
 		fmt.Fprintf(m.Out, "Downloading %s from repo %s\n", dep.Name, dep.Repository)
 
+		// Any failure to resolve/download a chart should fail:
+		// https://github.com/kubernetes/helm/issues/1439
 		churl, err := findChartURL(dep.Name, dep.Version, dep.Repository, repos)
 		if err != nil {
-			fmt.Fprintf(m.Out, "WARNING: %s (skipped)", err)
-			continue
+			return fmt.Errorf("could not find %s: %s", churl, err)
 		}
 
 		if _, _, err := dl.DownloadTo(churl, "", destPath); err != nil {
-			fmt.Fprintf(m.Out, "WARNING: Could not download %s: %s (skipped)", churl, err)
-			continue
+			return fmt.Errorf("could not download %s: %s", churl, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This changes the behavior of the bulk downloader to fail as soon as it
encounters a dependency that it cannot fetch.

Closes #1439

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1466)

<!-- Reviewable:end -->
