### PR TITLE
fix(tiller): increase the max message size for grpc

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -24,7 +24,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 
 	"k8s.io/helm/pkg/proto/hapi/services"
 	"k8s.io/helm/pkg/storage"
@@ -41,7 +40,7 @@ const (
 // rootServer is the root gRPC server.
 //
 // Each gRPC service registers itself to this server during init().
-var rootServer = grpc.NewServer()
+var rootServer = tiller.NewServer()
 
 // env is the default environment.
 //

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/technosophos/moniker"
@@ -80,6 +81,17 @@ var ListDefaultLimit int64 = 512
 // the final ? to + to require that the pattern match at least once. This modification
 // prevents an empty string from matching.
 var ValidName = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$")
+
+// maxMsgSize use 10MB as the default message size limit.
+// grpc library default is 4MB
+var maxMsgSize = 1024 * 1024 * 10
+
+// NewServer creates a new grpc server.
+func NewServer() *grpc.Server {
+	return grpc.NewServer(
+		grpc.MaxMsgSize(maxMsgSize),
+	)
+}
 
 // ReleaseServer implements the server-side gRPC endpoint for the HAPI services.
 type ReleaseServer struct {


### PR DESCRIPTION
Increases the default message size from 4MB to 10MB.