### PR TITLE
Add .Template.BasePath to template system

### DIFF
--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -4,7 +4,7 @@ Objects are passed into a template from the template engine. And your code can p
 
 Objects can be simple, and have just one value. Or they can contain other objects or functions. For example. the `Release` object contains several objects (like `Release.Name`) and the `Files` object has a few functions.
 
-In the previous section, we use `{{.Release.Name}}` to insert the name of a release into a template. `Release` is one of four top-level objects that you can access in your templates.
+In the previous section, we use `{{.Release.Name}}` to insert the name of a release into a template. `Release` is one of the top-level objects that you can access in your templates.
 
 - `Release`: This object describes the release itself. It has several objects inside of it:
   - `Release.Name`: The release name
@@ -25,6 +25,9 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
   - `Capabilities.APIVersions.Has $version` indicates whether a version (`batch/v1`) is enabled on the cluster.
   - `Capabilities.KubeVersion` provides a way to look up the Kubernetes version. It has the following values: `Major`, `Minor`, `GitVersion`, `GitCommit`, `GitTreeState`, `BuildDate`, `GoVersion`, `Compiler`, and `Platform`.
   - `Capabilities.TillerVersion` provides a way to look up the Tiller version. It has the following values: `SemVer`, `GitCommit`, and `GitTreeState`.
+- `Template`: Contains information about the current template that is being executed
+  - `Name`: A namespaced filepath to the current template (e.g. `mychart/templates/mytemplate.yaml`)
+  - `BasePath`: The namespaced path to the templates directory of the current chart (e.g. `mychart/templates`). This can be used to [include template files](https://github.com/kubernetes/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change)
 
 The values are available to any top-level template. As we will see later, this does not necessarily mean that they will be available _everywhere_.
 

--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -80,7 +80,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/templates/secret.yaml") . | sha256sum }}
 [...]
 ```
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -120,6 +120,8 @@ type renderable struct {
 	tpl string
 	// vals are the values to be supplied to the template.
 	vals chartutil.Values
+	// namespace prefix to the templates of the current chart
+	basePath string
 }
 
 // alterFuncMap takes the Engine's FuncMap and adds context-specific functions.
@@ -178,7 +180,7 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 	for _, file := range files {
 		// At render time, add information about the template that is being rendered.
 		vals := tpls[file].vals
-		vals["Template"] = map[string]interface{}{"Name": file}
+		vals["Template"] = map[string]interface{}{"Name": file, "BasePath": tpls[file].basePath}
 		if err := t.ExecuteTemplate(&buf, file, vals); err != nil {
 			return map[string]string{}, fmt.Errorf("render error in %q: %s", file, err)
 		}
@@ -246,8 +248,9 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals char
 	}
 	for _, t := range c.Templates {
 		templates[path.Join(newParentID, t.Name)] = renderable{
-			tpl:  string(t.Data),
-			vals: cvals,
+			tpl:      string(t.Data),
+			vals:     cvals,
+			basePath: path.Join(newParentID, "templates"),
 		}
 	}
 }


### PR DESCRIPTION
Why is this useful?

This allows to reliably include template files from a charts templates directory for example as suggested [here](https://github.com/kubernetes/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change)
> `checksum/config: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}`

The above example has a problem that it doesn't work when the chart containing this is included as a subchart because the template name changes from `mychart/templates/secret.yaml` to `parentchart/charts/mychart/templates/secret.yaml`.

We also include templates in other templates heavily to build `ConfigMaps` that [contain template files](https://github.com/sapcc/openstack-helm/blob/master/keystone/templates/etc-configmap.yaml).
Right now we have to use an [ugly hack](https://github.com/sapcc/openstack-helm/blob/master/utils/templates/_include.tpl) to make this work.

This PR would allow to include a template regardless of the charts location by writing something like:

` {{ include (print $.Template.BasePath "/secret.yaml") . }}`
