### PR TITLE
fix(helm): improve URL comparison logic

### DIFF
--- a/cmd/helm/downloader/manager.go
+++ b/cmd/helm/downloader/manager.go
@@ -313,12 +313,21 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) {
 func urlsAreEqual(a, b string) bool {
 	au, err := url.Parse(a)
 	if err != nil {
+		a = filepath.Clean(a)
+		b = filepath.Clean(b)
 		// If urls are paths, return true only if they are an exact match
 		return a == b
 	}
 	bu, err := url.Parse(b)
 	if err != nil {
 		return false
+	}
+
+	for _, u := range []*url.URL{au, bu} {
+		if u.Path == "" {
+			u.Path = "/"
+		}
+		u.Path = filepath.Clean(u.Path)
 	}
 	return au.String() == bu.String()
 }

--- a/cmd/helm/downloader/manager_test.go
+++ b/cmd/helm/downloader/manager_test.go
@@ -135,3 +135,27 @@ func TestGetRepoNames(t *testing.T) {
 		}
 	}
 }
+
+func TestUrlsAreEqual(t *testing.T) {
+	for _, tt := range []struct {
+		a, b  string
+		match bool
+	}{
+		{"http://example.com", "http://example.com", true},
+		{"http://example.com", "http://another.example.com", false},
+		{"https://example.com", "https://example.com", true},
+		{"http://example.com/", "http://example.com", true},
+		{"https://example.com", "http://example.com", false},
+		{"http://example.com/foo", "http://example.com/foo/", true},
+		{"http://example.com/foo//", "http://example.com/foo/", true},
+		{"http://example.com/./foo/", "http://example.com/foo/", true},
+		{"http://example.com/bar/../foo/", "http://example.com/foo/", true},
+		{"/foo", "/foo", true},
+		{"/foo", "/foo/", true},
+		{"/foo/.", "/foo/", true},
+	} {
+		if tt.match != urlsAreEqual(tt.a, tt.b) {
+			t.Errorf("Expected %q==%q to be %t", tt.a, tt.b, tt.match)
+		}
+	}
+}


### PR DESCRIPTION
Normalize URLs before comparing them. This deviates slightly from the
URL spec, but in order to accomodate the predominant use pattern for
Helm. Specifically, './', '../', and '/' are all "interpreted" to be
filepath-like.

Closes #1588