### PR TITLE
docs(chart_template_guide): fix spacing

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -35,11 +35,11 @@ Each of these is a simple TOML file (think old-school Windows INI files). We kno
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
-  {{- $files := .Files}}
+  {{- $files := .Files }}
   {{- range tuple "config1.toml" "config2.toml" "config3.toml" }}
-  {{.}}: |-
+  {{ . }}: |-
     {{ $files.Get . }}
   {{- end }}
 ```
@@ -71,11 +71,11 @@ When working with a Secret resource, you can import a file and have the template
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.Release.Name}}-secret
+  name: {{ .Release.Name }}-secret
 type: Opaque
 data:
   token: |-
-    {{.Files.Get "config1.toml" | b64enc}}
+    {{ .Files.Get "config1.toml" | b64enc }}
 ```
 
 The above will take the same `config1.toml` file we used before and encode it:

--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -21,13 +21,13 @@ The first control structure we'll look at is for conditionally including blocks 
 The basic structure for a conditional looks like this:
 
 ```
-{{if PIPELINE}}
+{{ if PIPELINE }}
   # Do something
-{{else if OTHER PIPELINE}}
+{{ else if OTHER PIPELINE }}
   # Do something else
 {{ else }}
   # Default case
-{{end}}
+{{ end }}
 ```
 
 Notice that we're now talking about _pipelines_ instead of values. The reason for this is to make it clear that control structures can execute an entire pipeline, not just evaluate a value.
