### PR TITLE
feat(helm): support 'helm create --starter=mypack'

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -19,9 +19,11 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 func TestCreateCmd(t *testing.T) {
@@ -68,4 +70,94 @@ func TestCreateCmd(t *testing.T) {
 	if c.Metadata.ApiVersion != chartutil.ApiVersionV1 {
 		t.Errorf("Wrong API version: %q", c.Metadata.ApiVersion)
 	}
+}
+
+func TestCreateStarterCmd(t *testing.T) {
+	cname := "testchart"
+	// Make a temp dir
+	tdir, err := ioutil.TempDir("", "helm-create-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tdir)
+
+	thome, err := tempHelmHome(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := homePath()
+	helmHome = thome
+	defer func() {
+		helmHome = old
+		os.RemoveAll(thome)
+	}()
+
+	// Create a starter.
+	starterchart := filepath.Join(thome, "starters")
+	os.Mkdir(starterchart, 0755)
+	if dest, err := chartutil.Create(&chart.Metadata{Name: "starterchart"}, starterchart); err != nil {
+		t.Fatalf("Could not create chart: %s", err)
+	} else {
+		t.Logf("Created %s", dest)
+	}
+	tplpath := filepath.Join(starterchart, "starterchart", "templates", "foo.tpl")
+	if err := ioutil.WriteFile(tplpath, []byte("test"), 0755); err != nil {
+		t.Fatalf("Could not write template: %s", err)
+	}
+
+	// CD into it
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tdir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(pwd)
+
+	// Run a create
+	cmd := newCreateCmd(os.Stdout)
+	cmd.ParseFlags([]string{"--starter", "starterchart"})
+	if err := cmd.RunE(cmd, []string{cname}); err != nil {
+		t.Errorf("Failed to run create: %s", err)
+		return
+	}
+
+	// Test that the chart is there
+	if fi, err := os.Stat(cname); err != nil {
+		t.Fatalf("no chart directory: %s", err)
+	} else if !fi.IsDir() {
+		t.Fatalf("chart is not directory")
+	}
+
+	c, err := chartutil.LoadDir(cname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Metadata.Name != cname {
+		t.Errorf("Expected %q name, got %q", cname, c.Metadata.Name)
+	}
+	if c.Metadata.ApiVersion != chartutil.ApiVersionV1 {
+		t.Errorf("Wrong API version: %q", c.Metadata.ApiVersion)
+	}
+
+	if l := len(c.Templates); l != 5 {
+		t.Errorf("Expected 5 templates, got %d", l)
+	}
+
+	found := false
+	for _, tpl := range c.Templates {
+		if tpl.Name == "templates/foo.tpl" {
+			found = true
+			data := tpl.Data
+			if string(data) != "test" {
+				t.Errorf("Expected template 'test', got %q", string(data))
+			}
+		}
+	}
+	if !found {
+		t.Error("Did not find foo.tpl")
+	}
+
 }

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -241,7 +241,7 @@ func tempHelmHome(t *testing.T) (string, error) {
 //
 // t is used only for logging.
 func ensureTestHome(home helmpath.Home, t *testing.T) error {
-	configDirectories := []string{home.String(), home.Repository(), home.Cache(), home.LocalRepository()}
+	configDirectories := []string{home.String(), home.Repository(), home.Cache(), home.LocalRepository(), home.Starters()}
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {
 			if err := os.MkdirAll(p, 0755); err != nil {

--- a/cmd/helm/helmpath/helmhome.go
+++ b/cmd/helm/helmpath/helmhome.go
@@ -53,6 +53,11 @@ func (h Home) CacheIndex(name string) string {
 	return filepath.Join(string(h), target)
 }
 
+// Starters returns the path to the Helm starter packs.
+func (h Home) Starters() string {
+	return filepath.Join(string(h), "starters")
+}
+
 // LocalRepository returns the location to the local repo.
 //
 // The local repo is the one used by 'helm serve'

--- a/cmd/helm/helmpath/helmhome_test.go
+++ b/cmd/helm/helmpath/helmhome_test.go
@@ -33,4 +33,5 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.LocalRepository(), "/r/repository/local")
 	isEq(t, hh.Cache(), "/r/repository/cache")
 	isEq(t, hh.CacheIndex("t"), "/r/repository/cache/t-index.yaml")
+	isEq(t, hh.Starters(), "/r/starters")
 }

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -143,7 +143,7 @@ func (i *initCmd) run() error {
 //
 // If $HELM_HOME does not exist, this function will create it.
 func ensureHome(home helmpath.Home, out io.Writer) error {
-	configDirectories := []string{home.String(), home.Repository(), home.Cache(), home.LocalRepository()}
+	configDirectories := []string{home.String(), home.Repository(), home.Cache(), home.LocalRepository(), home.Starters()}
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {
 			fmt.Fprintf(out, "Creating %s \n", p)

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -543,3 +543,21 @@ commands. However, Helm does not provide tools for uploading charts to
 remote repository servers. This is because doing so would add
 substantial requirements to an implementing server, and thus raise the
 barrier for setting up a repository.
+
+## Chart Starter Packs
+
+The `helm create` command takes an optional `--starter` option that lets you
+specify a "starter chart".
+
+Starters are just regular charts, but are located in `$HELM_HOME/starters`.
+As a chart developer, you may author charts that are specifically designed
+to be used as starters. Such charts should be designed with the following
+considerations in mind:
+
+- The `Chart.yaml` will be overwritten by the genertor.
+- Users will expect to modify such a chart's contents, so documentation
+  should indicate how users can do so.
+
+Currently the only way to add a chart to `$HELM_HOME/starters` is to manually
+copy it there. In your chart's documentation, you may want to explain that
+process.

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -175,6 +175,17 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 `
 
+// CreateFrom creates a new chart, but scaffolds it from the src chart.
+func CreateFrom(chartfile *chart.Metadata, dest string, src string) error {
+	schart, err := Load(src)
+	if err != nil {
+		return fmt.Errorf("could not load %s: %s", src, err)
+	}
+
+	schart.Metadata = chartfile
+	return SaveDir(schart, dest)
+}
+
 // Create creates a new chart in a directory.
 //
 // Inside of dir, this will create a directory based on the name of

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -65,3 +65,37 @@ func TestSave(t *testing.T) {
 		t.Fatal("Values data did not match")
 	}
 }
+
+func TestSaveDir(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "helm-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:    "ahab",
+			Version: "1.2.3.4",
+		},
+		Values: &chart.Config{
+			Raw: "ship: Pequod",
+		},
+	}
+
+	if err := SaveDir(c, tmp); err != nil {
+		t.Fatalf("Failed to save: %s", err)
+	}
+
+	c2, err := LoadDir(tmp + "/ahab")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c2.Metadata.Name != c.Metadata.Name {
+		t.Fatalf("Expected chart archive to have %q, got %q", c.Metadata.Name, c2.Metadata.Name)
+	}
+	if c2.Values.Raw != c.Values.Raw {
+		t.Fatal("Values data did not match")
+	}
+}


### PR DESCRIPTION
This adds support for packs, pre-configured chart patterns that can be
used to quickly create a custom layout for your new chart.

- `helm init` now creates a `$HELM_HOME/starters` directory. You can copy charts into that directory
- `helm create` now takes `--starter=<string>`, where the value is the name of a chart inside of `$HELM_HOME/starters`.

If no starter is supplied, the default chart (hard-coded) is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1547)
<!-- Reviewable:end -->
