### PR TITLE
Add toToml template function

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b4a2318bb042d673a7843e99b9d4f096e8d0fd0a3ec94968534be4cf39101045
-updated: 2017-02-23T23:08:54.111587509Z
+hash: fcc928f9489a980f3431727c48e0fdbaabc24b1f84e8f0ba387292a1e63e4254
+updated: 2017-03-01T09:59:21.570122911-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -189,6 +189,8 @@ imports:
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/mitchellh/go-wordwrap
   version: ad45545899c7b13c020ea92b2072220eefad42b8
+- name: github.com/naoina/toml
+  version: 751171607256bb66e64c9f0220c00662420c38e9
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/PuerkitoBio/purell

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fcc928f9489a980f3431727c48e0fdbaabc24b1f84e8f0ba387292a1e63e4254
-updated: 2017-03-01T09:59:21.570122911-08:00
+hash: 02bce6ea185e5047edd61974566237d990bc8aa7951608f4a3a352f70b1bc897
+updated: 2017-03-01T11:15:43.421409397-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -189,8 +189,12 @@ imports:
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/mitchellh/go-wordwrap
   version: ad45545899c7b13c020ea92b2072220eefad42b8
+- name: github.com/naoina/go-stringutil
+  version: 6b638e95a32d0c1131db0e7fe83775cbea4a0d0b
 - name: github.com/naoina/toml
   version: 751171607256bb66e64c9f0220c00662420c38e9
+  subpackages:
+  - ast
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/PuerkitoBio/purell

--- a/glide.yaml
+++ b/glide.yaml
@@ -67,3 +67,4 @@ import:
 - package: github.com/facebookgo/symwalk
 - package: github.com/naoina/toml
   version: ~0.1.0
+- package: github.com/naoina/go-stringutil

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,3 +68,4 @@ import:
 - package: github.com/naoina/toml
   version: ~0.1.0
 - package: github.com/naoina/go-stringutil
+  version: ~0.1.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -65,8 +65,5 @@ import:
   version: ^0.2.1
 - package: github.com/evanphx/json-patch
 - package: github.com/facebookgo/symwalk
-testImports:
-- package: github.com/stretchr/testify
-  version: ^1.1.4
-  subpackages:
-  - assert
+- package: github.com/naoina/toml
+  version: ~0.1.0

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/naoina/toml"
 )
 
 // Files is a map of files in a chart that can be accessed from a template.
@@ -189,6 +190,19 @@ func FromYaml(str string) map[string]interface{} {
 		m["Error"] = err.Error()
 	}
 	return m
+}
+
+// ToToml takes an interface, marshals it to toml, and returns a string. It will
+// always return a string, even on marshal error (empty string).
+//
+// This is designed to be called from a template.
+func ToToml(v interface{}) string {
+	data, err := toml.Marshal(v)
+	if err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return string(data)
 }
 
 // ToJson takes an interface, marshals it to json, and returns a string. It will

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -111,6 +111,19 @@ func TestToYaml(t *testing.T) {
 	}
 }
 
+func TestToToml(t *testing.T) {
+	expect := "foo=\"bar\"\n"
+	v := struct {
+		Foo string `json:"foo"`
+	}{
+		Foo: "bar",
+	}
+
+	if got := ToToml(v); got != expect {
+		t.Errorf("Expected %q, got %q", expect, got)
+	}
+}
+
 func TestFromYaml(t *testing.T) {
 	doc := `hello: world
 one:

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -70,6 +70,7 @@ func FuncMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
+		"toToml":   chartutil.ToToml,
 		"toYaml":   chartutil.ToYaml,
 		"fromYaml": chartutil.FromYaml,
 		"toJson":   chartutil.ToJson,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -49,7 +49,7 @@ func TestFuncMap(t *testing.T) {
 	}
 
 	// Test for Engine-specific template functions.
-	expect := []string{"include", "toYaml", "fromYaml"}
+	expect := []string{"include", "toYaml", "fromYaml", "toToml", "toJson", "fromJson"}
 	for _, f := range expect {
 		if _, ok := fns[f]; !ok {
 			t.Errorf("Expected add-on function %q", f)


### PR DESCRIPTION
This pr adds a `toToml` template function that is modeled on `toYaml` and `toJson`.