### PR TITLE
fix(tests): Fixes broken unit test

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -351,6 +351,7 @@ func TestRootCmd(t *testing.T) {
 	}{
 		{
 			name: "defaults",
+			args: []string{"home"},
 			home: filepath.Join(os.Getenv("HOME"), "/.helm"),
 		},
 		{
@@ -365,6 +366,7 @@ func TestRootCmd(t *testing.T) {
 		},
 		{
 			name:   "with $HELM_HOME set",
+			args:   []string{"home"},
 			envars: map[string]string{"HELM_HOME": "/bar"},
 			home:   "/bar",
 		},


### PR DESCRIPTION
This fixes the broken unit test on master. The new unit test was not passing an explicit subcommand arg to the root command in the unit test.