### PR TITLE
fix(*): handle unreleased versioning

### DIFF
--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -408,7 +408,7 @@ func WithMaxHistory(max int32) HistoryOption {
 
 // NewContext creates a versioned context.
 func NewContext() context.Context {
-	md := metadata.Pairs("x-helm-api-client", version.Version)
+	md := metadata.Pairs("x-helm-api-client", version.GetVersion())
 	return metadata.NewContext(context.TODO(), md)
 }
 

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/helm/pkg/storage"
 	"k8s.io/helm/pkg/storage/driver"
 	"k8s.io/helm/pkg/tiller/environment"
+	"k8s.io/helm/pkg/version"
 )
 
 const notesText = "my notes here"
@@ -465,6 +466,7 @@ func TestInstallRelease_WithNotesRendered(t *testing.T) {
 }
 
 func TestInstallRelease_TillerVersion(t *testing.T) {
+	version.Version = "2.2.0"
 	c := helm.NewContext()
 	rs := rsFixture()
 
@@ -486,6 +488,7 @@ func TestInstallRelease_TillerVersion(t *testing.T) {
 }
 
 func TestInstallRelease_WrongTillerVersion(t *testing.T) {
+	version.Version = "2.2.0"
 	c := helm.NewContext()
 	rs := rsFixture()
 

--- a/pkg/tiller/server.go
+++ b/pkg/tiller/server.go
@@ -88,8 +88,8 @@ func versionFromContext(ctx context.Context) string {
 
 func checkClientVersion(ctx context.Context) error {
 	clientVersion := versionFromContext(ctx)
-	if !version.IsCompatible(clientVersion, version.Version) {
-		return fmt.Errorf("incompatible versions client: %s server: %s", clientVersion, version.Version)
+	if !version.IsCompatible(clientVersion, version.GetVersion()) {
+		return fmt.Errorf("incompatible versions client[%s] server[%s]", clientVersion, version.GetVersion())
 	}
 	return nil
 }

--- a/pkg/version/compatible.go
+++ b/pkg/version/compatible.go
@@ -18,12 +18,16 @@ package version // import "k8s.io/helm/pkg/version"
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
 )
 
 // IsCompatible tests if a client and server version are compatible.
 func IsCompatible(client, server string) bool {
+	if isUnreleased(client) || isUnreleased(server) {
+		return true
+	}
 	cv, err := semver.NewVersion(client)
 	if err != nil {
 		return false
@@ -54,4 +58,8 @@ func IsCompatibleRange(constraint, ver string) bool {
 		return false
 	}
 	return c.Check(sv)
+}
+
+func isUnreleased(v string) bool {
+	return strings.HasSuffix(v, "unreleased")
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
 	// Increment patch number for critical fixes to existing releases.
-	Version = "v2.3.x"
+	Version = "v2.3"
 
 	// BuildMetadata is extra build time data
 	BuildMetadata = "unreleased"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,10 +26,10 @@ var (
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
 	// Increment patch number for critical fixes to existing releases.
-	Version = "v2.3.0"
+	Version = "v2.3.x"
 
 	// BuildMetadata is extra build time data
-	BuildMetadata = ""
+	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1
 	GitCommit = ""
 	// GitTreeState is the state of the git tree

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,9 +1,9 @@
-MUTABLE_VERSION ?= canary
+MUTABLE_VERSION := canary
 
-GIT_COMMIT ?= $(shell git rev-parse HEAD)
-GIT_SHA ?= $(shell git rev-parse --short HEAD)
-GIT_TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null)
-GIT_DIRTY ?= $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
+GIT_COMMIT = $(shell git rev-parse HEAD)
+GIT_SHA    = $(shell git rev-parse --short HEAD)
+GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+GIT_DIRTY  = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
 ifdef VERSION
 	DOCKER_VERSION = $(VERSION)
@@ -11,14 +11,23 @@ ifdef VERSION
 endif
 
 DOCKER_VERSION ?= git-${GIT_SHA}
-BINARY_VERSION ?= ${GIT_TAG}-${GIT_SHA}
+BINARY_VERSION ?= ${GIT_TAG}
 
-IMAGE := ${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${SHORT_NAME}:${DOCKER_VERSION}
-MUTABLE_IMAGE := ${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
+# Only set Version if building a tag or VERSION is set
+ifneq ($(BINARY_VERSION),)
+	LDFLAGS += -X k8s.io/helm/pkg/version.Version=${BINARY_VERSION}
+endif
 
-LDFLAGS += -X k8s.io/helm/pkg/version.Version=${GIT_TAG}
+# Clear the "unreleased" string in BuildMetadata
+ifneq ($(GIT_TAG),)
+	LDFLAGS += -X k8s.io/helm/pkg/version.BuildMetadata=
+endif
+
 LDFLAGS += -X k8s.io/helm/pkg/version.GitCommit=${GIT_COMMIT}
 LDFLAGS += -X k8s.io/helm/pkg/version.GitTreeState=${GIT_DIRTY}
+
+IMAGE         := ${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${SHORT_NAME}:${DOCKER_VERSION}
+MUTABLE_IMAGE := ${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
 
 DOCKER_PUSH = docker push
 ifeq ($(DOCKER_REGISTRY),gcr.io)
@@ -26,10 +35,14 @@ ifeq ($(DOCKER_REGISTRY),gcr.io)
 endif
 
 info:
-	@echo "Build tag:       ${DOCKER_VERSION}"
-	@echo "Registry:        ${DOCKER_REGISTRY}"
-	@echo "Immutable tag:   ${IMAGE}"
-	@echo "Mutable tag:     ${MUTABLE_IMAGE}"
+	 @echo "Version:           ${VERSION}"
+	 @echo "Git Tag:           ${GIT_TAG}"
+	 @echo "Git Commit:        ${GIT_COMMIT}"
+	 @echo "Git Tree State:    ${GIT_DIRTY}"
+	 @echo "Docker Version:    ${DOCKER_VERSION}"
+	 @echo "Registry:          ${DOCKER_REGISTRY}"
+	 @echo "Immutable Image:   ${IMAGE}"
+	 @echo "Mutable Image:     ${MUTABLE_IMAGE}"
 
 .PHONY: docker-push
 docker-push: docker-mutable-push docker-immutable-push


### PR DESCRIPTION
Adds an `unreleased` flag to the version if not building from HEAD of a
tag. The compatibility check is bypassed if the client or server are
unreleased.

fixes #2110