### PR TITLE
feat(*): update to latest gRPC and Protobuf

### DIFF
--- a/_proto/Makefile
+++ b/_proto/Makefile
@@ -29,15 +29,19 @@ google_deps	 = Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptype
 .PHONY: all
 all: chart release services version
 
+.PHONY: chart
 chart:
 	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias):$(dst) $(chart_pbs)
 
+.PHONY: release
 release:
 	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias),$(version_ias):$(dst) $(release_pbs)
 
+.PHONY: services
 services:
 	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps),$(chart_ias),$(version_ias),$(release_ias):$(dst) $(services_pbs)
 
+.PHONY: version
 version:
 	PATH=../bin:$(PATH) protoc --$(target)_out=plugins=$(plugins),$(google_deps):$(dst) $(version_pbs)
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 59f320c07649cfd057b84f1044074670230fa3ca27b32632eb77a16a972adc8e
-updated: 2017-04-20T01:34:59.645884965-07:00
+hash: e9366bddb36a7120a832959c89f72f75d56b9f10f84820420795c668d9cb0987
+updated: 2017-04-27T14:23:27.66000871-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -123,7 +123,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/gogo/protobuf
-  version: e18d7aa8f8c624c915db340349aad4c49b10d173
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
   - proto
   - sortkeys
@@ -134,7 +134,7 @@ imports:
   subpackages:
   - lru
 - name: github.com/golang/protobuf
-  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
   - proto
   - ptypes/any
@@ -294,20 +294,23 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/grpc
-  version: b7f1379d3cbbbeb2ca3405852012e237aa05459e
+  version: 8050b9cbc271307e5a716a9d782803d09b0d6f2d
   subpackages:
   - codes
   - credentials
   - grpclog
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - stats
+  - tap
   - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
   version: fbd6803372f831e58b86c78d07421637a64ad768
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,13 +17,13 @@ import:
   version: ~1.2.3
 - package: github.com/technosophos/moniker
 - package: github.com/golang/protobuf
-  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
   - proto
   - ptypes/any
   - ptypes/timestamp
 - package: google.golang.org/grpc
-  version: 1.0.3
+  version: 1.2.1
 - package: k8s.io/apimachinery
 - package: k8s.io/client-go
 - package: k8s.io/kubernetes

