### PR TITLE
Align output of helm status resources output

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -19,6 +19,8 @@ package main
 import (
 	"fmt"
 	"io"
+	"regexp"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -89,7 +91,11 @@ func PrintStatus(out io.Writer, res *services.GetReleaseStatusResponse) {
 	}
 	fmt.Fprintf(out, "\n")
 	if len(res.Info.Status.Resources) > 0 {
-		fmt.Fprintf(out, "RESOURCES:\n%s\n", res.Info.Status.Resources)
+		re := regexp.MustCompile("  +")
+
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', tabwriter.TabIndent)
+		fmt.Fprintf(w, "RESOURCES:\n%s\n", re.ReplaceAllString(res.Info.Status.Resources, "\t"))
+		w.Flush()
 	}
 	if len(res.Info.Status.Notes) > 0 {
 		fmt.Fprintf(out, "NOTES:\n%s\n", res.Info.Status.Notes)


### PR DESCRIPTION
text/tabwriter is used to align resource list in columns

fixes #1593

This won't work well for missing data in columns (you get that in unbound PersistentVolumeClaims). This should be fixed, but will require much more work.

If you think it's ok to merge it as is, please do, if not - I will continue working on this fix next week.

Output before fix:
```
LAST DEPLOYED: Thu Jan  5 15:09:16 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                   CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
brazen-tapir-mariadb   10.0.0.81    <none>        3306/TCP   42m
brazen-tapir-wordpress   10.0.0.95   <pending>   80/TCP,443/TCP   42m

==> extensions/Deployment
NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
brazen-tapir-wordpress   1         1         1            0           42m
brazen-tapir-mariadb   1         1         1         0         42m

==> v1/PersistentVolumeClaim
NAME                               STATUS    VOLUME    CAPACITY   ACCESSMODES   AGE
brazen-tapir-wordpress-wordpress   Pending                                      42m
brazen-tapir-wordpress-apache   Pending                                 42m
brazen-tapir-mariadb   Pending                                 42m

==> v1/Secret
NAME                     TYPE      DATA      AGE
brazen-tapir-wordpress   Opaque    2         42m
brazen-tapir-mariadb   Opaque    2         42m

==> v1/ConfigMap
NAME                   DATA      AGE
brazen-tapir-mariadb   1         42m


NOTES:
1. Get the WordPress URL by running:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        Watch the status with: 'kubectl get svc -w brazen-tapir-wordpress'

  export SERVICE_IP=$(kubectl get svc --namespace default brazen-tapir-wordpress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo http://$SERVICE_IP/admin

2. Login with the following credentials to see your blog

  Username: user
  Password: bitnami
```

Output after fix:
```
LAST DEPLOYED: Thu Jan  5 15:09:16 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ConfigMap
NAME                  DATA  AGE
brazen-tapir-mariadb  1     1h

==> v1/Service
NAME                    CLUSTER-IP  EXTERNAL-IP  PORT(S)         AGE
brazen-tapir-mariadb    10.0.0.81   <none>       3306/TCP        1h
brazen-tapir-wordpress  10.0.0.95   <pending>    80/TCP,443/TCP  1h

==> extensions/Deployment
NAME                    DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
brazen-tapir-wordpress  1        1        1           0          1h
brazen-tapir-mariadb    1        1        1           0          1h

==> v1/PersistentVolumeClaim
NAME                              STATUS   VOLUME  CAPACITY  ACCESSMODES  AGE
brazen-tapir-wordpress-wordpress  Pending  1h
brazen-tapir-wordpress-apache     Pending  1h
brazen-tapir-mariadb              Pending  1h

==> v1/Secret
NAME                    TYPE    DATA  AGE
brazen-tapir-wordpress  Opaque  2     1h
brazen-tapir-mariadb    Opaque  2     1h


NOTES:
1. Get the WordPress URL by running:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        Watch the status with: 'kubectl get svc -w brazen-tapir-wordpress'

  export SERVICE_IP=$(kubectl get svc --namespace default brazen-tapir-wordpress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo http://$SERVICE_IP/admin

2. Login with the following credentials to see your blog

  Username: user
  Password: bitnami
```