### PR TITLE
docs(helm): change `trunc 24` in base charts

### DIFF
--- a/docs/examples/nginx/templates/_helpers.tpl
+++ b/docs/examples/nginx/templates/_helpers.tpl
@@ -2,15 +2,15 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 | trimSuffix "-" }}{{end}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{end}}
 
 {{/*
 Create a default fully qualified app name.
 
-We truncate at 24 chars because some Kubernetes name fields are limited to this
+We truncate at 63 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec).
 */}}
 {{define "fullname"}}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{end}}

--- a/docs/examples/nginx/templates/_helpers.tpl
+++ b/docs/examples/nginx/templates/_helpers.tpl
@@ -2,15 +2,15 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 | trimSuffix "-" }}{{end}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 54 | trimSuffix "-" }}{{end}}
 
 {{/*
 Create a default fully qualified app name.
 
-We truncate at 24 chars because some Kubernetes name fields are limited to this
+We truncate at 54 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec).
 */}}
 {{define "fullname"}}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{printf "%s-%s" .Release.Name $name | trunc 54 | trimSuffix "-" -}}
 {{end}}


### PR DESCRIPTION
The upper limit for a chart name is now 54 characters, instead of
14 or 24 in older versions of Kubernetes. This replaces `trunc 24`
in the example chart provided to `trunc 54` to reflect the new
length available.

Closes #1637