### PR TITLE
fix(helm): fix broken --values flag

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -171,7 +171,7 @@ func (u *upgradeCmd) vals() ([]byte, error) {
 			return []byte{}, err
 		}
 
-		if err := yaml.Unmarshal(bytes, base); err != nil {
+		if err := yaml.Unmarshal(bytes, &base); err != nil {
 			return []byte{}, fmt.Errorf("failed to parse %s: %s", u.valuesFile, err)
 		}
 	}


### PR DESCRIPTION
This fixes the 'helm upgrade --values', which I broke when fixing
'--set'.

Closes #1631