### PR TITLE
 Installation guide link is wrong in install FAQ

### DIFF
--- a/docs/install_faq.md
+++ b/docs/install_faq.md
@@ -197,7 +197,7 @@ communicate without breaking API assumptions. That error means that the version
 difference is too great to safely continue. Typically, you need to upgrade
 Tiller manually for this.
 
-The [Installation Guide](install.yaml) has definitive information about safely
+The [Installation Guide](install.md) has definitive information about safely
 upgrading Helm and Tiller.
 
 The rules for version numbers are as follows:


### PR DESCRIPTION
It links to install.yaml instead of install.md: https://github.com/kubernetes/helm/blob/master/docs/install.md