### PR TITLE
Fail template execution if included template fails

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -138,12 +138,12 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 	}
 
 	// Add the 'include' function here so we can close over t.
-	funcMap["include"] = func(name string, data interface{}) string {
+	funcMap["include"] = func(name string, data interface{}) (string, error) {
 		buf := bytes.NewBuffer(nil)
 		if err := t.ExecuteTemplate(buf, name, data); err != nil {
-			buf.WriteString(err.Error())
+			return "", err
 		}
-		return buf.String()
+		return buf.String(), nil
 	}
 
 	// Add the 'required' function here


### PR DESCRIPTION
I'm not sure if I'm missing something but this little change ensures that the template rendering fails when `include` fails which I find super awesome.

Previously this was not the case but the error was just included in the parent template like so:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: config
data:
  kubeconfig: |-
    template: kube-master/templates/_openstack.config.tpl:3:14: executing "kube-master/templates/_openstack.config.tpl" at <required "missing au...>: error calling required: missing authURL
``` 

This even gives a somewhat readable errors message for deeper nestings e.g.:
```
Error: render error in "kube-master/templates/controller-manager.yaml": template: kube-master/templates/controller-manager.yaml:20:29: executing "kube-master/templates/controller-manager.yaml" at <include (print $.Tem...>: error calling include: template: kube-master/templates/secrets.yaml:10:23: executing "kube-master/templates/secrets.yaml" at <include (print $.Tem...>: error calling include: template: kube-master/templates/_openstack.config.tpl:3:14: executing "kube-master/templates/_openstack.config.tpl" at <required "missing au...>: error calling required: missing authURL
```
Meaning: 
* kube-master/templates/controller-manager.yaml *included:*
  * kube-master/templates/secrets.yaml *included:*
    * kube-master/templates/_openstack.config.tpl *which failed*