### PR TITLE
fix(Makefile): build windows amd64 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= gcr.io
 IMAGE_PREFIX    ?= kubernetes-helm
 SHORT_NAME      ?= tiller
-TARGETS         = darwin/amd64 linux/amd64 linux/386
+TARGETS         = darwin/amd64 linux/amd64 linux/386 windows/amd64
 DIST_DIRS       = find * -type d -exec
 
 # go option


### PR DESCRIPTION
This adds back support for Windows now that it has been tested by the
community.

Closes #1596