### PR TITLE
fix(helm): fix windows support with port forward connection in setupConnection

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -141,7 +141,7 @@ func setupConnection(c *cobra.Command, args []string) error {
 			return err
 		}
 
-		tillerHost = fmt.Sprintf(":%d", tunnel.Local)
+		tillerHost = fmt.Sprintf("localhost:%d", tunnel.Local)
 		if flagDebug {
 			fmt.Printf("Created tunnel using local port: '%d'\n", tunnel.Local)
 		}


### PR DESCRIPTION
fix(helm): fix windows support with port forward connection in setupConnection

This fixes the port forward connection using helm on windows by assigning explicitely 'localhost' to 'TillerHost' in 'setupConnection'. Otherwise, the connection between the helm client with the Tiller server deployed on Kubernetes will not work.