### PR TITLE
fix(helm): prepend repo URL to packages missing scheme

### DIFF
--- a/docs/chart_repository_faq.md
+++ b/docs/chart_repository_faq.md
@@ -10,6 +10,8 @@ send us a pull request.
 
 **Q: Why do I get a `unsupported protocol scheme ""` error when trying to fetch a chart from my custom repo?**
 
-A: This is likely caused by you creating your chart repo index without specifying the `--url` flag.
+A: (Helm < 2.5.0) This is likely caused by you creating your chart repo index without specifying the `--url` flag.
 Try recreating your `index.yaml` file with a command like `heml repo index --url http://my-repo/charts .`,
 and then re-uploading it to your custom charts repo.
+
+This behavior was changed in Helm 2.5.0.

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -215,6 +215,12 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 		return u, r.Client, fmt.Errorf("invalid chart URL format: %s", ref)
 	}
 
+	// If the URL is relative (no scheme), prepend the chart repo's base URL
+	if !u.IsAbs() {
+		u, err = url.Parse(rc.URL + "/" + u.Path)
+		return u, r.Client, err
+	}
+
 	return u, r.Client, nil
 }
 

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -42,6 +42,7 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "full URL, with authentication", ref: "http://username:password@example.com/foo-1.2.3.tgz", expect: "http://username:password@example.com/foo-1.2.3.tgz"},
 		{name: "reference, testing repo", ref: "testing/alpine", expect: "http://example.com/alpine-1.2.3.tgz"},
 		{name: "reference, version, testing repo", ref: "testing/alpine", version: "0.2.0", expect: "http://example.com/alpine-0.2.0.tgz"},
+		{name: "reference, version, malformed repo", ref: "malformed/alpine", version: "1.2.3", expect: "http://dl.example.com/alpine-1.2.3.tgz"},
 		{name: "full URL, HTTPS, irrelevant version", ref: "https://example.com/foo-1.2.3.tgz", version: "0.1.0", expect: "https://example.com/foo-1.2.3.tgz", fail: true},
 		{name: "full URL, file", ref: "file:///foo-1.2.3.tgz", fail: true},
 		{name: "invalid", ref: "invalid-1.2.3", fail: true},

--- a/pkg/downloader/testdata/helmhome/repository/cache/malformed-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/malformed-index.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      urls:
+        - alpine-1.2.3.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 1.2.3
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""

--- a/pkg/downloader/testdata/helmhome/repository/repositories.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/repositories.yaml
@@ -8,3 +8,5 @@ repositories:
     url: "http://username:password@example.com"
   - name: kubernetes-charts
     url: "http://example.com/charts"
+  - name: malformed
+    url: "http://dl.example.com"


### PR DESCRIPTION
When a repository is generated without --url, the packages in that
repository do not have FQDNs. In this case, the URL prefix (FQDN plus
base path) should be derived from the repository's base URL. This seems
to be a regression that crept in around Helm 2.2.0. This is now fixed.

Closes #2315
Closes #2510