### PR TITLE
fix(tiller): allow release name to be up to 53 chars

### DIFF
--- a/docs/chart_template_guide/getting_started.md
+++ b/docs/chart_template_guide/getting_started.md
@@ -141,9 +141,9 @@ Hard-coding the `name:` into a resource is usually considered to be bad practice
 Names should be unique to a release. So we might want to generate a name field
 by inserting the release name.
 
-**TIP:** The `name:` field is limited to 24 characters because of limitations to
-the DNS system (long story). For that reason, release names are limited to
-14 characters.
+**TIP:** The `name:` field is limited to 63 characters because of limitations to
+the DNS system. For that reason, release names are limited to 53 characters.
+Kubernetes 1.3 and earlier limited to only 24 characters (thus 14 character names).
 
 Let's alter `configmap.yaml` accordingly.
 

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -45,10 +45,10 @@ import (
 
 // releaseNameMaxLen is the maximum length of a release name.
 //
-// This is designed to accommodate the usage of release name in the 'name:'
-// field of Kubernetes resources. Many of those fields are limited to 24
-// characters in length. See https://github.com/kubernetes/helm/issues/1071
-const releaseNameMaxLen = 14
+// As of Kubernetes 1.4, the max limit on a name is 63 chars. We reserve 10 for
+// charts to add data. Effectively, that gives us 53 chars.
+// See https://github.com/kubernetes/helm/issues/1528
+const releaseNameMaxLen = 53
 
 // NOTESFILE_SUFFIX that we want to treat special. It goes through the templating engine
 // but it's not a yaml file (resource) hence can't have hooks, etc. And the user actually

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -180,7 +180,7 @@ func TestUniqName(t *testing.T) {
 		{"angry-panda", "", false, true},
 		{"happy-panda", "", false, true},
 		{"happy-panda", "happy-panda", true, false},
-		{"hungry-hungry-hippos", "", true, true}, // Exceeds max name length
+		{"hungry-hungry-hungry-hungry-hungry-hungry-hungry-hungry-hippos", "", true, true}, // Exceeds max name length
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This raises the limit from 14 to 53 chars based on the Kubernetes 1.4
name limit.

Closes #1528

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1560)
<!-- Reviewable:end -->
