### PR TITLE
fix(tiller): allow 3rd party APIs

### DIFF
--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -101,6 +101,7 @@ func TestPerform(t *testing.T) {
 		}
 
 		c := New(nil)
+		c.IncludeThirdPartyAPIs = false
 		c.ClientForMapping = func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
 			return &fake.RESTClient{}, nil
 		}
@@ -121,12 +122,15 @@ func TestPerform(t *testing.T) {
 
 func TestReal(t *testing.T) {
 	t.Skip("This is a live test, comment this line to run")
-	if err := New(nil).Create("test", strings.NewReader(guestbookManifest)); err != nil {
+	c := New(nil)
+	c.IncludeThirdPartyAPIs = false
+	if err := c.Create("test", strings.NewReader(guestbookManifest)); err != nil {
 		t.Fatal(err)
 	}
 
 	testSvcEndpointManifest := testServiceManifest + "\n---\n" + testEndpointManifest
-	c := New(nil)
+	c = New(nil)
+	c.IncludeThirdPartyAPIs = false
 	if err := c.Create("test-delete", strings.NewReader(testSvcEndpointManifest)); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This feature has been disabled in the past because simply enabling the
feature causes the Kubernetes library to make requests to a server.
Thus, running any tests that use the 'pkg/kube' library has required
running a kube API server.

This patch makes it possible to selectively activate 3rdParty API
support, and then disables that support during testing.

Future versions of the Kubernetes library appear to make it easier to
configure and mock this behavior, so this is most likely a stop-gap
measure. (Famous last words.)

Closes #1468 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1473)

<!-- Reviewable:end -->
