### PR TITLE
Validates chart-dir before running dependency list command

### DIFF
--- a/pkg/chartutil/chartfile_test.go
+++ b/pkg/chartutil/chartfile_test.go
@@ -95,3 +95,16 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 		}
 	}
 }
+
+func TestIsChartDir(t *testing.T) {
+	validChartDir, err := IsChartDir("testdata/frobnitz")
+	if !validChartDir {
+		t.Errorf("unexpected error while reading chart-directory: (%v)", err)
+		return
+	}
+	validChartDir, err = IsChartDir("testdata")
+	if validChartDir || err == nil {
+		t.Errorf("expected error but did not get any")
+		return
+	}
+}

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -48,6 +48,9 @@ func Load(name string) (*chart.Chart, error) {
 		return nil, err
 	}
 	if fi.IsDir() {
+		if validChart, err := IsChartDir(name); !validChart {
+			return nil, err
+		}
 		return LoadDir(name)
 	}
 	return LoadFile(name)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/2276: helm dependency list hangs if run on large directory