### PR TITLE
fix(helm): fix nil pointer in requirements.go

### DIFF
--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -384,8 +384,9 @@ func processImportValues(c *chart.Chart, v *chart.Config) error {
 	if err != nil {
 		return err
 	}
+
 	// set the new values
-	c.Values.Raw = string(y)
+	c.Values = &chart.Config{Raw: string(y)}
 
 	return nil
 }


### PR DESCRIPTION
This fixes a segfault that was the result of assigning to a property of
a nil pointer.

Closes #2244