### PR TITLE
fix(tiller): make GetReleaseContent return any release

### DIFF
--- a/pkg/tiller/release_content.go
+++ b/pkg/tiller/release_content.go
@@ -28,7 +28,7 @@ func (s *ReleaseServer) GetReleaseContent(c ctx.Context, req *services.GetReleas
 	}
 
 	if req.Version <= 0 {
-		rel, err := s.env.Releases.Deployed(req.Name)
+		rel, err := s.env.Releases.Last(req.Name)
 		return &services.GetReleaseContentResponse{Release: rel}, err
 	}
 


### PR DESCRIPTION
For some reason, GetReleaseContent was configured to return the latest
release only if it is in state DEPLOYED. But a release with a version is
returned regardless of release. This made it really hard to debug failed
releases, even though we have the data to show.

Closes #2525