### PR TITLE
(bugfix/cmd/helm/history): update history table MaxColWidth

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -97,7 +97,7 @@ func (cmd *historyCmd) run() error {
 
 func formatHistory(rls []*release.Release) string {
 	tbl := uitable.New()
-	tbl.MaxColWidth = 30
+	tbl.MaxColWidth = 60
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "DESCRIPTION")
 	for i := len(rls) - 1; i >= 0; i-- {
 		r := rls[i]


### PR DESCRIPTION
update `helm history` table to match `helm list` MaxColWidth to stop longer <release_name>-<chart_version> variants. Long term would be to implement `-o wide` to use shorter column widths unless specifically asked.

https://github.com/kubernetes/helm/blob/8d75b0c0c0b50f52f8313cbaf41b9fcb775345cf/cmd/helm/history.go#L100
https://github.com/kubernetes/helm/blob/8d75b0c0c0b50f52f8313cbaf41b9fcb775345cf/cmd/helm/list.go#L200

Example

Before
```
helm history jaunty-llama
REVISION	UPDATED                 	STATUS  	CHART                         
1       	Fri Feb  3 15:58:10 2017	DEPLOYED	alpine-1.0.847.192312075-16...
```
After
```
./helm history jaunty-llama
REVISION	UPDATED                 	STATUS  	CHART                              	DESCRIPTION
1       	Fri Feb  3 15:58:10 2017	DEPLOYED	alpine-1.0.847.192312075-165164_365	
```