### PR TITLE
Improve `helm status` help text

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -29,6 +29,12 @@ import (
 
 var statusHelp = `
 This command shows the status of a named release.
+The status consists of:
+- last deployment time
+- k8s namespace in which the release lives
+- state of the release (can be: UNKNOWN, DEPLOYED, DELETED, SUPERSEDED, FAILED or DELETING)
+- list of resources that this release consists of, sorted by kind
+- additional notes provided by the chart
 `
 
 type statusCmd struct {

--- a/docs/helm/helm_status.md
+++ b/docs/helm/helm_status.md
@@ -7,6 +7,12 @@ displays the status of the named release
 
 
 This command shows the status of a named release.
+The status consists of:
+- last deployment time
+- k8s namespace in which the release lives
+- state of the release (can be: UNKNOWN, DEPLOYED, DELETED, SUPERSEDED, FAILED or DELETING)
+- list of resources that this release consists of, sorted by kind
+- additional notes provided by the chart
 
 
 ```

--- a/docs/man/man1/helm_status.1
+++ b/docs/man/man1/helm_status.1
@@ -16,6 +16,12 @@ helm\-status \- displays the status of the named release
 .SH DESCRIPTION
 .PP
 This command shows the status of a named release.
+The status consists of:
+- last deployment time
+- k8s namespace in which the release lives
+- state of the release (can be: UNKNOWN, DEPLOYED, DELETED, SUPERSEDED, FAILED or DELETING)
+- list of resources that this release consists of, sorted by kind
+- additional notes provided by the chart
 
 
 .SH OPTIONS


### PR DESCRIPTION
`helm status -h` now shows what kind of information is displayed when
running `helm status`

fixes #1783