### PR TITLE
Add ToToml function

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -65,8 +65,4 @@ import:
   version: ^0.2.1
 - package: github.com/evanphx/json-patch
 - package: github.com/facebookgo/symwalk
-testImports:
-- package: github.com/stretchr/testify
-  version: ^1.1.4
-  subpackages:
-  - assert
+- package: github.com/naoina/toml

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/naoina/toml"
 )
 
 // Files is a map of files in a chart that can be accessed from a template.
@@ -189,6 +190,19 @@ func FromYaml(str string) map[string]interface{} {
 		m["Error"] = err.Error()
 	}
 	return m
+}
+
+// ToToml takes an interface, marshals it to yaml, and returns a string. It will
+// always return a string, even on marshal error (empty string).
+//
+// This is designed to be called from a template.
+func ToToml(v interface{}) string {
+	data, err := toml.Marshall(v)
+	if err != nil {
+		// Swallow error inside of a template.
+		return ""
+	}
+	return string(data)
 }
 
 // ToJson takes an interface, marshals it to json, and returns a string. It will

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -111,6 +111,19 @@ func TestToYaml(t *testing.T) {
 	}
 }
 
+func TestToToml(t *testing) {
+	expect := "foo = bar\n"
+	v := struct {
+		Foo string `json:"foo"`
+	}{
+		Foo: "bar",
+	}
+
+	if got := ToToml(v); got != expect {
+		t.Errorf("Expected %q, got %q", expect, got)
+	}
+}
+
 func TestFromYaml(t *testing.T) {
 	doc := `hello: world
 one:

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -70,6 +70,7 @@ func FuncMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
+		"toToml":   chartutil.ToToml,
 		"toYaml":   chartutil.ToYaml,
 		"fromYaml": chartutil.FromYaml,
 		"toJson":   chartutil.ToJson,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -49,7 +49,7 @@ func TestFuncMap(t *testing.T) {
 	}
 
 	// Test for Engine-specific template functions.
-	expect := []string{"include", "toYaml", "fromYaml"}
+	expect := []string{"include", "toYaml", "fromYaml", "toJson", "fromJson", "toToml"}
 	for _, f := range expect {
 		if _, ok := fns[f]; !ok {
 			t.Errorf("Expected add-on function %q", f)


### PR DESCRIPTION
This adds an additional template function `toToml` which outputs the [toml](https://github.com/naoina/toml) representation of the input object.

I was having a bit of trouble trying to build Helm locally so I might be missing something glaring. If so I'm happy to close this PR. I have emulated the existing functions to add the new one.