### PR TITLE
fix(helm): Fix log import

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -22,6 +22,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"time"
 


### PR DESCRIPTION
`make bootstrap build` fails due to compilation error on HEAD.