### PR TITLE
fix(helm) change name length limit to 63 for `helm create`

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -162,16 +162,16 @@ const defaultHelpers = `{{/* vim: set filetype=mustache: */}}
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 `
 

--- a/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
+++ b/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
@@ -2,15 +2,15 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 24 | trimSuffix "-" }}{{end}}
+{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{end}}
 
 {{/*
 Create a default fully qualified app name.
 
-We truncate at 24 chars because some Kubernetes name fields are limited to this
+We truncate at 63 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec).
 */}}
 {{define "fullname"}}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{end}}


### PR DESCRIPTION
since kubernetes 1.4, the upper limit for resource name is 63 characters,
so it is better to change the template when running `helm create` accordingly.