### PR TITLE
fix(helm): manifests string parsing works for newlines in the manifests

### DIFF
--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -35,7 +35,6 @@ var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 
 // SplitManifests takes a string of manifest and returns a map contains individual manifests
 func SplitManifests(bigfile string) map[string]string {
-	// This is not the best way of doing things, but it's how k8s itself does it.
 	// Basically, we're quickly splitting a stream of YAML documents into an
 	// array of YAML docs. In the current implementation, the file name is just
 	// a place holder, and doesn't have any further meaning.

--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -19,7 +19,6 @@ package releaseutil
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 // SimpleHead defines what the structure of the head of a manifest file

--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -40,7 +40,9 @@ func SplitManifests(bigfile string) map[string]string {
 	sep := "\n---\n"
 	tpl := "manifest-%d"
 	res := map[string]string{}
-	tmp := strings.Split(bigfile, sep)
+	// Making sure yaml formatting doesn't matter when generating manifest from string.
+	bigFileTmp := strings.TrimSpace(bigfile)
+	tmp := strings.Split(bigFileTmp, sep)
 	for i, d := range tmp {
 		res[fmt.Sprintf(tpl, i)] = d
 	}

--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -32,19 +32,19 @@ type SimpleHead struct {
 	} `json:"metadata,omitempty"`
 }
 
+var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+
 // SplitManifests takes a string of manifest and returns a map contains individual manifests
 func SplitManifests(bigfile string) map[string]string {
 	// This is not the best way of doing things, but it's how k8s itself does it.
 	// Basically, we're quickly splitting a stream of YAML documents into an
 	// array of YAML docs. In the current implementation, the file name is just
 	// a place holder, and doesn't have any further meaning.
-	sep := regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 	tpl := "manifest-%d"
 	res := map[string]string{}
-	// Making sure YAML formatting doesn't matter when generating manifest from string.
-	bigFileTmp := strings.TrimSpace(bigfile)
-	tmp := sep.Split(bigFileTmp, -1)
-	for i, d := range tmp {
+	// Making sure that any extra whitespace in YAML stream doesn't interfere in splitting documents correctly.
+	docs := sep.Split(bigfile, -1)
+	for i, d := range docs {
 		res[fmt.Sprintf(tpl, i)] = d
 	}
 	return res

--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -18,6 +18,7 @@ package releaseutil
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -37,12 +38,12 @@ func SplitManifests(bigfile string) map[string]string {
 	// Basically, we're quickly splitting a stream of YAML documents into an
 	// array of YAML docs. In the current implementation, the file name is just
 	// a place holder, and doesn't have any further meaning.
-	sep := "\n---\n"
+	sep := regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 	tpl := "manifest-%d"
 	res := map[string]string{}
-	// Making sure yaml formatting doesn't matter when generating manifest from string.
+	// Making sure YAML formatting doesn't matter when generating manifest from string.
 	bigFileTmp := strings.TrimSpace(bigfile)
-	tmp := strings.Split(bigFileTmp, sep)
+	tmp := sep.Split(bigFileTmp, -1)
 	for i, d := range tmp {
 		res[fmt.Sprintf(tpl, i)] = d
 	}


### PR DESCRIPTION
Now new line such as:
```
(blank line)
---
apiVersion: v1
kind: Pod
metadata:
  name: "keystone-tempest-test"
  annotations:
    "helm.sh/hook": test-success
spec:
  containers:
...
```
doesn't return a whitespace while parsing through the manifests.

Trying to fix #2158