### PR TITLE
able to build without being in a git repository

### DIFF
--- a/versioning.mk
+++ b/versioning.mk
@@ -1,9 +1,9 @@
 MUTABLE_VERSION ?= canary
 
-GIT_COMMIT := $(shell git rev-parse HEAD)
-GIT_SHA := $(shell git rev-parse --short HEAD)
-GIT_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null)
-GIT_DIRTY = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_SHA ?= $(shell git rev-parse --short HEAD)
+GIT_TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null)
+GIT_DIRTY ?= $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
 ifdef VERSION
 	DOCKER_VERSION = $(VERSION)


### PR DESCRIPTION
**Use case:** for safety reasons one might like to store any external source code dependencies for a project on a private, secure storage, typically git repository snapshots in tgz + version metadata.

**Problem:** Currently it is a requirement to build the helm&tiller binaries in the cloned git repository. This is because various version informations are [fetched](https://github.com/kubernetes/helm/blob/master/versioning.mk#L5) from the git history. The thing is that the build even succeed without git repo, but at runtime it will fail with version mismatch as nothing was compiled into the binaries:
```
Error: client version is incompatible
```

**Solution:** Actually if you provide the necessary data to ```make bootstrap```, it solves the problem already now:
```
make GIT_TAG=v2.2.0 GIT_SHA=deadbeef GIT_COMMIT=deadbeef GIT_DIRTY=clean bootstrap build
```
However it prints the git error messages, which is not optimal, actually it shall make the compilation fail. The real solution would be to get conditional assignements in the versioning.mk file, so it somehow would be officially tolerated if user wants to supply metadata by hand.
