### PR TITLE
fix(make): fix license check

### DIFF
--- a/scripts/validate-license.sh
+++ b/scripts/validate-license.sh
@@ -17,10 +17,9 @@ set -euo pipefail
 IFS=$'\n\t'
 
 find_files() {
-  find . -not \( \
+  find ./_proto ./cmd ./pkg ./scripts ./rootfs ./docs -not \( \
     \( \
-      -wholename './vendor' \
-      -o -wholename './pkg/proto' \
+      -wholename './pkg/proto' \
       -o -wholename '*testdata*' \
     \) -prune \
   \) \


### PR DESCRIPTION
An error in the way license checks are evaluated is causing CI failures.

Closes #1856