### PR TITLE
fix(pkg/chartutil): add error if chart yaml not in directory

### DIFF
--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -87,6 +87,10 @@ func LoadArchive(in io.Reader) (*chart.Chart, error) {
 		parts := strings.Split(hd.Name, "/")
 		n := strings.Join(parts[1:], "/")
 
+		if parts[0] == "Chart.yaml" {
+			return nil, errors.New("chart yaml not in base directory")
+		}
+
 		if _, err := io.Copy(b, tr); err != nil {
 			return &chart.Chart{}, err
 		}


### PR DESCRIPTION
Addresses: #1171

Notes
-  Adds an error when the `Chart.yaml` file is found in the root directory.

I am not quite sure if this is the best way to handle this ticket... since it does not explicitly look for directory in the Archived file.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1486)
<!-- Reviewable:end -->
