### PR TITLE
fix(makefile): skip license check on _ directories

### DIFF
--- a/scripts/validate-license.sh
+++ b/scripts/validate-license.sh
@@ -22,6 +22,7 @@ find_files() {
       -wholename './vendor' \
       -o -wholename './pkg/proto' \
       -o -wholename '*testdata*' \
+      -o -wholename './_*' \
     \) -prune \
   \) \
   \( -name '*.go' -o -name '*.sh' -o -name 'Dockerfile' \)


### PR DESCRIPTION
This skips license checks on `./_*`.

See #1641