### PR TITLE
feat(cmd/helm/installer): add support for upgrading service account

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -58,6 +58,7 @@ func Upgrade(client internalclientset.Interface, opts *Options) error {
 	}
 	obj.Spec.Template.Spec.Containers[0].Image = opts.selectImage()
 	obj.Spec.Template.Spec.Containers[0].ImagePullPolicy = opts.pullPolicy()
+	obj.Spec.Template.Spec.ServiceAccountName = opts.ServiceAccount
 	if _, err := client.Extensions().Deployments(opts.Namespace).Update(obj); err != nil {
 		return err
 	}

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -329,11 +329,12 @@ func TestInstall_canary(t *testing.T) {
 
 func TestUpgrade(t *testing.T) {
 	image := "gcr.io/kubernetes-helm/tiller:v2.0.0"
-
+	serviceAccount := "newServiceAccount"
 	existingDeployment := deployment(&Options{
-		Namespace: api.NamespaceDefault,
-		ImageSpec: "imageToReplace",
-		UseCanary: false,
+		Namespace:      api.NamespaceDefault,
+		ImageSpec:      "imageToReplace",
+		ServiceAccount: "serviceAccountToReplace",
+		UseCanary:      false,
 	})
 	existingService := service(api.NamespaceDefault)
 
@@ -347,13 +348,17 @@ func TestUpgrade(t *testing.T) {
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
 		}
+		sa := obj.Spec.Template.Spec.ServiceAccountName
+		if sa != serviceAccount {
+			t.Errorf("expected serviceAccountName = '%s', got '%s'", serviceAccount, sa)
+		}
 		return true, obj, nil
 	})
 	fc.AddReactor("get", "services", func(action testcore.Action) (bool, runtime.Object, error) {
 		return true, existingService, nil
 	})
 
-	opts := &Options{Namespace: api.NamespaceDefault, ImageSpec: image}
+	opts := &Options{Namespace: api.NamespaceDefault, ImageSpec: image, ServiceAccount: serviceAccount}
 	if err := Upgrade(fc, opts); err != nil {
 		t.Errorf("unexpected error: %#+v", err)
 	}


### PR DESCRIPTION
Previously, `helm init --upgrade --service-account=foo` would not actually update the service account in tiller's deployment.