### PR TITLE
scripts/get with version lock

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -19,7 +19,7 @@
 
 PROJECT_NAME="helm"
 
-: ${HELM_INSTALL_DIR:="/usr/local/bin"}
+: "${HELM_INSTALL_DIR:="/usr/local/bin"}"
 
 # initArch discovers the architecture for this system.
 initArch() {
@@ -38,7 +38,7 @@ initArch() {
 
 # initOS discovers the operating system for this system.
 initOS() {
-  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+  OS=$(uname | tr '[:upper:]' '[:lower:]')
 
   case "$OS" in
     # Minimalist GNU for Windows
@@ -119,8 +119,9 @@ downloadFile() {
 # installs it.
 installFile() {
   HELM_TMP="/tmp/$PROJECT_NAME"
-  local sum=$(openssl sha -sha256 ${HELM_TMP_FILE} | awk '{print $2}')
-  local expected_sum=$(cat ${HELM_SUM_FILE})
+  local sum=$(openssl sha -sha256 "${HELM_TMP_FILE}" | awk '{print $2}')
+  local expected_sum=$(cat "${HELM_SUM_FILE}")
+
   if [ "$sum" != "$expected_sum" ]; then
     echo "SHA sum of $HELM_TMP does not match. Aborting."
     exit 1
@@ -147,7 +148,6 @@ fail_trap() {
 testVersion() {
   set +e
   echo "$PROJECT_NAME installed into $HELM_INSTALL_DIR/$PROJECT_NAME"
-  HELM="$(which $PROJECT_NAME)"
   if [ "$?" = "1" ]; then
     echo "$PROJECT_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
     exit 1
@@ -164,7 +164,16 @@ set -e
 initArch
 initOS
 verifySupported
-checkLatestVersion
+if [[ "$1" =~ ^v[0-9].[0-9].[0-9]$ ]];
+then
+  TAG="$1"
+elif [ ! $1 ];
+then
+  checkLatestVersion
+else
+  echo "Version tag $1 not match"
+  exit 1
+fi
 if ! checkHelmInstalledVersion; then
   downloadFile
   installFile

--- a/scripts/get
+++ b/scripts/get
@@ -164,14 +164,14 @@ set -e
 initArch
 initOS
 verifySupported
-if [[ "$1" =~ ^v[0-9].[0-9].[0-9]$ ]];
+if [[ "$1" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]];
 then
   TAG="$1"
 elif [ ! $1 ];
 then
   checkLatestVersion
 else
-  echo "Version tag $1 not match"
+  echo "Version tag $1 not match. Get tag from https://github.com/kubernetes/helm/releases"
   exit 1
 fi
 if ! checkHelmInstalledVersion; then


### PR DESCRIPTION
This is very important when we like to freeze version always on the last tested stable. 
Last 2.4.1 not works as should be and it is always installed for new clients.
This will add an option to override and lock version installed. Old scripts/get behavior not changed.

Example:
```
curl -q -s https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh && \
chmod 700 get_helm.sh && \
./get_helm.sh v2.3.1
```

How it works?:
```
$ ./get_helm.sh
Helm v2.4.1 is available. Upgrading from version v2.3.1.
Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.4.1-darwin-amd64.tar.gz
^CFailed to install helm
	For support, go to https://github.com/kubernetes/helm.


$ ./get_helm.sh v2.3.1
Helm v2.3.1 is up-to-date.
helm installed into /usr/local/bin/helm
Run 'helm init' to configure helm.

$ ./get_helm.sh 2.3.1
Version tag 2.3.1 not match
Failed to install helm
	For support, go to https://github.com/kubernetes/helm.
```

