### PR TITLE
fix(helm): Add processing of global helmignore file

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -138,6 +138,19 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	// Find and add plugins
 	loadPlugins(cmd, helmpath.Home(homePath()), out)
 
+	// Load helmignore file, BuildIgnoreFiles will find helm client location
+	// for global ignore file, but it needs a current folder location to check
+	// for local helmignore file.
+	// ignoreFiles := BuildIgnoreFiles(func() string {
+	BuildIgnoreFiles(func() string {
+		// Need to figure out how to get working path
+		topdir, err := filepath.Abs("./")
+		if err == nil {
+			topdir += string(filepath.Separator)
+		}
+		return topdir
+	}())
+
 	return cmd
 }
 

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -31,6 +31,7 @@ import (
 
 	"k8s.io/helm/cmd/helm/helmpath"
 	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/ignore"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/provenance"
 	"k8s.io/helm/pkg/repo"
@@ -197,4 +198,29 @@ func promptUser(name string) ([]byte, error) {
 	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return pw, err
+}
+
+// BuildIgnoreFiles loads global helmignore file if it exists and
+// helmignore file from the current folder into a slice of strings.
+func BuildIgnoreFiles(dir string) []string {
+	ignoreFiles := []string{}
+
+	topdir, err := filepath.Abs(dir)
+	if err == nil {
+		topdir += string(filepath.Separator)
+
+		f, err := os.Open(topdir + ignore.HelmIgnore)
+		if err == nil {
+			defer f.Close()
+			ignoreFiles = append(ignoreFiles, topdir+ignore.HelmIgnore)
+		}
+	}
+	homeDir := fmt.Sprintf("%s", helmpath.Home(homePath()))
+	f, err := os.Open(homeDir + ignore.HelmIgnore)
+	if err == nil {
+		defer f.Close()
+		ignoreFiles = append(ignoreFiles, topdir+ignore.HelmIgnore)
+	}
+
+	return ignoreFiles
 }

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -214,10 +214,25 @@ func LoadFile(name string) (*chart.Chart, error) {
 	return LoadArchive(raw)
 }
 
+// LoadIgnoreFiles loads helmignore files and returns a reader.
+func LoadIgnoreFiles(ignoreFiles []string) *bytes.Reader {
+	buff := bytes.NewBuffer(nil)
+
+	for _, ignf := range ignoreFiles {
+		f, err := os.Open(ignf)
+		if err == nil {
+			defer f.Close()
+			io.Copy(buff, f)
+		}
+	}
+
+	return bytes.NewReader(buff.Bytes())
+}
+
 // LoadDir loads from a directory.
 //
 // This loads charts only from directories.
-func LoadDir(dir string) (*chart.Chart, error) {
+func LoadDir(dir string, ignoreFiles ...string) (*chart.Chart, error) {
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -227,13 +242,12 @@ func LoadDir(dir string) (*chart.Chart, error) {
 	c := &chart.Chart{}
 
 	rules := ignore.Empty()
-	ifile := filepath.Join(topdir, ignore.HelmIgnore)
-	if _, err := os.Stat(ifile); err == nil {
-		r, err := ignore.ParseFile(ifile)
+	r := LoadIgnoreFiles(ignoreFiles)
+	if r.Len() > 0 {
+		rules, err = ignore.Parse(r)
 		if err != nil {
 			return c, err
 		}
-		rules = r
 	}
 	rules.AddDefaults()
 


### PR DESCRIPTION
In addition to processing helmignore file located in the current
directory, this patch adds processing of the global helmignore located
in helm's client default location.

Closes #1674