### PR TITLE
docs(OWNERS): initial add of owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+maintainers:
+  - adamreese
+  - michelleN
+  - migmartri
+  - prydonius
+  - technosophos
+  - thomastaylor312
+  - vaikas-google
+  - viglesiasce
+reviewers:
+  - adamreese
+  - fibonacci1729
+  - michelleN
+  - migmartri
+  - prydonius
+  - sebgoa
+  - technosophos
+  - thomastaylor312
+  - vaikas-google
+  - viglesiasce


### PR DESCRIPTION
This is to comply with the Kubernetes project guidelines.

- maintainers: Those responsible for steering the Helm project
- reviewers: Those who have authoritative LGTM on issues in the queue

Closes #1906