### PR TITLE
feat(*): allow tiller to be installed in an alternate namespace

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/helm/cmd/helm/helmpath"
 	"k8s.io/helm/cmd/helm/installer"
 	"k8s.io/helm/pkg/repo"
-	"k8s.io/helm/pkg/tiller/environment"
 )
 
 const initDesc = `
@@ -75,8 +74,7 @@ type initCmd struct {
 
 func newInitCmd(out io.Writer) *cobra.Command {
 	i := &initCmd{
-		out:       out,
-		namespace: environment.TillerNamespace,
+		out: out,
 	}
 
 	cmd := &cobra.Command{
@@ -87,6 +85,7 @@ func newInitCmd(out io.Writer) *cobra.Command {
 			if len(args) != 0 {
 				return errors.New("This command does not accept arguments")
 			}
+			i.namespace = tillerNamespace
 			i.home = helmpath.Home(homePath())
 			return i.run()
 		},

--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -88,7 +88,12 @@ func generateDeployment(namespace, image string) *extensions.Deployment {
 							Name:            "tiller",
 							Image:           image,
 							ImagePullPolicy: "IfNotPresent",
-							Ports:           []api.ContainerPort{{ContainerPort: 44134, Name: "tiller"}},
+							Ports: []api.ContainerPort{
+								{ContainerPort: 44134, Name: "tiller"},
+							},
+							Env: []api.EnvVar{
+								{Name: "TILLER_NAMESPACE", Value: namespace},
+							},
 							LivenessProbe: &api.Probe{
 								Handler: api.Handler{
 									HTTPGet: &api.HTTPGetAction{

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -57,6 +57,10 @@ func TestDeploymentManifest(t *testing.T) {
 		if got := dep.Spec.Template.Spec.Containers[0].Image; got != tt.expect {
 			t.Errorf("%s: expected image %q, got %q", tt.name, tt.expect, got)
 		}
+
+		if got := dep.Spec.Template.Spec.Containers[0].Env[0].Value; got != api.NamespaceDefault {
+			t.Errorf("%s: expected namespace %q, got %q", tt.name, api.NamespaceDefault, got)
+		}
 	}
 }
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -110,11 +110,15 @@ You can explicitly tell `helm init` to...
 - Install the canary build with the `--canary-image` flag
 - Install a particular image (version) with `--tiller-image`
 - Install to a particular cluster with `--kube-context`
+- Install into a particular namespace with `--tiller-namespace`
 
 Once Tiller is installed, running `helm version` should show you both
 the client and server version. (If it shows only the client version,
 `helm` cannot yet connect to the server. Use `kubectl` to see if any
 `tiller` pods are running.)
+
+If Helm will look for Tiller in the `kube-system` namespace unless
+`--tiller-namespace` or `TILLER_NAMESPACE` is set.
 
 ### Installing Tiller Canary Builds
 

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -33,8 +33,8 @@ import (
 	"k8s.io/helm/pkg/storage/driver"
 )
 
-// TillerNamespace is the namespace tiller is running in.
-const TillerNamespace = "kube-system"
+// DefaultTillerNamespace is the default namespace for tiller.
+const DefaultTillerNamespace = "kube-system"
 
 // GoTplEngine is the name of the Go template engine, as registered in the EngineYard.
 const GoTplEngine = "gotpl"


### PR DESCRIPTION
Adds `--tiller-namespace` flag and `TILLER_NAMESPACE` envvar
to use tiller in an alternate namespace.

closes #1418