### PR TITLE
Add check to stop helm 'waiting' for external services to become ready

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -136,6 +136,11 @@ func podsReady(pods []v1.Pod) bool {
 
 func servicesReady(svc []v1.Service) bool {
 	for _, s := range svc {
+		// ExternalName Services are external to cluster so helm shouldn't be checking to see if they're 'ready' (i.e. have an IP Set)
+		if s.Spec.Type == v1.ServiceTypeExternalName {
+			continue
+		}
+
 		// Make sure the service is not explicitly set to "None" before checking the IP
 		if s.Spec.ClusterIP != v1.ClusterIPNone && !v1.IsServiceIPSet(&s) {
 			return false


### PR DESCRIPTION
We noticed that externalServices were causing our `helm install --wait ...` to hang/fail unexpectedly, and after looking at the logic it appears externalNamed services are being checked for an IP and hence failing the 'ready' check.

I don't think helm is capable of determining if an external service is healthy or not since it's outside of the scope of the cluster, so I've added an exception in this commit.

What do you guys think?