### PR TITLE
fix(tller): allow deep merge of global maps

### DIFF
--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -251,11 +251,16 @@ top: yup
 global:
   name: Ishmael
   subject: Queequeg
+  nested:
+    boat: true
 
 pequod:
   global:
     name: Stinky
     harpooner: Tashtego
+    nested:
+      boat: false
+      sail: true
   ahab:
     scope: whale
 `
@@ -295,6 +300,12 @@ func TestCoalesceValues(t *testing.T) {
 		{"{{.pequod.global.subject}}", "Queequeg"},
 		{"{{.spouter.global.name}}", "Ishmael"},
 		{"{{.spouter.global.harpooner}}", "<no value>"},
+
+		{"{{.global.nested.boat}}", "true"},
+		{"{{.pequod.global.nested.boat}}", "true"},
+		{"{{.spouter.global.nested.boat}}", "true"},
+		{"{{.pequod.global.nested.sail}}", "true"},
+		{"{{.spouter.global.nested.sail}}", "<no value>"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This reverts a previous decision to only do shallow merges of globals.
It allows globals to be nested maps.