### PR TITLE
If not mercurial, clone with git. dont exit if no mercurial is there

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,6 @@ coverage:
 
 HAS_GLIDE := $(shell command -v glide;)
 HAS_GOX := $(shell command -v gox;)
-HAS_HG := $(shell command -v hg;)
 HAS_GIT := $(shell command -v git;)
 
 .PHONY: bootstrap
@@ -113,11 +112,8 @@ ifndef HAS_GOX
 	go get -u github.com/mitchellh/gox
 endif
 
-ifndef HAS_HG
-	@echo "Mercurial is not installed! Checking for Git"
 ifndef HAS_GIT
-	$(error You must either install Mercurial  or Git)
-endif
+	$(error You must install Git)
 endif
 	glide install --strip-vendor
 	go build -o bin/protoc-gen-go ./vendor/github.com/golang/protobuf/protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,12 @@ endif
 ifndef HAS_GOX
 	go get -u github.com/mitchellh/gox
 endif
+
 ifndef HAS_HG
-	$(error You must install Mercurial (hg))
-endif
+	@echo "Mercurial is not installed! Checking for Git"
 ifndef HAS_GIT
-	$(error You must install Git)
+	$(error You must either install Mercurial  or Git)
+endif
 endif
 	glide install --strip-vendor
 	go build -o bin/protoc-gen-go ./vendor/github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
Current code in makefile exits if no hg is available though there exists code to allow clone via git. Fixed code to proceed if either git or hg is available 