### PR TITLE
feat(helm): allow specifying --set multiple times

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -52,6 +52,14 @@ func TestInstall(t *testing.T) {
 			resp:     releaseMock(&releaseOptions{name: "virgil"}),
 			expected: "virgil",
 		},
+		// Install, values from cli via multiple --set
+		{
+			name:     "install with multiple values",
+			args:     []string{"testdata/testcharts/alpine"},
+			flags:    strings.Split("--set foo=bar", "--set bar=foo"),
+			resp:     releaseMock(&releaseOptions{name: "virgil"}),
+			expected: "virgil",
+		},
 		// Install, values from yaml
 		{
 			name:     "install with values",

--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -62,8 +62,7 @@ helm install [CHART]
       --namespace string       namespace to install the release into
       --no-hooks               prevent hooks from running during install
       --replace                re-use the given name, even if that name is already used. This is unsafe in production
-      --set value              set values on the command line. Separate values with commas: key1=val1,key2=val2 (default null
-)
+      --set stringArray        set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
   -f, --values string          specify values in a YAML file
       --verify                 verify the package before installing it
       --version string         specify the exact chart version to install. If this is not specified, the latest version is installed

--- a/docs/helm/helm_upgrade.md
+++ b/docs/helm/helm_upgrade.md
@@ -29,8 +29,7 @@ helm upgrade [RELEASE] [CHART]
   -i, --install            if a release by this name doesn't already exist, run an install
       --keyring string     path to the keyring that contains public singing keys (default "/Users/mattbutcher/.gnupg/pubring.gpg")
       --namespace string   namespace to install the release into (only used if --install is set) (default "default")
-      --set value          set values on the command line. Separate values with commas: key1=val1,key2=val2 (default null
-)
+      --set stringArray     set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
   -f, --values string      path to a values YAML file
       --verify             verify the provenance of the chart before upgrading
       --version string     specify the exact chart version to use. If this is not specified, the latest version is used


### PR DESCRIPTION
This PR adds support to specify multiple `--set` flags on `install` and `upgrade` commands. The comma-separated behavior doesn't change, even when specifying comma-separated key-values in multiple `--set` flags.

This PR fixes #1751.