### PR TITLE
fix(helm): Don't assume index.yaml is sorted

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -243,6 +243,7 @@ func loadIndex(data []byte) (*IndexFile, error) {
 	if err := yaml.Unmarshal(data, i); err != nil {
 		return i, err
 	}
+	i.SortEntries()
 	if i.APIVersion == "" {
 		// When we leave Beta, we should remove legacy support and just
 		// return this error:

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	testfile = "testdata/local-index.yaml"
+	testfile          = "testdata/local-index.yaml"
 	unorderedTestfile = "testdata/local-index-unordered.yaml"
-	testRepo = "test-repo"
+	testRepo          = "test-repo"
 )
 
 func TestIndexFile(t *testing.T) {

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	testfile = "testdata/local-index.yaml"
+	unorderedTestfile = "testdata/local-index-unordered.yaml"
 	testRepo = "test-repo"
 )
 
@@ -76,6 +77,18 @@ func TestLoadIndex(t *testing.T) {
 
 func TestLoadIndexFile(t *testing.T) {
 	i, err := LoadIndexFile(testfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifyLocalIndex(t, i)
+}
+
+func TestLoadUnorderedIndex(t *testing.T) {
+	b, err := ioutil.ReadFile(unorderedTestfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	i, err := loadIndex(b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/repo/testdata/local-index-unordered.yaml
+++ b/pkg/repo/testdata/local-index-unordered.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+      name: nginx
+      description: string
+      version: 0.1.0
+      home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+  alpine:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+      name: alpine
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      keywords:
+        - linux
+        - alpine
+        - small
+        - sumtin
+      digest: "sha256:1234567890abcdef"


### PR DESCRIPTION
This change sorts the helm index file after downloading from a repo.

Closes #2186