### PR TITLE
Fix up onboarding experience when using Helm create

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -106,7 +106,7 @@ spec:
         app: {{ template "fullname" . }}
     spec:
       containers:
-      - name: nginx
+      - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -152,8 +152,8 @@ const defaultNotes = `1. Get the application URL by running these commands:
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:{{ .Values.service.externalPort }}
-  kubectl port-forward $POD_NAME {{ .Values.service.externalPort }}:{{ .Values.service.externalPort }}
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}
 `
 

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -114,11 +114,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 80
+            port: {{ .Values.service.internalPort }}
         readinessProbe:
           httpGet:
             path: /
-            port: 80
+            port: {{ .Values.service.internalPort }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
 `

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -151,7 +151,7 @@ const defaultNotes = `1. Get the application URL by running these commands:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.service.externalPort }}
   kubectl port-forward $POD_NAME {{ .Values.service.externalPort }}:{{ .Values.service.externalPort }}
 {{- end }}


### PR DESCRIPTION
These commits make it easier to use helm create as the starting point for chart creation. 

To test:

```shell
$ helm create nginx
$ helm install nginx
```

In order to do another simple-ish web application (other than Nginx) all you should need to do is change the image, tag, and port values in the values.yml.

I could add a configure health check section too, similar to what we do with resources.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1494)
<!-- Reviewable:end -->
