### PR TITLE
ref/installer: pass arguments in options struct to installer apis

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -143,12 +143,13 @@ func (i *initCmd) run() error {
 			}
 			i.kubeClient = c
 		}
-		if err := installer.Install(i.kubeClient, i.namespace, i.image, i.canary, flagDebug); err != nil {
+		opts := &installer.Options{Namespace: i.namespace, ImageSpec: i.image, UseCanary: i.canary}
+		if err := installer.Install(i.kubeClient, opts); err != nil {
 			if !kerrors.IsAlreadyExists(err) {
 				return fmt.Errorf("error installing: %s", err)
 			}
 			if i.upgrade {
-				if err := installer.Upgrade(i.kubeClient, i.namespace, i.image, i.canary); err != nil {
+				if err := installer.Upgrade(i.kubeClient, opts); err != nil {
 					return fmt.Errorf("error when upgrading: %s", err)
 				}
 				fmt.Fprintln(i.out, "\nTiller (the helm server side component) has been upgraded to the current version.")

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -45,7 +45,6 @@ func TestDeploymentManifest(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		o, err := DeploymentManifest(api.NamespaceDefault, tt.image, tt.canary)
 		if err != nil {
 			t.Fatalf("%s: error %q", tt.name, err)
@@ -109,7 +108,8 @@ func TestInstall(t *testing.T) {
 		return true, obj, nil
 	})
 
-	if err := Install(fc, api.NamespaceDefault, image, false, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault, ImageSpec: image}
+	if err := Install(fc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 
@@ -133,7 +133,8 @@ func TestInstall_canary(t *testing.T) {
 		return true, obj, nil
 	})
 
-	if err := Install(fc, api.NamespaceDefault, "", true, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault, UseCanary: true}
+	if err := Install(fc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 
@@ -164,7 +165,8 @@ func TestUpgrade(t *testing.T) {
 		return true, existingService, nil
 	})
 
-	if err := Upgrade(fc, api.NamespaceDefault, image, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault, ImageSpec: image}
+	if err := Upgrade(fc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 
@@ -202,7 +204,8 @@ func TestUpgrade_serviceNotFound(t *testing.T) {
 		return true, obj, nil
 	})
 
-	if err := Upgrade(fc, api.NamespaceDefault, image, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault, ImageSpec: image}
+	if err := Upgrade(fc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 

--- a/cmd/helm/installer/options.go
+++ b/cmd/helm/installer/options.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+// Options control how to install tiller into a cluster, upgrade, and uninstall tiller from a cluster.
+type Options struct {
+	// EnableTLS instructs tiller to serve with TLS enabled.
+	//
+	// Implied by VerifyTLS. If set the TLSKey and TLSCert are required.
+	EnableTLS bool
+
+	// VerifyTLS instructs tiller to serve with TLS enabled verify remote certificates.
+	//
+	// If set TLSKey, TLSCert, TLSCaCert are required.
+	VerifyTLS bool
+
+	// UseCanary indicates that tiller should deploy using the latest tiller image.
+	UseCanary bool
+
+	// Namespace is the kubernetes namespace to use to deploy tiller.
+	Namespace string
+
+	// ImageSpec indentifies the image tiller will use when deployed.
+	//
+	// Valid if and only if UseCanary is false.
+	ImageSpec string
+
+	// TLSKeyFile identifies the file containing the pem encoded TLS private
+	// key tiller should use.
+	//
+	// Required and valid if and only if EnableTLS or VerifyTLS is set.
+	TLSKey string
+
+	// TLSCertFile identifies the file containing the pem encoded TLS
+	// certificate tiller should use.
+	//
+	// Required and valid if and only if EnableTLS or VerifyTLS is set.
+	TLSCertFile string
+
+	// TLSCaCertFile identifies the file containing the pem encoded TLS CA
+	// certificate tiller should use to verify remotes certificates.
+	//
+	// Required and valid if and only if VerifyTLS is set.
+	TLSCaCertFile string
+}

--- a/cmd/helm/installer/uninstall.go
+++ b/cmd/helm/installer/uninstall.go
@@ -31,19 +31,19 @@ import (
 )
 
 // Uninstall uses kubernetes client to uninstall tiller
-func Uninstall(kubeClient internalclientset.Interface, kubeCmd *kube.Client, namespace string, verbose bool) error {
-	if _, err := kubeClient.Core().Services(namespace).Get("tiller-deploy"); err != nil {
+func Uninstall(kubeClient internalclientset.Interface, kubeCmd *kube.Client, opts *Options) error {
+	if _, err := kubeClient.Core().Services(opts.Namespace).Get("tiller-deploy"); err != nil {
 		if !kerrors.IsNotFound(err) {
 			return err
 		}
-	} else if err := deleteService(kubeClient.Core(), namespace); err != nil {
+	} else if err := deleteService(kubeClient.Core(), opts.Namespace); err != nil {
 		return err
 	}
-	if obj, err := kubeClient.Extensions().Deployments(namespace).Get("tiller-deploy"); err != nil {
+	if obj, err := kubeClient.Extensions().Deployments(opts.Namespace).Get("tiller-deploy"); err != nil {
 		if !kerrors.IsNotFound(err) {
 			return err
 		}
-	} else if err := deleteDeployment(kubeCmd, namespace, obj); err != nil {
+	} else if err := deleteDeployment(kubeCmd, opts.Namespace, obj); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/helm/installer/uninstall_test.go
+++ b/cmd/helm/installer/uninstall_test.go
@@ -73,7 +73,8 @@ func TestUninstall(t *testing.T) {
 	rf := &fakeReaperFactory{Factory: f, reaper: r}
 	kc := &kube.Client{Factory: rf}
 
-	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault}
+	if err := Uninstall(fc, kc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 
@@ -106,7 +107,8 @@ func TestUninstall_serviceNotFound(t *testing.T) {
 	rf := &fakeReaperFactory{Factory: f, reaper: r}
 	kc := &kube.Client{Factory: rf}
 
-	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault}
+	if err := Uninstall(fc, kc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 
@@ -142,7 +144,8 @@ func TestUninstall_deploymentNotFound(t *testing.T) {
 	rf := &fakeReaperFactory{Factory: f, reaper: r}
 	kc := &kube.Client{Factory: rf}
 
-	if err := Uninstall(fc, kc, api.NamespaceDefault, false); err != nil {
+	opts := &Options{Namespace: api.NamespaceDefault}
+	if err := Uninstall(fc, kc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}
 

--- a/cmd/helm/reset.go
+++ b/cmd/helm/reset.go
@@ -104,7 +104,7 @@ func (d *resetCmd) run() error {
 		return fmt.Errorf("There are still %d deployed releases (Tip: use --force).", len(res.Releases))
 	}
 
-	if err := installer.Uninstall(d.kubeClient, d.kubeCmd, d.namespace, flagDebug); err != nil {
+	if err := installer.Uninstall(d.kubeClient, d.kubeCmd, &installer.Options{Namespace: d.namespace}); err != nil {
 		return fmt.Errorf("error unstalling Tiller: %s", err)
 	}
 


### PR DESCRIPTION
As new infrastructure surrounding tiller is introduced we should move to a more flexible idiom for passing arguments to the installer apis. This PR introduces an Options struct to do so.