### PR TITLE
Separate manifests printed by "helm init" with YAML document boundary markers

### DIFF
--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -156,13 +156,19 @@ func TestInitCmd_dryRun(t *testing.T) {
 	if err := cmd.run(); err != nil {
 		t.Fatal(err)
 	}
-	if len(fc.Actions()) != 0 {
-		t.Error("expected no server calls")
+	if got := len(fc.Actions()); got != 0 {
+		t.Errorf("expected no server calls, got %d", got)
 	}
 
-	var y map[string]interface{}
-	if err := yaml.Unmarshal(buf.Bytes(), &y); err != nil {
-		t.Errorf("Expected parseable YAML, got %q\n\t%s", buf.String(), err)
+	docs := bytes.Split(buf.Bytes(), []byte("\n---"))
+	if got, want := len(docs), 2; got != want {
+		t.Fatalf("Expected document count of %d, got %d", want, got)
+	}
+	for _, doc := range docs {
+		var y map[string]interface{}
+		if err := yaml.Unmarshal(doc, &y); err != nil {
+			t.Errorf("Expected parseable YAML, got %q\n\t%s", doc, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Partially addressing #2181, in order to allow the stream emitted by _helm init --debug_ to be fed back into _kubectl create/apply -f_, use YAML starting and ending document boundary markers instead of blank lines to separate the individual manifests.

Note that _helm init_ will now print an ending document boundary marker after the last manifest, so that a YAML parser will stop reading primary content there and tolerate any comments and whitespace that follows.