### PR TITLE
Detect if tiller is running in hosted mode for Helm commands.

### DIFF
--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -57,11 +57,11 @@ func TestInitCmd(t *testing.T) {
 	if len(actions) != 2 {
 		t.Errorf("Expected 2 actions, got %d", len(actions))
 	}
-	if !actions[0].Matches("create", "deployments") {
-		t.Errorf("unexpected action: %v, expected create deployment", actions[0])
+	if !actions[0].Matches("create", "services") {
+		t.Errorf("unexpected action: %v, expected create service", actions[0])
 	}
-	if !actions[1].Matches("create", "services") {
-		t.Errorf("unexpected action: %v, expected create service", actions[1])
+	if !actions[1].Matches("create", "deployments") {
+		t.Errorf("unexpected action: %v, expected create deployment", actions[1])
 	}
 	expected := "Tiller (the helm server side component) has been installed into your Kubernetes Cluster."
 	if !strings.Contains(buf.String(), expected) {


### PR DESCRIPTION
Partially addresses https://github.com/kubernetes/helm/issues/2124

What is done?
- `helm init` will create the service before deployment. This will result in error for clusters using hosted tiller and will avoid installing the deployment.
- Upgrade will ignore if hosted tiller is used.
- Uninstall works as before. So, users will be able to uninstall a hosted tiller and do a helm init to run tiller in incluster mode.
- `setupConnection` will use the `externalName` if it detects the hosted mode tiller and will not open the tunnel.

I am assuming that cluster operators (like AppsCode) will create the Tiller service in the default Tiller namespace when a cluster is provisioned. `helm init` only installs tiller in incluster mode.

What's next:
- Once this pr is merged, my pr for tiller auth will send kube api server host address in header to Tiller if `usesHostedTiller` is true.

cc: @technosophos @adamreese 