### PR TITLE
Link to the Helm Chart repository from the Helm project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ pre-configured Kubernetes resources.
 
 Use Helm to...
 
-- Find and use popular software packaged as Kubernetes charts
+- Find and use [popular software packaged as Kubernetes charts](https://github.com/kubernetes/charts)
 - Share your own applications as Kubernetes charts
 - Create reproducible builds of your Kubernetes applications
 - Intelligently manage your Kubernetes manifest files


### PR DESCRIPTION
The current README makes no mention of the Chart repository or where to find it. You have to Google to find it or stumble upon it. It was frustrating to come to the Helm project and not easily be able to find where the chart repository was - even though I knew it existed. This patch will make that easier for others.