### PR TITLE
fix(helm): Fake tillerHost at version cmd tests

### DIFF
--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -39,6 +39,7 @@ func TestVersion(t *testing.T) {
 		{"server", false, true, []string{"-s"}, false},
 	}
 
+	tillerHost = "fake-localhost"
 	for _, tt := range tests {
 		b := new(bytes.Buffer)
 		c := &fakeReleaseClient{}


### PR DESCRIPTION
Version cmd tries to [set up a tunnel](https://github.com/kubernetes/helm/blob/master/cmd/helm/version.go#L78) at RunE instead of using the PersistentPreRunE. That means that for each version test ([3](https://github.com/kubernetes/helm/blob/master/cmd/helm/version_test.go#L31)) it tries to set up the tunnel. When running the tests on an internetless or without a valid k8s environment, the tunnel will fail with a timeout of 20 seconds, meaning that it will take 60 seconds just to run the version cmd tests.

This commit adds a fake tillerHost so it will [not](https://github.com/kubernetes/helm/blob/master/cmd/helm/helm.go#L156) try to setup the tunnel.