### PR TITLE
Set Helm deployment to pull IfNotPresent

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -86,7 +86,7 @@ func generateDeployment(image string) *extensions.Deployment {
 						{
 							Name:            "tiller",
 							Image:           image,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: "IfNotPresent",
 							Ports:           []api.ContainerPort{{ContainerPort: 44134, Name: "tiller"}},
 							LivenessProbe: &api.Probe{
 								Handler: api.Handler{


### PR DESCRIPTION
Helm uses fixed tags (e.g. `v2.0.2`) so there should be no need to pull a new image every time.

I came across this on my minkube setup. I routinely start/stop my VM. The helm deploy fails occasionally because it cannot pull a new image. This is because my network connection is flaky. I investigated the deployment template used to install tiller. This change should make the things more stable in some use cases.  Granted it assumes the image associated with a tag never changes. I'm not sure if tiller uses this strategy so I figured I would propose this change.