### PR TITLE
Fix indent for defaultDeployment

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -169,7 +169,7 @@ spec:
             path: /
             port: {{ .Values.service.internalPort }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 10 }}
 `
 
 const defaultService = `apiVersion: v1


### PR DESCRIPTION
IMHO the indent of the resources block is to large in die default Template.
Not really important, but I think it would be nice to stay consistent with the rest of the yamls (which have a 2 space indent).

For comparison:

Old:
```
        resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
```

New
```
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 100m
            memory: 128Mi
```