### PR TITLE
feat(helm): import child values to parent

### DIFF
--- a/docs/charts.md
+++ b/docs/charts.md
@@ -304,13 +304,58 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
 
 #### Importing Child Values via requirements.yaml
 
-In some cases it is desirable to allow a child chart's values to propagate to the parent chart and be shared 
-as common defaults. The values to be imported can be specified in the parent chart's requirements.yaml 
-using a YAML list format that contains the source of the values to be imported (child) and the 
-destination path in the parent chart's values (parent).
+In some cases it is desirable to allow a child chart's values to propagate to the parent chart and be 
+shared as common defaults. An additional benefit of using the `exports` format is that it will enable future 
+tooling to introspect user settable values.
 
-The optional `import-values` in the example below instructs Helm to take any values found at `child:` 
-path and copy them to the path at `parent:`
+The keys containing the values to be imported can be specified in the parent chart's requirements.yaml using 
+a YAML list. Each item in the list is a key which is imported from the child chart's `exports` field. 
+
+To import values not contained in the `exports` key, use the [child/parent](#using-the-child/parent-format) format.
+
+##### Using the exports format
+
+If a child chart's values.yaml contains an `exports` field at the root, it's contents may be imported 
+directly into the parent's values by specifying the keys to import as in the example below:
+
+````
+# parent's requirements.yaml
+    ...
+    import-values:
+      - data
+````  
+````
+# child's values.yaml
+
+...
+exports:
+  data:
+    myint: 99
+````  
+
+Since we are specifying the key `data` in our import list, Helm looks in the the `exports` field of the child 
+chart for `data` key and imports its contents. 
+
+The final parent values would contain our exported field:
+
+````
+# parent's values
+...
+myint: 99
+
+````
+
+Please note the parent key `data` is not contained in the parent's final values. If you need to specify the 
+parent key, use the 'child/parent' format. 
+
+##### Using the child/parent format
+
+To access values that are not contained in the `exports` key of the child chart's values, you will need to 
+specify the source key of the values to be imported (`child`) and the destination path in the parent chart's 
+values (`parent`).
+
+The `import-values` in the example below instructs Helm to take any values found at `child:` path and copy them 
+to the parent's values at the path specified in `parent:`
 
 ````
 # parent's requirements.yaml
@@ -332,7 +377,7 @@ to the `myimports` key in the parent chart's values as detailed below:
 myimports:
   myint: 0
   mybool: false
-  mystring: "helm rocks"
+  mystring: "helm rocks!"
   
 
 ````
@@ -353,46 +398,11 @@ The parent chart's resulting values would be:
 myimports:
   myint: 999
   mybool: true
-  mystring: "helm rocks"
+  mystring: "helm rocks!"
 
 ````
 
 The parent's final values now contains the `myint` and `mybool` fields imported from subchart1.
-
-##### Using the exports convention
-
-If a values.yaml contains an `exports` field at the root, it's contents may be imported 
-directly into the parent's values by using a simple string format as in the example below:
-
-````
-# parent's requirements.yaml
-    ...
-    import-values:
-      - data
-````  
-````
-# child values
-
-...
-exports:
-  data:
-    myint:99
-````  
-
-Since we are using the simple string `data` in our import list, Helm looks in the the `exports` 
-field of the child chart for `data` key and imports its contents.   
-
-The final parent values would contain our exported field.
-
-````
-# parent's values
-...
-myint: 99
-
-````
-
-Please note the parent key `data` is not contained in the parent's final values. If 
-you need to specify the parent key, use the 'child/parent' format.
 
 ## Templates and Values
 

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -306,44 +306,44 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
 
 In some cases it is desirable to allow a child chart's values to propagate to the parent chart and be 
 shared as common defaults. An additional benefit of using the `exports` format is that it will enable future 
-tooling to introspect user settable values.
+tooling to introspect user-settable values.
 
-The keys containing the values to be imported can be specified in the parent chart's requirements.yaml using 
-a YAML list. Each item in the list is a key which is imported from the child chart's `exports` field. 
+The keys containing the values to be imported can be specified in the parent chart's `requirements.yaml` file 
+using a YAML list. Each item in the list is a key which is imported from the child chart's `exports` field. 
 
 To import values not contained in the `exports` key, use the [child/parent](#using-the-child/parent-format) format.
+Examples of both formats are described below.
 
 ##### Using the exports format
 
-If a child chart's values.yaml contains an `exports` field at the root, it's contents may be imported 
+If a child chart's `values.yaml` file contains an `exports` field at the root, its contents may be imported 
 directly into the parent's values by specifying the keys to import as in the example below:
 
-````
-# parent's requirements.yaml
+```yaml
+# parent's requirements.yaml file
     ...
     import-values:
       - data
-````  
-````
-# child's values.yaml
-
+```
+```yaml
+# child's values.yaml file
 ...
 exports:
   data:
     myint: 99
-````  
+```
 
 Since we are specifying the key `data` in our import list, Helm looks in the the `exports` field of the child 
 chart for `data` key and imports its contents. 
 
 The final parent values would contain our exported field:
 
-````
-# parent's values
+```yaml
+# parent's values file
 ...
 myint: 99
 
-````
+```
 
 Please note the parent key `data` is not contained in the parent's final values. If you need to specify the 
 parent key, use the 'child/parent' format. 
@@ -357,42 +357,41 @@ values (`parent`).
 The `import-values` in the example below instructs Helm to take any values found at `child:` path and copy them 
 to the parent's values at the path specified in `parent:`
 
-````
-# parent's requirements.yaml
+```yaml
+# parent's requirements.yaml file
 dependencies:
-      - name: subchart1
-        repository: http://localhost:10191
-        version: 0.1.0
-        ...
-        import-values:
-          - child: default.data
-            parent: myimports
-````
+  - name: subchart1
+    repository: http://localhost:10191
+    version: 0.1.0
+    ...
+    import-values:
+      - child: default.data
+        parent: myimports
+```
 In the above example, values found at `default.data` in the subchart1's values will be imported
 to the `myimports` key in the parent chart's values as detailed below: 
 
-````
-# parent's values
+```yaml
+# parent's values.yaml file
 
 myimports:
   myint: 0
   mybool: false
   mystring: "helm rocks!"
   
-
-````
-````
-# subchart1's values.yaml
+```
+```yaml
+# subchart1's values.yaml file
 
 default:
   data:
     myint: 999
     mybool: true
     
-````
+```
 The parent chart's resulting values would be:
 
-````
+```yaml
 # parent's final values
 
 myimports:
@@ -400,7 +399,7 @@ myimports:
   mybool: true
   mystring: "helm rocks!"
 
-````
+```
 
 The parent's final values now contains the `myint` and `mybool` fields imported from subchart1.
 

--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -360,9 +360,6 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 						"child":  "exports." + iv,
 						"parent": ".",
 					}
-					/*nm := make(map[string]string)
-					nm["child"] = "exports." + iv
-					nm["parent"] = "."*/
 					outiv = append(outiv, nm)
 					s := r.Name + "." + nm["child"]
 					vm, err := cvals.Table(s)

--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -316,6 +316,9 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 		return nil
 	}
 	cvals, err := CoalesceValues(c, v)
