### PR TITLE
<chart>.tgz  will now be downloaded to "$HELM_HOME/cache/archive" directory

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -273,6 +273,7 @@ func ensureDirectories(home helmpath.Home, out io.Writer) error {
 		home.LocalRepository(),
 		home.Plugins(),
 		home.Starters(),
+		home.Archive(),
 	}
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -399,7 +399,11 @@ func locateChartPath(repoURL, name, version string, verify bool, keyring,
 		name = chartURL
 	}
 
-	filename, _, err := dl.DownloadTo(name, version, ".")
+	if _, err := os.Stat(settings.Home.Archive()); os.IsNotExist(err) {
+		os.MkdirAll(settings.Home.Archive(), 0744)
+	}
+
+	filename, _, err := dl.DownloadTo(name, version, settings.Home.Archive())
 	if err == nil {
 		lname, err := filepath.Abs(filename)
 		if err != nil {

--- a/pkg/helm/helmpath/helmhome.go
+++ b/pkg/helm/helmpath/helmhome.go
@@ -81,3 +81,8 @@ func (h Home) LocalRepository(elem ...string) string {
 func (h Home) Plugins() string {
 	return h.Path("plugins")
 }
+
+// Archive returns the path to download chart archives
+func (h Home) Archive() string {
+	return h.Path("cache", "archive")
+}

--- a/pkg/helm/helmpath/helmhome_unix_test.go
+++ b/pkg/helm/helmpath/helmhome_unix_test.go
@@ -37,6 +37,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.Cache(), "/r/repository/cache")
 	isEq(t, hh.CacheIndex("t"), "/r/repository/cache/t-index.yaml")
 	isEq(t, hh.Starters(), "/r/starters")
+	isEq(t, hh.Archive(), "/r/cache/archive")
 }
 
 func TestHelmHome_expand(t *testing.T) {

--- a/pkg/helm/helmpath/helmhome_windows_test.go
+++ b/pkg/helm/helmpath/helmhome_windows_test.go
@@ -34,4 +34,5 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.Cache(), "r:\\repository\\cache")
 	isEq(t, hh.CacheIndex("t"), "r:\\repository\\cache\\t-index.yaml")
 	isEq(t, hh.Starters(), "r:\\starters")
+	isEq(t, hh.Archive(), "r:\\cache\\archive")
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/2142