### PR TITLE
fix(tiller): improve deletion failure handling

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -18,6 +18,7 @@ package kube // import "k8s.io/helm/pkg/kube"
 
 import (
 	"bytes"
+	goerrors "errors"
 	"fmt"
 	"io"
 	"log"
@@ -40,6 +41,9 @@ import (
 	"k8s.io/kubernetes/pkg/util/yaml"
 	"k8s.io/kubernetes/pkg/watch"
 )
+
+// ErrNoObjectsVisited indicates that during a visit operation, no matching objects were found.
+var ErrNoObjectsVisited = goerrors.New("no objects visited")
 
 // Client represents a client capable of communicating with the Kubernetes API.
 type Client struct {
@@ -279,7 +283,7 @@ func perform(c *Client, namespace string, reader io.Reader, fn ResourceActorFunc
 	case err != nil:
 		return err
 	case len(infos) == 0:
-		return fmt.Errorf("no objects visited")
+		return ErrNoObjectsVisited
 	}
 	for _, info := range infos {
 		if err := fn(info); err != nil {


### PR DESCRIPTION
This does the following to improve deletion failure handling:

- In an UninstallRelease operation, the release is marked DELETED
  as soon as the basic checks are passed. This resolves 1508. I filed a
  followup issue for doing this even better when we can modify protos
  again.
- If a YAML manifest fails to parse, the error messages now suggests
  that the record is corrupt, and the resources must be manually
  deleted.
- If a resource is missing during deletion, the error messages now make
  it clear that an object was skipped, but that the deletion continued.

Closes #1508

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1512)
<!-- Reviewable:end -->
