### PR TITLE
feat(helm): Add Files.AsSecrets, Files.AsConfig, path functions

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -18,6 +18,7 @@ Helm provides access to files through the `.Files` object. Before we get going w
 - [Glob patterns](#glob-patterns)
 - [ConfigMap and Secrets utility functions](#configmap-and-secrets-utility-functions)
 - [Secrets](#secrets)
+- [Lines](#lines)
 
 <!-- tocstop -->
 
@@ -188,6 +189,17 @@ type: Opaque
 data:
   token: |-
     bWVzc2FnZSA9IEhlbGxvIGZyb20gY29uZmlnIDEK
+```
+
+## Lines
+
+Sometimes it is desireable to access each line of a file in your template. We
+provide a convenient `Lines` method for this.
+
+```yaml
+data:
+  some-file.txt: {{ range .Files.Lines "foo/bar.txt" }}
+    {{ . }}{{ end }}
 ```
 
 Currently, there is no way to pass files external to the chart during `helm install`. So if you are asking users to supply data, it must be loaded using `helm install -f` or `helm install --set`.

--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -14,6 +14,7 @@ Helm provides access to files through the `.Files` object. Before we get going w
 <!-- toc -->
 
 - [Basic example](#basic-example)
+- [Path helpers](#path-helpers)
 - [Glob patterns](#glob-patterns)
 - [ConfigMap and Secrets utility functions](#configmap-and-secrets-utility-functions)
 - [Secrets](#secrets)
@@ -78,11 +79,26 @@ data:
     message = Goodbye from config 3
 ```
 
+## Path helpers
+
+When working with files, it can be very useful to perform some standard
+operations on the file paths themselves. To help with this, Helm imports many of
+the functions from Go's [path](https://golang.org/pkg/path/) package for your
+use. They are all accessible with the same names as in the Go package, but
+with a lowercase first letter. For example, `Base` becomes `base`, etc.
+
+The imported functions are:
+- Base
+- Dir
+- Ext
+- IsAbs
+- Clean
+
 ## Glob patterns
 
 As your chart grows, you may find you have a greater need to organize your
 files more, and so we provide a `Files.Glob(pattern string)` method to assist
-in extracting certain files with all the flexibility of [glob patterns](//godoc.org/github.com/gobwas/glob).
+in extracting certain files with all the flexibility of [glob patterns](https://godoc.org/github.com/gobwas/glob).
 
 `.Glob` returns a `Files` type, so you may call any of the `Files` methods on
 the returned object.

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -18,6 +18,7 @@ package chartutil
 import (
 	"encoding/base64"
 	"path"
+	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -144,6 +145,15 @@ func (f Files) AsSecrets() string {
 	}
 
 	return ToYaml(m)
+}
+
+// Lines returns
+func (f Files) Lines(string path) []string {
+	if f == nil || f[path] == nil {
+		return []string{}
+	}
+
+	return strings.Split(string(f[path]), "\n")
 }
 
 // ToYaml takes an interface, marshals it to yaml, and returns a string. It will

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -146,6 +146,10 @@ func (f Files) AsSecrets() string {
 	return ToYaml(m)
 }
 
+// ToYaml takes an interface, marshals it to yaml, and returns a string. It will
+// always return a string, even on marshal error (empty string).
+//
+// This is designed to be called from a template.
 func ToYaml(v interface{}) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -147,8 +147,14 @@ func (f Files) AsSecrets() string {
 	return ToYaml(m)
 }
 
-// Lines returns
-func (f Files) Lines(string path) []string {
+// Lines returns each line of a named file (split by "\n") as a slice, so it can
+// be ranged over in your templates.
+//
+// This is designed to be called from a template.
+//
+// {{ range .Files.Lines "foo/bar.html" }}
+// {{ . }}{{ end }}
+func (f Files) Lines(path string) []string {
 	if f == nil || f[path] == nil {
 		return []string{}
 	}

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -29,6 +29,7 @@ var cases = []struct {
 	{"ship/stowaway.txt", "Legatt"},
 	{"story/name.txt", "The Secret Sharer"},
 	{"story/author.txt", "Joseph Conrad"},
+	{"multiline/test.txt", "bar\nfoo"},
 }
 
 func getTestFiles() []*any.Any {
@@ -84,6 +85,17 @@ func TestToSecret(t *testing.T) {
 
 	out := f.Glob("ship/**").AsSecrets()
 	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0\n", out)
+}
+
+func TestLines(t *testing.T) {
+	as := assert.New(t)
+
+	f := NewFiles(getTestFiles())
+
+	out := f.Lines("multiline/test.txt")
+	as.Len(out, 2)
+
+	as.Equal("bar", out[0])
 }
 
 func TestToYaml(t *testing.T) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -71,11 +71,6 @@ func FuncMap() template.FuncMap {
 	// Add some extra functionality
 	extra := template.FuncMap{
 		"toYaml": chartutil.ToYaml,
-		"base":   path.Base,
-		"dir":    path.Dir,
-		"ext":    path.Ext,
-		"isAbs":  path.IsAbs,
-		"clean":  path.Clean,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -70,7 +70,7 @@ func FuncMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
-		"toYaml": files.ToYaml,
+		"toYaml": chartutil.ToYaml,
 		"base":   path.Base,
 		"dir":    path.Dir,
 		"ext":    path.Ext,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -27,19 +27,6 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 )
 
-func TestToYaml(t *testing.T) {
-	expect := "foo: bar\n"
-	v := struct {
-		Foo string `json:"foo"`
-	}{
-		Foo: "bar",
-	}
-
-	if got := toYaml(v); got != expect {
-		t.Errorf("Expected %q, got %q", expect, got)
-	}
-}
-
 func TestEngine(t *testing.T) {
 	e := New()
 


### PR DESCRIPTION
This PR adds a number of useful utilities for working with files and file paths.

- Several of the StdLib path functions have been exposed to templates for working with file paths
- The `Files` type learned to serialize itself to valid YAML maps for both config maps and secrets via `Files.AsConfig()` and `Files.AsSecrets()`

A few possible edits I was unsure on:

- `AsConfig()` and `AsSecrets()` could instead return maps intended to be passed to `toYaml` or `toJson`(does that exist?) to support either use case. I chose YAML because I think that's probably the most commonly used language, but I know there are people out there using JSON.
- This could be more composable. For example, `{{ Files.Glob "secrets/*" | secretMap | flattenDir | toYaml }}`.
- I'm not attached to the method names at all. There may be more semantic/evocative names for what these methods do. I just didn't want to overdo it with `ToKubeConfigMapYAMLKeys()` or some such nonsense. :smile: