### PR TITLE
fix(helm): reverted upgrade of imdario/mergo

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0098f4e67e62df017349dfc51afcb25c4a7927b3cc032c0fb983d6e0c86942b9
-updated: 2017-05-02T12:34:53.4235593-06:00
+hash: e323e66f9aba77578f7dcc0886e3117ebc373bc391374b2d5ddd293c276c8966
+updated: 2017-05-02T22:27:03.674351365-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -153,7 +153,7 @@ imports:
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
-  version: 3e95a51e0639b4cf372f2ccf74c86749d747fbdc
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jonboulle/clockwork

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,10 @@ import:
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - package: github.com/Masterminds/vcs
   version: ~1.11.0
+
+  # Pin version of mergo that is compatible with both sprig and Kubernetes
+- package: github.com/imdario/mergo
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - package: github.com/Masterminds/sprig
   version: ^2.11
 - package: github.com/ghodss/yaml


### PR DESCRIPTION
    Reverted the version of mergo to a version that was known to work
    with both kubernetes and sprig.

    Closes #2376