### PR TITLE
docs: Fix typo in command line

### DIFF
--- a/docs/chart_repository_faq.md
+++ b/docs/chart_repository_faq.md
@@ -11,7 +11,7 @@ send us a pull request.
 **Q: Why do I get a `unsupported protocol scheme ""` error when trying to fetch a chart from my custom repo?**
 
 A: (Helm < 2.5.0) This is likely caused by you creating your chart repo index without specifying the `--url` flag.
-Try recreating your `index.yaml` file with a command like `heml repo index --url http://my-repo/charts .`,
+Try recreating your `index.yaml` file with a command like `helm repo index --url http://my-repo/charts .`,
 and then re-uploading it to your custom charts repo.
 
 This behavior was changed in Helm 2.5.0.


### PR DESCRIPTION
This is just a fix for a typo inside a command line example.