### PR TITLE
fix(plugins): add error when updating modified plugins

### DIFF
--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,6 +16,7 @@ limitations under the License.
 package installer // import "k8s.io/helm/pkg/plugin/installer"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -92,6 +93,9 @@ func (i *VCSInstaller) Install() error {
 // Update updates a remote repository
 func (i *VCSInstaller) Update() error {
 	debug("updating %s", i.Repo.Remote())
+	if i.Repo.IsDirty() {
+		return errors.New("plugin repo was modified")
+	}
 	if err := i.Repo.Update(); err != nil {
 		return err
 	}

--- a/pkg/plugin/installer/vcs_installer_test.go
+++ b/pkg/plugin/installer/vcs_installer_test.go
@@ -195,9 +195,9 @@ func TestVCSInstallerUpdate(t *testing.T) {
 	os.Remove(filepath.Join(i.Path(), "plugin.yaml"))
 	// Testing update for error
 	if err := Update(i); err == nil {
-		t.Error("expected error for plugin metadata missing, got none")
-	} else if err.Error() != "plugin metadata (plugin.yaml) missing" {
-		t.Errorf("expected error for plugin metadata missing, got (%v)", err)
+		t.Error("expected error for plugin modified, got none")
+	} else if err.Error() != "plugin repo was modified" {
+		t.Errorf("expected error for plugin modified, got (%v)", err)
 	}
 
 }


### PR DESCRIPTION
If git has autosetuprebase enabled pulling will fail without a
descriptive error message.