### PR TITLE
fix(helm): manifests string parsing works for newlines in the manifests

### DIFF
--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -40,7 +40,9 @@ func SplitManifests(bigfile string) map[string]string {
 	sep := "\n---\n"
 	tpl := "manifest-%d"
 	res := map[string]string{}
-	tmp := strings.Split(bigfile, sep)
+	// Making sure yaml formatting doesn't matter when generating manifest from string.
+	bigFileTmp := strings.TrimSpace(bigfile)
+	tmp := strings.Split(bigFileTmp, sep)
 	for i, d := range tmp {
 		res[fmt.Sprintf(tpl, i)] = d
 	}


### PR DESCRIPTION
Now new line such as:
```
(blank line)
---
apiVersion: v1
kind: Pod
metadata:
  name: "keystone-tempest-test"
  annotations:
    "helm.sh/hook": test-success
spec:
  containers:
...
```
doesn't return a whitespace when parsing through the manifest string.

Trying to fix #2158