### PR TITLE
fix(helm): fix bug when helm update can't find release 1.

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -79,11 +79,7 @@ func newHistoryCmd(c helm.Interface, w io.Writer) *cobra.Command {
 }
 
 func (cmd *historyCmd) run() error {
-	opts := []helm.HistoryOption{
-		helm.WithMaxHistory(cmd.max),
-	}
-
-	r, err := cmd.helmc.ReleaseHistory(cmd.rls, opts...)
+	r, err := cmd.helmc.ReleaseHistory(cmd.rls, helm.WithMaxHistory(cmd.max))
 	if err != nil {
 		return prettyError(err)
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -134,7 +134,7 @@ func (u *upgradeCmd) run() error {
 		// The returned error is a grpc.rpcError that wraps the message from the original error.
 		// So we're stuck doing string matching against the wrapped error, which is nested somewhere
 		// inside of the grpc.rpcError message.
-		_, err := u.client.ReleaseContent(u.release, helm.ContentReleaseVersion(1))
+		_, err := u.client.ReleaseHistory(u.release, helm.WithMaxHistory(1))
 		if err != nil && strings.Contains(err.Error(), driver.ErrReleaseNotFound.Error()) {
 			fmt.Fprintf(u.out, "Release %q does not exist. Installing it now.\n", u.release)
 			ic := &installCmd{


### PR DESCRIPTION
If a release's v1 config map was removed, 'helm upgrade' would fail. It
was calling the wrong function to get its history. This has been fixed.

Closes #1829