### PR TITLE
fix(tiller): enforce release name length on uninstall

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -31,6 +32,7 @@ import (
 	kberrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kblabels "k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/validation"
 
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 )
@@ -119,6 +121,9 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 func (cfgmaps *ConfigMaps) Query(labels map[string]string) ([]*rspb.Release, error) {
 	ls := kblabels.Set{}
 	for k, v := range labels {
+		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
+			return nil, fmt.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
+		}
 		ls[k] = v
 	}
 

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -957,6 +957,10 @@ func (s *ReleaseServer) UninstallRelease(c ctx.Context, req *services.UninstallR
 		return nil, errMissingRelease
 	}
 
+	if len(req.Name) > releaseNameMaxLen {
+		return nil, fmt.Errorf("release name %q exceeds max length of %d", req.Name, releaseNameMaxLen)
+	}
+
 	rels, err := s.env.Releases.History(req.Name)
 	if err != nil {
 		log.Printf("uninstall: Release not loaded: %s", req.Name)


### PR DESCRIPTION
If a selector is created from invalid values it will return nil.

Which is EVERYTHING!!!

closes: #2115