### PR TITLE
fix(helm): write yaml without exec permission

### DIFF
--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -56,5 +56,5 @@ func SaveChartfile(filename string, cf *chart.Metadata) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, out, 0755)
+	return ioutil.WriteFile(filename, out, 0644)
 }


### PR DESCRIPTION
I believe there's no reason to make yamls executable, e.g. in `helm create` `Chart.yaml` is made executable.