### PR TITLE
fix(helm): pass the no-hooks flag during upgrade

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -135,7 +135,12 @@ func (u *upgradeCmd) run() error {
 		return err
 	}
 
-	_, err = u.client.UpdateRelease(u.release, chartPath, helm.UpdateValueOverrides(rawVals), helm.UpgradeDryRun(u.dryRun), helm.UpgradeDisableHooks(u.disableHooks))
+	_, err = u.client.UpdateRelease(
+		u.release,
+		chartPath,
+		helm.UpdateValueOverrides(rawVals),
+		helm.UpgradeDryRun(u.dryRun),
+		helm.UpgradeDisableHooks(u.disableHooks))
 	if err != nil {
 		return fmt.Errorf("UPGRADE FAILED: %v", prettyError(err))
 	}

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -132,6 +132,7 @@ func (h *Client) UpdateRelease(rlsName string, chstr string, opts ...UpdateOptio
 	req.Chart = chart
 	req.DryRun = h.opts.dryRun
 	req.Name = rlsName
+	req.DisableHooks = h.opts.disableHooks
 	ctx := NewContext()
 
 	if h.opts.before != nil {


### PR DESCRIPTION
Helm upgrades were not passing the no-hooks value to the server.

Closes #1590