### PR TITLE
fix(helm): fix sort order on helm search

### DIFF
--- a/cmd/helm/search/search.go
+++ b/cmd/helm/search/search.go
@@ -62,6 +62,7 @@ const verSep = "$$"
 
 // AddRepo adds a repository index to the search index.
 func (i *Index) AddRepo(rname string, ind *repo.IndexFile, all bool) {
+	ind.SortEntries()
 	for name, ref := range ind.Entries {
 		if len(ref) == 0 {
 			// Skip chart names that have zero releases.
@@ -175,7 +176,7 @@ func (i *Index) SearchRegexp(re string, threshold int) ([]*Result, error) {
 	return buf, nil
 }
 
-// Chart returns the ChartRef for a particular name.
+// Chart returns the ChartVersion for a particular name.
 func (i *Index) Chart(name string) (*repo.ChartVersion, error) {
 	c, ok := i.charts[name]
 	if !ok {
@@ -220,6 +221,8 @@ func (s scoreSorter) Less(a, b int) bool {
 		if err != nil {
 			return true
 		}
+		// Sort so that the newest chart is higher than the oldest chart. This is
+		// the opposite of what you'd expect in a function called Less.
 		return v1.GreaterThan(v2)
 	}
 	return first.Name < second.Name

--- a/cmd/helm/search/search_test.go
+++ b/cmd/helm/search/search_test.go
@@ -26,14 +26,16 @@ import (
 
 func TestSortScore(t *testing.T) {
 	in := []*Result{
-		{Name: "bbb", Score: 0},
+		{Name: "bbb", Score: 0, Chart: &repo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.3"}}},
 		{Name: "aaa", Score: 5},
 		{Name: "abb", Score: 5},
 		{Name: "aab", Score: 0},
 		{Name: "bab", Score: 5},
+		{Name: "ver", Score: 5, Chart: &repo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.4"}}},
+		{Name: "ver", Score: 5, Chart: &repo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.3"}}},
 	}
-	expect := []string{"aab", "bbb", "aaa", "abb", "bab"}
-	expectScore := []int{0, 0, 5, 5, 5}
+	expect := []string{"aab", "bbb", "aaa", "abb", "bab", "ver", "ver"}
+	expectScore := []int{0, 0, 5, 5, 5, 5, 5}
 	SortScore(in)
 
 	// Test Score
@@ -47,6 +49,14 @@ func TestSortScore(t *testing.T) {
 		if expect[i] != in[i].Name {
 			t.Errorf("Sort error: expected %s, got %s", expect[i], in[i].Name)
 		}
+	}
+
+	// Test version of last two items
+	if in[5].Chart.Version != "1.2.4" {
+		t.Errorf("Expected 1.2.4, got %s", in[5].Chart.Version)
+	}
+	if in[6].Chart.Version != "1.2.3" {
+		t.Error("Expected 1.2.3 to be last")
 	}
 }
 
@@ -120,6 +130,20 @@ func TestAll(t *testing.T) {
 	all = i.All()
 	if len(all) != 5 {
 		t.Errorf("Expected 5 entries, got %d", len(all))
+	}
+}
+
+func TestAddRepo_Sort(t *testing.T) {
+	i := loadTestIndex(t, true)
+	sr, err := i.Search("testing/santa-maria", 100, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch := sr[0]
+	expect := "1.2.3"
+	if ch.Chart.Version != expect {
+		t.Errorf("Expected %q, got %q", expect, ch.Chart.Version)
 	}
 }
 

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -39,7 +39,7 @@ func TestSearchCmd(t *testing.T) {
 		{
 			name:   "search for 'alpine', expect two matches",
 			args:   []string{"alpine"},
-			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.1.0  \tDeploy a basic Alpine Linux pod",
+			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod",
 		},
 		{
 			name:   "search for 'alpine' with versions, expect three matches",
@@ -56,7 +56,7 @@ func TestSearchCmd(t *testing.T) {
 			name:   "search for 'alp[a-z]+', expect two matches",
 			args:   []string{"alp[a-z]+"},
 			flags:  []string{"--regexp"},
-			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.1.0  \tDeploy a basic Alpine Linux pod",
+			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod",
 			regexp: true,
 		},
 		{


### PR DESCRIPTION
During search index construction, records were not correctly sorted by
version number, which resulted in the wrong records being inserted into
the index.

Along the way, added tests and fixed a few comments.

Closes #1897