### PR TITLE
adjust the check parameter order for uninstall 

### DIFF
--- a/pkg/tiller/release_uninstall.go
+++ b/pkg/tiller/release_uninstall.go
@@ -30,12 +30,6 @@ import (
 
 // UninstallRelease deletes all of the resources associated with this release, and marks the release DELETED.
 func (s *ReleaseServer) UninstallRelease(c ctx.Context, req *services.UninstallReleaseRequest) (*services.UninstallReleaseResponse, error) {
-	err := s.env.Releases.LockRelease(req.Name)
-	if err != nil {
-		return nil, err
-	}
-	defer s.env.Releases.UnlockRelease(req.Name)
-
 	if !ValidName.MatchString(req.Name) {
 		s.Log("uninstall: Release not found: %s", req.Name)
 		return nil, errMissingRelease
@@ -44,6 +38,12 @@ func (s *ReleaseServer) UninstallRelease(c ctx.Context, req *services.UninstallR
 	if len(req.Name) > releaseNameMaxLen {
 		return nil, fmt.Errorf("release name %q exceeds max length of %d", req.Name, releaseNameMaxLen)
 	}
+
+	err := s.env.Releases.LockRelease(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer s.env.Releases.UnlockRelease(req.Name)
 
 	rels, err := s.env.Releases.History(req.Name)
 	if err != nil {


### PR DESCRIPTION
Adjust the  check parameter order in uninstall processing, move  the   regex  and length check before 

get  release locker.  #2529 