### PR TITLE
Increase column width when listing releases

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -194,7 +194,7 @@ func (l *listCmd) statusCodes() []release.Status_Code {
 
 func formatList(rels []*release.Release) string {
 	table := uitable.New()
-	table.MaxColWidth = 30
+	table.MaxColWidth = 60
 	table.AddRow("NAME", "REVISION", "UPDATED", "STATUS", "CHART")
 	for _, r := range rels {
 		c := fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -166,7 +166,7 @@ func (p *packageCmd) clearsign(filename string) error {
 // promptUser implements provenance.PassphraseFetcher
 func promptUser(name string) ([]byte, error) {
 	fmt.Printf("Password for key %q >  ", name)
-	pw, err := terminal.ReadPassword(syscall.Stdin)
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return pw, err
 }


### PR DESCRIPTION
After #1560 was merged, names of releases can now be up to 53 characters long, up from 14 previously. When listing releases, the maximum column width is 30 characters, meaning it's not possible to get the full name of releases using the full available length.

This change just increases the maximum column width to 60, to allow for longer release names.

PS.
I'm working on getting a CLA signed by my employer, even if it does seem a bit silly for such a small change. :)