### PR TITLE
feat(README): Adding roadmap location

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ including installing pre-releases.
 - [History](docs/history.md) - A brief history of the project
 - [Glossary](docs/glossary.md) - Decode the Helm vocabulary
 
+## Roadmap
+
+The [Helm roadmap is currently located on the wiki](https://github.com/kubernetes/helm/wiki/Roadmap).
+
 ## Community, discussion, contribution, and support
 
 You can reach the Helm community and developers via the following channels:


### PR DESCRIPTION
To exit incubation the roadmap needs to be listed in the wiki per
the incubator documentation. For more detail see
https://github.com/kubernetes/community/blob/master/incubator.md