### PR TITLE
build helm binary in tiller image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 _dist/
 _proto/*.pb.go
 bin/
+rootfs/helm
 rootfs/tiller
 rootfs/rudder
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ check-docker:
 docker-binary: BINDIR = ./rootfs
 docker-binary: GOFLAGS += -a -installsuffix cgo
 docker-binary:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/helm $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/tiller $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
 
 .PHONY: docker-build

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,10 +14,11 @@
 
 FROM alpine:3.7
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates socat && rm -rf /var/cache/apk/*
 
 ENV HOME /tmp
 
+COPY helm /bin/helm
 COPY tiller /bin/tiller
 
 EXPOSE 44134


### PR DESCRIPTION
This enhancement slows down `make docker-binary` since the helm client needs to be built, and the tiller image is slightly larger now that the helm client is present in the image, but this gives users a Docker image with both the `helm` and `tiller` binaries available in the image.

I'm not asking for this to be accepted, just proposing a solution to the problem.