### PR TITLE
fix(helm): add trimSuffix to helper functions

### DIFF
--- a/docs/examples/nginx/templates/_helpers.tpl
+++ b/docs/examples/nginx/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 }}{{end}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 | trimSuffix "-" }}{{end}}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 */}}
 {{define "fullname"}}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{end}}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -162,7 +162,7 @@ const defaultHelpers = `{{/* vim: set filetype=mustache: */}}
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -171,7 +171,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 `
 

--- a/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
+++ b/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 }}{{end}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 | trimSuffix "-" }}{{end}}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 */}}
 {{define "fullname"}}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{end}}


### PR DESCRIPTION
A name ending with "-" fails the kubernetes regex tests. 