### PR TITLE
Add linux/arm64 to cross-compile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= gcr.io
 IMAGE_PREFIX    ?= kubernetes-helm
 SHORT_NAME      ?= tiller
-TARGETS         = darwin/amd64 linux/amd64 linux/386 linux/arm windows/amd64
+TARGETS         = darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 windows/amd64
 DIST_DIRS       = find * -type d -exec
 APP             = helm
 


### PR DESCRIPTION
This adds the `linux/arm64` target to the cross-compile work done in #1722.

<details>
<summary>It builds on my machine:</summary>

```
$ make build-cross dist VERSION=v2.1.3
CGO_ENABLED=0 gox -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 windows/amd64'  -tags '' -ldflags ' -X k8s.io/helm/pkg/version.Version=v2.1.0 -X k8s.io/helm/pkg/version.GitCommit=7389b341c767259a8367132b72035e59a5ee67c7 -X k8s.io/helm/pkg/version.GitTreeState=dirty -extldflags "-static"' k8s.io/helm/cmd/helm
Number of parallel builds: 2

-->   windows/amd64: k8s.io/helm/cmd/helm
-->       linux/386: k8s.io/helm/cmd/helm
-->    darwin/amd64: k8s.io/helm/cmd/helm
-->     linux/amd64: k8s.io/helm/cmd/helm
-->       linux/arm: k8s.io/helm/cmd/helm
-->     linux/arm64: k8s.io/helm/cmd/helm
( \
	cd _dist && \
	find * -type d -exec cp ../LICENSE {} \; && \
	find * -type d -exec cp ../README.md {} \; && \
	find * -type d -exec tar -zcf helm-v2.1.3-{}.tar.gz {} \; && \
	find * -type d -exec zip -r helm-v2.1.3-{}.zip {} \; \
)
  adding: darwin-amd64/ (stored 0%)
  adding: darwin-amd64/LICENSE (deflated 65%)
  adding: darwin-amd64/README.md (deflated 60%)
  adding: darwin-amd64/helm (deflated 79%)
  adding: linux-386/ (stored 0%)
  adding: linux-386/LICENSE (deflated 65%)
  adding: linux-386/README.md (deflated 60%)
  adding: linux-386/helm (deflated 77%)
  adding: linux-amd64/ (stored 0%)
  adding: linux-amd64/LICENSE (deflated 65%)
  adding: linux-amd64/README.md (deflated 60%)
  adding: linux-amd64/helm (deflated 79%)
  adding: linux-arm/ (stored 0%)
  adding: linux-arm/LICENSE (deflated 65%)
  adding: linux-arm/README.md (deflated 60%)
  adding: linux-arm/helm (deflated 77%)
  adding: linux-arm64/ (stored 0%)
  adding: linux-arm64/LICENSE (deflated 65%)
  adding: linux-arm64/README.md (deflated 60%)
  adding: linux-arm64/helm (deflated 81%)
  adding: windows-amd64/ (stored 0%)
  adding: windows-amd64/LICENSE (deflated 65%)
  adding: windows-amd64/README.md (deflated 60%)
  adding: windows-amd64/helm.exe (deflated 79%)
```
</summary>
</details>