### PR TITLE
fix(helm): return error when dependencies are missing

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -134,9 +134,9 @@ func TestInstall(t *testing.T) {
 		},
 		// Install, chart with missing dependencies in /charts
 		{
-			name:     "install chart with missing dependencies",
-			args:     []string{"testdata/testcharts/chart-missing-deps"},
-			expected: "Warning: reqsubchart2 is in requirements.yaml but not in the charts/ directory!",
+			name: "install chart with missing dependencies",
+			args: []string{"testdata/testcharts/chart-missing-deps"},
+			err:  true,
 		},
 	}
 

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -127,7 +127,9 @@ func (p *packageCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if reqs, err := chartutil.LoadRequirements(ch); err == nil {
-		checkDependencies(ch, reqs, p.out)
+		if err := checkDependencies(ch, reqs, p.out); err != nil {
+			return err
+		}
 	}
 
 	var dest string

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -118,8 +118,8 @@ func TestPackage(t *testing.T) {
 		{
 			name:    "package testdata/testcharts/chart-missing-deps",
 			args:    []string{"testdata/testcharts/chart-missing-deps"},
-			expect:  "Warning: reqsubchart2 is in requirements.yaml but not in the charts/ directory!\n",
 			hasfile: "chart-missing-deps-0.1.0.tgz",
+			err:     true,
 		},
 	}
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -166,7 +166,9 @@ func (u *upgradeCmd) run() error {
 	// Check chart requirements to make sure all dependencies are present in /charts
 	if ch, err := chartutil.Load(chartPath); err == nil {
 		if req, err := chartutil.LoadRequirements(ch); err == nil {
-			checkDependencies(ch, req, u.out)
+			if err := checkDependencies(ch, req, u.out); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -138,10 +138,10 @@ func TestUpgradeCmd(t *testing.T) {
 			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
 		},
 		{
-			name:     "upgrade a release with missing dependencies",
-			args:     []string{"bonkers-bunny", missingDepsPath},
-			resp:     releaseMock(&releaseOptions{name: "bonkers-bunny", version: 1, chart: ch3}),
-			expected: "Warning: reqsubchart2 is in requirements.yaml but not in the charts/ directory!",
+			name: "upgrade a release with missing dependencies",
+			args: []string{"bonkers-bunny", missingDepsPath},
+			resp: releaseMock(&releaseOptions{name: "bonkers-bunny", version: 1, chart: ch3}),
+			err:  true,
 		},
 	}
 


### PR DESCRIPTION
This upgrades a warning to an error in cases where `requirements.yaml`
contains a requirement, but it's missing in charts/

This impacts install, upgrade, and package.

Closes #2209