### PR TITLE
fix(helm): add --destination flag to 'helm package'

### DIFF
--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -95,6 +95,20 @@ func TestPackage(t *testing.T) {
 			hasfile: "alpine-0.1.0.tgz",
 		},
 		{
+			name:    "package --destination toot",
+			args:    []string{"testdata/testcharts/alpine"},
+			flags:   map[string]string{"destination": "toot"},
+			expect:  "",
+			hasfile: "toot/alpine-0.1.0.tgz",
+		},
+		{
+			name:   "package --destination does-not-exist",
+			args:   []string{"testdata/testcharts/alpine"},
+			flags:  map[string]string{"destination": "does-not-exist"},
+			expect: "stat does-not-exist: no such file or directory",
+			err:    true,
+		},
+		{
 			name:    "package --sign --key=KEY --keyring=KEYRING testdata/testcharts/alpine",
 			args:    []string{"testdata/testcharts/alpine"},
 			flags:   map[string]string{"sign": "1", "keyring": "testdata/helm-test-key.secret", "key": "helm-test"},
@@ -121,6 +135,10 @@ func TestPackage(t *testing.T) {
 
 	t.Logf("Running tests in %s", tmp)
 	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir("toot", 0777); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This adds a flag similar to the --destination flag on 'helm fetch',
allowing control over the destination for the packaged .tgz file.

Closes #2117