### PR TITLE
feat(tiller): add {{.Capabilities}} object

### DIFF
--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -20,6 +20,11 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
 - `Files`: This provides access to all non-special files in a chart. While you cannot use it to access templates, you can use it to access other files in the chart. See the section _Accessing Files_ for more.
   - `Files.Get` is a function for getting a file by name (`.Files.Get config.ini`)
   - `Files.GetBytes` is a function for getting the contents of a file as an array of bytes instead of as a string. This is useful for things like images.
+- `Capabilities`: This provides information about what capabilities the Kubernetes cluster supports.
+  - `Capabilities.APIVersions` is a set of versions.
+  - `Capabilities.APIVersions.Has $version` indicates whether a version (`batch/v1`) is enabled on the cluster.
+  - `Capabilities.KubeVersion` provides a way to look up the Kubernetes version. It has the following values: `Major`, `Minor`, `GitVersion`, `GitCommit`, `GitTreeState`, `BuildDate`, `GoVersion`, `Compiler`, and `Platform`.
+  - `Capabilities.TillerVersion` provides a way to look up the Tiller version. It has the following values: `SemVer`, `GitCommit`, and `GitTreeState`.
 
 The values are available to any top-level template. As we will see later, this does not necessarily mean that they will be available _everywhere_.
 

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -305,6 +305,10 @@ sensitive_.
   files that are present. Files can be accessed using `{{index .Files "file.name"}}`
   or using the `{{.Files.Get name}}` or `{{.Files.GetString name}}` functions. You can
   also access the contents of the file as `[]byte` using `{{.Files.GetBytes}}`
