### PR TITLE
fix(helm): add 'skip-refresh' flag to 'helm init'

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -62,16 +62,17 @@ const (
 )
 
 type initCmd struct {
-	image      string
-	clientOnly bool
-	canary     bool
-	upgrade    bool
-	namespace  string
-	dryRun     bool
-	out        io.Writer
-	home       helmpath.Home
-	opts       installer.Options
-	kubeClient internalclientset.Interface
+	image       string
+	clientOnly  bool
+	canary      bool
+	upgrade     bool
+	namespace   string
+	dryRun      bool
+	skipRefresh bool
+	out         io.Writer
+	home        helmpath.Home
+	opts        installer.Options
+	kubeClient  internalclientset.Interface
 }
 
 func newInitCmd(out io.Writer) *cobra.Command {
@@ -99,6 +100,7 @@ func newInitCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&i.upgrade, "upgrade", false, "upgrade if tiller is already installed")
 	f.BoolVarP(&i.clientOnly, "client-only", "c", false, "if set does not install tiller")
 	f.BoolVar(&i.dryRun, "dry-run", false, "do not install local or remote")
+	f.BoolVar(&i.skipRefresh, "skip-refresh", false, "do not refresh (download) the local repository cache")
 
 	// f.BoolVar(&tlsEnable, "tiller-tls", false, "install tiller with TLS enabled")
 	// f.BoolVar(&tlsVerify, "tiller-tls-verify", false, "install tiller with TLS enabled and to verify remote certificates")
@@ -176,7 +178,7 @@ func (i *initCmd) run() error {
 	if err := ensureDirectories(i.home, i.out); err != nil {
 		return err
 	}
-	if err := ensureDefaultRepos(i.home, i.out); err != nil {
+	if err := ensureDefaultRepos(i.home, i.out, i.skipRefresh); err != nil {
 		return err
 	}
 	if err := ensureRepoFileFormat(i.home.RepositoryFile(), i.out); err != nil {
@@ -242,12 +244,12 @@ func ensureDirectories(home helmpath.Home, out io.Writer) error {
 	return nil
 }
 
-func ensureDefaultRepos(home helmpath.Home, out io.Writer) error {
+func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) error {
 	repoFile := home.RepositoryFile()
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewRepoFile()
-		sr, err := initStableRepo(home.CacheIndex(stableRepository))
+		sr, err := initStableRepo(home.CacheIndex(stableRepository), skipRefresh)
 		if err != nil {
 			return err
 		}
@@ -266,7 +268,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer) error {
 	return nil
 }
 
-func initStableRepo(cacheFile string) (*repo.Entry, error) {
+func initStableRepo(cacheFile string, skipRefresh bool) (*repo.Entry, error) {
 	c := repo.Entry{
 		Name:  stableRepository,
 		URL:   stableRepositoryURL,
@@ -275,6 +277,10 @@ func initStableRepo(cacheFile string) (*repo.Entry, error) {
 	r, err := repo.NewChartRepository(&c)
 	if err != nil {
 		return nil, err
+	}
+
+	if skipRefresh {
+		return &c, nil
 	}
 
 	// In this case, the cacheFile is always absolute. So passing empty string

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -179,7 +179,10 @@ func TestEnsureHome(t *testing.T) {
 	if err := ensureDirectories(hh, b); err != nil {
 		t.Error(err)
 	}
-	if err := ensureDefaultRepos(hh, b); err != nil {
+	if err := ensureDefaultRepos(hh, b, false); err != nil {
+		t.Error(err)
+	}
+	if err := ensureDefaultRepos(hh, b, true); err != nil {
 		t.Error(err)
 	}
 	if err := ensureRepoFileFormat(hh.RepositoryFile(), b); err != nil {

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -161,7 +161,6 @@ func (r *ChartRepository) DownloadIndexFile(cachePath string) error {
 	if !filepath.IsAbs(cp) {
 		cp = filepath.Join(cachePath, cp)
 	}
-	println("Writing to", cp)
 
 	return ioutil.WriteFile(cp, index, 0644)
 }


### PR DESCRIPTION
This exposes the skip-refresh flag to helm init to make it possible to
initialize Helm without fetching the index.yaml of the stable repo.
This mirrors the behavior of 'helm dep up's skip-refresh flag.

Closes #2127