### PR TITLE
fix(helm): delete outdated deps

### DIFF
--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -28,10 +28,15 @@ const dependencyUpDesc = `
 Update the on-disk dependencies to mirror the requirements.yaml file.
 
 This command verifies that the required charts, as expressed in 'requirements.yaml',
-are present in 'charts/' and are at an acceptable version.
+are present in 'charts/' and are at an acceptable version. It will pull down
+the latest charts that satisfy the dependencies, and clean up old dependencies.
 
 On successful update, this will generate a lock file that can be used to
 rebuild the requirements to an exact version.
+
+Dependencies are not required to be represented in 'requirements.yaml'. For that
+reason, an update command will not remove charts unless they are (a) present
+in the requirements.yaml file, but (b) at the wrong version.
 `
 
 // dependencyUpdateCmd describes a 'helm dependency update'


### PR DESCRIPTION
This fixes a bug in 'helm dep up' which left old versions of a
dependency after an update.

Closes #1864