### PR TITLE
feat(helm): Add  command to uninstall Tiller

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -120,6 +120,7 @@ func newRootCmd(out io.Writer) *cobra.Command {
 		newCompletionCmd(out),
 		newHomeCmd(out),
 		newInitCmd(out),
+		newResetCmd(nil, out),
 		newVersionCmd(nil, out),
 
 		// Hidden documentation generator command: 'helm docs'
@@ -236,4 +237,10 @@ func getKubeClient(context string) (*restclient.Config, *internalclientset.Clien
 		return nil, nil, fmt.Errorf("could not get kubernetes client: %s", err)
 	}
 	return config, client, nil
+}
+
+// getKubeCmd is a convenience method for creating kubernetes cmd client
+// for a given kubeconfig context
+func getKubeCmd(context string) *kube.Client {
+	return kube.New(kube.GetConfig(context))
 }

--- a/cmd/helm/installer/uninstall.go
+++ b/cmd/helm/installer/uninstall.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+import (
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+
+	"k8s.io/helm/pkg/kube"
+)
+
+// Uninstall uses kubernetes client to uninstall tiller
+func Uninstall(kubeClient internalclientset.Interface, kubeCmd *kube.Client, namespace string, verbose bool) error {
+	if _, err := kubeClient.Core().Services(namespace).Get("tiller-deploy"); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+	} else if err := deleteService(kubeClient.Core(), namespace); err != nil {
+		return err
+	}
+	if obj, err := kubeClient.Extensions().Deployments(namespace).Get("tiller-deploy"); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+	} else if err := deleteDeployment(kubeCmd, namespace, obj); err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteService deletes the Tiller Service resource
+func deleteService(client internalversion.ServicesGetter, namespace string) error {
+	return client.Services(namespace).Delete("tiller-deploy", &api.DeleteOptions{})
+}
+
+// deleteDeployment deletes the Tiller Deployment resource
+// We need to use the kubeCmd reaper instead of the kube API because GC for deployment dependents
+// is not yet supported at the k8s server level (<= 1.5)
+func deleteDeployment(kubeCmd *kube.Client, namespace string, obj *extensions.Deployment) error {
+	obj.Kind = "Deployment"
+	obj.APIVersion = "extensions/v1beta1"
+	buf, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	reader := strings.NewReader(string(buf))
+	infos, err := kubeCmd.Build(namespace, reader)
+	if err != nil {
+		return err
+	}
+	for _, info := range infos {
+		reaper, err := kubeCmd.Reaper(info.Mapping)
+		if err != nil {
+			return err
+		}
+		err = reaper.Stop(info.Namespace, info.Name, 0, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/helm/installer/uninstall_test.go
+++ b/cmd/helm/installer/uninstall_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	testcore "k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"k8s.io/helm/pkg/kube"
+)
+
+type fakeReaper struct {
+	namespace string
+	name      string
+}
+
+func (r *fakeReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *api.DeleteOptions) error {
+	r.namespace = namespace
+	r.name = name
+	return nil
+}
+
+type fakeReaperFactory struct {
+	cmdutil.Factory
+	reaper kubectl.Reaper
+}
+
+func (f *fakeReaperFactory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error) {
+	return f.reaper, nil
+}
+
+func TestUninstall(t *testing.T) {
+	existingService := service(api.NamespaceDefault)
+	existingDeployment := deployment(api.NamespaceDefault, "image", false)
+
+	fc := &fake.Clientset{}
+	fc.AddReactor("get", "services", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, existingService, nil
+	})
+	fc.AddReactor("delete", "services", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	fc.AddReactor("get", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, existingDeployment, nil
+	})
+
+	f, _, _, _ := cmdtesting.NewAPIFactory()
+	r := &fakeReaper{}
+	rf := &fakeReaperFactory{Factory: f, reaper: r}
+	kc := &kube.Client{Factory: rf}
+
+	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+		t.Errorf("unexpected error: %#+v", err)
+	}
+
+	if actions := fc.Actions(); len(actions) != 3 {
+		t.Errorf("unexpected actions: %v, expected 3 actions got %d", actions, len(actions))
+	}
+
+	if r.namespace != api.NamespaceDefault {
+		t.Errorf("unexpected reaper namespace: %s", r.name)
+	}
+
+	if r.name != "tiller-deploy" {
+		t.Errorf("unexpected reaper name: %s", r.name)
+	}
+}
+
+func TestUninstall_serviceNotFound(t *testing.T) {
+	existingDeployment := deployment(api.NamespaceDefault, "imageToReplace", false)
+
+	fc := &fake.Clientset{}
+	fc.AddReactor("get", "services", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(api.Resource("services"), "1")
+	})
+	fc.AddReactor("get", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, existingDeployment, nil
+	})
+
+	f, _, _, _ := cmdtesting.NewAPIFactory()
+	r := &fakeReaper{}
+	rf := &fakeReaperFactory{Factory: f, reaper: r}
+	kc := &kube.Client{Factory: rf}
+
+	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+		t.Errorf("unexpected error: %#+v", err)
+	}
+
+	if actions := fc.Actions(); len(actions) != 2 {
+		t.Errorf("unexpected actions: %v, expected 2 actions got %d", actions, len(actions))
+	}
+
+	if r.namespace != api.NamespaceDefault {
+		t.Errorf("unexpected reaper namespace: %s", r.name)
+	}
+
+	if r.name != "tiller-deploy" {
+		t.Errorf("unexpected reaper name: %s", r.name)
+	}
+}
+
+func TestUninstall_deploymentNotFound(t *testing.T) {
+	existingService := service(api.NamespaceDefault)
+
+	fc := &fake.Clientset{}
+	fc.AddReactor("get", "services", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, existingService, nil
+	})
+	fc.AddReactor("delete", "services", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	fc.AddReactor("get", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(api.Resource("deployments"), "1")
+	})
+
+	f, _, _, _ := cmdtesting.NewAPIFactory()
+	r := &fakeReaper{}
+	rf := &fakeReaperFactory{Factory: f, reaper: r}
+	kc := &kube.Client{Factory: rf}
+
+	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+		t.Errorf("unexpected error: %#+v", err)
+	}
+
+	if actions := fc.Actions(); len(actions) != 3 {
+		t.Errorf("unexpected actions: %v, expected 3 actions got %d", actions, len(actions))
+	}
+
+	if r.namespace != "" {
+		t.Errorf("unexpected reaper namespace: %s", r.name)
+	}
+
+	if r.name != "" {
+		t.Errorf("unexpected reaper name: %s", r.name)
+	}
+}

