### PR TITLE
fix(helm): fix broken cache paths in repositories

### DIFF
--- a/cmd/helm/home.go
+++ b/cmd/helm/home.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"k8s.io/helm/cmd/helm/helmpath"
 )
 
 var longHomeHelp = `
@@ -34,7 +35,17 @@ func newHomeCmd(out io.Writer) *cobra.Command {
 		Short: "displays the location of HELM_HOME",
 		Long:  longHomeHelp,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(out, homePath()+"\n")
+			h := helmpath.Home(homePath())
+			fmt.Fprintf(out, "%s\n", h)
+			if flagDebug {
+				fmt.Fprintf(out, "Repository: %s\n", h.Repository())
+				fmt.Fprintf(out, "RepositoryFile: %s\n", h.RepositoryFile())
+				fmt.Fprintf(out, "Cache: %s\n", h.Cache())
+				fmt.Fprintf(out, "Stable CacheIndex: %s\n", h.CacheIndex("stable"))
+				fmt.Fprintf(out, "Starters: %s\n", h.Starters())
+				fmt.Fprintf(out, "LocalRepository: %s\n", h.LocalRepository())
+				fmt.Fprintf(out, "Plugins: %s\n", h.Plugins())
+			}
 		},
 	}
 

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -228,7 +228,9 @@ func initStableRepo(cacheFile string) (*repo.Entry, error) {
 		return nil, err
 	}
 
-	if err := r.DownloadIndexFile(); err != nil {
+	// In this case, the cacheFile is always absolute. So passing empty string
+	// is safe.
+	if err := r.DownloadIndexFile(""); err != nil {
 		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
 	}
 

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -102,7 +102,7 @@ func addRepository(name, url string, home helmpath.Home, certFile, keyFile, caFi
 		return err
 	}
 
-	if err := r.DownloadIndexFile(); err != nil {
+	if err := r.DownloadIndexFile(home.Cache()); err != nil {
 		return fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", url, err.Error())
 	}
 

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -43,7 +43,7 @@ func TestUpdateCmd(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer) {
+	updater := func(repos []*repo.ChartRepository, out io.Writer, hh helmpath.Home) {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
@@ -90,7 +90,7 @@ func TestUpdateCharts(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	updateCharts([]*repo.ChartRepository{r}, b)
+	updateCharts([]*repo.ChartRepository{r}, b, hh)
 
 	got := b.String()
 	if strings.Contains(got, "Unable to get an update") {

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -30,7 +30,10 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/ghodss/yaml"
 
+	// FIXME: This violates the package rules. A `cmd` should not be imported by
+	// something in 'pkg'
 	"k8s.io/helm/cmd/helm/helmpath"
+
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/repo"
@@ -375,7 +378,7 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 		}
 		wg.Add(1)
 		go func(r *repo.ChartRepository) {
-			if err := r.DownloadIndexFile(); err != nil {
+			if err := r.DownloadIndexFile(m.HelmHome.Cache()); err != nil {
 				fmt.Fprintf(out, "...Unable to get an update from the %q chart repository (%s):\n\t%s\n", r.Config.Name, r.Config.URL, err)
 			} else {
 				fmt.Fprintf(out, "...Successfully got an update from the %q chart repository\n", r.Config.Name)

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -142,7 +142,7 @@ func TestDownloadIndexFile(t *testing.T) {
 		t.Errorf("Problem creating chart repository from %s: %v", testRepo, err)
 	}
 
-	if err := r.DownloadIndexFile(); err != nil {
+	if err := r.DownloadIndexFile(""); err != nil {
 		t.Errorf("%#v", err)
 	}
 


### PR DESCRIPTION
A regression was committed during 2.2.0 that broke the repositories.yaml
file format, switching the cache path from relative to absolute. This
fixes the error.

Closes #1974