--- a/pkg/proto/hapi/chart/config.pb.go
+++ b/pkg/proto/hapi/chart/config.pb.go
@@ -24,6 +24,13 @@ func (m *Config) String() string            { return proto.CompactTextString(m) 
 func (*Config) ProtoMessage()               {}
 func (*Config) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
 
+func (m *Config) GetRaw() string {
+	if m != nil {
+		return m.Raw
+	}
+	return ""
+}
+
 func (m *Config) GetValues() map[string]*Value {
 	if m != nil {
 		return m.Values
@@ -40,6 +47,13 @@ func (m *Value) Reset()                    { *m = Value{} }
 func (m *Value) String() string            { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()               {}
 func (*Value) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{1} }
+
+func (m *Value) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
+}
 
 func init() {
 	proto.RegisterType((*Config)(nil), "hapi.chart.Config")

--- a/pkg/proto/hapi/chart/metadata.pb.go
+++ b/pkg/proto/hapi/chart/metadata.pb.go
@@ -47,6 +47,20 @@ func (m *Maintainer) String() string            { return proto.CompactTextString
 func (*Maintainer) ProtoMessage()               {}
 func (*Maintainer) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
 
+func (m *Maintainer) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Maintainer) GetEmail() string {
+	if m != nil {
+		return m.Email
+	}
+	return ""
+}
+
 // 	Metadata for a Chart file. This models the structure of a Chart.yaml file.
 //
 // 	Spec: https://k8s.io/helm/blob/master/docs/design/chart_format.md#the-chart-file
@@ -89,11 +103,109 @@ func (m *Metadata) String() string            { return proto.CompactTextString(m
 func (*Metadata) ProtoMessage()               {}
 func (*Metadata) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{1} }
 
+func (m *Metadata) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Metadata) GetHome() string {
+	if m != nil {
+		return m.Home
+	}
+	return ""
+}
+
+func (m *Metadata) GetSources() []string {
+	if m != nil {
+		return m.Sources
+	}
+	return nil
+}
+
+func (m *Metadata) GetVersion() string {
+	if m != nil {
+		return m.Version
+	}
+	return ""
+}
+
+func (m *Metadata) GetDescription() string {
+	if m != nil {
+		return m.Description
+	}
+	return ""
+}
+
+func (m *Metadata) GetKeywords() []string {
+	if m != nil {
+		return m.Keywords
+	}
+	return nil
+}
+
 func (m *Metadata) GetMaintainers() []*Maintainer {
 	if m != nil {
 		return m.Maintainers
 	}
 	return nil
+}
+
+func (m *Metadata) GetEngine() string {
+	if m != nil {
+		return m.Engine
+	}
+	return ""
+}
+
+func (m *Metadata) GetIcon() string {
+	if m != nil {
+		return m.Icon
+	}
+	return ""
+}
+
+func (m *Metadata) GetApiVersion() string {
+	if m != nil {
+		return m.ApiVersion
+	}
+	return ""
+}
+
+func (m *Metadata) GetCondition() string {
+	if m != nil {
+		return m.Condition
+	}
+	return ""
+}
+
+func (m *Metadata) GetTags() string {
+	if m != nil {
+		return m.Tags
+	}
+	return ""
+}
+
+func (m *Metadata) GetAppVersion() string {
+	if m != nil {
+		return m.AppVersion
+	}
+	return ""
+}
+
+func (m *Metadata) GetDeprecated() bool {
+	if m != nil {
+		return m.Deprecated
+	}
+	return false
+}
+
+func (m *Metadata) GetTillerVersion() string {
+	if m != nil {
+		return m.TillerVersion
+	}
+	return ""
 }
 
 func init() {

--- a/pkg/proto/hapi/chart/template.pb.go
+++ b/pkg/proto/hapi/chart/template.pb.go
@@ -29,6 +29,20 @@ func (m *Template) String() string            { return proto.CompactTextString(m
 func (*Template) ProtoMessage()               {}
 func (*Template) Descriptor() ([]byte, []int) { return fileDescriptor3, []int{0} }
 
+func (m *Template) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Template) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*Template)(nil), "hapi.chart.Template")
 }

--- a/pkg/proto/hapi/release/hook.pb.go
+++ b/pkg/proto/hapi/release/hook.pb.go
@@ -109,11 +109,53 @@ func (m *Hook) String() string            { return proto.CompactTextString(m) }
 func (*Hook) ProtoMessage()               {}
 func (*Hook) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Hook) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Hook) GetKind() string {
+	if m != nil {
+		return m.Kind
+	}
+	return ""
+}
+
+func (m *Hook) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+func (m *Hook) GetManifest() string {
+	if m != nil {
+		return m.Manifest
+	}
+	return ""
+}
+
+func (m *Hook) GetEvents() []Hook_Event {
+	if m != nil {
+		return m.Events
+	}
+	return nil
+}
+
 func (m *Hook) GetLastRun() *google_protobuf.Timestamp {
 	if m != nil {
 		return m.LastRun
 	}
 	return nil
+}
+
+func (m *Hook) GetWeight() int32 {
+	if m != nil {
+		return m.Weight
+	}
+	return 0
 }
 
 func init() {

--- a/pkg/proto/hapi/release/info.pb.go
+++ b/pkg/proto/hapi/release/info.pb.go
@@ -58,6 +58,13 @@ func (m *Info) GetDeleted() *google_protobuf.Timestamp {
 	return nil
 }
 
+func (m *Info) GetDescription() string {
+	if m != nil {
+		return m.Description
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*Info)(nil), "hapi.release.Info")
 }

