### PR TITLE
install: Return more user-friendly response on eexists

### DIFF
--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -588,7 +588,7 @@ func (s *ReleaseServer) uniqName(start string, reuse bool) (string, error) {
 			return "", errors.New("cannot re-use a name that is still in use")
 		}
 
-		return "", fmt.Errorf("a release named %q already exists", start)
+		return "", fmt.Errorf("a release named %q already exists.\nPlease run: helm ls --all %q; helm del --help", start, start)
 	}
 
 	maxTries := 5


### PR DESCRIPTION
Most newcomers hit helm's 'feature' there deleted instalations are not really deleted.
Use-case
helm install  --name gitlab-ce-1 ./stable/gitlab-ce
helm delete gitlab-ce-1
 helm list
 helm install  --name gitlab-ce-1 ./stable/gitlab-ce
Error: a release named "gitlab-ce-1" already exists

There is a lot duplicated bugs in bugzilla which simply explains that packages
should be deleted with --pure flag. But such bugs appeared again and again
because this behavior is not obvious.

Let's help user to figure out what happens ASAP.