### PR TITLE
feat(helm): add local path support for deps in requirements.yaml

### DIFF
--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -127,7 +127,7 @@ func (l *dependencyListCmd) run() error {
 	r, err := chartutil.LoadRequirements(c)
 	if err != nil {
 		if err == chartutil.ErrRequirementsNotFound {
-			fmt.Fprintf(l.out, "WARNING: no requirements at %s/charts", l.chartpath)
+			fmt.Fprintf(l.out, "WARNING: no requirements at %s/charts\n", l.chartpath)
 			return nil
 		}
 		return err

--- a/docs/helm/helm_dependency.md
+++ b/docs/helm/helm_dependency.md
@@ -46,7 +46,7 @@ For example,
     dependencies:
 	- name: nginx
 	  version: "1.2.3"
-	  repository: "file://../depedency_chart/nginx"
+	  repository: "file://../dependency_chart/nginx"
 If the dependency chart is retrieved locally, it is not required to have the repository
 added to helm by "helm add repo". Version matching is also supported for this case.
 

--- a/docs/helm/helm_dependency.md
+++ b/docs/helm/helm_dependency.md
@@ -39,6 +39,16 @@ appending '/index.yaml' to the URL, it should be able to retrieve the chart
 repository's index. Note: 'repository' cannot be a repository alias. It must be
 a URL.
 
+Starting from 2.2.0, repository can be defined as the path to the directory of
+the dependency charts stored locally. The path should start with a prefix of "file://".
+For example,
+    # requirements.yaml
+    dependencies:
+	- name: nginx
+	  version: "1.2.3"
+	  repository: "file://../depedency_chart/nginx"
+If the dependency chart is retrieved locally, it is not required to have the repository
+added to helm by "helm add repo". Version matching is also supported for this case.
 
 ### Options inherited from parent commands
 

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -313,13 +313,13 @@ func (m *Manager) getRepoNames(deps []*chartutil.Dependency) (map[string]string,
 	for _, dd := range deps {
 		// if dep chart is from local path, verify the path is valid
 		if strings.HasPrefix(dd.Repository, "file://") {
-			depPath, err := filepath.Abs(dd.Repository[7:])
+			depPath, err := filepath.Abs(strings.TrimPrefix(dd.Repository, "file://"))
 			if err != nil {
 				return nil, err
 			}
 
 			if _, err = os.Stat(depPath); os.IsNotExist(err) {
-				return nil, fmt.Errorf("directory %s not found: %s", depPath, err)
+				return nil, fmt.Errorf("directory %s not found", depPath)
 			}
 
 			fmt.Fprintf(m.Out, "Repository from local path: %s\n", dd.Repository)

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -113,6 +113,13 @@ func TestGetRepoNames(t *testing.T) {
 			},
 			expect: map[string]string{"oedipus-rex": "testing"},
 		},
+		{
+			name: "repo from local path",
+			req: []*chartutil.Dependency{
+				{Name: "local-dep", Repository: "file://./testdata/signtest"},
+			},
+			expect: map[string]string{"local-dep": "file://./testdata/signtest"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -65,6 +65,8 @@ func (r *Resolver) Resolve(reqs *chartutil.Requirements, repoNames map[string]st
 
 			if _, err = os.Stat(depPath); os.IsNotExist(err) {
 				return nil, fmt.Errorf("directory %s not found", depPath)
+			} else if err != nil {
+				return nil, err
 			}
 
 			locked[i] = &chartutil.Dependency{

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -58,7 +58,7 @@ func (r *Resolver) Resolve(reqs *chartutil.Requirements, repoNames map[string]st
 	missing := []string{}
 	for i, d := range reqs.Dependencies {
 		if strings.HasPrefix(d.Repository, "file://") {
-			depPath, err := filepath.Abs(d.Repository[7:])
+			depPath, err := filepath.Abs(strings.TrimPrefix(d.Repository, "file://"))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -55,6 +57,23 @@ func (r *Resolver) Resolve(reqs *chartutil.Requirements, repoNames map[string]st
 	locked := make([]*chartutil.Dependency, len(reqs.Dependencies))
 	missing := []string{}
 	for i, d := range reqs.Dependencies {
+		if strings.HasPrefix(d.Repository, "file://") {
+			depPath, err := filepath.Abs(d.Repository[7:])
+			if err != nil {
+				return nil, err
+			}
+
+			if _, err = os.Stat(depPath); os.IsNotExist(err) {
+				return nil, fmt.Errorf("directory %s not found", depPath)
+			}
+
+			locked[i] = &chartutil.Dependency{
+				Name:       d.Name,
+				Repository: d.Repository,
+				Version:    d.Version,
+			}
+			continue
+		}
 		constraint, err := semver.NewConstraint(d.Version)
 		if err != nil {
 			return nil, fmt.Errorf("dependency %q has an invalid version/constraint format: %s", d.Name, err)

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -77,6 +77,15 @@ func TestResolve(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "repo from local invalid path",
+			req: &chartutil.Requirements{
+				Dependencies: []*chartutil.Dependency{
+					{Name: "notexist", Repository: "file://../testdata/notexist", Version: "0.1.0"},
+				},
+			},
+			err: true,
+		},
 	}
 
 	repoNames := map[string]string{"alpine": "kubernetes-charts", "redis": "kubernetes-charts"}

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -78,7 +78,20 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
-			name: "repo from local invalid path",
+			name: "repo from valid local path",
+			req: &chartutil.Requirements{
+				Dependencies: []*chartutil.Dependency{
+					{Name: "signtest", Repository: "file://../testdata/testcharts/signtest", Version: "0.1.0"},
+				},
+			},
+			expect: &chartutil.RequirementsLock{
+				Dependencies: []*chartutil.Dependency{
+					{Name: "signtest", Repository: "file://../testdata/testcharts/signtest", Version: "0.1.0"},
+				},
+			},
+		},
+		{
+			name: "repo from invalid local path",
 			req: &chartutil.Requirements{
 				Dependencies: []*chartutil.Dependency{
 					{Name: "notexist", Repository: "file://../testdata/notexist", Version: "0.1.0"},

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -81,12 +81,12 @@ func TestResolve(t *testing.T) {
 			name: "repo from valid local path",
 			req: &chartutil.Requirements{
 				Dependencies: []*chartutil.Dependency{
-					{Name: "signtest", Repository: "file://../testdata/testcharts/signtest", Version: "0.1.0"},
+					{Name: "signtest", Repository: "file://../../cmd/helm/testdata/testcharts/signtest", Version: "0.1.0"},
 				},
 			},
 			expect: &chartutil.RequirementsLock{
 				Dependencies: []*chartutil.Dependency{
-					{Name: "signtest", Repository: "file://../testdata/testcharts/signtest", Version: "0.1.0"},
+					{Name: "signtest", Repository: "file://../../cmd/helm/testdata/testcharts/signtest", Version: "0.1.0"},
 				},
 			},
 		},


### PR DESCRIPTION
The following commands:
helm dep update
helm dep build
are now able to take a requirements.yaml with dependency charts' repo defined as:
file://../local/path or file:///root/path

closes: #1884