### PR TITLE
fix(helm): add message if release deleted successfully

### DIFF
--- a/cmd/helm/delete.go
+++ b/cmd/helm/delete.go
@@ -69,6 +69,8 @@ func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 				if err := del.run(); err != nil {
 					return err
 				}
+
+				fmt.Fprintf(out, "release \"%s\" deleted\n", del.name)
 			}
 			return nil
 		},


### PR DESCRIPTION
kubernetes has explicit delete message that user can know resources being deleted for sure,
suggest also add this behavior to helm, as it is too 'quiet' for deletion operation right now.