### PR TITLE
fix checksum example

### DIFF
--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -80,7 +80,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/templates/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 [...]
 ```
 


### PR DESCRIPTION
$.Template.BasePath already contains "templates/"