### PR TITLE
ref(helm): make FakeReleaseClient public

### DIFF
--- a/cmd/helm/delete_test.go
+++ b/cmd/helm/delete_test.go
@@ -62,7 +62,7 @@ func TestDelete(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newDeleteCmd(c, out)
 	})
 }

--- a/cmd/helm/delete_test.go
+++ b/cmd/helm/delete_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestDelete(t *testing.T) {
@@ -60,7 +62,7 @@ func TestDelete(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newDeleteCmd(c, out)
 	})
 }

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestGetHooks(t *testing.T) {
@@ -37,7 +39,7 @@ func TestGetHooks(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newGetHooksCmd(c, out)
 	})
 }

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -39,7 +39,7 @@ func TestGetHooks(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newGetHooksCmd(c, out)
 	})
 }

--- a/cmd/helm/get_manifest_test.go
+++ b/cmd/helm/get_manifest_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestGetManifest(t *testing.T) {
@@ -37,7 +39,7 @@ func TestGetManifest(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newGetManifestCmd(c, out)
 	})
 }

--- a/cmd/helm/get_manifest_test.go
+++ b/cmd/helm/get_manifest_test.go
@@ -39,7 +39,7 @@ func TestGetManifest(t *testing.T) {
 			err:  true,
 		},
 	}
-	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newGetManifestCmd(c, out)
 	})
 }

--- a/cmd/helm/get_test.go
+++ b/cmd/helm/get_test.go
@@ -39,7 +39,7 @@ func TestGetCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newGetCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/get_test.go
+++ b/cmd/helm/get_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestGetCmd(t *testing.T) {
@@ -37,7 +39,7 @@ func TestGetCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newGetCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestGetValuesCmd(t *testing.T) {
@@ -36,7 +38,7 @@ func TestGetValuesCmd(t *testing.T) {
 			err:  true,
 		},
 	}
-	cmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newGetValuesCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -38,7 +38,7 @@ func TestGetValuesCmd(t *testing.T) {
 			err:  true,
 		},
 	}
-	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newGetValuesCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -120,14 +120,14 @@ func releaseMock(opts *releaseOptions) *release.Release {
 	}
 }
 
-// releaseCmd is a command that works with a FakeReleaseClient
-type releaseCmd func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command
+// releaseCmd is a command that works with a FakeClient
+type releaseCmd func(c *helm.FakeClient, out io.Writer) *cobra.Command
 
 // runReleaseCases runs a set of release cases through the given releaseCmd.
 func runReleaseCases(t *testing.T, tests []releaseCase, rcmd releaseCmd) {
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		c := &helm.FakeReleaseClient{
+		c := &helm.FakeClient{
 			Rels: []*release.Release{tt.resp},
 		}
 		cmd := rcmd(c, &buf)

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -67,7 +67,7 @@ func TestHistoryCmd(t *testing.T) {
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		frc := &helm.FakeReleaseClient{Rels: tt.resp}
+		frc := &helm.FakeClient{Rels: tt.resp}
 		cmd := newHistoryCmd(frc, &buf)
 		cmd.ParseFlags(tt.args)
 

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"testing"
 
+	"k8s.io/helm/pkg/helm"
 	rpb "k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -66,7 +67,7 @@ func TestHistoryCmd(t *testing.T) {
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		frc := &fakeReleaseClient{rels: tt.resp}
+		frc := &helm.FakeReleaseClient{Rels: tt.resp}
 		cmd := newHistoryCmd(frc, &buf)
 		cmd.ParseFlags(tt.args)
 

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -148,7 +148,7 @@ func TestInstall(t *testing.T) {
 		},
 	}
 
-	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newInstallCmd(c, out)
 	})
 }

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestInstall(t *testing.T) {
@@ -146,7 +148,7 @@ func TestInstall(t *testing.T) {
 		},
 	}
 
