### PR TITLE
fix(helm): don't pass nil-opt to ReleaseContent

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -96,7 +96,7 @@ func (h *Client) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.Unins
 
 	if h.opts.dryRun {
 		// In the dry run case, just see if the release exists
-		r, err := h.ReleaseContent(rlsName, nil)
+		r, err := h.ReleaseContent(rlsName)
 		if err != nil {
 			return &rls.UninstallReleaseResponse{}, err
 		}


### PR DESCRIPTION
Hi, now that my earlier fix for `DeleteRelease` was merged (respect dryRun in DeleteRelease), it triggered/exposed an additional bug in the dryRun code path. See my fix. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/helm/1578)
<!-- Reviewable:end -->
