### PR TITLE
Fix SIGSEGV fault

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -87,7 +87,8 @@ func main() {
 func start(c *cobra.Command, args []string) {
 	clientset, err := kube.New(nil).ClientSet()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot initialize Kubernetes connection: %s", err)
+		fmt.Fprintf(os.Stderr, "Cannot initialize Kubernetes connection: %s\n", err)
+		os.Exit(1)
 	}
 
 	switch store {


### PR DESCRIPTION
While running tiller if it fails to connect to kubernetes cluster it was trowing error and proceeding further and hitting with SIGSEGV fault, to avoid this I'm adding a code here to exit once it hits a error

**Before fix:**

```
[root@localhost rootfs]# ./tiller 
Cannot initialize Kubernetes connection: Get http://localhost:8080/api: dial tcp [::1]:8080: getsockopt: connection refusedpanic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x11ca8]

goroutine 1 [running]:
panic(0x13d2fc0, 0xc42000a0b0)
	/usr/local/go/src/runtime/panic.go:500 +0x3a8
main.start(0x1e53e00, 0x1e86bf0, 0x0, 0x0)
	/root/helm_ws/src/k8s.io/helm/cmd/tiller/tiller.go:97 +0x9c0
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).execute(0x1e53e00, 0xc42000a2c0, 0x0, 0x0, 0x0, 0x0)
	/root/helm_ws/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:603 +0x6c4
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1e53e00, 0x1e53e00, 0x0, 0x0)
	/root/helm_ws/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:689 +0x3f4
k8s.io/helm/vendor/github.com/spf13/cobra.(*Command).Execute(0x1e53e00, 0x0, 0x0)
	/root/helm_ws/src/k8s.io/helm/vendor/github.com/spf13/cobra/command.go:648 +0x34
main.main()
	/root/helm_ws/src/k8s.io/helm/cmd/tiller/tiller.go:84 +0x148
```

**After the fix:**

```
[root@localhost rootfs]# ./tiller 
Cannot initialize Kubernetes connection: Get http://localhost:8080/api: dial tcp [::1]:8080: getsockopt: connection refused
[root@localhost rootfs]#
```