### PR TITLE
Add `--upgrade` option to `init`. Fixes #1782.

### DIFF
--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -89,7 +89,8 @@ func TestInitCmd_exsits(t *testing.T) {
 	if err := cmd.run(); err != nil {
 		t.Errorf("expected error: %v", err)
 	}
-	expected := "Warning: Tiller is already installed in the cluster. (Use --client-only to suppress this message.)"
+	expected := "Warning: Tiller is already installed in the cluster.\n" +
+		"(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)"
 	if !strings.Contains(buf.String(), expected) {
 		t.Errorf("expected %q, got %q", expected, buf.String())
 	}


### PR DESCRIPTION
An attempt to fix #1782.

I've simply taken the approach that if tiller exists, and the upgrade flag is given, update the image no matter what. If you update to what was already set, k8s should handle this as a simple no-op.

While working on this I discovered that the tests using the `fake` module doesn't actually work. The ReactionFuncs are never triggered. Since I couldn't figure out what was wrong there, I decided to just leave my test in, even though it doesn't actually test anything (it passes no matter what). If someone fixes the framework, it should work (similar to the others), but I couldn't actually test that.

The tests work by checking expectations in the reaction funcs, but when those aren't called, no check is performed and the test passes even if it shouldn't have. It might be worth adding a clause that fails the test if the reaction func hasn't been executed at all, but I decided that was outside the scope for this change.