### PR TITLE
Releases are locked to avoid parallel changes

### DIFF
--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -272,3 +272,31 @@ func assertErrNil(eh func(args ...interface{}), err error, message string) {
 		eh(fmt.Sprintf("%s: %q", message, err))
 	}
 }
+
+func TestReleaseLocksNotExist(t *testing.T) {
+	s := Init(driver.NewMemory())
+
+	err := s.LockRelease("no-such-release")
+
+	if err == nil {
+		t.Errorf("Exptected error when trying to lock non-existing release, got nil")
+	}
+}
+
+func TestReleaseLocks(t *testing.T) {
+	s := Init(driver.NewMemory())
+
+	releaseName := "angry-beaver"
+	rls := ReleaseTestData{
+		Name:    releaseName,
+		Version: 1,
+	}.ToRelease()
+
+	s.Create(rls)
+
+	err := s.LockRelease(releaseName)
+	if err != nil {
+		t.Errorf("Exptected nil err when locking existing release")
+	}
+	s.UnlockRelease(releaseName)
+}

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -283,6 +283,12 @@ func (s *ReleaseServer) GetReleaseContent(c ctx.Context, req *services.GetReleas
 
 // UpdateRelease takes an existing release and new information, and upgrades the release.
 func (s *ReleaseServer) UpdateRelease(c ctx.Context, req *services.UpdateReleaseRequest) (*services.UpdateReleaseResponse, error) {
+	err := s.env.Releases.LockRelease(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer s.env.Releases.UnlockRelease(req.Name)
+
 	currentRelease, updatedRelease, err := s.prepareUpdate(req)
 	if err != nil {
 		return nil, err
@@ -465,6 +471,12 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 
 // RollbackRelease rolls back to a previous version of the given release.
 func (s *ReleaseServer) RollbackRelease(c ctx.Context, req *services.RollbackReleaseRequest) (*services.RollbackReleaseResponse, error) {
+	err := s.env.Releases.LockRelease(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer s.env.Releases.UnlockRelease(req.Name)
+
 	currentRelease, targetRelease, err := s.prepareRollback(req)
 	if err != nil {
 		return nil, err
@@ -983,6 +995,12 @@ func (s *ReleaseServer) purgeReleases(rels ...*release.Release) error {
 
 // UninstallRelease deletes all of the resources associated with this release, and marks the release DELETED.
 func (s *ReleaseServer) UninstallRelease(c ctx.Context, req *services.UninstallReleaseRequest) (*services.UninstallReleaseResponse, error) {
+	err := s.env.Releases.LockRelease(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer s.env.Releases.UnlockRelease(req.Name)
+
 	if !ValidName.MatchString(req.Name) {
 		log.Printf("uninstall: Release not found: %s", req.Name)
 		return nil, errMissingRelease


### PR DESCRIPTION
Environment is supplied with release lock map which allows to lock a
release by name to make sure that update, rollback or uninstall aren't
running on one release at the same time.

fixes #2146