### PR TITLE
feat(1480): add --version flag to package command

### DIFF
--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -26,7 +26,29 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/cmd/helm/helmpath"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
+
+func TestSetVersion(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:    "prow",
+			Version: "0.0.1",
+		},
+	}
+	expect := "1.2.3-beta.5"
+	if err := setVersion(c, expect); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Metadata.Version != expect {
+		t.Errorf("Expected %q, got %q", expect, c.Metadata.Version)
+	}
+
+	if err := setVersion(c, "monkeyface"); err == nil {
+		t.Error("Expected bogus version to return an error.")
+	}
+}
 
 func TestPackage(t *testing.T) {
 


### PR DESCRIPTION
This adds a `helm package --version=SEMVER` param that allows users to
set a version during a package operation.

Closes #1480
Closes #1699