### PR TITLE
Skip rendering partials

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -193,6 +193,11 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 	rendered := make(map[string]string, len(files))
 	var buf bytes.Buffer
 	for _, file := range files {
+		// Don't render partials. We don't care out the direct output of partials.
+		// They are only included from other templates.
+		if strings.HasPrefix(path.Base(file), "_") {
+			continue
+		}
 		// At render time, add information about the template that is being rendered.
 		vals := tpls[file].vals
 		vals["Template"] = map[string]interface{}{"Name": file, "BasePath": tpls[file].basePath}


### PR DESCRIPTION
Why?

We often use partials for [generating templated configfiles](https://github.com/sapcc/helm-charts/blob/master/openstack/keystone/templates/etc/_keystone.conf.tpl).
We then include them in configmaps and secrets like this:
```
...
data:
  keystone.conf: |-
{{ include (print $.Template.BasePath "/etc/_keystone.conf.tpl") . | indent 4 }}
```

If such a partial is meant to be included with a different value scope then the chart the implicit rendering of the partial might fail because it expects different values.

Not rendering partials ensures that partials are only every rendered with the intended values as specified in the `include` statement.