### PR TITLE
Add more object kinds to sorted installation order

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -24,8 +24,12 @@ import (
 type SortOrder []string
 
 // InstallOrder is the order in which manifests should be installed (by Kind).
+//
+// Those occurring earlier in the list get installed before those occurring later in the list.
 var InstallOrder SortOrder = []string{
 	"Namespace",
+	"ResourceQuota",
+	"LimitRange",
 	"Secret",
 	"ConfigMap",
 	"PersistentVolume",
@@ -36,32 +40,42 @@ var InstallOrder SortOrder = []string{
 	"Role",
 	"RoleBinding",
 	"Service",
+	"DaemonSet",
 	"Pod",
 	"ReplicationController",
+	"ReplicaSet",
 	"Deployment",
-	"DaemonSet",
-	"Ingress",
+	"StatefulSet",
 	"Job",
+	"CronJob",
+	"Ingress",
 }
 
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
+//
+// Those occurring earlier in the list get uninstalled before those occurring later in the list.
 var UninstallOrder SortOrder = []string{
+	"Ingress",
 	"Service",
-	"Pod",
-	"ReplicationController",
+	"CronJob",
+	"Job",
+	"StatefulSet",
 	"Deployment",
+	"ReplicaSet",
+	"ReplicationController",
+	"Pod",
 	"DaemonSet",
-	"ConfigMap",
-	"Secret",
-	"PersistentVolumeClaim",
-	"PersistentVolume",
 	"RoleBinding",
 	"Role",
 	"ClusterRoleBinding",
 	"ClusterRole",
 	"ServiceAccount",
-	"Ingress",
-	"Job",
+	"PersistentVolumeClaim",
+	"PersistentVolume",
+	"ConfigMap",
+	"Secret",
+	"LimitRange",
+	"ResourceQuota",
 	"Namespace",
 }
 

--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -26,12 +26,12 @@ import (
 func TestKindSorter(t *testing.T) {
 	manifests := []manifest{
 		{
-			name:    "m",
+			name:    "i",
 			content: "",
 			head:    &util.SimpleHead{Kind: "ClusterRole"},
 		},
 		{
-			name:    " ",
+			name:    "j",
 			content: "",
 			head:    &util.SimpleHead{Kind: "ClusterRoleBinding"},
 		},
@@ -41,7 +41,17 @@ func TestKindSorter(t *testing.T) {
 			head:    &util.SimpleHead{Kind: "ConfigMap"},
 		},
 		{
-			name:    "k",
+			name:    "u",
+			content: "",
+			head:    &util.SimpleHead{Kind: "CronJob"},
+		},
+		{
+			name:    "n",
+			content: "",
+			head:    &util.SimpleHead{Kind: "DaemonSet"},
+		},
+		{
+			name:    "r",
 			content: "",
 			head:    &util.SimpleHead{Kind: "Deployment"},
 		},
@@ -51,34 +61,84 @@ func TestKindSorter(t *testing.T) {
 			head:    &util.SimpleHead{Kind: "HonkyTonkSet"},
 		},
 		{
-			name:    "s",
+			name:    "v",
+			content: "",
+			head:    &util.SimpleHead{Kind: "Ingress"},
+		},
+		{
+			name:    "t",
 			content: "",
 			head:    &util.SimpleHead{Kind: "Job"},
 		},
 		{
-			name:    "h",
+			name:    "c",
+			content: "",
+			head:    &util.SimpleHead{Kind: "LimitRange"},
+		},
+		{
+			name:    "a",
 			content: "",
 			head:    &util.SimpleHead{Kind: "Namespace"},
 		},
 		{
-			name:    "w",
+			name:    "f",
 			content: "",
-			head:    &util.SimpleHead{Kind: "Role"},
+			head:    &util.SimpleHead{Kind: "PersistentVolume"},
+		},
+		{
+			name:    "g",
+			content: "",
+			head:    &util.SimpleHead{Kind: "PersistentVolumeClaim"},
 		},
 		{
 			name:    "o",
 			content: "",
-			head:    &util.SimpleHead{Kind: "RoleBinding"},
+			head:    &util.SimpleHead{Kind: "Pod"},
 		},
 		{
-			name:    "r",
+			name:    "q",
 			content: "",
-			head:    &util.SimpleHead{Kind: "Service"},
+			head:    &util.SimpleHead{Kind: "ReplicaSet"},
+		},
+		{
+			name:    "p",
+			content: "",
+			head:    &util.SimpleHead{Kind: "ReplicationController"},
+		},
+		{
+			name:    "b",
+			content: "",
+			head:    &util.SimpleHead{Kind: "ResourceQuota"},
+		},
+		{
+			name:    "k",
+			content: "",
+			head:    &util.SimpleHead{Kind: "Role"},
 		},
 		{
 			name:    "l",
 			content: "",
+			head:    &util.SimpleHead{Kind: "RoleBinding"},
+		},
+		{
+			name:    "d",
+			content: "",
+			head:    &util.SimpleHead{Kind: "Secret"},
+		},
+		{
+			name:    "m",
+			content: "",
+			head:    &util.SimpleHead{Kind: "Service"},
+		},
+		{
+			name:    "h",
+			content: "",
 			head:    &util.SimpleHead{Kind: "ServiceAccount"},
+		},
+		{
+			name:    "s",
+			content: "",
+			head:    &util.SimpleHead{Kind: "StatefulSet"},
 		},
 	}
 
@@ -87,11 +147,14 @@ func TestKindSorter(t *testing.T) {
 		order       SortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "helm works!"},
-		{"uninstall", UninstallOrder, "rkeow mlsh!"},
+		{"install", InstallOrder, "abcdefghijklmnopqrstuv!"},
+		{"uninstall", UninstallOrder, "vmutsrqponlkjihgfedcba!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {
+			if got, want := len(test.expected), len(manifests); got != want {
+				t.Fatalf("Expected %d names in order, got %d", want, got)
+			}
 			defer buf.Reset()
 			for _, r := range sortByKind(manifests, test.order) {
 				buf.WriteString(r.name)


### PR DESCRIPTION
Related to #2199 and #2200, address the following Kubernetes object kinds in Tiller's installation and uninstallation order:
- _CronJob_
- _LimitRange_
- _ReplicaSet_
- _ResourceQuota_
- _StatefulSet_

Furthermore, adjust the installation and uninstallation order to better respect likely dependencies. Bare pods remain a difficult one to place properly in both sequences.

I revised the uninstallation order in particular to be more closely symmetric—at least in several of its runs—with the installation order. It is hard to tell how much of the current two sequences are carefully considered, so let me know if you both agree with my proposed order and whether there are comments that we can add to help future maintainers understand what must be left in place. It's really a topological sort of a graph we haven't defined, but there are several such potential sorts of that graph.