### PR TITLE
fix(helm): fix broken unit test

### DIFF
--- a/cmd/helm/search/search_test.go
+++ b/cmd/helm/search/search_test.go
@@ -139,6 +139,7 @@ func TestAddRepo_Sort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	SortScore(sr)
 
 	ch := sr[0]
 	expect := "1.2.3"


### PR DESCRIPTION
I recently added a test to check the sorting of search results.
Unfortunately, the test didn't actually sort the results (_sigh_), so
it was failing occasionally on map ordering.

This adds the sort function that is supposed to be tested.

Closes #1925