### PR TITLE
use openssl instead of shasum

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -95,7 +95,7 @@ downloadFile() {
 # installs it.
 installFile() {
   HELM_TMP="/tmp/$PROJECT_NAME"
-  local sum=$(shasum -a 256 ${HELM_TMP_FILE} | awk '{print $1}')
+  local sum=$(openssl sha -sha256 ${HELM_TMP_FILE} | awk '{print $2}')
   local expected_sum=$(cat ${HELM_SUM_FILE})
   if [ "$sum" != "$expected_sum" ]; then
     echo "SHA sum of $HELM_TMP does not match. Aborting."


### PR DESCRIPTION
shasum is not on many platforms (like centos), use openssl instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1553)
<!-- Reviewable:end -->
