### PR TITLE
feat(charts): Move bucket to domain from path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Think of it like apt/yum/homebrew for Kubernetes.
 
 Binary downloads of the Beta.2 Helm client can be found at the following links:
 
-- [OSX](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-darwin-amd64.tar.gz)
-- [Linux](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-amd64.tar.gz)
-- [Linux 32-bit](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-386.tar.gz)
+- [OSX](https://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-darwin-amd64.tar.gz)
+- [Linux](https://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-amd64.tar.gz)
+- [Linux 32-bit](https://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-386.tar.gz)
 
 Unpack the `helm` binary and add it to your PATH and you are good to go! OS X/[Cask](https://caskroom.github.io/) users can `brew cask install helm`.
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Think of it like apt/yum/homebrew for Kubernetes.
 
 Binary downloads of the Beta.2 Helm client can be found at the following links:
 
-- [OSX](http://storage.googleapis.com/kubernetes-helm/helm-v2.0.0-beta.2-darwin-amd64.tar.gz)
-- [Linux](http://storage.googleapis.com/kubernetes-helm/helm-v2.0.0-beta.2-linux-amd64.tar.gz)
-- [Linux 32-bit](http://storage.googleapis.com/kubernetes-helm/helm-v2.0.0-beta.2-linux-386.tar.gz)
+- [OSX](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-darwin-amd64.tar.gz)
+- [Linux](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-amd64.tar.gz)
+- [Linux 32-bit](http://kubernetes-helm.storage.googleapis.com/helm-v2.0.0-beta.2-linux-386.tar.gz)
 
 Unpack the `helm` binary and add it to your PATH and you are good to go! OS X/[Cask](https://caskroom.github.io/) users can `brew cask install helm`.
 

--- a/cmd/helm/downloader/manager_test.go
+++ b/cmd/helm/downloader/manager_test.go
@@ -79,7 +79,7 @@ func TestFindChartURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if churl != "http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz" {
+	if churl != "https://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz" {
 		t.Errorf("Unexpected URL %q", churl)
 	}
 

--- a/cmd/helm/downloader/manager_test.go
+++ b/cmd/helm/downloader/manager_test.go
@@ -79,7 +79,7 @@ func TestFindChartURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if churl != "http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz" {
+	if churl != "http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz" {
 		t.Errorf("Unexpected URL %q", churl)
 	}
 

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
@@ -3,7 +3,7 @@ entries:
   alpine:
     - name: alpine
       urls:
-        - http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -16,7 +16,7 @@ entries:
       icon: ""
     - name: alpine
       urls:
-        - http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -30,7 +30,7 @@ entries:
   mariadb:
     - name: mariadb
       urls:
-        - http://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
       checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
       home: https://mariadb.org
       sources:

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
@@ -3,7 +3,7 @@ entries:
   alpine:
     - name: alpine
       urls:
-        - http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -16,7 +16,7 @@ entries:
       icon: ""
     - name: alpine
       urls:
-        - http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -30,7 +30,7 @@ entries:
   mariadb:
     - name: mariadb
       urls:
-        - http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
       checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
       home: https://mariadb.org
       sources:

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
@@ -17,7 +17,7 @@ entries:
     - name: alpine
       urls:
         - http://example.com/alpine-0.2.0.tgz
-        - http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:

--- a/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/downloader/testdata/helmhome/repository/cache/testing-index.yaml
@@ -17,7 +17,7 @@ entries:
     - name: alpine
       urls:
         - http://example.com/alpine-0.2.0.tgz
-        - http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -55,7 +55,7 @@ To dump a manifest containing the Tiller deployment YAML, combine the
 const (
 	stableRepository    = "stable"
 	localRepository     = "local"
-	stableRepositoryURL = "http://storage.googleapis.com/kubernetes-charts"
+	stableRepositoryURL = "http://kubernetes-charts.storage.googleapis.com/"
 	// This is the IPv4 loopback, not localhost, because we have to force IPv4
 	// for Dockerized Helm: https://github.com/kubernetes/helm/issues/1410
 	localRepositoryURL = "http://127.0.0.1:8879/charts"

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -55,7 +55,7 @@ To dump a manifest containing the Tiller deployment YAML, combine the
 const (
 	stableRepository    = "stable"
 	localRepository     = "local"
-	stableRepositoryURL = "http://kubernetes-charts.storage.googleapis.com/"
+	stableRepositoryURL = "https://kubernetes-charts.storage.googleapis.com/"
 	// This is the IPv4 loopback, not localhost, because we have to force IPv4
 	// for Dockerized Helm: https://github.com/kubernetes/helm/issues/1410
 	localRepositoryURL = "http://127.0.0.1:8879/charts"

--- a/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   alpine:
     - name: alpine
-      url: http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
+      url: https://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -14,7 +14,7 @@ entries:
       engine: ""
       icon: ""
     - name: alpine
-      url: http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
+      url: https://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -27,7 +27,7 @@ entries:
       icon: ""
   mariadb:
     - name: mariadb
-      url: http://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
+      url: https://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
       checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
       home: https://mariadb.org
       sources:

--- a/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   alpine:
     - name: alpine
-      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.1.0.tgz
+      url: http://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -14,7 +14,7 @@ entries:
       engine: ""
       icon: ""
     - name: alpine
-      url: http://storage.googleapis.com/kubernetes-charts/alpine-0.2.0.tgz
+      url: http://kubernetes-charts.storage.googleapis.com/alpine-0.2.0.tgz
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
@@ -27,7 +27,7 @@ entries:
       icon: ""
   mariadb:
     - name: mariadb
-      url: http://storage.googleapis.com/kubernetes-charts/mariadb-0.3.0.tgz
+      url: http://kubernetes-charts.storage.googleapis.com/mariadb-0.3.0.tgz
       checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
       home: https://mariadb.org
       sources:

--- a/cmd/helm/testdata/repositories.yaml
+++ b/cmd/helm/testdata/repositories.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 repositories:
   - name: charts
-    url: "http://kubernetes-charts.storage.googleapis.com"
+    url: "https://kubernetes-charts.storage.googleapis.com"
   - name: local
     url: "http://localhost:8879/charts"

--- a/cmd/helm/testdata/repositories.yaml
+++ b/cmd/helm/testdata/repositories.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 repositories:
   - name: charts
-    url: "http://storage.googleapis.com/kubernetes-charts"
+    url: "http://kubernetes-charts.storage.googleapis.com"
   - name: local
     url: "http://localhost:8879/charts"

--- a/cmd/helm/testdata/testcache/foobar-index.yaml
+++ b/cmd/helm/testdata/testcache/foobar-index.yaml
@@ -1,5 +1,5 @@
 foobar-0.1.0:
-  url: http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+  url: https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
   name: foobar
   removed: false
   chartfile:
@@ -11,7 +11,7 @@ foobar-0.1.0:
       - dummy
       - hokey
 oddness-1.2.3:
-  url: http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+  url: https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
   name: oddness
   removed: false
   chartfile:

--- a/cmd/helm/testdata/testcache/foobar-index.yaml
+++ b/cmd/helm/testdata/testcache/foobar-index.yaml
@@ -1,5 +1,5 @@
 foobar-0.1.0:
-  url: http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+  url: http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
   name: foobar
   removed: false
   chartfile:
@@ -11,7 +11,7 @@ foobar-0.1.0:
       - dummy
       - hokey
 oddness-1.2.3:
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+  url: http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
   name: oddness
   removed: false
   chartfile:

--- a/cmd/helm/testdata/testcache/local-index.yaml
+++ b/cmd/helm/testdata/testcache/local-index.yaml
@@ -1,5 +1,5 @@
 nginx-0.1.0:
-  url: http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+  url: https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
   name: nginx
   removed: false
   chartfile:
@@ -12,7 +12,7 @@ nginx-0.1.0:
       - web server
       - proxy
 alpine-1.0.0:
-  url: http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+  url: https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
   name: alpine
   removed: false
   chartfile:

--- a/cmd/helm/testdata/testcache/local-index.yaml
+++ b/cmd/helm/testdata/testcache/local-index.yaml
@@ -1,5 +1,5 @@
 nginx-0.1.0:
-  url: http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+  url: http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
   name: nginx
   removed: false
   chartfile:
@@ -12,7 +12,7 @@ nginx-0.1.0:
       - web server
       - proxy
 alpine-1.0.0:
-  url: http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+  url: http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
   name: alpine
   removed: false
   chartfile:
@@ -25,4 +25,3 @@ alpine-1.0.0:
       - alpine
       - small
       - sumtin
-

--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -146,7 +146,7 @@ Charts repository hosts its charts, so you may want to take a
 [peek at that project](https://github.com/kubernetes/charts) if you get stuck.
 
 **Note:** A public GCS bucket can be accessed via simple HTTPS at this address
-`https://storage.googleapis.com/bucket-name`.
+`https://bucket-name.storage.googleapis.com/`.
 
 ### Github Pages example
 
@@ -228,7 +228,7 @@ packaged chart to that directory.
 $ helm package docs/examples/alpine/
 $ mkdir fantastic-charts
 $ mv alpine-0.1.0.tgz fantastic-charts/
-$ helm repo index . --url https://storage.googleapis.com/fantastic-charts
+$ helm repo index . --url https://fantastic-charts.storage.googleapis.com
 ```
 
 The last command takes the path of the local directory that you just created and
@@ -263,9 +263,9 @@ repo add [NAME] [URL]` command with any name they would like to use to
 reference the repository.
 
 ```console
-$ helm repo add fantastic-charts https://storage.googleapis.com/fantastic-charts
+$ helm repo add fantastic-charts https://fantastic-charts.storage.googleapis.com
 $ helm repo list
-fantastic-charts    https://storage.googleapis.com/fantastic-charts
+fantastic-charts    https://fantastic-charts.storage.googleapis.com
 ```
 
 **Note:** A repository will not be added if it does not contain a valid

--- a/docs/chart_repository_sync_example.md
+++ b/docs/chart_repository_sync_example.md
@@ -19,7 +19,7 @@ $ mv alpine-0.1.0.tgz fantastic-charts/
 Use helm to generate an updated index.yaml file by passing in the directory path and the url of the remote repository to the `helm repo index` command like this:
 
 ```console
-$ helm repo index fantastic-charts/ --url https://storage.googleapis.com/fantastic-charts
+$ helm repo index fantastic-charts/ --url https://fantastic-charts.storage.googleapis.com
 ```
 This will generate an updated index.yaml file and place in the `fantastic-charts/` directory.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,7 +57,7 @@ the latest master branch. They are not official releases, and may not be
 stable. However, they offer the opportunity to test the cutting edge
 features.
 
-Canary Helm binaries are stored in the [Kubernetes Helm GCS bucket](http://kubernetes-helm.storage.googleapis.com).
+Canary Helm binaries are stored in the [Kubernetes Helm GCS bucket](https://kubernetes-helm.storage.googleapis.com).
 Here are links to the common builds:
 
 - [Linux AMD64](https://kubernetes-helm.storage.googleapis.com/helm-canary-linux-amd64.tar.gz)

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,12 +57,12 @@ the latest master branch. They are not official releases, and may not be
 stable. However, they offer the opportunity to test the cutting edge
 features.
 
-Canary Helm binaries are stored in the [Kubernetes Helm GCS bucket](http://storage.googleapis.com/kubernetes-helm).
+Canary Helm binaries are stored in the [Kubernetes Helm GCS bucket](http://kubernetes-helm.storage.googleapis.com).
 Here are links to the common builds:
 
-- [Linux AMD64](http://storage.googleapis.com/kubernetes-helm/helm-canary-linux-amd64.tar.gz)
-- [OSX AMD64](http://storage.googleapis.com/kubernetes-helm/helm-canary-darwin-amd64.tar.gz)
-- [Experimental Windows AMD64](http://storage.googleapis.com/kubernetes-helm/helm-canary-windows-amd64.zip)
+- [Linux AMD64](https://kubernetes-helm.storage.googleapis.com/helm-canary-linux-amd64.tar.gz)
+- [OSX AMD64](https://kubernetes-helm.storage.googleapis.com/helm-canary-darwin-amd64.tar.gz)
+- [Experimental Windows AMD64](https://kubernetes-helm.storage.googleapis.com/helm-canary-windows-amd64.zip)
 
 ### From Source (Linux, Mac OSX)
 

--- a/docs/install_faq.md
+++ b/docs/install_faq.md
@@ -14,7 +14,7 @@ I want to know more about my downloading options.
 **Q: I can't get to GitHub releases of the newest Helm. Where are they?**
 
 A: We no longer use GitHub releases. Binaries are now stored in a
-[GCS public bucket](http://kubernetes-helm.storage.googleapis.com).
+[GCS public bucket](https://kubernetes-helm.storage.googleapis.com).
 
 **Q: Why aren't there Debian/Fedora/... native packages of Helm?**
 

--- a/docs/install_faq.md
+++ b/docs/install_faq.md
@@ -14,7 +14,7 @@ I want to know more about my downloading options.
 **Q: I can't get to GitHub releases of the newest Helm. Where are they?**
 
 A: We no longer use GitHub releases. Binaries are now stored in a
-[GCS public bucket](http://storage.googleapis.com/kubernetes-helm/).
+[GCS public bucket](http://kubernetes-helm.storage.googleapis.com).
 
 **Q: Why aren't there Debian/Fedora/... native packages of Helm?**
 

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -338,7 +338,7 @@ You can see which repositories are configured using `helm repo list`:
 ```console
 $ helm repo list
 NAME           	URL
-stable         	http://kubernetes-charts.storage.googleapis.com
+stable         	https://kubernetes-charts.storage.googleapis.com
 local          	http://localhost:8879/charts
 mumoshu        	https://mumoshu.github.io/charts
 ```

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -338,7 +338,7 @@ You can see which repositories are configured using `helm repo list`:
 ```console
 $ helm repo list
 NAME           	URL
-stable         	http://storage.googleapis.com/kubernetes-charts
+stable         	http://kubernetes-charts.storage.googleapis.com
 local          	http://localhost:8879/charts
 mumoshu        	https://mumoshu.github.io/charts
 ```

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -188,7 +188,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something",
 			},
 			URLs: []string{
-				"http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz",
+				"http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz",
 				"http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
@@ -202,7 +202,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something/else",
 			},
 			URLs: []string{
-				"http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz",
+				"http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
 		},
@@ -215,7 +215,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something",
 			},
 			URLs: []string{
-				"http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz",
+				"http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
 		},

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -188,7 +188,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something",
 			},
 			URLs: []string{
-				"http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz",
+				"https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz",
 				"http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
@@ -202,7 +202,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something/else",
 			},
 			URLs: []string{
-				"http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz",
+				"https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
 		},
@@ -215,7 +215,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 				Home:        "https://github.com/something",
 			},
 			URLs: []string{
-				"http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz",
+				"https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
 		},

--- a/pkg/repo/testdata/local-index.yaml
+++ b/pkg/repo/testdata/local-index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
       name: nginx
       description: string
       version: 0.2.0
@@ -13,7 +13,7 @@ entries:
         - web server
         - proxy
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
       name: nginx
       description: string
       version: 0.1.0
@@ -25,7 +25,7 @@ entries:
         - proxy
   alpine:
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
         - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
       name: alpine
       description: string
@@ -37,4 +37,3 @@ entries:
         - small
         - sumtin
       digest: "sha256:1234567890abcdef"
-

--- a/pkg/repo/testdata/local-index.yaml
+++ b/pkg/repo/testdata/local-index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
       name: nginx
       description: string
       version: 0.2.0
@@ -13,7 +13,7 @@ entries:
         - web server
         - proxy
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
       name: nginx
       description: string
       version: 0.1.0
@@ -25,7 +25,7 @@ entries:
         - proxy
   alpine:
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
         - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
       name: alpine
       description: string

--- a/pkg/repo/testdata/server/index.yaml
+++ b/pkg/repo/testdata/server/index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
       name: nginx
       description: string
       version: 0.1.0
@@ -13,7 +13,7 @@ entries:
         - web server
         - proxy
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
       name: nginx
       description: string
       version: 0.2.0
@@ -25,7 +25,7 @@ entries:
         - proxy
   alpine:
     - urls:
-        - http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+        - https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
         - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
       name: alpine
       description: string

--- a/pkg/repo/testdata/server/index.yaml
+++ b/pkg/repo/testdata/server/index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/nginx-0.1.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
       name: nginx
       description: string
       version: 0.1.0
@@ -13,7 +13,7 @@ entries:
         - web server
         - proxy
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/nginx-0.2.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
       name: nginx
       description: string
       version: 0.2.0
@@ -25,7 +25,7 @@ entries:
         - proxy
   alpine:
     - urls:
-        - http://storage.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+        - http://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
         - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
       name: alpine
       description: string
@@ -37,4 +37,3 @@ entries:
         - small
         - sumtin
       digest: "sha256:1234567890abcdef"
-

--- a/scripts/get
+++ b/scripts/get
@@ -56,7 +56,7 @@ verifySupported() {
     exit 1
   fi
 
-  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then 
+  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
     echo "Either curl or wget is required"
     exit 1
   fi
@@ -74,7 +74,7 @@ downloadFile() {
   fi
 
   HELM_DIST="helm-$TAG-$OS-$ARCH.tar.gz"
-  DOWNLOAD_URL="http://storage.googleapis.com/kubernetes-helm/$HELM_DIST"
+  DOWNLOAD_URL="http://kubernetes-helm.storage.googleapis.com/$HELM_DIST"
   CHECKSUM_URL="$DOWNLOAD_URL.sha256"
   HELM_TMP_FILE="/tmp/$HELM_DIST"
   HELM_SUM_FILE="/tmp/$HELM_DIST.sha256"

--- a/scripts/get
+++ b/scripts/get
@@ -74,7 +74,7 @@ downloadFile() {
   fi
 
   HELM_DIST="helm-$TAG-$OS-$ARCH.tar.gz"
-  DOWNLOAD_URL="http://kubernetes-helm.storage.googleapis.com/$HELM_DIST"
+  DOWNLOAD_URL="https://kubernetes-helm.storage.googleapis.com/$HELM_DIST"
   CHECKSUM_URL="$DOWNLOAD_URL.sha256"
   HELM_TMP_FILE="/tmp/$HELM_DIST"
   HELM_SUM_FILE="/tmp/$HELM_DIST.sha256"


### PR DESCRIPTION
A bucket name in the path can be migrated to a custom k8s domain
name. This is in preperation for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1545)
<!-- Reviewable:end -->
