### PR TITLE
Play nicely with roles that don't allow creating namespaces

### DIFF
--- a/pkg/kube/namespace.go
+++ b/pkg/kube/namespace.go
@@ -32,10 +32,19 @@ func createNamespace(client internalclientset.Interface, namespace string) error
 	return err
 }
 
+func getNamespace(client internalclientset.Interface, namespace string) (*api.Namespace, error) {
+	return client.Core().Namespaces().Get(namespace)
+}
+
 func ensureNamespace(client internalclientset.Interface, namespace string) error {
-	err := createNamespace(client, namespace)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
+	if _, getError := getNamespace(client, namespace); getError != nil && errors.IsNotFound(getError) {
+		createError := createNamespace(client, namespace)
+		if createError != nil {
+			return createError
+		}
+	} else if getError != nil {
+		return getError
 	}
+
 	return nil
 }


### PR DESCRIPTION
It is unnecessary to create a namespace just to test that it exists.
Roles that don't have post namespace will error out even if the namespace exists
and it is possible to install the package anyway. This patch Gets a namespace and
only creates one if it doesn't exist.

For issue #1714 