### PR TITLE
fix(1488): suppress gRPC logs and errors

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -20,11 +20,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned"
 
@@ -89,6 +92,9 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	p.StringVar(&tillerHost, "host", thost, "address of tiller. Overrides $HELM_HOST")
 	p.StringVar(&kubeContext, "kube-context", "", "name of the kubeconfig context to use")
 	p.BoolVarP(&flagDebug, "debug", "", false, "enable verbose output")
+
+	// Tell gRPC not to log to console.
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 
 	rup := newRepoUpdateCmd(out)
 	rup.Deprecated = "use 'helm repo update'\n"

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -101,7 +102,10 @@ func (v *versionCmd) run() error {
 		if grpc.Code(err) == codes.Unimplemented {
 			return errors.New("server is too old to know its version")
 		}
-		return err
+		if flagDebug {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		return errors.New("cannot connect to Tiller")
 	}
 	fmt.Fprintf(v.out, "Server: %#v\n", resp.Version)
 	return nil


### PR DESCRIPTION
If gRPC fails to make a connection, the result is a log message and a
verbose error. This suppresses log output and replaces the error with a
much more succinct one.

Closes #1488

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1490)
<!-- Reviewable:end -->