--- a/cmd/helm/reset_test.go
+++ b/cmd/helm/reset_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+
+	"k8s.io/helm/cmd/helm/helmpath"
+	"k8s.io/helm/pkg/proto/hapi/release"
+)
+
+func TestResetCmd(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(home)
+
+	var buf bytes.Buffer
+	c := &fakeReleaseClient{}
+	fc := fake.NewSimpleClientset()
+	cmd := &resetCmd{
+		out:        &buf,
+		home:       helmpath.Home(home),
+		client:     c,
+		kubeClient: fc,
+		namespace:  api.NamespaceDefault,
+	}
+	if err := cmd.run(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	actions := fc.Actions()
+	if len(actions) != 2 {
+		t.Errorf("Expected 2 actions, got %d", len(actions))
+	}
+	if !actions[0].Matches("get", "services") {
+		t.Errorf("unexpected action: %v, expected get service", actions[1])
+	}
+	if !actions[1].Matches("get", "deployments") {
+		t.Errorf("unexpected action: %v, expected get deployment", actions[0])
+	}
+	expected := "Tiller (the helm server side component) has been uninstalled from your Kubernetes Cluster."
+	if !strings.Contains(buf.String(), expected) {
+		t.Errorf("expected %q, got %q", expected, buf.String())
+	}
+	if _, err := os.Stat(home); err != nil {
+		t.Errorf("Helm home directory %s does not exists", home)
+	}
+}
+
+func TestResetCmd_removeHelmHome(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(home)
+
+	var buf bytes.Buffer
+	c := &fakeReleaseClient{}
+	fc := fake.NewSimpleClientset()
+	cmd := &resetCmd{
+		removeHelmHome: true,
+		out:            &buf,
+		home:           helmpath.Home(home),
+		client:         c,
+		kubeClient:     fc,
+		namespace:      api.NamespaceDefault,
+	}
+	if err := cmd.run(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	actions := fc.Actions()
+	if len(actions) != 2 {
+		t.Errorf("Expected 2 actions, got %d", len(actions))
+	}
+	if !actions[0].Matches("get", "services") {
+		t.Errorf("unexpected action: %v, expected get service", actions[1])
+	}
+	if !actions[1].Matches("get", "deployments") {
+		t.Errorf("unexpected action: %v, expected get deployment", actions[0])
+	}
+	expected := "Tiller (the helm server side component) has been uninstalled from your Kubernetes Cluster."
+	if !strings.Contains(buf.String(), expected) {
+		t.Errorf("expected %q, got %q", expected, buf.String())
+	}
+	if _, err := os.Stat(home); err == nil {
+		t.Errorf("Helm home directory %s already exists", home)
+	}
+}
+
+func TestReset_deployedReleases(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(home)
+
+	var buf bytes.Buffer
+	resp := []*release.Release{
+		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+	}
+	c := &fakeReleaseClient{
+		rels: resp,
+	}
+	fc := fake.NewSimpleClientset()
+	cmd := &resetCmd{
+		out:        &buf,
+		home:       helmpath.Home(home),
+		client:     c,
+		kubeClient: fc,
+		namespace:  api.NamespaceDefault,
+	}
+	err = cmd.run()
+	expected := "There are still 1 deployed releases (Tip: use --force)"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(home); err != nil {
+		t.Errorf("Helm home directory %s does not exists", home)
+	}
+}
+
+func TestReset_forceFlag(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(home)
+
+	var buf bytes.Buffer
+	resp := []*release.Release{
+		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+	}
+	c := &fakeReleaseClient{
+		rels: resp,
+	}
+	fc := fake.NewSimpleClientset()
+	cmd := &resetCmd{
+		force:      true,
+		out:        &buf,
+		home:       helmpath.Home(home),
+		client:     c,
+		kubeClient: fc,
+		namespace:  api.NamespaceDefault,
+	}
+	if err := cmd.run(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	actions := fc.Actions()
+	if len(actions) != 2 {
+		t.Errorf("Expected 2 actions, got %d", len(actions))
+	}
+	if !actions[0].Matches("get", "services") {
+		t.Errorf("unexpected action: %v, expected get service", actions[1])
+	}
+	if !actions[1].Matches("get", "deployments") {
+		t.Errorf("unexpected action: %v, expected get deployment", actions[0])
+	}
+	expected := "Tiller (the helm server side component) has been uninstalled from your Kubernetes Cluster."
+	if !strings.Contains(buf.String(), expected) {
+		t.Errorf("expected %q, got %q", expected, buf.String())
+	}
+	if _, err := os.Stat(home); err != nil {
+		t.Errorf("Helm home directory %s does not exists", home)
+	}
+}


### PR DESCRIPTION
This PR adds a command to uninstall `Tiller` from the Kubernetes cluster and delete the local configuration (`$HELM_HOME`).

As a safeguard, it will not uninstall `Tiller` if there are deployed releases, but this behavior can be overridden by using the `-force` flag.

This PR does NOT purge any configMap, this feature can be added later.

I personally don't like the `deinit` verb, but didn't find any more appropriate alternative name. I thought about using `uninstall`, but this might be confusing for users, as `install` is to install charts not the Tiller. So I'm open to suggestions.