### PR TITLE
fixed fromYaml | toJson

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -22,7 +22,7 @@ import (
 	"path"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gobwas/glob"


### PR DESCRIPTION
I have got init containers in my chart and want to describe them in yaml, defined in a seperate template that I could then call and convert via 'fromYaml | toJson' .
Turns out just unmarshaling the yaml and marshaling the json doesn't work, as discussed [here](http://stackoverflow.com/questions/40737122/convert-yaml-to-json-without-struct-golang).

I can also provide an example:
```
{{- define "example-yaml" -}}
name: "dry"
httpd: "test"
test:
  var: "test"
{{- end -}}
{{- define "example-test" -}}
{
  "name": "dry",
  "httpd": "test",
  "test": {
    "var": "test"
  }
}
{{- end -}}
```

If called from within another template like this:

```
{{ include "example-yaml" . | fromYaml}}
{{ include "example-json" . | fromJson}}
{{ include "example-yaml" . | fromYaml | toJson}}
{{ include "example-json" . | fromJson | toJson}}
```

It returns

```
map[test:map[var:test] name:dry httpd:test]
map[name:dry httpd:test test:map[var:test]]

{"httpd":"test","name":"dry","test":{"var":"test"}}
```

You can see here that as described in the ToYaml function, toYaml returns an empty string on marshal error.

I have just switched the normal yaml library to the [ghodss/yaml](https://github.com/ghodss/yaml) wrapper which handles exactly this case and was already included in the packages. I have not been able to confirm if it works, so this is just a suggestion and needs to be tested