--- a/pkg/proto/hapi/release/release.pb.go
+++ b/pkg/proto/hapi/release/release.pb.go
@@ -42,6 +42,13 @@ func (m *Release) String() string            { return proto.CompactTextString(m)
 func (*Release) ProtoMessage()               {}
 func (*Release) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
 
+func (m *Release) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *Release) GetInfo() *Info {
 	if m != nil {
 		return m.Info
@@ -63,11 +70,32 @@ func (m *Release) GetConfig() *hapi_chart.Config {
 	return nil
 }
 
+func (m *Release) GetManifest() string {
+	if m != nil {
+		return m.Manifest
+	}
+	return ""
+}
+
 func (m *Release) GetHooks() []*Hook {
 	if m != nil {
 		return m.Hooks
 	}
 	return nil
+}
+
+func (m *Release) GetVersion() int32 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
+
+func (m *Release) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
 }
 
 func init() {

--- a/pkg/proto/hapi/release/status.pb.go
+++ b/pkg/proto/hapi/release/status.pb.go
@@ -69,6 +69,27 @@ func (m *Status) String() string            { return proto.CompactTextString(m) 
 func (*Status) ProtoMessage()               {}
 func (*Status) Descriptor() ([]byte, []int) { return fileDescriptor3, []int{0} }
 
+func (m *Status) GetCode() Status_Code {
+	if m != nil {
+		return m.Code
+	}
+	return Status_UNKNOWN
+}
+
+func (m *Status) GetResources() string {
+	if m != nil {
+		return m.Resources
+	}
+	return ""
+}
+
+func (m *Status) GetNotes() string {
+	if m != nil {
+		return m.Notes
+	}
+	return ""
+}
+
 func (m *Status) GetLastTestSuiteRun() *TestSuite {
 	if m != nil {
 		return m.LastTestSuiteRun

--- a/pkg/proto/hapi/release/test_run.pb.go
+++ b/pkg/proto/hapi/release/test_run.pb.go
@@ -51,6 +51,27 @@ func (m *TestRun) String() string            { return proto.CompactTextString(m)
 func (*TestRun) ProtoMessage()               {}
 func (*TestRun) Descriptor() ([]byte, []int) { return fileDescriptor4, []int{0} }
 
+func (m *TestRun) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *TestRun) GetStatus() TestRun_Status {
+	if m != nil {
+		return m.Status
+	}
+	return TestRun_UNKNOWN
+}
+
+func (m *TestRun) GetInfo() string {
+	if m != nil {
+		return m.Info
+	}
+	return ""
+}
+
 func (m *TestRun) GetStartedAt() *google_protobuf.Timestamp {
 	if m != nil {
 		return m.StartedAt

--- a/pkg/proto/hapi/services/tiller.pb.go
+++ b/pkg/proto/hapi/services/tiller.pb.go
@@ -138,6 +138,55 @@ func (m *ListReleasesRequest) String() string            { return proto.CompactT
 func (*ListReleasesRequest) ProtoMessage()               {}
 func (*ListReleasesRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *ListReleasesRequest) GetLimit() int64 {
+	if m != nil {
+		return m.Limit
+	}
+	return 0
+}
+
+func (m *ListReleasesRequest) GetOffset() string {
+	if m != nil {
+		return m.Offset
+	}
+	return ""
+}
+
+func (m *ListReleasesRequest) GetSortBy() ListSort_SortBy {
+	if m != nil {
+		return m.SortBy
+	}
+	return ListSort_UNKNOWN
+}
+
+func (m *ListReleasesRequest) GetFilter() string {
+	if m != nil {
+		return m.Filter
+	}
+	return ""
+}
+
+func (m *ListReleasesRequest) GetSortOrder() ListSort_SortOrder {
+	if m != nil {
+		return m.SortOrder
+	}
+	return ListSort_ASC
+}
+
+func (m *ListReleasesRequest) GetStatusCodes() []hapi_release3.Status_Code {
+	if m != nil {
+		return m.StatusCodes
+	}
+	return nil
+}
+
+func (m *ListReleasesRequest) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
+}
+
 // ListSort defines sorting fields on a release list.
 type ListSort struct {
 }
@@ -165,6 +214,27 @@ func (m *ListReleasesResponse) String() string            { return proto.Compact
 func (*ListReleasesResponse) ProtoMessage()               {}
 func (*ListReleasesResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *ListReleasesResponse) GetCount() int64 {
+	if m != nil {
+		return m.Count
+	}
+	return 0
+}
+
+func (m *ListReleasesResponse) GetNext() string {
+	if m != nil {
+		return m.Next
+	}
+	return ""
+}
+
+func (m *ListReleasesResponse) GetTotal() int64 {
+	if m != nil {
+		return m.Total
+	}
+	return 0
+}
+
 func (m *ListReleasesResponse) GetReleases() []*hapi_release5.Release {
 	if m != nil {
 		return m.Releases
@@ -185,6 +255,20 @@ func (m *GetReleaseStatusRequest) String() string            { return proto.Comp
 func (*GetReleaseStatusRequest) ProtoMessage()               {}
 func (*GetReleaseStatusRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
 
+func (m *GetReleaseStatusRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *GetReleaseStatusRequest) GetVersion() int32 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
+
 // GetReleaseStatusResponse is the response indicating the status of the named release.
 type GetReleaseStatusResponse struct {
 	// Name is the name of the release.
@@ -200,11 +284,25 @@ func (m *GetReleaseStatusResponse) String() string            { return proto.Com
 func (*GetReleaseStatusResponse) ProtoMessage()               {}
 func (*GetReleaseStatusResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
+func (m *GetReleaseStatusResponse) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *GetReleaseStatusResponse) GetInfo() *hapi_release4.Info {
 	if m != nil {
 		return m.Info
 	}
 	return nil
+}
+
+func (m *GetReleaseStatusResponse) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
 }
 
 // GetReleaseContentRequest is a request to get the contents of a release.
@@ -219,6 +317,20 @@ func (m *GetReleaseContentRequest) Reset()                    { *m = GetReleaseC
 func (m *GetReleaseContentRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetReleaseContentRequest) ProtoMessage()               {}
 func (*GetReleaseContentRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+func (m *GetReleaseContentRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *GetReleaseContentRequest) GetVersion() int32 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
 
 // GetReleaseContentResponse is a response containing the contents of a release.
 type GetReleaseContentResponse struct {
@@ -269,6 +381,13 @@ func (m *UpdateReleaseRequest) String() string            { return proto.Compact
 func (*UpdateReleaseRequest) ProtoMessage()               {}
 func (*UpdateReleaseRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
 
+func (m *UpdateReleaseRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *UpdateReleaseRequest) GetChart() *hapi_chart3.Chart {
 	if m != nil {
 		return m.Chart
@@ -281,6 +400,55 @@ func (m *UpdateReleaseRequest) GetValues() *hapi_chart.Config {
 		return m.Values
 	}
 	return nil
+}
+
+func (m *UpdateReleaseRequest) GetDryRun() bool {
+	if m != nil {
+		return m.DryRun
+	}
+	return false
+}
+
+func (m *UpdateReleaseRequest) GetDisableHooks() bool {
+	if m != nil {
+		return m.DisableHooks
+	}
+	return false
+}
+
+func (m *UpdateReleaseRequest) GetRecreate() bool {
+	if m != nil {
+		return m.Recreate
+	}
+	return false
+}
+
+func (m *UpdateReleaseRequest) GetTimeout() int64 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
+func (m *UpdateReleaseRequest) GetResetValues() bool {
+	if m != nil {
+		return m.ResetValues
+	}
+	return false
+}
+
+func (m *UpdateReleaseRequest) GetWait() bool {
+	if m != nil {
+		return m.Wait
+	}
+	return false
+}
+
+func (m *UpdateReleaseRequest) GetReuseValues() bool {
+	if m != nil {
+		return m.ReuseValues
+	}
+	return false
 }
 
 // UpdateReleaseResponse is the response to an update request.
@@ -322,6 +490,55 @@ func (m *RollbackReleaseRequest) Reset()                    { *m = RollbackRelea
 func (m *RollbackReleaseRequest) String() string            { return proto.CompactTextString(m) }
 func (*RollbackReleaseRequest) ProtoMessage()               {}
 func (*RollbackReleaseRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
+
+func (m *RollbackReleaseRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *RollbackReleaseRequest) GetDryRun() bool {
+	if m != nil {
+		return m.DryRun
+	}
+	return false
+}
+
+func (m *RollbackReleaseRequest) GetDisableHooks() bool {
+	if m != nil {
+		return m.DisableHooks
+	}
+	return false
+}
+
+func (m *RollbackReleaseRequest) GetVersion() int32 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
+
+func (m *RollbackReleaseRequest) GetRecreate() bool {
+	if m != nil {
+		return m.Recreate
+	}
+	return false
+}
+
+func (m *RollbackReleaseRequest) GetTimeout() int64 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
+func (m *RollbackReleaseRequest) GetWait() bool {
+	if m != nil {
+		return m.Wait
+	}
+	return false
+}
 
 // RollbackReleaseResponse is the response to an update request.
 type RollbackReleaseResponse struct {
@@ -386,6 +603,55 @@ func (m *InstallReleaseRequest) GetValues() *hapi_chart.Config {
 	return nil
 }
 
+func (m *InstallReleaseRequest) GetDryRun() bool {
+	if m != nil {
+		return m.DryRun
+	}
+	return false
+}
+
+func (m *InstallReleaseRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *InstallReleaseRequest) GetDisableHooks() bool {
+	if m != nil {
+		return m.DisableHooks
+	}
+	return false
+}
+
+func (m *InstallReleaseRequest) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
+}
+
+func (m *InstallReleaseRequest) GetReuseName() bool {
+	if m != nil {
+		return m.ReuseName
+	}
+	return false
+}
+
+func (m *InstallReleaseRequest) GetTimeout() int64 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
+func (m *InstallReleaseRequest) GetWait() bool {
+	if m != nil {
+		return m.Wait
+	}
+	return false
+}
+
 // InstallReleaseResponse is the response from a release installation.
 type InstallReleaseResponse struct {
 	Release *hapi_release5.Release `protobuf:"bytes,1,opt,name=release" json:"release,omitempty"`
@@ -420,6 +686,34 @@ func (m *UninstallReleaseRequest) String() string            { return proto.Comp
 func (*UninstallReleaseRequest) ProtoMessage()               {}
 func (*UninstallReleaseRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{13} }
 
+func (m *UninstallReleaseRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *UninstallReleaseRequest) GetDisableHooks() bool {
+	if m != nil {
+		return m.DisableHooks
+	}
+	return false
+}
+
+func (m *UninstallReleaseRequest) GetPurge() bool {
+	if m != nil {
+		return m.Purge
+	}
+	return false
+}
+
+func (m *UninstallReleaseRequest) GetTimeout() int64 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
 // UninstallReleaseResponse represents a successful response to an uninstall request.
 type UninstallReleaseResponse struct {
 	// Release is the release that was marked deleted.
@@ -438,6 +732,13 @@ func (m *UninstallReleaseResponse) GetRelease() *hapi_release5.Release {
 		return m.Release
 	}
 	return nil
+}
+
+func (m *UninstallReleaseResponse) GetInfo() string {
+	if m != nil {
+		return m.Info
+	}
+	return ""
 }
 
 // GetVersionRequest requests for version information.
@@ -478,6 +779,20 @@ func (m *GetHistoryRequest) String() string            { return proto.CompactTex
 func (*GetHistoryRequest) ProtoMessage()               {}
 func (*GetHistoryRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{17} }
 
+func (m *GetHistoryRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *GetHistoryRequest) GetMax() int32 {
+	if m != nil {
+		return m.Max
+	}
+	return 0
+}
+
 // GetHistoryResponse is received in response to a GetHistory rpc.
 type GetHistoryResponse struct {
 	Releases []*hapi_release5.Release `protobuf:"bytes,1,rep,name=releases" json:"releases,omitempty"`
@@ -510,6 +825,27 @@ func (m *TestReleaseRequest) String() string            { return proto.CompactTe
 func (*TestReleaseRequest) ProtoMessage()               {}
 func (*TestReleaseRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{19} }
 
+func (m *TestReleaseRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *TestReleaseRequest) GetTimeout() int64 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
+func (m *TestReleaseRequest) GetCleanup() bool {
+	if m != nil {
+		return m.Cleanup
+	}
+	return false
+}
+
 // TestReleaseResponse represents a message from executing a test
 type TestReleaseResponse struct {
 	Msg string `protobuf:"bytes,1,opt,name=msg" json:"msg,omitempty"`
@@ -519,6 +855,13 @@ func (m *TestReleaseResponse) Reset()                    { *m = TestReleaseRespo
 func (m *TestReleaseResponse) String() string            { return proto.CompactTextString(m) }
 func (*TestReleaseResponse) ProtoMessage()               {}
 func (*TestReleaseResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{20} }
+
+func (m *TestReleaseResponse) GetMsg() string {
+	if m != nil {
+		return m.Msg
+	}
+	return ""
+}
 
 func init() {
 	proto.RegisterType((*ListReleasesRequest)(nil), "hapi.services.tiller.ListReleasesRequest")
@@ -552,7 +895,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for ReleaseService service
 
@@ -993,7 +1336,7 @@ var _ReleaseService_serviceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "hapi/services/tiller.proto",
 }
 
 func init() { proto.RegisterFile("hapi/services/tiller.proto", fileDescriptor0) }

--- a/pkg/proto/hapi/version/version.pb.go
+++ b/pkg/proto/hapi/version/version.pb.go
@@ -40,6 +40,27 @@ func (m *Version) String() string            { return proto.CompactTextString(m)
 func (*Version) ProtoMessage()               {}
 func (*Version) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Version) GetSemVer() string {
+	if m != nil {
+		return m.SemVer
+	}
+	return ""
+}
+
+func (m *Version) GetGitCommit() string {
+	if m != nil {
+		return m.GitCommit
+	}
+	return ""
+}
+
+func (m *Version) GetGitTreeState() string {
+	if m != nil {
+		return m.GitTreeState
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*Version)(nil), "hapi.version.Version")
 }


### PR DESCRIPTION
Effectively, this switches us to gRPC's internal version 4. This is
compatible with protoc 3.2 and grpc-go 1.2.1.

Closes #2172 