### PR TITLE
feat(tiller): Stage 1 of new logging method

### DIFF
--- a/cmd/tiller/trace.go
+++ b/cmd/tiller/trace.go
@@ -17,17 +17,15 @@ limitations under the License.
 package main // import "k8s.io/helm/cmd/tiller"
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 
 	_ "net/http/pprof"
 
+	log "github.com/Sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 
 func startTracing(addr string) {
-	fmt.Printf("Tracing server is listening on %s\n", addr)
 	grpc.EnableTracing = true
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -41,9 +39,18 @@ func startTracing(addr string) {
 
 	go func() {
 		if err := http.ListenAndServe(addr, nil); err != nil {
-			log.Printf("tracing error: %s", err)
+			logger.WithFields(log.Fields{
+				"_module":  "trace",
+				"_context": "startTracing",
+				"error":    err,
+			}).Error("Tracing error")
 		}
 	}()
+	logger.WithFields(log.Fields{
+		"_module":  "trace",
+		"_context": "startTracing",
+		"address":  addr,
+	}).Info("Tracing server listening")
 }
 
 const traceIndexHTML = `<!DOCTYPE html>

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0d1c5b7304a853820dcaa296d3aa1f5f3466a8491dcef80cbcaf43c954acb2a8
-updated: 2017-03-20T15:26:55.446524716-07:00
+hash: 944effe504b921cc01b37b067b1739644c36eeda78a203f7d4cb6cc0eb2a0104
+updated: 2017-03-22T11:59:05.374528386-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -99,7 +99,7 @@ imports:
 - name: github.com/facebookgo/symwalk
   version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/ghodss/yaml
-  version: 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -186,7 +186,7 @@ imports:
 - name: github.com/Masterminds/sprig
   version: 23597e5f6ad0e4d590e71314bfd0251a4a3cf849
 - name: github.com/mattn/go-runewidth
-  version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
+  version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/mitchellh/go-wordwrap
   version: ad45545899c7b13c020ea92b2072220eefad42b8
 - name: github.com/naoina/go-stringutil
@@ -208,7 +208,7 @@ imports:
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - name: github.com/Sirupsen/logrus
-  version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/cobra
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
   subpackages:
@@ -216,7 +216,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/technosophos/moniker
-  version: ab470f5e105a44d0c87ea21bacd6a335c4816d83
+  version: 9f956786b91d9786ca11aa5be6104542fa911546
 - name: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
@@ -298,9 +298,9 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: k8s.io/kubernetes
-  version: 00a1fb254bd8e5235575fba1398b958943e39078
+  version: 894ff23729bbc0055907dd3a496afb725396adda
   subpackages:
   - cmd/kubeadm/app/apis/kubeadm
   - cmd/kubeadm/app/apis/kubeadm/install
@@ -510,5 +510,3 @@ testImports:
   version: e3a8ff8ce36581f87a15341206f205b1da467059
   subpackages:
   - assert
-  - mock
-  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -69,3 +69,5 @@ import:
   version: ~0.1.0
 - package: github.com/naoina/go-stringutil
   version: ~0.1.0
+- package: github.com/Sirupsen/logrus
+  version: ~0.11.5

--- a/pkg/kube/namespace.go
+++ b/pkg/kube/namespace.go
@@ -17,12 +17,18 @@ limitations under the License.
 package kube // import "k8s.io/helm/pkg/kube"
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
 func createNamespace(client internalclientset.Interface, namespace string) error {
+	logger.WithFields(log.Fields{
+		"_module":   "namespace",
+		"_context":  "createNamespace",
+		"namespace": namespace,
+	}).Debug("Creating new namespace")
 	ns := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			Name: namespace,
@@ -37,8 +43,18 @@ func getNamespace(client internalclientset.Interface, namespace string) (*api.Na
 }
 
 func ensureNamespace(client internalclientset.Interface, namespace string) error {
+	logger.WithFields(log.Fields{
+		"_module":   "namespace",
+		"_context":  "ensureNamespace",
+		"namespace": namespace,
+	}).Debug("Ensuring that namespace exists")
 	_, err := getNamespace(client, namespace)
 	if err != nil && errors.IsNotFound(err) {
+		logger.WithFields(log.Fields{
+			"_module":   "namespace",
+			"_context":  "ensureNamespace",
+			"namespace": namespace,
+		}).Debug("Namespace does not exist, creating")
 		return createNamespace(client, namespace)
 	}
 	return err

--- a/pkg/logutil/log.go
+++ b/pkg/logutil/log.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logutil
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// LogLevels is the mapping for
+var LogLevels = map[string]log.Level{
+	"ERROR": log.ErrorLevel,
+	"INFO":  log.InfoLevel,
+	"DEBUG": log.DebugLevel,
+}
+
+// GetLevel returns the proper logrus level for the given string level.
+// It returns an error if the level does not exist
+func GetLevel(level string) (log.Level, error) {
+	var logLevel log.Level
+	var ok bool
+	if logLevel, ok = LogLevels[level]; !ok {
+		return 0, fmt.Errorf("Invalid log level %s given. Must be one of: %s", level, strings.Join(GetLogLevels(), ", "))
+	}
+	return logLevel, nil
+
+}
+
+// GetLogLevels returns a list of allowed log levels. Helpful for error messages.
+func GetLogLevels() []string {
+	var levels []string
+	for k := range LogLevels {
+		levels = append(levels, k)
+	}
+	return levels
+}

--- a/pkg/logutil/log_test.go
+++ b/pkg/logutil/log_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2017 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,24 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube
+package logutil
 
 import (
-	"flag"
-	"fmt"
-	"os"
-
-	log "github.com/Sirupsen/logrus"
+	"testing"
 )
 
-var logger *log.Entry
-
-func init() {
-	if level := os.Getenv("KUBE_LOG_LEVEL"); level != "" {
-		flag.Set("vmodule", fmt.Sprintf("loader=%s,round_trippers=%s,request=%s", level, level, level))
-		flag.Set("logtostderr", "true")
+func TestValidGetLevel(t *testing.T) {
+	_, err := GetLevel("ERROR")
+	if err != nil {
+		t.Errorf("Should have gotten valid log level. Got error instead: %v", err)
 	}
-	logger = log.WithFields(log.Fields{
-		"_package": "kube",
-	})
+}
+
+func TestInvalidGetLevel(t *testing.T) {
+	logLevel, err := GetLevel("BLAH")
+	if err == nil {
+		t.Errorf("Should have gotten error. Got log level instead: %v", logLevel)
+	}
 }


### PR DESCRIPTION
This is the first part of what will be several PRs to better the logging on Tiller. This adds a `--log-level` flag with 3 configurable levels for Tiller and adds logging for the `main` and `kube` packages.

To avoid creating one giant PR and to allow for feedback on the logging methodology before doing it to everything, this only introduces the changes to the aforementioned packages. 1 or 2 follow up PRs will add the new logging method to all Tiller components and add documentation.