### PR TITLE
Replaced InstallRelease with InstallReleaseFromChart in cmd/install.go

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -202,14 +202,17 @@ func (i *installCmd) run() error {
 	}
 
 	// Check chart requirements to make sure all dependencies are present in /charts
-	if c, err := chartutil.Load(i.chartPath); err == nil {
-		if req, err := chartutil.LoadRequirements(c); err == nil {
-			checkDependencies(c, req, i.out)
-		}
+	chartRequested, err := chartutil.Load(i.chartPath)
+	if err != nil {
+		return prettyError(err)
 	}
 
-	res, err := i.client.InstallRelease(
-		i.chartPath,
+	if req, err := chartutil.LoadRequirements(chartRequested); err == nil {
+		checkDependencies(chartRequested, req, i.out)
+	}
+
+	res, err := i.client.InstallReleaseFromChart(
+		chartRequested,
 		i.namespace,
 		helm.ValueOverrides(rawVals),
 		helm.ReleaseName(i.name),


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/2240

`helm install` command was calling chartutil.Load twice,
once from `run` method and
another time from `client.InstallRelease` which is called from `run` method in `cmd/helm/install.go`