### PR TITLE
fix(helm): suprress info message for 'helm inspect'

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -346,7 +346,9 @@ func locateChartPath(name, version string, verify bool, keyring string) (string,
 		if err != nil {
 			return filename, err
 		}
-		fmt.Printf("Fetched %s to %s\n", name, filename)
+		if flagDebug {
+			fmt.Printf("Fetched %s to %s\n", name, filename)
+		}
 		return lname, nil
 	} else if flagDebug {
 		return filename, err


### PR DESCRIPTION
There was an informational message being printed that is unnecessary,
but prevented shell scripting the results of inspect calls.

Closes #1574