### PR TITLE
Add a checksum function to the template engine

### DIFF
--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -61,6 +61,29 @@ Because YAML ascribes significance to indentation levels and whitespace,
 this is one great way to include snippets of code, but handle
 indentation in a relevant context.
 
+## Automatically Roll Deployments When ConfigMaps or Secrets change
+
+Often times configmaps or secrets are injected as configuration
+files in containers.
+Depending on the application a restart may be required should those
+be updated with a subsequent `helm upgrade`, but if the
+deployment spec itself didn't change the application keeps running
+with the old configuration resulting in an inconsistent deployment.
+
+The `sha256sum` function can be used together with the `include`
+function to ensure a deployments template section is updated if another
+spec changes: 
+
+```
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include "mychart/templates/configmap.yaml" . | sha256sum }}
+[...]    
+```
+
 ## Using "Partials" and Template Includes
 
 Sometimes you want to create some reusable parts in your chart, whether

--- a/glide.lock
+++ b/glide.lock
@@ -264,7 +264,7 @@ imports:
 - name: github.com/Masterminds/semver
   version: 808ed7761c233af2de3f9729a041d68c62527f3a
 - name: github.com/Masterminds/sprig
-  version: 8f797f5b23118d8fe846c4296b0ad55044201b14
+  version: 3fb136ad254dd34998b95f8d523b09a0dafa31b5
 - name: github.com/mattn/go-runewidth
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/matttproud/golang_protobuf_extensions


### PR DESCRIPTION
This PR adds a `checksum` function to the template engine which is very useful to trigger redeployments of applications if another spec changes.

A very practical use case is to restart applications if a configmap (or secret) is changed (See doc update in this PR)

I used base64 encoding instead of hex because it produces shorter strings but that could be changed to hex, I don't really care.

I also named the function `checksum` instead of `sha256` because I thought users shouldn't really care about the details and treat this is an opaque function that generates good hashes.

/cc @technosophos

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1513)
<!-- Reviewable:end -->
