### PR TITLE
fix(helm): Ensures tiller pod lands on a linux node

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -166,6 +166,9 @@ func generateDeployment(opts *Options) *extensions.Deployment {
 							},
 						},
 					},
+					NodeSelector: map[string]string{
+						"beta.kubernetes.io/os": "linux",
+					},
 					SecurityContext: &api.PodSecurityContext{
 						HostNetwork: opts.EnableHostNetwork,
 					},


### PR DESCRIPTION
Without a node selector to ensure that tiller deploys on a linux node, the tiller pod can have issues starting in a mixed cluster.

Fixes #2420