### PR TITLE
making precedence explanation less ambiguous

### DIFF
--- a/docs/chart_template_guide/values_files.md
+++ b/docs/chart_template_guide/values_files.md
@@ -7,7 +7,7 @@ In the previous section we looked at the built-n objects that Helm templates off
 - A values file if passed into `helm install` or `helm update` with the `-f` flag (`helm install -f myvals.yaml ./mychart`)
 - Individual parameters passed with `--set` (such as `helm install --set foo=bar ./mychart`)
 
-The list above is in order of specificity: `values.yaml` is the default, and can be overridden by a parent chart's `values.yaml`, which can in turn be overridden by a user-supplied values file or `--set` parameters.
+The list above is in order of specificity: `values.yaml` is the default, which can be overridden by a parent chart's `values.yaml`, which can in turn be overridden by a user-supplied values file, which can in turn be overridden by `--set` parameters.
 
 Values files are plain YAML files. Let's edit `mychart/values.yaml` and then edit our ConfigMap template.
 


### PR DESCRIPTION
The "or" was making me wonder whether individual `--set` values really do override the user-set values file.