### PR TITLE
Remove service.type mention from ingress docs

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -63,7 +63,7 @@ service:
   internalPort: 80
 ingress:
   enabled: false
-  # Used to create Ingress record (should used with service.type: ClusterIP).
+  # Used to create an Ingress record.
   hosts:
     - chart-example.local
   annotations:


### PR DESCRIPTION
`helm create` creates a chart with the following section:

```yaml
ingress:
  enabled: false
  # Used to create Ingress record (should used with service.type: ClusterIP).
```

This is quite deceitful because on Google Container Engine (one of the most popular Kubernetes provisioners) the default ingress controller does not work with service.type: ClusterIP, it requires service.type: NodePort:

<https://github.com/kubernetes/ingress/tree/master/controllers/gce>: *Remember that the GCE L7 is routing you through the NodePort service*
<https://github.com/kubernetes/kubernetes/issues/26508>: *nodeport is a requirement of the GCE Ingress controller (and cloud controllers in general)*

I think this comment should either be removed or amended correspondingly.