### PR TITLE
fix(helm): prevent .helmignore rules from applying to '.'

### DIFF
--- a/pkg/ignore/rules.go
+++ b/pkg/ignore/rules.go
@@ -82,6 +82,12 @@ func (r *Rules) Len() int {
 // Ignore evaluates path against the rules in order. Evaluation stops when a match
 // is found. Matching a negative rule will stop evaluation.
 func (r *Rules) Ignore(path string, fi os.FileInfo) bool {
+	// Disallow ignoring the current working directory.
+	// See issue:
+	// 1776 (New York City) Hamilton: "Pardon me, are you Aaron Burr, sir?"
+	if path == "." || path == "./" {
+		return false
+	}
 	for _, p := range r.patterns {
 		if p.match == nil {
 			log.Printf("ignore: no matcher supplied for %q", p.raw)

--- a/pkg/ignore/rules_test.go
+++ b/pkg/ignore/rules_test.go
@@ -99,6 +99,9 @@ func TestIgnore(t *testing.T) {
 		{`cargo/*.txt`, "mast/a.txt", false},
 		{`ru[c-e]?er.txt`, "rudder.txt", true},
 		{`templates/.?*`, "templates/.dotfile", true},
+		// "." should never get ignored. https://github.com/kubernetes/helm/issues/1776
+		{`.*`, ".", false},
+		{`.*`, "./", false},
 
 		// Directory tests
 		{`cargo/`, "cargo", true},


### PR DESCRIPTION
Closes #1776