### PR TITLE
fix(helm): fix prompt error on Windows build

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -166,7 +166,7 @@ func (p *packageCmd) clearsign(filename string) error {
 // promptUser implements provenance.PassphraseFetcher
 func promptUser(name string) ([]byte, error) {
 	fmt.Printf("Password for key %q >  ", name)
-	pw, err := terminal.ReadPassword(syscall.Stdin)
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return pw, err
 }


### PR DESCRIPTION
This backs out an earlier change that removed an int type assertion.