@@ -48,12 +48,12 @@ Let's add a simple conditional to our ConfigMap. We'll add another setting if th
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | default "tea" | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
-  {{if eq .Values.favorite.drink "coffee"}}mug: true{{end}}
+  drink: {{ .Values.favorite.drink | default "tea" | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
+  {{ if eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
 ```
 
 Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:
@@ -79,11 +79,11 @@ While we're looking at conditionals, we should take a quick look at the way whit
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | default "tea" | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
+  drink: {{ .Values.favorite.drink | default "tea" | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
   {{if eq .Values.favorite.drink "coffee"}}
     mug: true
   {{end}}
@@ -119,11 +119,11 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | default "tea" | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
+  drink: {{ .Values.favorite.drink | default "tea" | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
   {{if eq .Values.favorite.drink "coffee"}}
   mug: true
   {{end}}
@@ -160,11 +160,11 @@ Using this syntax, we can modify our template to get rid of those new lines:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | default "tea" | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
+  drink: {{ .Values.favorite.drink | default "tea" | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
   {{- if eq .Values.favorite.drink "coffee"}}
   mug: true
   {{- end}}
@@ -176,11 +176,11 @@ Just for the same of making this point clear, let's adjust the above, and substi
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | default "tea" | quote}}
-  food: {{.Values.favorite.food | upper | quote}}*
+  drink: {{ .Values.favorite.drink | default "tea" | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}*
 **{{- if eq .Values.favorite.drink "coffee"}}
   mug: true*
 **{{- end}}
@@ -205,7 +205,7 @@ data:
 Be careful with the chomping modifiers. It is easy to accidentally do things like this:
 
 ```yaml
-  food: {{.Values.favorite.food | upper | quote}}
+  food: {{ .Values.favorite.food | upper | quote }}
   {{- if eq .Values.favorite.drink "coffee" -}}
   mug: true
   {{- end -}}
@@ -234,12 +234,12 @@ Scopes can be changed. `with` can allow you to set the current scope (`.`) to a 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
   {{- end }}
 ```
 
@@ -251,9 +251,9 @@ But here's a note of caution! Inside of the restricted scope, you will not be ab
 
 ```yaml
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
-  release: {{.Release.Name}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
+  release: {{ .Release.Name }}
   {{- end }}
 ```
 
@@ -261,10 +261,10 @@ It will produce an error because `Release.Name` is not inside of the restricted 
 
 ```yaml
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
   {{- end }}
-  release: {{.Release.Name}}
+  release: {{ .Release.Name }}
 ```
 
 After looking a `range`, we will take a look at template variables, which offer one solution to the scoping issue above.
@@ -292,23 +292,23 @@ Now we have a list (called a `slice` in templates) of `pizzaToppings`. We can mo
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
   {{- end }}
   toppings: |-
     {{- range .Values.pizzaToppings }}
-    - {{. | title | quote }}
+    - {{ . | title | quote }}
     {{- end }}
 
 ```
 
 Let's take a closer look at the `toppings:` list. The `range` function will "range over" (iterate through) the `pizzaToppings` list. But now something interesting happens. Just like `with` sets the scope of `.`, so does a `range` operator. Each time through the loop, `.` is set to the current pizza topping. That is, the first time, `.` is set to `mushrooms`. The second iteration it is set to `cheese`, and so on.
 
-We can send the value of `.` directly down a pipeline, so when we do `{{. | title | quote }}`, it sends `.` to `title` (title case function) and then to `quote`. If we run this template, the output will be:
+We can send the value of `.` directly down a pipeline, so when we do `{{ . | title | quote }}`, it sends `.` to `title` (title case function) and then to `quote`. If we run this template, the output will be:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -336,7 +336,7 @@ Sometimes it's useful to be able to quickly make a list inside of your template,
 ```yaml
   sizes: |-
     {{- range tuple "small" "medium" "large" }}
-    - {{.}}
+    - {{ . }}
     {{- end }}
 ```
 

--- a/docs/chart_template_guide/functions_and_pipelines.md
+++ b/docs/chart_template_guide/functions_and_pipelines.md
@@ -8,11 +8,11 @@ Let's start with a best practice: When injecting strings from the `.Values` obje
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{quote .Values.favorite.drink}}
-  food: {{quote .Values.favorite.food}}
+  drink: {{ quote .Values.favorite.drink }}
+  food: {{ quote .Values.favorite.food }}
 ```
 
 Template functions follow the syntax `functionName arg1 arg2...`. In the snippet above, `quote .Values.favorite.drink` calls the `quote` function and passes it a single argument.
@@ -29,11 +29,11 @@ One of the powerful features of the template language is its concept of _pipelin
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | quote}}
-  food: {{.Values.favorite.food | quote}}
+  drink: {{ .Values.favorite.drink | quote }}
+  food: {{ .Values.favorite.food | quote }}
 ```
 
 In this example, instead of calling `quote ARGUMENT`, we inverted the order. We "sent" the argument to the function using a pipeline (`|`): `.Values.favorite.drink | quote`. Using pipelines, we can chain several functions together:
@@ -42,11 +42,11 @@ In this example, instead of calling `quote ARGUMENT`, we inverted the order. We 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
+  drink: {{ .Values.favorite.drink | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
 ```
 
 > Inverting the order is a common practice in templates. You will see `.val | quote` more often than `quote .val`. Either practice is fine.
@@ -73,11 +73,11 @@ When pipelining arguments like this, the result of the first evaluation (`.Value
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink | repeat 5 | quote}}
-  food: {{.Values.favorite.food | upper | quote}}
+  drink: {{ .Values.favorite.drink | repeat 5 | quote }}
+  food: {{ .Values.favorite.food | upper | quote }}
 ```
 
 The `repeat` function will echo the given string the given number of times, so we will get this for output:
@@ -99,7 +99,7 @@ data:
 One function frequently used in templates is the `default` function: `default DEFAULT_VALUE GIVEN_VALUE`. This function allows you to specify a default value inside of the template, in case the value is omitted. Let's use it to modify the drink example above:
 
 ```yaml
-drink: {{.Values.favorite.drink | default "tea" | quote}}
+drink: {{ .Values.favorite.drink | default "tea" | quote }}
 ```
 
 If we run this as normal, we'll get our `coffee`:

--- a/docs/chart_template_guide/getting_started.md
+++ b/docs/chart_template_guide/getting_started.md
@@ -151,17 +151,17 @@ Let's alter `configmap.yaml` accordingly.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
 ```
 
 The big change comes in the value of the `name:` field, which is now
-`{{.Release.Name}}-configmap`.
+`{{ .Release.Name }}-configmap`.
 
 > A template directive is enclosed in `{{` and `}}` blocks.
 
-The template directive `{{.Release.Name}}` injects the release name into the template. The values that are passed into a template can be thought of as _namespaced objects_, where a dot (`.`) separates each namespaced element.
+The template directive `{{ .Release.Name }}` injects the release name into the template. The values that are passed into a template can be thought of as _namespaced objects_, where a dot (`.`) separates each namespaced element.
 
 The leading dot before `Release` indicates that we start with the top-most namespace for this scope (we'll talk about scope in a bit). So we could read `.Release.Name` as "start at the top namespace, find the `Release` object, then look inside of it for an object called `Name`".
 

--- a/docs/chart_template_guide/notes_files.md
+++ b/docs/chart_template_guide/notes_files.md
@@ -7,14 +7,14 @@ To add installation notes to your chart, simply create a `templates/NOTES.txt` f
 Let's create a simple `NOTES.txt` file:
 
 ```
-Thank you for installing {{.Chart.Name}}.
+Thank you for installing {{ .Chart.Name }}.
 
-Your release is named {{.Release.Name}}.
+Your release is named {{ .Release.Name }}.
 
 To learn more about the release, try:
 
-  $ helm status {{.Release.Name}}
-  $ helm get {{.Release.Name}}
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}
 
 ```
 

--- a/docs/chart_template_guide/subcharts_and_globals.md
+++ b/docs/chart_template_guide/subcharts_and_globals.md
@@ -38,9 +38,9 @@ Next, we'll create a new ConfigMap template in `mychart/charts/subchart/template
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-cfgmap2
+  name: {{ .Release.Name }}-cfgmap2
 data:
-  dessert: {{.Values.dessert}}
+  dessert: {{ .Values.dessert }}
 ```
 
 Because every subchart is a _stand-alone chart_, we can test `mysubchart` on its own:
@@ -124,7 +124,7 @@ global:
   salad: caesar
 ```
 
-Because of the way globals work, both `mychart/templates/configmap.yaml` and `mysubchart/templates/configmap.yaml` should be able to access that value as `{{.Values.global.salad}}`.
+Because of the way globals work, both `mychart/templates/configmap.yaml` and `mysubchart/templates/configmap.yaml` should be able to access that value as `{{ .Values.global.salad}}`.
 
 `mychart/templates/configmap.yaml`:
 
@@ -132,9 +132,9 @@ Because of the way globals work, both `mychart/templates/configmap.yaml` and `my
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
-  salad: {{.Values.global.salad}}
+  salad: {{ .Values.global.salad }}
 ```
 
 `mysubchart/tempaltes/configmap.yaml`:
@@ -143,10 +143,10 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-cfgmap2
+  name: {{ .Release.Name }}-cfgmap2
 data:
-  dessert: {{.Values.dessert}}
-  salad: {{.Values.global.salad}}
+  dessert: {{ .Values.dessert }}
+  salad: {{ .Values.global.salad }}
 ```
 
 Now if we run a dry run install, we'll see the same value in both outputs:
@@ -181,11 +181,11 @@ Parent charts and subcharts can share templates. This can become very powerful w
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-cfgmap2
-  {{block "labels" .}}from: mysubchart{{end}}
+  name: {{ .Release.Name }}-cfgmap2
+  {{block "labels" . }}from: mysubchart{{ end }}
 data:
-  dessert: {{.Values.dessert}}
-  salad: {{.Values.global.salad}}
+  dessert: {{ .Values.dessert }}
+  salad: {{ .Values.global.salad }}
 ```
 
 Running this would produce:
@@ -205,7 +205,7 @@ data:
 Note that the `from:` line says `mysubchart`. In a previous section, we created `mychart/templates/_helpers.tpl`. Let's define a new named template there called `labels` to match the declaration on the block above.
 
 ```yaml
-{{- define "labels" }}from: mychart{{end}}
+{{- define "labels" }}from: mychart{{ end }}
 ```
 
 Recall how the labels on templates are _globally shared_. That means that if we create a block named `labels` in one chart, and then define an override named `labels` in another chart, the override will be applied.

--- a/docs/chart_template_guide/values_files.md
+++ b/docs/chart_template_guide/values_files.md
@@ -23,13 +23,13 @@ Now we can use this inside of a template:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favoriteDrink}}
+  drink: {{ .Values.favoriteDrink }}
 ```
 
-Notice on the last line we access `favoriteDrink` as an attribute of `Values`: `{{.Values.favoriteDrink}}`.
+Notice on the last line we access `favoriteDrink` as an attribute of `Values`: `{{ .Values.favoriteDrink}}`.
 
 Let's see how this renders.
 
@@ -89,11 +89,11 @@ Now we would have to modify the template slightly:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
-  drink: {{.Values.favorite.drink}}
-  food: {{.Values.favorite.food}}
+  drink: {{ .Values.favorite.drink }}
+  food: {{ .Values.favorite.food }}
 ```
 
 While structuring data this way is possible, the recommendation is that you keep your values trees shallow, favoring flatness. When we look at assigning values to subcharts, we'll see how values are named using a tree structure.

--- a/docs/chart_template_guide/variables.md
+++ b/docs/chart_template_guide/variables.md
@@ -6,9 +6,9 @@ In an earlier example, we saw that this code will fail:
 
 ```yaml
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
-  release: {{.Release.Name}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
+  release: {{ .Release.Name }}
   {{- end }}
 ```
 
@@ -20,14 +20,14 @@ In Helm templates, a variable is a named reference to another object. It follows
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
   {{- $relname := .Release.Name -}}
   {{- with .Values.favorite }}
-  drink: {{.drink | default "tea" | quote}}
-  food: {{.food | upper | quote}}
-  release: {{$relname}}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
+  release: {{ $relname }}
   {{- end }}
 ```
 
@@ -53,7 +53,7 @@ Variables are particularly useful in `range` loops. They can be used on list-lik
 ```yaml
   toppings: |-
     {{- range $index, $topping := .Values.pizzaToppings }}
-      {{$index}}: {{$topping}}
+      {{ $index }}: {{ $topping }}
     {{- end }}
 
 ```
@@ -74,11 +74,11 @@ For data structures that have both a key and a value, we can use `range` to get 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Release.Name}}-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   myvalue: "Hello World"
   {{- range $key, $val := .Values.favorite }}
-  {{$key}}: {{$val | quote}}
+  {{ $key }}: {{ $val | quote }}
   {{- end}}
 ```
 


### PR DESCRIPTION
Consistently add spacing for '{{ $foo }}'

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1514)
<!-- Reviewable:end -->
