### PR TITLE
Write repo file using atomicfile

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -102,6 +102,8 @@ imports:
   version: ba18e35c5c1b36ef6334cad706eb681153d2d379
 - name: github.com/exponent-io/jsonpath
   version: d6023ce2651d8eafb5c75bb0c7167536102ec9f5
+- name: github.com/facebookgo/atomicfile
+  version: 2de1f203e7d5e386a6833233882782932729f27e
 - name: github.com/facebookgo/symwalk
   version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/ghodss/yaml

--- a/glide.yaml
+++ b/glide.yaml
@@ -41,6 +41,7 @@ import:
 - package: github.com/gobwas/glob
   version: ^0.2.1
 - package: github.com/evanphx/json-patch
+- package: github.com/facebookgo/atomicfile
 - package: github.com/facebookgo/symwalk
 - package: github.com/BurntSushi/toml
   version: ~0.3.0

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/facebookgo/atomicfile"
 	"github.com/ghodss/yaml"
 )
 
@@ -134,9 +135,24 @@ func (r *RepoFile) Remove(name string) bool {
 
 // WriteFile writes a repositories file to the given path.
 func (r *RepoFile) WriteFile(path string, perm os.FileMode) error {
+	f, err := atomicfile.New(path, os.FileMode(0666))
+	if err != nil {
+		return err
+	}
+
 	data, err := yaml.Marshal(r)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, perm)
+
+	_, err = f.File.Write(data)
+	if err != nil {
+		return err
+	}
+
+	if err = f.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This prevents clients to risk seeing half-written files on POSIX systems.