### PR TITLE
Removing compiled chart when 'install' is run with '--dry-run'

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -258,6 +258,12 @@ func (i *installCmd) run() error {
 
 	// If this is a dry run, we can't display status.
 	if i.dryRun {
+		// If this is a dry run, we should delete the compiled chart tarball to remain idempotent.
+		debug("Dry run: removing compiled chart: %s\n", i.chartPath)
+		err := os.Remove(i.chartPath)
+		if err != nil {
+			prettyError(err)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
👋  Thought I'd try my hand at taking on #1841, which (to my understanding) came to the conclusion of removing the compiled chart tarball (to remain idempotent) if `helm install` received the `--dry-run` argument. This is my first attempt at writing Go. Hope it's a good one! :crossed_fingers: 