### PR TITLE
add InstallReleaseFromChart and UpdateReleaseFromChart

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -135,6 +135,12 @@ func (c *fakeReleaseClient) InstallRelease(chStr, ns string, opts ...helm.Instal
 	}, nil
 }
 
+func (c *fakeReleaseClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...helm.InstallOption) (*rls.InstallReleaseResponse, error) {
+	return &rls.InstallReleaseResponse{
+		Release: c.rels[0],
+	}, nil
+}
+
 func (c *fakeReleaseClient) DeleteRelease(rlsName string, opts ...helm.DeleteOption) (*rls.UninstallReleaseResponse, error) {
 	return nil, nil
 }
@@ -159,6 +165,10 @@ func (c *fakeReleaseClient) GetVersion(opts ...helm.VersionOption) (*rls.GetVers
 }
 
 func (c *fakeReleaseClient) UpdateRelease(rlsName string, chStr string, opts ...helm.UpdateOption) (*rls.UpdateReleaseResponse, error) {
+	return nil, nil
+}
+
+func (c *fakeReleaseClient) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...helm.UpdateOption) (*rls.UpdateReleaseResponse, error) {
 	return nil, nil
 }
 

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 
 	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
 )
 
@@ -59,7 +60,7 @@ func (h *Client) ListReleases(opts ...ReleaseListOption) (*rls.ListReleasesRespo
 	return h.list(ctx, req)
 }
 
-// InstallRelease installs a new chart and returns the release response.
+// InstallRelease loads a chart from chstr, installs it and returns the release response.
 func (h *Client) InstallRelease(chstr, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
 	// load the chart to install
 	chart, err := chartutil.Load(chstr)
@@ -67,6 +68,11 @@ func (h *Client) InstallRelease(chstr, ns string, opts ...InstallOption) (*rls.I
 		return nil, err
 	}
 
+	return h.InstallReleaseFromChart(chart, ns, opts...)
+}
+
+// InstallReleaseFromChart installs a new chart and returns the release response.
+func (h *Client) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
 	// apply the install options
 	for _, opt := range opts {
 		opt(&h.opts)
@@ -116,13 +122,19 @@ func (h *Client) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.Unins
 	return h.delete(ctx, req)
 }
 
-// UpdateRelease updates a release to a new/different chart
+// UpdateRelease loads a chart from chstr and updates a release to a new/different chart
 func (h *Client) UpdateRelease(rlsName string, chstr string, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
 	// load the chart to update
 	chart, err := chartutil.Load(chstr)
 	if err != nil {
 		return nil, err
 	}
+
+	return h.UpdateReleaseFromChart(rlsName, chart, opts...)
+}
+
+// UpdateReleaseFromChart updates a release to a new/different chart
+func (h *Client) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
 
 	// apply the update options
 	for _, opt := range opts {

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helm
 
 import (
+	"k8s.io/helm/pkg/proto/hapi/chart"
 	rls "k8s.io/helm/pkg/proto/hapi/services"
 )
 
@@ -24,9 +25,11 @@ import (
 type Interface interface {
 	ListReleases(opts ...ReleaseListOption) (*rls.ListReleasesResponse, error)
 	InstallRelease(chStr, namespace string, opts ...InstallOption) (*rls.InstallReleaseResponse, error)
+	InstallReleaseFromChart(chart *chart.Chart, namespace string, opts ...InstallOption) (*rls.InstallReleaseResponse, error)
 	DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error)
 	ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.GetReleaseStatusResponse, error)
 	UpdateRelease(rlsName, chStr string, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error)
+	UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error)
 	RollbackRelease(rlsName string, opts ...RollbackOption) (*rls.RollbackReleaseResponse, error)
 	ReleaseContent(rlsName string, opts ...ContentOption) (*rls.GetReleaseContentResponse, error)
 	ReleaseHistory(rlsName string, opts ...HistoryOption) (*rls.GetHistoryResponse, error)


### PR DESCRIPTION
When using `k8s.io/helm/pkg/helm` as a third party client, I am using `chartutil.LoadArchive()` to load a chart from a tarball opened as an `io.Reader`. After that is loaded, I wish to install that chart, however `InstallRelease()` only accepts a path rather than something of type `*chart.Chart`. This adds a new function called `InstallReleaseFromChart()` which allows one to load a chart separate from the path, then install said chart.

Usage sort of looks something like this in code form:

```
import (
	"fmt"

	"k8s.io/helm/pkg/chartutil"
	"k8s.io/helm/pkg/helm"
)

client := &helm.Client{}
chart, _ := chartutil.LoadArchive(chartArchive)
releaseResp, _ := client.InstallReleaseFromChart(chart, "default")
fmt.Fprintf(conn, "%s\n", releaseResp.Info.Status.String())
```

Things I'm concerned about:

 - Is backwards compatibility a concern here WRT other external users using `InstallRelease()`?
 - As a third-party client user, is this actually the correct way I should be loading and installing/upgrading a chart, or is there another package I should be using?

Cheers! ⚓️ 