### PR TITLE
fix(1516): use correct value reference in boilerplate NOTES.txt

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -149,7 +149,7 @@ const defaultNotes = `1. Get the application URL by running these commands:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"


### PR DESCRIPTION
When creating a new chart using `helm create` as a starting point, the resulting chart is not installable as-is because the `NOTES.txt` throws an error. It references `Master.ServicePort` even though no such value exists in the boilerplate `values.yaml`.

This fixes that by changing the reference to `service.externalPort`, which does exist and is more correct anyway.

Closes #1516.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1517)
<!-- Reviewable:end -->
