### PR TITLE
feat(helm): Add Files.Glob method to permit file organization

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -67,6 +67,8 @@ data:
     message = Goodbye from config 3
 ```
 
+## Glob patterns
+
 As your chart grows, you may find you have a greater need to organize your
 files more, and so we provide a `Files.Glob(pattern string)` method to assist
 in extracting certain files however you need.
@@ -80,8 +82,6 @@ foo/:
 bar/:
   bar.go bar.conf baz.yaml
 ```
-
-## Glob patterns
 
 You have multiple options with Globs:
 

--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -9,6 +9,8 @@ Helm provides access to files through the `.Files` object. Before we get going w
 	- Files in `templates/` cannot be accessed.
 - Charts to not preserve UNIX mode information, so file-level permissions will have no impact on the availability of a file when it comes to the `.Files` object.
 
+## Basic example
+
 With those caveats behind, let's write a template that reads three files into our ConfigMap. To get started, we will add three files to the chart, putting all three directly inside of the `mychart/` directory.
 
 `config1.toml`:
@@ -64,6 +66,42 @@ data:
   config3.toml: |-
     message = Goodbye from config 3
 ```
+
+As your chart grows, you may find you have a greater need to organize your
+files more, and so we provide a `Files.Glob(pattern string)` method to assist
+in extracting certain files however you need.
+
+For example, imagine the directory structure:
+
+```
+foo/: 
+  foo.txt foo.yaml
+
+bar/:
+  bar.go bar.conf baz.yaml
+```
+
+## Glob patterns
+
+You have multiple options with Globs:
+
+
+```yaml
+{{ range $path := .Files.Glob "**.yaml" }}
+{{ $path }}: |
+{{ .Files.Get $path }}
+{{ end }}
+```
+
+Or
+
+```yaml
+{{ range $path, $bytes := .Files.Glob "foo/*" }}
+{{ $path }}: '{{ b64enc $bytes }}'
+{{ end }}
+```
+
+## Secrets
 
 When working with a Secret resource, you can import a file and have the template base-64 encode it for you:
 

--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -71,7 +71,7 @@ data:
 
 As your chart grows, you may find you have a greater need to organize your
 files more, and so we provide a `Files.Glob(pattern string)` method to assist
-in extracting certain files however you need.
+in extracting certain files with all the flexibility of [glob patterns](//godoc.org/github.com/gobwas/glob).
 
 For example, imagine the directory structure:
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 89695daf5f2de706b79fdd8e8b095f9514f418c0fbcf80d7fdca4c208d114d19
-updated: 2016-11-29T14:56:31.55726541-07:00
+hash: 707ac6d1785d0029397f2f9a3b0bc45f7d8ce819f14f6c246967b0a404627a2c
+updated: 2016-12-01T09:07:51.289370422-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -103,6 +103,16 @@ imports:
   version: 465937c80b3c07a7c7ad20cc934898646a91c1de
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/gobwas/glob
+  version: 0354991b92587e2742549d3036f3b5bae5ab03f2
+  subpackages:
+  - compiler
+  - match
+  - syntax
+  - syntax/ast
+  - syntax/lexer
+  - util/runes
+  - util/strings
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -49,3 +49,5 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - openpgp
+- package: github.com/gobwas/glob
+  version: ^0.2.1

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -64,6 +64,7 @@ func (f Files) Get(name string) string {
 // matched  files.
 //
 // This is designed to be called from a template.
+//
 // {{ range $name, $content := .Files.Glob("foo/**") }}
 // {{ $name }}: |
 // {{ .Files.Get($name) | indent 4 }}{{ end }}


### PR DESCRIPTION
This adds a simple Files.Glob method which returns another Files object, permitting flexible file organization for Chart authors.