### PR TITLE
Fixing plugin test

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -74,7 +74,7 @@ func TestLoadDir(t *testing.T) {
 		t.Errorf("Expected dir %q, got %q", dirname, plug.Dir)
 	}
 
-	expect := Metadata{
+	expect := &Metadata{
 		Name:        "hello",
 		Version:     "0.1.0",
 		Usage:       "usage",
@@ -84,8 +84,8 @@ func TestLoadDir(t *testing.T) {
 		IgnoreFlags: true,
 	}
 
-	if reflect.DeepEqual(expect, plug.Metadata) {
-		t.Errorf("Expected name %v, got %v", expect, plug.Metadata)
+	if !reflect.DeepEqual(expect, plug.Metadata) {
+		t.Errorf("Expected plugin metadata %v, got %v", expect, plug.Metadata)
 	}
 }
 

--- a/pkg/plugin/testdata/plugdir/hello/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/hello/plugin.yaml
@@ -3,6 +3,6 @@ version: "0.1.0"
 usage: "usage"
 description: |-
   description
-command: "$HELM_PLUGIN_SELF/helm-hello"
+command: "$HELM_PLUGIN_SELF/hello.sh"
 useTunnel: true
 ignoreFlags: true


### PR DESCRIPTION
In the TestLoadDir test case, currently reflect.DeepEqual is expected to fail by error. Expected metadata is different than in the fixture yaml. Also, the type of the struct is mismatching in DeepEqual call (struct vs pointer to struct).