### PR TITLE
ref(tiller): refactor release_server.go APIs into logical files.

### DIFF
--- a/pkg/tiller/release_testing.go
+++ b/pkg/tiller/release_testing.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tiller
+
+import (
+	"k8s.io/helm/pkg/proto/hapi/release"
+	"k8s.io/helm/pkg/proto/hapi/services"
+	reltesting "k8s.io/helm/pkg/releasetesting"
+)
+
+// RunReleaseTest runs pre-defined tests stored as hooks on a given release
+func (s *ReleaseServer) RunReleaseTest(req *services.TestReleaseRequest, stream services.ReleaseService_RunReleaseTestServer) error {
+
+	if !ValidName.MatchString(req.Name) {
+		return errMissingRelease
+	}
+
+	// finds the non-deleted release with the given name
+	rel, err := s.env.Releases.Last(req.Name)
+	if err != nil {
+		return err
+	}
+
+	testEnv := &reltesting.Environment{
+		Namespace:  rel.Namespace,
+		KubeClient: s.env.KubeClient,
+		Timeout:    req.Timeout,
+		Stream:     stream,
+	}
+
+	tSuite, err := reltesting.NewTestSuite(rel)
+	if err != nil {
+		s.Log("Error creating test suite for %s", rel.Name)
+		return err
+	}
+
+	if err := tSuite.Run(testEnv); err != nil {
+		s.Log("Error running test suite for %s", rel.Name)
+		return err
+	}
+
+	rel.Info.Status.LastTestSuiteRun = &release.TestSuite{
+		StartedAt:   tSuite.StartedAt,
+		CompletedAt: tSuite.CompletedAt,
+		Results:     tSuite.Results,
+	}
+
+	if req.Cleanup {
+		testEnv.DeleteTestPods(tSuite.TestManifests)
+	}
+
+	if err := s.env.Releases.Update(rel); err != nil {
+		s.Log("test: Failed to store updated release: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/tiller/release_version.go
+++ b/pkg/tiller/release_version.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tiller
+
+import (
+	ctx "golang.org/x/net/context"
+	"k8s.io/helm/pkg/proto/hapi/services"
+	"k8s.io/helm/pkg/version"
+)
+
+// GetVersion sends the server version.
+func (s *ReleaseServer) GetVersion(c ctx.Context, req *services.GetVersionRequest) (*services.GetVersionResponse, error) {
+	v := version.GetVersionProto()
+	return &services.GetVersionResponse{Version: v}, nil
+}


### PR DESCRIPTION
*ReleaseServer.RunReleaseTest -> tiller/release_testing.go
*ReleaseServer.GetVersion         -> tiller/release_version.go