### PR TITLE
test(cmd): add unit test for chart backed by basic auth

### DIFF
--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -268,6 +268,15 @@ $ helm repo list
 fantastic-charts    https://fantastic-charts.storage.googleapis.com
 ```
 
+If the charts are backed by HTTP basic authentication, you can also supply the
+username and password here:
+
+```console
+$ helm repo add fantastic-charts https://username:password@fantastic-charts.storage.googleapis.com
+$ helm repo list
+fantastic-charts    https://username:password@fantastic-charts.storage.googleapis.com
+```
+
 **Note:** A repository will not be added if it does not contain a valid
 `index.yaml`.
 


### PR DESCRIPTION
This verifies that by adding user information in the chart repo URL
via `helm repo add`, it will be attached to the request when downloading
the chart tarball and provenance file.