### PR TITLE
fix(tiller): Adds missing import back

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -22,6 +22,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"time"
 


### PR DESCRIPTION
PR #2513 was behind master when merged. Other commits were added that required the use of the log package. This re-adds that package.