### PR TITLE
fix(helm): handle errors when plugin command is not found

### DIFF
--- a/cmd/helm/plugins.go
+++ b/cmd/helm/plugins.go
@@ -78,9 +78,11 @@ func loadPlugins(baseCmd *cobra.Command, home helmpath.Home, out io.Writer) {
 				prog.Stdout = out
 				prog.Stderr = os.Stderr
 				if err := prog.Run(); err != nil {
-					eerr := err.(*exec.ExitError)
-					os.Stderr.Write(eerr.Stderr)
-					return fmt.Errorf("plugin %q exited with error", md.Name)
+					if eerr, ok := err.(*exec.ExitError); ok {
+						os.Stderr.Write(eerr.Stderr)
+						return fmt.Errorf("plugin %q exited with error", md.Name)
+					}
+					return err
 				}
 				return nil
 			},


### PR DESCRIPTION
If a 'command:' is not found for a plugin, it will not result in an
ExitError, but in a PathError. This prevents that condition from
panicing.

Closes #1609