### PR TITLE
CAFile is now optional, in that case the default RootCAs are used

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -50,7 +50,7 @@ func (g *httpGetter) Get(href string) (*bytes.Buffer, error) {
 // newHTTPGetter constructs a valid http/https client as Getter
 func newHTTPGetter(URL, CertFile, KeyFile, CAFile string) (Getter, error) {
 	var client httpGetter
-	if CertFile != "" && KeyFile != "" && CAFile != "" {
+	if CertFile != "" && KeyFile != "" {
 		tlsConf, err := tlsutil.NewClientTLS(CertFile, KeyFile, CAFile)
 		if err != nil {
 			return nil, fmt.Errorf("can't create TLS config for client: %s", err.Error())

--- a/pkg/tlsutil/tls.go
+++ b/pkg/tlsutil/tls.go
@@ -29,14 +29,17 @@ func NewClientTLS(certFile, keyFile, caFile string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cp, err := CertPoolFromFile(caFile)
-	if err != nil {
-		return nil, err
-	}
-	return &tls.Config{
+	config := tls.Config{
 		Certificates: []tls.Certificate{*cert},
-		RootCAs:      cp,
-	}, nil
+	}
+	if caFile != "" {
+		cp, err := CertPoolFromFile(caFile)
+		if err != nil {
+			return nil, err
+		}
+		config.RootCAs = cp
+	}
+	return &config, nil
 }
 
 // CertPoolFromFile returns an x509.CertPool containing the certificates


### PR DESCRIPTION
In some situations one doesn't have to define any root certificates (for example when using Let's encrypt), but currently it is mandatory to do so. This PR changes the `--ca-file` to flag optional, in that case the OS's default root certificates are used.