### PR TITLE
feat(helm): add newline to fetch --verify output

### DIFF
--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -124,7 +124,7 @@ func (f *fetchCmd) run() error {
 	}
 
 	if f.verify {
-		fmt.Fprintf(f.out, "Verification: %v", v)
+		fmt.Fprintf(f.out, "Verification: %v\n", v)
 	}
 
 	// After verification, untar the chart into the requested directory.


### PR DESCRIPTION
This simply adds a newline character to the end of the output of a (successful) invocation of `helm fetch --verify <chart>`, so that the returned bash prompt is on a new line, rather than directly following the output.