### PR TITLE
Added release-name to helm delete error

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -137,7 +137,7 @@ func (u *upgradeCmd) run() error {
 		// So we're stuck doing string matching against the wrapped error, which is nested somewhere
 		// inside of the grpc.rpcError message.
 		_, err := u.client.ReleaseHistory(u.release, helm.WithMaxHistory(1))
-		if err != nil && strings.Contains(err.Error(), driver.ErrReleaseNotFound.Error()) {
+		if err != nil && strings.Contains(err.Error(), driver.ErrReleaseNotFound(u.release).Error()) {
 			fmt.Fprintf(u.out, "Release %q does not exist. Installing it now.\n", u.release)
 			ic := &installCmd{
 				chartPath:    chartPath,

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -70,7 +70,7 @@ func (cfgmaps *ConfigMaps) Get(key string) (*rspb.Release, error) {
 	obj, err := cfgmaps.impl.Get(key)
 	if err != nil {
 		if kberrs.IsNotFound(err) {
-			return nil, ErrReleaseNotFound
+			return nil, ErrReleaseNotFound(key)
 		}
 
 		logerrf(err, "get: failed to get %q", key)
@@ -136,7 +136,7 @@ func (cfgmaps *ConfigMaps) Query(labels map[string]string) ([]*rspb.Release, err
 	}
 
 	if len(list.Items) == 0 {
-		return nil, ErrReleaseNotFound
+		return nil, ErrReleaseNotFound(labels["NAME"])
 	}
 
 	var results []*rspb.Release
@@ -169,7 +169,7 @@ func (cfgmaps *ConfigMaps) Create(key string, rls *rspb.Release) error {
 	// push the configmap object out into the kubiverse
 	if _, err := cfgmaps.impl.Create(obj); err != nil {
 		if kberrs.IsAlreadyExists(err) {
-			return ErrReleaseExists
+			return ErrReleaseExists(rls.Name)
 		}
 
 		logerrf(err, "create: failed to create")
@@ -207,7 +207,7 @@ func (cfgmaps *ConfigMaps) Delete(key string) (rls *rspb.Release, err error) {
 	// fetch the release to check existence
 	if rls, err = cfgmaps.Get(key); err != nil {
 		if kberrs.IsNotFound(err) {
-			return nil, ErrReleaseNotFound
+			return nil, ErrReleaseNotFound(key)
 		}
 
 		logerrf(err, "delete: failed to get release %q", key)

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -17,18 +17,18 @@ limitations under the License.
 package driver // import "k8s.io/helm/pkg/storage/driver"
 
 import (
-	"errors"
+	"fmt"
 
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 )
 
 var (
 	// ErrReleaseNotFound indicates that a release is not found.
-	ErrReleaseNotFound = errors.New("release: not found")
+	ErrReleaseNotFound = func(release string) error { return fmt.Errorf("release: %q not found", release) }
 	// ErrReleaseExists indicates that a release already exists.
-	ErrReleaseExists = errors.New("release: already exists")
+	ErrReleaseExists = func(release string) error { return fmt.Errorf("release: %q already exists", release) }
 	// ErrInvalidKey indicates that a release key could not be parsed.
-	ErrInvalidKey = errors.New("release: invalid key")
+	ErrInvalidKey = func(release string) error { return fmt.Errorf("release: %q invalid key", release) }
 )
 
 // Creator is the interface that wraps the Create method.

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -53,16 +53,16 @@ func (mem *Memory) Get(key string) (*rspb.Release, error) {
 	case 2:
 		name, ver := elems[0], elems[1]
 		if _, err := strconv.Atoi(ver); err != nil {
-			return nil, ErrInvalidKey
+			return nil, ErrInvalidKey(key)
 		}
 		if recs, ok := mem.cache[name]; ok {
 			if r := recs.Get(key); r != nil {
 				return r.rls, nil
 			}
 		}
-		return nil, ErrReleaseNotFound
+		return nil, ErrReleaseNotFound(key)
 	default:
-		return nil, ErrInvalidKey
+		return nil, ErrInvalidKey(key)
 	}
 }
 
@@ -126,7 +126,7 @@ func (mem *Memory) Update(key string, rls *rspb.Release) error {
 		rs.Replace(key, newRecord(key, rls))
 		return nil
 	}
-	return ErrReleaseNotFound
+	return ErrReleaseNotFound(rls.Name)
 }
 
 // Delete deletes a release or returns ErrReleaseNotFound.
@@ -137,16 +137,16 @@ func (mem *Memory) Delete(key string) (*rspb.Release, error) {
 	case 2:
 		name, ver := elems[0], elems[1]
 		if _, err := strconv.Atoi(ver); err != nil {
-			return nil, ErrInvalidKey
+			return nil, ErrInvalidKey(key)
 		}
 		if recs, ok := mem.cache[name]; ok {
 			if r := recs.Remove(key); r != nil {
 				return r.rls, nil
 			}
 		}
-		return nil, ErrReleaseNotFound
+		return nil, ErrReleaseNotFound(key)
 	default:
-		return nil, ErrInvalidKey
+		return nil, ErrInvalidKey(key)
 	}
 }
 

--- a/pkg/storage/driver/records.go
+++ b/pkg/storage/driver/records.go
@@ -36,7 +36,7 @@ func (rs *records) Add(r *record) error {
 	}
 
 	if rs.Exists(r.key) {
-		return ErrReleaseExists
+		return ErrReleaseExists(r.key)
 	}
 
 	*rs = append(*rs, r)

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/services"
 	reltesting "k8s.io/helm/pkg/releasetesting"
 	relutil "k8s.io/helm/pkg/releaseutil"
-	"k8s.io/helm/pkg/storage/driver"
 	"k8s.io/helm/pkg/tiller/environment"
 	"k8s.io/helm/pkg/timeconv"
 	"k8s.io/helm/pkg/version"
@@ -621,7 +620,7 @@ func (s *ReleaseServer) uniqName(start string, reuse bool) (string, error) {
 		if len(name) > releaseNameMaxLen {
 			name = name[:releaseNameMaxLen]
 		}
-		if _, err := s.env.Releases.Get(name, 1); err == driver.ErrReleaseNotFound {
+		if _, err := s.env.Releases.Get(name, 1); strings.Contains(err.Error(), "not found") {
 			return name, nil
 		}
 		log.Printf("info: Name %q is taken. Searching again.", name)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/2251
In case a user tries to delete a non-existent release,
the error message displayed was missing release-name.