-	runReleaseCases(t, tests, func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	runReleaseCases(t, tests, func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newInstallCmd(c, out)
 	})
 }

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -102,7 +102,7 @@ func TestListCmd(t *testing.T) {
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		c := &helm.FakeReleaseClient{
+		c := &helm.FakeClient{
 			Rels: tt.resp,
 		}
 		cmd := newListCmd(c, &buf)

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"testing"
 
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -101,8 +102,8 @@ func TestListCmd(t *testing.T) {
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		c := &fakeReleaseClient{
-			rels: tt.resp,
+		c := &helm.FakeReleaseClient{
+			Rels: tt.resp,
 		}
 		cmd := newListCmd(c, &buf)
 		cmd.ParseFlags(tt.args)

--- a/cmd/helm/release_testing_test.go
+++ b/cmd/helm/release_testing_test.go
@@ -83,7 +83,7 @@ func TestReleaseTesting(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c := &helm.FakeReleaseClient{Responses: tt.responses}
+		c := &helm.FakeClient{Responses: tt.responses}
 
 		buf := bytes.NewBuffer(nil)
 		cmd := newReleaseTestCmd(c, buf)

--- a/cmd/helm/release_testing_test.go
+++ b/cmd/helm/release_testing_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"testing"
 
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -82,7 +83,7 @@ func TestReleaseTesting(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c := &fakeReleaseClient{responses: tt.responses}
+		c := &helm.FakeReleaseClient{Responses: tt.responses}
 
 		buf := bytes.NewBuffer(nil)
 		cmd := newReleaseTestCmd(c, buf)

--- a/cmd/helm/reset_test.go
+++ b/cmd/helm/reset_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
@@ -38,7 +39,7 @@ func TestResetCmd(t *testing.T) {
 	defer os.Remove(home)
 
 	var buf bytes.Buffer
-	c := &fakeReleaseClient{}
+	c := &helm.FakeReleaseClient{}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{
 		out:        &buf,
@@ -71,7 +72,7 @@ func TestResetCmd_removeHelmHome(t *testing.T) {
 	defer os.Remove(home)
 
 	var buf bytes.Buffer
-	c := &fakeReleaseClient{}
+	c := &helm.FakeReleaseClient{}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{
 		removeHelmHome: true,
@@ -108,8 +109,8 @@ func TestReset_deployedReleases(t *testing.T) {
 	resp := []*release.Release{
 		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
 	}
-	c := &fakeReleaseClient{
-		rels: resp,
+	c := &helm.FakeReleaseClient{
+		Rels: resp,
 	}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{
@@ -140,8 +141,8 @@ func TestReset_forceFlag(t *testing.T) {
 	resp := []*release.Release{
 		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
 	}
-	c := &fakeReleaseClient{
-		rels: resp,
+	c := &helm.FakeReleaseClient{
+		Rels: resp,
 	}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{

--- a/cmd/helm/reset_test.go
+++ b/cmd/helm/reset_test.go
@@ -39,7 +39,7 @@ func TestResetCmd(t *testing.T) {
 	defer os.Remove(home)
 
 	var buf bytes.Buffer
-	c := &helm.FakeReleaseClient{}
+	c := &helm.FakeClient{}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{
 		out:        &buf,
@@ -72,7 +72,7 @@ func TestResetCmd_removeHelmHome(t *testing.T) {
 	defer os.Remove(home)
 
 	var buf bytes.Buffer
-	c := &helm.FakeReleaseClient{}
+	c := &helm.FakeClient{}
 	fc := fake.NewSimpleClientset()
 	cmd := &resetCmd{
 		removeHelmHome: true,
@@ -109,7 +109,7 @@ func TestReset_deployedReleases(t *testing.T) {
 	resp := []*release.Release{
 		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
 	}
-	c := &helm.FakeReleaseClient{
+	c := &helm.FakeClient{
 		Rels: resp,
 	}
 	fc := fake.NewSimpleClientset()
@@ -141,7 +141,7 @@ func TestReset_forceFlag(t *testing.T) {
 	resp := []*release.Release{
 		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
 	}
-	c := &helm.FakeReleaseClient{
+	c := &helm.FakeClient{
 		Rels: resp,
 	}
 	fc := fake.NewSimpleClientset()

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -52,7 +52,7 @@ func TestRollbackCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newRollbackCmd(c, out)
 	}
 

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/helm/pkg/helm"
 )
 
 func TestRollbackCmd(t *testing.T) {
@@ -50,7 +52,7 @@ func TestRollbackCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newRollbackCmd(c, out)
 	}
 

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/spf13/cobra"
 
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/timeconv"
 )
@@ -106,14 +107,14 @@ func TestStatusCmd(t *testing.T) {
 		},
 	}
 
-	scmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	scmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newStatusCmd(c, out)
 	}
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		c := &fakeReleaseClient{
-			rels: []*release.Release{tt.rel},
+		c := &helm.FakeReleaseClient{
+			Rels: []*release.Release{tt.rel},
 		}
 		cmd := scmd(c, &buf)
 		cmd.ParseFlags(tt.flags)

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -107,13 +107,13 @@ func TestStatusCmd(t *testing.T) {
 		},
 	}
 
-	scmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	scmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newStatusCmd(c, out)
 	}
 
 	var buf bytes.Buffer
 	for _, tt := range tests {
-		c := &helm.FakeReleaseClient{
+		c := &helm.FakeClient{
 			Rels: []*release.Release{tt.rel},
 		}
 		cmd := scmd(c, &buf)

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -153,7 +153,7 @@ func TestUpgradeCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newUpgradeCmd(c, out)
 	}
 

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
@@ -152,7 +153,7 @@ func TestUpgradeCmd(t *testing.T) {
 		},
 	}
 
-	cmd := func(c *fakeReleaseClient, out io.Writer) *cobra.Command {
+	cmd := func(c *helm.FakeReleaseClient, out io.Writer) *cobra.Command {
 		return newUpgradeCmd(c, out)
 	}
 

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/version"
 )
 
@@ -42,7 +43,7 @@ func TestVersion(t *testing.T) {
 	settings.TillerHost = "fake-localhost"
 	for _, tt := range tests {
 		b := new(bytes.Buffer)
-		c := &fakeReleaseClient{}
+		c := &helm.FakeReleaseClient{}
 
 		cmd := newVersionCmd(c, b)
 		cmd.ParseFlags(tt.args)

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -43,7 +43,7 @@ func TestVersion(t *testing.T) {
 	settings.TillerHost = "fake-localhost"
 	for _, tt := range tests {
 		b := new(bytes.Buffer)
-		c := &helm.FakeReleaseClient{}
+		c := &helm.FakeClient{}
 
 		cmd := newVersionCmd(c, b)
 		cmd.ParseFlags(tt.args)

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm // import "k8s.io/helm/pkg/helm"
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/proto/hapi/release"
+	rls "k8s.io/helm/pkg/proto/hapi/services"
+	"k8s.io/helm/pkg/proto/hapi/version"
+)
+
+// FakeReleaseClient implements Interface
+type FakeReleaseClient struct {
+	Rels      []*release.Release
+	Responses map[string]release.TestRun_Status
+	Err       error
+}
+
+var _ Interface = &FakeReleaseClient{}
+var _ Interface = (*FakeReleaseClient)(nil)
+
+// Listreleases lists the current releases
+func (c *FakeReleaseClient) ListReleases(opts ...ReleaseListOption) (*rls.ListReleasesResponse, error) {
+	resp := &rls.ListReleasesResponse{
+		Count:    int64(len(c.Rels)),
+		Releases: c.Rels,
+	}
+	return resp, c.Err
+}
+
+// InstallRelease returns a response with the first Release on the fake release client
+func (c *FakeReleaseClient) InstallRelease(chStr, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
+	return &rls.InstallReleaseResponse{
+		Release: c.Rels[0],
+	}, nil
+}
+
+// InstallReleaseFromChart returns a response with the first Release on the fake release client
+func (c *FakeReleaseClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
+	return &rls.InstallReleaseResponse{
+		Release: c.Rels[0],
+	}, nil
+}
+
+// DeleteRelease returns nil, nil
+func (c *FakeReleaseClient) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error) {
+	return nil, nil
+}
+
+// UpdateRelease returns nil, nil
+func (c *FakeReleaseClient) UpdateRelease(rlsName string, chStr string, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
+	return nil, nil
+}
+
+// GetVersion returns a fake version
+func (c *FakeReleaseClient) GetVersion(opts ...VersionOption) (*rls.GetVersionResponse, error) {
+	return &rls.GetVersionResponse{
+		Version: &version.Version{
+			SemVer: "1.2.3-fakeclient+testonly",
+		},
+	}, nil
+}
+
+// UpdateReleaseFromChart returns nil, nil
+func (c *FakeReleaseClient) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
+	return nil, nil
+}
+
+// RollbackRelease returns nil, nil
+func (c *FakeReleaseClient) RollbackRelease(rlsName string, opts ...RollbackOption) (*rls.RollbackReleaseResponse, error) {
+	return nil, nil
+}
+
+// ReleaseStatus returns a release status response with info from the first release in the fake
+// release client
+func (c *FakeReleaseClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.GetReleaseStatusResponse, error) {
+	if c.Rels[0] != nil {
+		return &rls.GetReleaseStatusResponse{
+			Name:      c.Rels[0].Name,
+			Info:      c.Rels[0].Info,
+			Namespace: c.Rels[0].Namespace,
+		}, nil
+	}
+	return nil, fmt.Errorf("No such release: %s", rlsName)
+}
+
+// ReleaseContent returns the configuration for the first release in the fake release client
+func (c *FakeReleaseClient) ReleaseContent(rlsName string, opts ...ContentOption) (resp *rls.GetReleaseContentResponse, err error) {
+	if len(c.Rels) > 0 {
+		resp = &rls.GetReleaseContentResponse{
+			Release: c.Rels[0],
+		}
+	}
+	return resp, c.Err
+}
+
+// ReleaseHistory returns a release's revision history.
+func (c *FakeReleaseClient) ReleaseHistory(rlsName string, opts ...HistoryOption) (*rls.GetHistoryResponse, error) {
+	return &rls.GetHistoryResponse{Releases: c.Rels}, c.Err
+}
+
+// RunReleaseTest executes a pre-defined tests on a release
+func (c *FakeReleaseClient) RunReleaseTest(rlsName string, opts ...ReleaseTestOption) (<-chan *rls.TestReleaseResponse, <-chan error) {
+
+	results := make(chan *rls.TestReleaseResponse)
+	errc := make(chan error, 1)
+
+	go func() {
+		var wg sync.WaitGroup
+		for m, s := range c.Responses {
+			wg.Add(1)
+
+			go func(msg string, status release.TestRun_Status) {
+				defer wg.Done()
+				results <- &rls.TestReleaseResponse{Msg: msg, Status: status}
+			}(m, s)
+		}
+
+		wg.Wait()
+		close(results)
+		close(errc)
+	}()
+
+	return results, errc
+}
+
+// Option returns the fake release client
+func (c *FakeReleaseClient) Option(opt ...Option) Interface {
+	return c
+}

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -26,18 +26,18 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/version"
 )
 
-// FakeReleaseClient implements Interface
-type FakeReleaseClient struct {
+// FakeClient implements Interface
+type FakeClient struct {
 	Rels      []*release.Release
 	Responses map[string]release.TestRun_Status
 	Err       error
 }
 
-var _ Interface = &FakeReleaseClient{}
-var _ Interface = (*FakeReleaseClient)(nil)
+var _ Interface = &FakeClient{}
+var _ Interface = (*FakeClient)(nil)
 
-// Listreleases lists the current releases
-func (c *FakeReleaseClient) ListReleases(opts ...ReleaseListOption) (*rls.ListReleasesResponse, error) {
+// ListReleases lists the current releases
+func (c *FakeClient) ListReleases(opts ...ReleaseListOption) (*rls.ListReleasesResponse, error) {
 	resp := &rls.ListReleasesResponse{
 		Count:    int64(len(c.Rels)),
 		Releases: c.Rels,
@@ -46,31 +46,31 @@ func (c *FakeReleaseClient) ListReleases(opts ...ReleaseListOption) (*rls.ListRe
 }
 
 // InstallRelease returns a response with the first Release on the fake release client
-func (c *FakeReleaseClient) InstallRelease(chStr, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
+func (c *FakeClient) InstallRelease(chStr, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
 	return &rls.InstallReleaseResponse{
 		Release: c.Rels[0],
 	}, nil
 }
 
 // InstallReleaseFromChart returns a response with the first Release on the fake release client
-func (c *FakeReleaseClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
+func (c *FakeClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...InstallOption) (*rls.InstallReleaseResponse, error) {
 	return &rls.InstallReleaseResponse{
 		Release: c.Rels[0],
 	}, nil
 }
 
 // DeleteRelease returns nil, nil
-func (c *FakeReleaseClient) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error) {
+func (c *FakeClient) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error) {
 	return nil, nil
 }
 
 // UpdateRelease returns nil, nil
-func (c *FakeReleaseClient) UpdateRelease(rlsName string, chStr string, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
+func (c *FakeClient) UpdateRelease(rlsName string, chStr string, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
 	return nil, nil
 }
 
 // GetVersion returns a fake version
-func (c *FakeReleaseClient) GetVersion(opts ...VersionOption) (*rls.GetVersionResponse, error) {
+func (c *FakeClient) GetVersion(opts ...VersionOption) (*rls.GetVersionResponse, error) {
 	return &rls.GetVersionResponse{
 		Version: &version.Version{
 			SemVer: "1.2.3-fakeclient+testonly",
@@ -79,18 +79,18 @@ func (c *FakeReleaseClient) GetVersion(opts ...VersionOption) (*rls.GetVersionRe
 }
 
 // UpdateReleaseFromChart returns nil, nil
-func (c *FakeReleaseClient) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
+func (c *FakeClient) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...UpdateOption) (*rls.UpdateReleaseResponse, error) {
 	return nil, nil
 }
 
 // RollbackRelease returns nil, nil
-func (c *FakeReleaseClient) RollbackRelease(rlsName string, opts ...RollbackOption) (*rls.RollbackReleaseResponse, error) {
+func (c *FakeClient) RollbackRelease(rlsName string, opts ...RollbackOption) (*rls.RollbackReleaseResponse, error) {
 	return nil, nil
 }
 
 // ReleaseStatus returns a release status response with info from the first release in the fake
 // release client
-func (c *FakeReleaseClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.GetReleaseStatusResponse, error) {
+func (c *FakeClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.GetReleaseStatusResponse, error) {
 	if c.Rels[0] != nil {
 		return &rls.GetReleaseStatusResponse{
 			Name:      c.Rels[0].Name,
@@ -102,7 +102,7 @@ func (c *FakeReleaseClient) ReleaseStatus(rlsName string, opts ...StatusOption) 
 }
 
 // ReleaseContent returns the configuration for the first release in the fake release client
-func (c *FakeReleaseClient) ReleaseContent(rlsName string, opts ...ContentOption) (resp *rls.GetReleaseContentResponse, err error) {
+func (c *FakeClient) ReleaseContent(rlsName string, opts ...ContentOption) (resp *rls.GetReleaseContentResponse, err error) {
 	if len(c.Rels) > 0 {
 		resp = &rls.GetReleaseContentResponse{
 			Release: c.Rels[0],
@@ -112,12 +112,12 @@ func (c *FakeReleaseClient) ReleaseContent(rlsName string, opts ...ContentOption
 }
 
 // ReleaseHistory returns a release's revision history.
-func (c *FakeReleaseClient) ReleaseHistory(rlsName string, opts ...HistoryOption) (*rls.GetHistoryResponse, error) {
+func (c *FakeClient) ReleaseHistory(rlsName string, opts ...HistoryOption) (*rls.GetHistoryResponse, error) {
 	return &rls.GetHistoryResponse{Releases: c.Rels}, c.Err
 }
 
 // RunReleaseTest executes a pre-defined tests on a release
-func (c *FakeReleaseClient) RunReleaseTest(rlsName string, opts ...ReleaseTestOption) (<-chan *rls.TestReleaseResponse, <-chan error) {
+func (c *FakeClient) RunReleaseTest(rlsName string, opts ...ReleaseTestOption) (<-chan *rls.TestReleaseResponse, <-chan error) {
 
 	results := make(chan *rls.TestReleaseResponse)
 	errc := make(chan error, 1)
@@ -142,6 +142,6 @@ func (c *FakeReleaseClient) RunReleaseTest(rlsName string, opts ...ReleaseTestOp
 }
 
 // Option returns the fake release client
-func (c *FakeReleaseClient) Option(opt ...Option) Interface {
+func (c *FakeClient) Option(opt ...Option) Interface {
 	return c
 }


### PR DESCRIPTION
so it can be used by other projects that use the helm client

*also renamed to FakeClient