+- `Capabilities`: A map-like object that contains information about the versions
+  of Kubernetes (`{{.Capabilities.KubeVersion}}`, Tiller
+  (`{{.Capabilities.TillerVersion}}`, and the supported Kubernetes API versions
+  (`{{.Capabilities.APIVersions.Has "batch/v1"`)
 
 **NOTE:** Any unknown Chart.yaml fields will be dropped. They will not
 be accessible inside of the `Chart` object. Thus, Chart.yaml cannot be

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chartutil
+
+import (
+	tversion "k8s.io/helm/pkg/proto/hapi/version"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
+var DefaultVersionSet = NewVersionSet("v1")
+
+// Capabilities describes the capabilities of the Kubernetes cluster that Tiller is attached to.
+type Capabilities struct {
+	// List of all supported API versions
+	APIVersions VersionSet
+	// KubeVerison is the Kubernetes version
+	KubeVersion *version.Info
+	// TillerVersion is the Tiller version
+	//
+	// This always comes from pkg/version.GetVersionProto().
+	TillerVersion *tversion.Version
+}
+
+// VersionSet is a set of Kubernetes API versions.
+type VersionSet map[string]interface{}
+
+// NewVersionSet creates a new version set from a list of strings.
+func NewVersionSet(apiVersions ...string) VersionSet {
+	vs := VersionSet{}
+	for _, v := range apiVersions {
+		vs[v] = struct{}{}
+	}
+	return vs
+}
+
+// Has returns true if the version string is in the set.
+//
+//	vs.Has("extensions/v1beta1")
+func (v VersionSet) Has(apiVersion string) bool {
+	_, ok := v[apiVersion]
+	return ok
+}

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chartutil
+
+import (
+	"testing"
+)
+
+func TestVersionSet(t *testing.T) {
+	vs := NewVersionSet("v1", "extensions/v1beta1")
+	if d := len(vs); d != 2 {
+		t.Errorf("Expected 2 versions, got %d", d)
+	}
+
+	if !vs.Has("extensions/v1beta1") {
+		t.Error("Expected to find extensions/v1beta1")
+	}
+
+	if vs.Has("Spanish/inquisition") {
+		t.Error("No one expects the Spanish/inquisition")
+	}
+}
+
+func TestDefaultVersionSet(t *testing.T) {
+	if !DefaultVersionSet.Has("v1") {
+		t.Error("Expected core v1 version set")
+	}
+	if d := len(DefaultVersionSet); d != 1 {
+		t.Errorf("Expected only one version, got %d", d)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	cap := Capabilities{
+		APIVersions: DefaultVersionSet,
+	}
+
+	if !cap.APIVersions.Has("v1") {
+		t.Error("APIVersions should have v1")
+	}
+}

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -332,7 +332,20 @@ type ReleaseOptions struct {
 }
 
 // ToRenderValues composes the struct from the data coming from the Releases, Charts and Values files
+//
+// WARNING: This function is deprecated for Helm > 2.1.99 Use ToRenderValuesCaps() instead. It will
+// remain in the codebase to stay SemVer compliant.
+//
+// In Helm 3.0, this will be changed to accept Capabilities as a fourth parameter.
 func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options ReleaseOptions) (Values, error) {
+	caps := &Capabilities{APIVersions: DefaultVersionSet}
+	return ToRenderValuesCaps(chrt, chrtVals, options, caps)
+}
+
+// ToRenderValuesCaps composes the struct from the data coming from the Releases, Charts and Values files
+//
+// This takes both ReleaseOptions and Capabilities to merge into the render values.
+func ToRenderValuesCaps(chrt *chart.Chart, chrtVals *chart.Config, options ReleaseOptions, caps *Capabilities) (Values, error) {
 
 	top := map[string]interface{}{
 		"Release": map[string]interface{}{
@@ -344,8 +357,9 @@ func ToRenderValues(chrt *chart.Chart, chrtVals *chart.Config, options ReleaseOp
 			"Revision":  options.Revision,
 			"Service":   "Tiller",
 		},
-		"Chart": chrt.Metadata,
-		"Files": NewFiles(chrt.Files),
+		"Chart":        chrt.Metadata,
+		"Files":        NewFiles(chrt.Files),
+		"Capabilities": caps,
 	}
 
 	vals, err := CoalesceValues(chrt, chrtVals)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -222,10 +222,11 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals char
 		}
 
 		cvals = map[string]interface{}{
-			"Values":  newVals,
-			"Release": parentVals["Release"],
-			"Chart":   c.Metadata,
-			"Files":   chartutil.NewFiles(c.Files),
+			"Values":       newVals,
+			"Release":      parentVals["Release"],
+			"Chart":        c.Metadata,
+			"Files":        chartutil.NewFiles(c.Files),
+			"Capabilities": parentVals["Capabilities"],
 		}
 	}
 

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -51,7 +51,8 @@ func Templates(linter *support.Linter) {
 	}
 
 	options := chartutil.ReleaseOptions{Name: "testRelease", Time: timeconv.Now(), Namespace: "testNamespace"}
-	valuesToRender, err := chartutil.ToRenderValues(chart, chart.Values, options)
+	caps := &chartutil.Capabilities{APIVersions: chartutil.DefaultVersionSet}
+	valuesToRender, err := chartutil.ToRenderValuesCaps(chart, chart.Values, options, caps)
 	if err != nil {
 		// FIXME: This seems to generate a duplicate, but I can't find where the first
 		// error is coming from.

--- a/pkg/tiller/hooks.go
+++ b/pkg/tiller/hooks.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -61,21 +62,6 @@ type simpleHead struct {
 	} `json:"metadata,omitempty"`
 }
 
-type versionSet map[string]struct{}
-
-func newVersionSet(apiVersions ...string) versionSet {
-	vs := versionSet{}
-	for _, v := range apiVersions {
-		vs[v] = struct{}{}
-	}
-	return vs
-}
-
-func (v versionSet) Has(apiVersion string) bool {
-	_, ok := v[apiVersion]
-	return ok
-}
-
 // manifest represents a manifest file, which has a name and some content.
 type manifest struct {
 	name    string
@@ -104,7 +90,7 @@ type manifest struct {
 //
 // Files that do not parse into the expected format are simply placed into a map and
 // returned.
-func sortManifests(files map[string]string, apis versionSet, sort SortOrder) ([]*release.Hook, []manifest, error) {
+func sortManifests(files map[string]string, apis chartutil.VersionSet, sort SortOrder) ([]*release.Hook, []manifest, error) {
 	hs := []*release.Hook{}
 	generic := []manifest{}
 

--- a/pkg/tiller/hooks_test.go
+++ b/pkg/tiller/hooks_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -118,7 +119,7 @@ metadata:
 		manifests[o.path] = o.manifest
 	}
 
-	hs, generic, err := sortManifests(manifests, newVersionSet("v1", "v1beta1"), InstallOrder)
+	hs, generic, err := sortManifests(manifests, chartutil.NewVersionSet("v1", "v1beta1"), InstallOrder)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -183,7 +184,7 @@ metadata:
 }
 
 func TestVersionSet(t *testing.T) {
-	vs := newVersionSet("v1", "v1beta1", "extensions/alpha5", "batch/v1")
+	vs := chartutil.NewVersionSet("v1", "v1beta1", "extensions/alpha5", "batch/v1")
 
 	if l := len(vs); l != 4 {
 		t.Errorf("Expected 4, got %d", l)


### PR DESCRIPTION
This adds the {{.Capabilities}} object to the template variables so that
chart authors can write charts that are aware of teh Kubernetes
capabilities of the current cluster.

Closes #1608