### PR TITLE
feat/tls: Support optional TLS for helm / tiller

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -87,10 +87,3 @@ func (g *getCmd) run() error {
 	}
 	return printRelease(g.out, res.Release)
 }
-
-func ensureHelmClient(h helm.Interface) helm.Interface {
-	if h != nil {
-		return h
-	}
-	return helm.NewClient(helm.Host(tillerHost))
-}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -100,11 +100,11 @@ func newInitCmd(out io.Writer) *cobra.Command {
 	f.BoolVarP(&i.clientOnly, "client-only", "c", false, "if set does not install tiller")
 	f.BoolVar(&i.dryRun, "dry-run", false, "do not install local or remote")
 
-	// f.BoolVar(&tlsEnable, "tiller-tls", false, "install tiller with TLS enabled")
-	// f.BoolVar(&tlsVerify, "tiller-tls-verify", false, "install tiller with TLS enabled and to verify remote certificates")
-	// f.StringVar(&tlsKeyFile, "tiller-tls-key", "", "path to TLS key file to install with tiller")
-	// f.StringVar(&tlsCertFile, "tiller-tls-cert", "", "path to TLS certificate file to install with tiller")
-	// f.StringVar(&tlsCaCertFile, "tls-ca-cert", "", "path to CA root certificate")
+	f.BoolVar(&tlsEnable, "tiller-tls", false, "install tiller with TLS enabled")
+	f.BoolVar(&tlsVerify, "tiller-tls-verify", false, "install tiller with TLS enabled and to verify remote certificates")
+	f.StringVar(&tlsKeyFile, "tiller-tls-key", "", "path to TLS key file to install with tiller")
+	f.StringVar(&tlsCertFile, "tiller-tls-cert", "", "path to TLS certificate file to install with tiller")
+	f.StringVar(&tlsCaCertFile, "tls-ca-cert", "", "path to CA root certificate")
 
 	return cmd
 }

--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -17,6 +17,8 @@ limitations under the License.
 package helm
 
 import (
+	"crypto/tls"
+
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
@@ -38,6 +40,8 @@ type options struct {
 	host string
 	// if set dry-run helm client calls
 	dryRun bool
+	// if set enable TLS on helm client calls
+	useTLS bool
 	// if set, re-use an existing name
 	reuseName bool
 	// if set, performs pod restart during upgrade/rollback
@@ -46,6 +50,8 @@ type options struct {
 	disableHooks bool
 	// name of release
 	releaseName string
+	// tls.Config to use for rpc if tls enabled
+	tlsConfig *tls.Config
 	// release list options are applied directly to the list releases request
 	listReq rls.ListReleasesRequest
 	// release install options are applied directly to the install release request
@@ -74,6 +80,14 @@ type options struct {
 func Host(host string) Option {
 	return func(opts *options) {
 		opts.host = host
+	}
+}
+
+// WithTLS specifies the tls configuration if the helm client is enabled to use TLS.
+func WithTLS(cfg *tls.Config) Option {
+	return func(opts *options) {
+		opts.useTLS = true
+		opts.tlsConfig = cfg
 	}
 }
 

--- a/pkg/tiller/server.go
+++ b/pkg/tiller/server.go
@@ -32,13 +32,18 @@ import (
 // grpc library default is 4MB
 var maxMsgSize = 1024 * 1024 * 10
 
-// NewServer creates a new grpc server.
-func NewServer() *grpc.Server {
-	return grpc.NewServer(
+// DefaultServerOpts returns the set of default grpc ServerOption's that Tiller requires.
+func DefaultServerOpts() []grpc.ServerOption {
+	return []grpc.ServerOption{
 		grpc.MaxMsgSize(maxMsgSize),
 		grpc.UnaryInterceptor(newUnaryInterceptor()),
 		grpc.StreamInterceptor(newStreamInterceptor()),
-	)
+	}
+}
+
+// NewServer creates a new grpc server.
+func NewServer(opts ...grpc.ServerOption) *grpc.Server {
+	return grpc.NewServer(append(DefaultServerOpts(), opts...)...)
 }
 
 func newUnaryInterceptor() grpc.UnaryServerInterceptor {

--- a/pkg/tlsutil/cfg.go
+++ b/pkg/tlsutil/cfg.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// Options represents configurable options used to create client and server TLS configurations.
+type Options struct {
+	CaCertFile string
+	// If either the KeyFile or CertFile is empty, ClientConfig() will not load them,
+	// preventing helm from authenticating to Tiller. They are required to be non-empty
+	// when calling ServerConfig, otherwise an error is returned.
+	KeyFile  string
+	CertFile string
+	// Client-only options
+	InsecureSkipVerify bool
+	// Server-only options
+	ClientAuth tls.ClientAuthType
+}
+
+// ClientConfig retusn a TLS configuration for use by a Helm client.
+func ClientConfig(opts Options) (cfg *tls.Config, err error) {
+	var cert *tls.Certificate
+	var pool *x509.CertPool
+
+	if opts.CertFile != "" || opts.KeyFile != "" {
+		if cert, err = CertFromFilePair(opts.CertFile, opts.KeyFile); err != nil {
+			return nil, fmt.Errorf("could not load x509 key pair (cert: %q, key: %q): %v", opts.CertFile, opts.KeyFile, err)
+		}
+	}
+	if !opts.InsecureSkipVerify && opts.CaCertFile != "" {
+		if pool, err = CertPoolFromFile(opts.CaCertFile); err != nil {
+			return nil, err
+		}
+	}
+
+	cfg = &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify, Certificates: []tls.Certificate{*cert}, RootCAs: pool}
+	return cfg, nil
+}
+
+// ServerConfig returns a TLS configuration for use by the Tiller server.
+func ServerConfig(opts Options) (cfg *tls.Config, err error) {
+	var cert *tls.Certificate
+	var pool *x509.CertPool
+
+	if cert, err = CertFromFilePair(opts.CertFile, opts.KeyFile); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("could not load x509 key pair (cert: %q, key: %q): %v", opts.CertFile, opts.KeyFile, err)
+		}
+		return nil, fmt.Errorf("could not read x509 key pair (cert: %q, key: %q): %v", opts.CertFile, opts.KeyFile, err)
+	}
+	if opts.ClientAuth >= tls.VerifyClientCertIfGiven && opts.CaCertFile != "" {
+		if pool, err = CertPoolFromFile(opts.CaCertFile); err != nil {
+			return nil, err
+		}
+	}
+
+	cfg = &tls.Config{MinVersion: tls.VersionTLS12, ClientAuth: opts.ClientAuth, Certificates: []tls.Certificate{*cert}, ClientCAs: pool}
+	return cfg, nil
+}


### PR DESCRIPTION
**Tasks/Todos:**
- [x]  Add ```pkg/tlsutil/cfg.go``` to support constructing *tls.Config for helm / tiller
- [x]  Add TLS flags to tiller and support defaults extracted from OS environment.
- [x]  Add helm option to support enabling TLS on client calls.
- [x]  Add flags to ```helm init``` to support deployment of tiller with TLS enabled: 
                 * ```--tiller-tls```
                 * ```--tiller-tls-verify```
                 * ```--tiller-tls-cert```
                 * ```--tiller-tls-key```
                 * ```--tls-ca-cert```
- [x]  Add kubernetes secret and mount as volume to tiller container. Update tiller deployment.
- [x]  Add TLS flags to helm and support defaults extracted from OS environment.