+	if err != nil {
+		log.Fatalf("Error coalescing values for ImportValues %s", err)
+	}
 	nv := v.GetValues()
 	b := make(map[string]interface{})
 	for kk, v3 := range nv {
@@ -369,7 +372,7 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 
 	cv, err := coalesceValues(c, b)
 	if err != nil {
-		log.Fatalf("Error coalescing values for ImportValues %s", err)
+		log.Fatalf("Error coalescing processed values for ImportValues %s", err)
 	}
 	y, err := yaml.Marshal(cv)
 	if err != nil {

--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -351,7 +351,7 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 					}
 				case string:
 					nm := make(map[string]string)
-					nm["child"] = riv.(string)
+					nm["child"] = "exports." + riv.(string)
 					nm["parent"] = "."
 					outiv = append(outiv, nm)
 					s := r.Name + "." + nm["child"]

--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -328,7 +328,7 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 		if len(r.ImportValues) > 0 {
 			var outiv []interface{}
 			for _, riv := range r.ImportValues {
-				switch tr := riv.(type) {
+				switch riv.(type) {
 				case map[string]interface{}:
 					if m, ok := riv.(map[string]interface{}); ok {
 						nm := make(map[string]string)
@@ -350,8 +350,6 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 						}
 					}
 				case string:
-					log.Printf("its a string %v", tr)
-					// todo validation
 					nm := make(map[string]string)
 					nm["child"] = riv.(string)
 					nm["parent"] = "."

--- a/pkg/chartutil/requirements_test.go
+++ b/pkg/chartutil/requirements_test.go
@@ -226,6 +226,12 @@ func TestProcessRequirementsImportValues(t *testing.T) {
 	e["imported-from-chartA-via-chart1.limits.memory"] = "300Mi"
 	e["imported-from-chartA-via-chart1.limits.volume"] = "11"
 	e["imported-from-chartA-via-chart1.requests.truthiness"] = "0.01"
+	// single list items (looks for exports. parent key)
+	e["imported-from-chartB-via-chart1.databint"] = "1"
+	e["imported-from-chartB-via-chart1.databstr"] = "x.y.z"
+	e["parent1c3"] = "true"
+	// checks that a chartb value was merged in with charta values
+	e["imported-from-chartA-via-chart1.resources.limits.shares"] = "100"
 
 	verifyRequirementsImportValues(t, c, v, e)
 }
@@ -252,6 +258,12 @@ func verifyRequirementsImportValues(t *testing.T, c *chart.Chart, v *chart.Confi
 			s := strconv.FormatFloat(pv.(float64), 'f', -1, 64)
 			if s != vv {
 				t.Errorf("Failed to match imported float value %v with expected %v", s, vv)
+				return
+			}
+		case bool:
+			b := strconv.FormatBool(pv.(bool))
+			if b != vv {
+				t.Errorf("Failed to match imported bool value %v with expected %v", b, vv)
 				return
 			}
 		default:

--- a/pkg/chartutil/requirements_test.go
+++ b/pkg/chartutil/requirements_test.go
@@ -217,21 +217,65 @@ func TestProcessRequirementsImportValues(t *testing.T) {
 	v := &chart.Config{Raw: ""}
 
 	e := make(map[string]string)
-	e["imported-from-chart1.type"] = "ClusterIP"
-	e["imported-from-chart1.name"] = "nginx"
-	e["imported-from-chart1.externalPort"] = "80"
-	// this doesn't exist in imported table. it should merge and remain unchanged
-	e["imported-from-chart1.notimported1"] = "1"
-	e["imported-from-chartA-via-chart1.limits.cpu"] = "300m"
-	e["imported-from-chartA-via-chart1.limits.memory"] = "300Mi"
-	e["imported-from-chartA-via-chart1.limits.volume"] = "11"
-	e["imported-from-chartA-via-chart1.requests.truthiness"] = "0.01"
-	// single list items (looks for exports. parent key)
-	e["imported-from-chartB-via-chart1.databint"] = "1"
-	e["imported-from-chartB-via-chart1.databstr"] = "x.y.z"
-	e["parent1c3"] = "true"
-	// checks that a chartb value was merged in with charta values
-	e["imported-from-chartA-via-chart1.resources.limits.shares"] = "100"
+
+	e["imported-chart1.SC1bool"] = "true"
+	e["imported-chart1.SC1float"] = "3.14"
+	e["imported-chart1.SC1int"] = "100"
+	e["imported-chart1.SC1string"] = "dollywood"
+	e["imported-chart1.SC1extra1"] = "11"
+	e["imported-chart1.SPextra1"] = "helm rocks"
+	e["imported-chart1.SC1extra1"] = "11"
+
+	e["imported-chartA.SCAbool"] = "false"
+	e["imported-chartA.SCAfloat"] = "3.1"
+	e["imported-chartA.SCAint"] = "55"
+	e["imported-chartA.SCAstring"] = "jabba"
+	e["imported-chartA.SPextra3"] = "1.337"
+	e["imported-chartA.SC1extra2"] = "1.337"
+	e["imported-chartA.SCAnested1.SCAnested2"] = "true"
+
+	e["imported-chartA-B.SCAbool"] = "false"
+	e["imported-chartA-B.SCAfloat"] = "3.1"
+	e["imported-chartA-B.SCAint"] = "55"
+	e["imported-chartA-B.SCAstring"] = "jabba"
+
+	e["imported-chartA-B.SCBbool"] = "true"
+	e["imported-chartA-B.SCBfloat"] = "7.77"
+	e["imported-chartA-B.SCBint"] = "33"
+	e["imported-chartA-B.SCBstring"] = "boba"
+	e["imported-chartA-B.SPextra5"] = "k8s"
+	e["imported-chartA-B.SC1extra5"] = "tiller"
+
+	e["overridden-chart1.SC1bool"] = "false"
+	e["overridden-chart1.SC1float"] = "3.141592"
+	e["overridden-chart1.SC1int"] = "99"
+	e["overridden-chart1.SC1string"] = "pollywog"
+	e["overridden-chart1.SPextra2"] = "42"
+
+	e["overridden-chartA.SCAbool"] = "true"
+	e["overridden-chartA.SCAfloat"] = "41.3"
+	e["overridden-chartA.SCAint"] = "808"
+	e["overridden-chartA.SCAstring"] = "jaberwocky"
+	e["overridden-chartA.SPextra4"] = "true"
+
+	e["overridden-chartA-B.SCAbool"] = "true"
+	e["overridden-chartA-B.SCAfloat"] = "41.3"
+	e["overridden-chartA-B.SCAint"] = "808"
+	e["overridden-chartA-B.SCAstring"] = "jaberwocky"
+	e["overridden-chartA-B.SCBbool"] = "false"
+	e["overridden-chartA-B.SCBfloat"] = "1.99"
+	e["overridden-chartA-B.SCBint"] = "77"
+	e["overridden-chartA-B.SCBstring"] = "jango"
+	e["overridden-chartA-B.SPextra6"] = "111"
+	e["overridden-chartA-B.SCAextra1"] = "23"
+	e["overridden-chartA-B.SCBextra1"] = "13"
+	e["overridden-chartA-B.SC1extra6"] = "77"
+
+	// `exports` style
+	e["SCBexported1B"] = "1965"
+	e["SC1extra7"] = "true"
+	e["SCBexported2A"] = "blaster"
+	e["global.SC1exported2.all.SC1exported3"] = "SC1expstr"
 
 	verifyRequirementsImportValues(t, c, v, e)
 }

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
@@ -2,24 +2,16 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 # subchartA
-replicaCount: 1
-image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
 service:
   name: nginx
   type: ClusterIP
   externalPort: 80
   internalPort: 80
-resources:
-  limits:
-    cpu: 300m
-    memory: 300Mi
-    plasticity: 1.7331
-    volume: 11
-  requests:
-    cpu: 350m
-    memory: 350Mi
-    truthiness: 0.01
+SCAdata:
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAstring: "jabba"
+  SCAnested1:
+    SCAnested2: true
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
@@ -1,6 +1,7 @@
 # Default values for subchart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+# subchartA
 replicaCount: 1
 image:
   repository: nginx
@@ -13,9 +14,12 @@ service:
   internalPort: 80
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 300m
+    memory: 300Mi
+    plasticity: 1.7331
+    volume: 11
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 350m
+    memory: 350Mi
+    truthiness: 0.01
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
@@ -18,4 +18,12 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-
+exports:
+  convention1:
+    data:
+      databint: 1
+      databstr: x.y.z
+  convention2:
+    resources:
+      limits:
+        shares: 100

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
@@ -19,7 +19,7 @@ exports:
       SCBexported1B: 1965
 
   SCBexported2:
-      SCBexported2A: "blaster"
+    SCBexported2A: "blaster"
 
 global:
   kolla:

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
@@ -1,29 +1,37 @@
 # Default values for subchart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
-image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
 service:
   name: nginx
   type: ClusterIP
   externalPort: 80
   internalPort: 80
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+
+SCBdata:
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: "boba"
+
 exports:
-  convention1:
-    data:
-      databint: 1
-      databstr: x.y.z
-  convention2:
-    resources:
-      limits:
-        shares: 100
+  SCBexported1:
+    SCBexported1A:
+      SCBexported1B: 1965
+
+  SCBexported2:
+      SCBexported2A: "blaster"
+
+global:
+    kolla:
+        nova:
+            api:
+                all:
+                    port: 8774
+            metadata:
+                all:
+                    port: 8775
+test:
+  dummy: 1
+
+
+

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartB/values.yaml
@@ -22,16 +22,14 @@ exports:
       SCBexported2A: "blaster"
 
 global:
-    kolla:
-        nova:
-            api:
-                all:
-                    port: 8774
-            metadata:
-                all:
-                    port: 8775
-test:
-  dummy: 1
+  kolla:
+    nova:
+      api:
+        all:
+          port: 8774
+      metadata:
+        all:
+          port: 8775
 
 
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
@@ -16,6 +16,9 @@ dependencies:
         repository: http://localhost:10191
         version: 0.1.0
         condition: subchartb.enabled
+        import-values:
+          - convention1
+          - convention2
         tags:
           - front-end
           - subchartb

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
@@ -6,6 +6,12 @@ dependencies:
         tags:
           - front-end
           - subcharta
+        import-values:
+          - child: resources.limits
+            parent: imported-from-chartA.limits
+          - child: resources.requests
+            parent: imported-from-chartA.requests
+
       - name: subchartb
         repository: http://localhost:10191
         version: 0.1.0

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/requirements.yaml
@@ -7,18 +7,26 @@ dependencies:
           - front-end
           - subcharta
         import-values:
-          - child: resources.limits
-            parent: imported-from-chartA.limits
-          - child: resources.requests
-            parent: imported-from-chartA.requests
+          - child: SCAdata
+            parent: imported-chartA
+          - child: SCAdata
+            parent: overridden-chartA
+          - child: SCAdata
+            parent: imported-chartA-B
 
       - name: subchartb
         repository: http://localhost:10191
         version: 0.1.0
         condition: subchartb.enabled
         import-values:
-          - convention1
-          - convention2
+          - child: SCBdata
+            parent: imported-chartB
+          - child: SCBdata
+            parent: imported-chartA-B
+          - child: exports.SCBexported2
+            parent: exports.SCBexported2
+          - SCBexported1
+
         tags:
           - front-end
           - subchartb

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
@@ -48,8 +48,8 @@ SCBexported1A:
   SC1extra7: true
 
 exports:
-    SC1exported1:
-      global:
-        SC1exported2:
-          all:
-            SC1exported3: "SC1expstr"
+  SC1exported1:
+    global:
+      SC1exported2:
+        all:
+          SC1exported3: "SC1expstr"

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
@@ -1,6 +1,7 @@
 # Default values for subchart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+# subchart1
 replicaCount: 1
 image:
   repository: nginx
@@ -13,9 +14,11 @@ service:
   internalPort: 80
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 200m
+    memory: 200Mi
+    plasticity: 0
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 250m
+    memory: 250Mi
+    truthiness: 200
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
@@ -21,4 +21,7 @@ resources:
     cpu: 250m
     memory: 250Mi
     truthiness: 200
+exports:
+  convention3:
+    parent1c3: true
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
@@ -2,26 +2,54 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 # subchart1
-replicaCount: 1
-image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
 service:
   name: nginx
   type: ClusterIP
   externalPort: 80
   internalPort: 80
-resources:
-  limits:
-    cpu: 200m
-    memory: 200Mi
-    plasticity: 0
-  requests:
-    cpu: 250m
-    memory: 250Mi
-    truthiness: 200
-exports:
-  convention3:
-    parent1c3: true
 
+
+SC1data:
+  SC1bool: true
+  SC1float: 3.14
+  SC1int: 100
+  SC1string: "dollywood"
+  SC1extra1: 11
+
+imported-chartA:
+  SC1extra2: 1.337
+
+overridden-chartA:
+  SCAbool: true
+  SCAfloat: 3.14
+  SCAint: 100
+  SCAstring: "jabathehut"
+  SC1extra3: true
+
+imported-chartA-B:
+  SC1extra5: "tiller"
+
+overridden-chartA-B:
+  SCAbool: true
+  SCAfloat: 3.33
+  SCAint: 555
+  SCAstring: "wormwood"
+  SCAextra1: 23
+
+  SCBbool: true
+  SCBfloat: 0.25
+  SCBint: 98
+  SCBstring: "murkwood"
+  SCBextra1: 13
+
+  SC1extra6: 77
+
+SCBexported1A:
+  SC1extra7: true
+
+exports:
+    SC1exported1:
+      global:
+        SC1exported2:
+          all:
+            SC1exported3: "SC1expstr"

--- a/pkg/chartutil/testdata/subpop/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/requirements.yaml
@@ -11,6 +11,12 @@ dependencies:
             parent: imported-from-chart1
           - child: imported-from-chartA
             parent: imported-from-chartA-via-chart1
+          - convention3
+          # this merges chartb "shares" into charta "limits"
+          - child: resources.limits
+            parent: imported-from-chartA-via-chart1.resources.limits
+          - child: data
+            parent: imported-from-chartB-via-chart1
       - name: subchart2
         repository: http://localhost:10191
         version: 0.1.0

--- a/pkg/chartutil/testdata/subpop/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/requirements.yaml
@@ -7,16 +7,21 @@ dependencies:
           - front-end
           - subchart1
         import-values:
-          - child: service
-            parent: imported-from-chart1
-          - child: imported-from-chartA
-            parent: imported-from-chartA-via-chart1
-          - convention3
-          # this merges chartb "shares" into charta "limits"
-          - child: resources.limits
-            parent: imported-from-chartA-via-chart1.resources.limits
-          - child: data
-            parent: imported-from-chartB-via-chart1
+          - child: SC1data
+            parent: imported-chart1
+          - child: SC1data
+            parent: overridden-chart1
+          - child: imported-chartA
+            parent: imported-chartA
+          - child: imported-chartA-B
+            parent: imported-chartA-B
+          - child: overridden-chartA-B
+            parent: overridden-chartA-B
+          - child: SCBexported1A
+            parent: .
+          - SCBexported2
+          - SC1exported1
+
       - name: subchart2
         repository: http://localhost:10191
         version: 0.1.0

--- a/pkg/chartutil/testdata/subpop/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/requirements.yaml
@@ -6,6 +6,11 @@ dependencies:
         tags:
           - front-end
           - subchart1
+        import-values:
+          - child: service
+            parent: imported-from-chart1
+          - child: imported-from-chartA
+            parent: imported-from-chartA-via-chart1
       - name: subchart2
         repository: http://localhost:10191
         version: 0.1.0

--- a/pkg/chartutil/testdata/subpop/values.yaml
+++ b/pkg/chartutil/testdata/subpop/values.yaml
@@ -1,6 +1,20 @@
 # parent/values.yaml
 
 # switch-like
+imported-from-chart1:
+  name: bathtubginx
+  type: None
+  externalPort: 25
+  notimported1: 1
+
+imported-from-chartA-via-chart1:
+  limits:
+    cpu: 100m
+    memory: 100Mi
+    notimported2: 100
+  requests:
+    truthiness: 33.3
+
 tags:
   front-end: true
   back-end: false

--- a/pkg/chartutil/testdata/subpop/values.yaml
+++ b/pkg/chartutil/testdata/subpop/values.yaml
@@ -1,19 +1,39 @@
 # parent/values.yaml
 
-# switch-like
-imported-from-chart1:
-  name: bathtubginx
-  type: None
-  externalPort: 25
-  notimported1: 1
+imported-chart1:
+  SPextra1: "helm rocks"
 
-imported-from-chartA-via-chart1:
-  limits:
-    cpu: 100m
-    memory: 100Mi
-    notimported2: 100
-  requests:
-    truthiness: 33.3
+overridden-chart1:
+  SC1bool: false
+  SC1float: 3.141592
+  SC1int: 99
+  SC1string: "pollywog"
+  SPextra2: 42
+
+
+imported-chartA:
+  SPextra3: 1.337
+
+overridden-chartA:
+  SCAbool: true
+  SCAfloat: 41.3
+  SCAint: 808
+  SCAstring: "jaberwocky"
+  SPextra4: true
+
+imported-chartA-B:
+  SPextra5: "k8s"
+
+overridden-chartA-B:
+  SCAbool: true
+  SCAfloat: 41.3
+  SCAint: 808
+  SCAstring: "jaberwocky"
+  SCBbool: false
+  SCBfloat: 1.99
+  SCBint: 77
+  SCBstring: "jango"
+  SPextra6: 111
 
 tags:
   front-end: true

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -97,6 +97,10 @@ func (h *Client) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...
 	if err != nil {
 		return nil, err
 	}
+	err = chartutil.ProcessRequirementsImportValues(req.Chart, req.Values)
+	if err != nil {
+		return nil, err
+	}
 
 	return h.install(ctx, req)
 }
@@ -163,6 +167,10 @@ func (h *Client) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts
 		}
 	}
 	err := chartutil.ProcessRequirementsEnabled(req.Chart, req.Values)
+	if err != nil {
+		return nil, err
+	}
+	err = chartutil.ProcessRequirementsImportValues(req.Chart, req.Values)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -141,7 +141,7 @@ func TestResolve(t *testing.T) {
 }
 
 func TestHashReq(t *testing.T) {
-	expect := "sha256:c8250374210bd909cef274be64f871bd4e376d4ecd34a1589b5abf90b68866ba"
+	expect := "sha256:1feffe2016ca113f64159d91c1f77d6a83bcd23510b171d9264741bf9d63f741"
 	req := &chartutil.Requirements{
 		Dependencies: []*chartutil.Dependency{
 			{Name: "alpine", Version: "0.1.0", Repository: "http://localhost:8879/charts"},


### PR DESCRIPTION
Implements a mechanism in requirements.yaml to allow the import
and re-parenting of value table from child chart.

Closes #1995