### PR TITLE
Fix for vbom.ml bootstrap

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -620,6 +620,8 @@ imports:
   - pkg/watch/json
 - name: vbom.ml/util
   version: db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394
+  repo: https://github.com/fvbommel/util.git
+  vcs: git
   subpackages:
   - sortorder
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,6 +45,10 @@ import:
 - package: github.com/chai2010/gettext-go
 - package: github.com/prometheus/client_golang
   version: v0.8.0
+- package: vbom.ml/util
+  repo: https://github.com/fvbommel/util.git
+  vcs: git
+
 testImports:
 - package: github.com/stretchr/testify
   version: ^1.1.4


### PR DESCRIPTION
[WARN]	Unable to checkout vbom.ml/util
[ERROR]	Update failed for vbom.ml/util: Cannot detect VCS
[ERROR]	Failed to install: Cannot detect VCS
Makefile:120: recipe for target 'bootstrap' failed