### PR TITLE
fix(helm): respect dryRun opt in DeleteRelease

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -89,6 +89,11 @@ func (h *Client) InstallRelease(chstr, ns string, opts ...InstallOption) (*rls.I
 
 // DeleteRelease uninstalls a named release and returns the response.
 func (h *Client) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error) {
+	// apply the uninstall options
+	for _, opt := range opts {
+		opt(&h.opts)
+	}
+
 	if h.opts.dryRun {
 		// In the dry run case, just see if the release exists
 		r, err := h.ReleaseContent(rlsName, nil)
@@ -96,11 +101,6 @@ func (h *Client) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.Unins
 			return &rls.UninstallReleaseResponse{}, err
 		}
 		return &rls.UninstallReleaseResponse{Release: r.Release}, nil
-	}
-
-	// apply the uninstall options
-	for _, opt := range opts {
-		opt(&h.opts)
 	}
 
 	req := &h.opts.uninstallReq


### PR DESCRIPTION
Apply `opts` first before testing for `dryRun`. Thanks to @tommym.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1527)
<!-- Reviewable:end -->
