### PR TITLE
feat(helm): allow disabling plugins

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -76,6 +76,7 @@ Common actions from this point include:
 Environment:
   $HELM_HOME          set an alternative location for Helm files. By default, these are stored in ~/.helm
   $HELM_HOST          set an alternative Tiller host. The format is host:port
+  $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
   $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-namespace")
   $KUBECONFIG         set an alternative Kubernetes configuration file (default "~/.kube/config")
 `

--- a/cmd/helm/plugins.go
+++ b/cmd/helm/plugins.go
@@ -37,6 +37,12 @@ const pluginEnvVar = "HELM_PLUGIN"
 // to inspect its environment and then add commands to the base command
 // as it finds them.
 func loadPlugins(baseCmd *cobra.Command, home helmpath.Home, out io.Writer) {
+
+	// If HELM_NO_PLUGINS is set to 1, do not load plugins.
+	if os.Getenv("HELM_NO_PLUGINS") == "1" {
+		return
+	}
+
 	plugdirs := os.Getenv(pluginEnvVar)
 	if plugdirs == "" {
 		plugdirs = home.Plugins()

--- a/cmd/helm/plugins_test.go
+++ b/cmd/helm/plugins_test.go
@@ -134,6 +134,28 @@ func TestLoadPlugins(t *testing.T) {
 	}
 }
 
+func TestLoadPlugins_HelmNoPlugins(t *testing.T) {
+	os.Setenv("HELM_NO_PLUGINS", "1")
+	defer os.Setenv("HELM_NO_PLUGINS", "0")
+
+	// Set helm home to point to testdata
+	old := helmHome
+	helmHome = "testdata/helmhome"
+	defer func() {
+		helmHome = old
+	}()
+	hh := helmpath.Home(homePath())
+
+	out := bytes.NewBuffer(nil)
+	cmd := &cobra.Command{}
+	loadPlugins(cmd, hh, out)
+	plugins := cmd.Commands()
+
+	if len(plugins) != 0 {
+		t.Fatalf("Expected 0 plugins, got %d", len(plugins))
+	}
+}
+
 func TestSetupEnv(t *testing.T) {
 	name := "pequod"
 	hh := helmpath.Home("testdata/helmhome")


### PR DESCRIPTION
This adds an environment variable, HELM_NO_PLUGINS, that can disable
the plugin system from loading plugins. It provides a general way for
turning the plugin system off.

Closes #1624