### PR TITLE
Feature/repo url trailing slash

### DIFF
--- a/cmd/helm/downloader/manager.go
+++ b/cmd/helm/downloader/manager.go
@@ -226,7 +226,7 @@ func (m *Manager) hasAllRepos(deps []*chartutil.Dependency) error {
 			found = true
 		} else {
 			for _, repo := range repos {
-				if urlsAreEqual(repo.URL, dd.Repository) {
+				if urlsAreEqual(repo.URL, strings.TrimSuffix(dd.Repository, "/")) {
 					found = true
 				}
 			}

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -95,7 +96,7 @@ func insertRepoLine(name, url string, home helmpath.Home) error {
 	}
 	f.Add(&repo.Entry{
 		Name:  name,
-		URL:   url,
+		URL:   strings.TrimSuffix(url, "/"),
 		Cache: filepath.Base(cif),
 	})
 	return f.WriteFile(home.RepositoryFile(), 0644)


### PR DESCRIPTION
Repository url should be normalized to always be without trailing slashes to avoid confusing behaviour like

```
$ helm repo add --debug schip http://helm.company.io/
"schip" has been added to your repositories

$ helm dependency update
Error: no repository definition for http://helm.company.io, http://helm.company.io. Try 'helm repo add'

$ helm repo list
NAME                 URL
kubernetes-charts    http://storage.googleapis.com/kubernetes-charts
schip                http://helm.company.io/

$ helm repo remove schip
"schip" has been removed from your repositories

$ helm repo add --debug schip http://helm.company.io
"schip" has been added to your repositories

$ helm repo list
NAME                 URL
kubernetes-charts    http://storage.googleapis.com/kubernetes-charts
schip                http://helm.company.io

$ helm dependency update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "schip" chart repository
...Successfully got an update from the "kubernetes-charts" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 2 charts
Downloading schip/helmtest from repo http://helm.company.io
```

It's my first PR, so any feedback would be appreciated.