### PR TITLE
feat(helm): support array index format for --set.

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -107,7 +107,6 @@ func DeploymentManifest(opts *Options) (string, error) {
 // resource.
 func ServiceManifest(namespace string) (string, error) {
 	obj := service(namespace)
-
 	buf, err := yaml.Marshal(obj)
 	return string(buf), err
 }

--- a/docs/chart_best_practices/values.md
+++ b/docs/chart_best_practices/values.md
@@ -113,6 +113,11 @@ servers:
     port: 81
 ```
 
+The above cannot be expressed with `--set` in Helm `<=2.4`. In Helm 2.5, the
+accessing the port on foo is `--set servers[0].port=80`. Not only is it harder
+for the user to figure out, but it is prone to errors if at some later time the
+order of the `servers` is changed.
+
 Easy to use:
 
 ```yaml
@@ -122,6 +127,8 @@ servers:
   bar:
     port: 81
 ```
+
+Accessing foo's port is much more obvious: `--set servers.foo.port=80`.
 
 ## Document 'values.yaml'
 

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -264,6 +264,22 @@ name:
   - c
 ```
 
+As of Helm 2.5.0, it is possible to access list items using an array index syntax.
+For example, `--set servers[0].port=80` becomes:
+
+```yaml
+servers:
+  - port: 80
+```
+
+Multiple values can be set this way. The line `--set servers[0].port=80,servers[0].host=example` becomes:
+
+```yaml
+servers:
+  - port: 80
+    host: example
+```
+
 Sometimes you need to use special characters in your `--set` lines. You can use
 a backslash to escape the characters; `--set name=value1\,value2` will become:
 
@@ -280,9 +296,9 @@ nodeSelector:
   kubernetes.io/role: master
 ```
 
-The `--set` syntax is not as expressive as YAML, especially when it comes to
-collections. And there is currently no method for expressing things such as "set
-the third item in a list to...".
+Deeply nested datastructures can be difficult to express using `--set`. Chart
+designers are encouraged to consider the `--set` usage when designing the format
+of a `values.yaml` file.
 
 ### More Installation Methods
 

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -21,6 +21,49 @@ import (
 	"github.com/ghodss/yaml"
 )
 
+func TestSetIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial []interface{}
+		expect  []interface{}
+		add     int
+		val     int
+	}{
+		{
+			name:    "short",
+			initial: []interface{}{0, 1},
+			expect:  []interface{}{0, 1, 2},
+			add:     2,
+			val:     2,
+		},
+		{
+			name:    "equal",
+			initial: []interface{}{0, 1},
+			expect:  []interface{}{0, 2},
+			add:     1,
+			val:     2,
+		},
+		{
+			name:    "long",
+			initial: []interface{}{0, 1, 2, 3, 4, 5},
+			expect:  []interface{}{0, 1, 2, 4, 4, 5},
+			add:     3,
+			val:     4,
+		},
+	}
+
+	for _, tt := range tests {
+		got := setIndex(tt.initial, tt.add, tt.val)
+		if len(got) != len(tt.expect) {
+			t.Fatalf("%s: Expected length %d, got %d", tt.name, len(tt.expect), len(got))
+		}
+
+		if gg := got[tt.add].(int); gg != tt.val {
+			t.Errorf("%s, Expected value %d, got %d", tt.name, tt.val, gg)
+		}
+	}
+}
+
 func TestParseSet(t *testing.T) {
 	tests := []struct {
 		str    string
@@ -154,6 +197,59 @@ func TestParseSet(t *testing.T) {
 		{
 			str: "name1={1021,902",
 			err: true,
+		},
+		// List support
+		{
+			str:    "list[0]=foo",
+			expect: map[string]interface{}{"list": []string{"foo"}},
+		},
+		{
+			str: "list[0].foo=bar",
+			expect: map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{"foo": "bar"},
+				},
+			},
+		},
+		{
+			str: "list[0].foo=bar,list[0].hello=world",
+			expect: map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{"foo": "bar", "hello": "world"},
+				},
+			},
+		},
+		{
+			str:    "list[0]=foo,list[1]=bar",
+			expect: map[string]interface{}{"list": []string{"foo", "bar"}},
+		},
+		{
+			str:    "list[0]=foo,list[1]=bar,",
+			expect: map[string]interface{}{"list": []string{"foo", "bar"}},
+		},
+		{
+			str:    "list[0]=foo,list[3]=bar",
+			expect: map[string]interface{}{"list": []interface{}{"foo", nil, nil, "bar"}},
+		},
+		{
+			str: "illegal[0]name.foo=bar",
+			err: true,
+		},
+		{
+			str:    "noval[0]",
+			expect: map[string]interface{}{"noval": []interface{}{}},
+		},
+		{
+			str:    "noval[0]=",
+			expect: map[string]interface{}{"noval": []interface{}{""}},
+		},
+		{
+			str:    "nested[0][0]=1",
+			expect: map[string]interface{}{"nested": []interface{}{[]interface{}{1}}},
+		},
+		{
+			str:    "nested[1][1]=1",
+			expect: map[string]interface{}{"nested": []interface{}{nil, []interface{}{nil, 1}}},
 		},
 	}
 


### PR DESCRIPTION
This adds support for specifying list position with an array index using
`--set`. For example, this now works: `--set servers[0].port=8080`

I marked this "breaking" because prior, `--set foo[0]=bar` would look for a literal key named `foo[0]`. Now it will look for `foo` and access the first index of its list.