### PR TITLE
fix(linter): remove spurious namespace error

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -104,8 +104,6 @@ func Templates(linter *support.Linter) {
 		if !validYaml {
 			continue
 		}
-
-		linter.RunLinterRule(support.ErrorSev, path, validateNoNamespace(yamlStruct))
 	}
 }
 
@@ -192,13 +190,6 @@ func validateNoMissingValues(templatesPath string, chartValues chartutil.Values,
 func validateYamlContent(err error) error {
 	if err != nil {
 		return fmt.Errorf("unable to parse YAML\n\t%s", err)
-	}
-	return nil
-}
-
-func validateNoNamespace(yamlStruct K8sYamlStruct) error {
-	if yamlStruct.Metadata.Namespace != "" {
-		return errors.New("namespace option is currently NOT supported")
 	}
 	return nil
 }


### PR DESCRIPTION
Long ago, Helm did not support cross-namespace installs. There was a
linter rule to catch this. When we changed the way Helm worked, we did
not remove the linter rule. This commit removes that linter rule.

Closes #1489

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1491)
<!-- Reviewable:end -->
