### PR TITLE
Allow deletion of a previous values file key

### DIFF
--- a/pkg/chartutil/testdata/moby/values.yaml
+++ b/pkg/chartutil/testdata/moby/values.yaml
@@ -2,3 +2,8 @@ scope: moby
 name: moby
 override: bad
 top: nope
+bottom: exists
+right: exists
+left: exists
+front: exists
+back: exists

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -281,6 +281,13 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}) (map[string]interf
 		if _, ok := v[key]; !ok {
 			// If the key is not in v, copy it from nv.
 			v[key] = val
+		} else if ok && v[key] == nil {
+			// When the YAML value is null, we remove the value's key.
+			// This allows Helm's various sources of values (value files or --set) to
+			// remove incompatible keys from any previous chart, file, or set values.
+			// ref: http://www.yaml.org/spec/1.2/spec.html#id2803362
+			delete(v, key)
+			continue
 		} else if dest, ok := v[key].(map[string]interface{}); ok {
 			// if v[key] is a table, merge nv's val table into v[key].
 			src, ok := val.(map[string]interface{})

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -277,6 +277,11 @@ func ttpl(tpl string, v map[string]interface{}) (string, error) {
 
 var testCoalesceValuesYaml = `
 top: yup
+bottom: null
+right: Null
+left: NULL
+front: ~
+back: ""
 
 global:
   name: Ishmael
@@ -316,6 +321,7 @@ func TestCoalesceValues(t *testing.T) {
 		expect string
 	}{
 		{"{{.top}}", "yup"},
+		{"{{.back}}", ""},
 		{"{{.name}}", "moby"},
 		{"{{.global.name}}", "Ishmael"},
 		{"{{.global.subject}}", "Queequeg"},
@@ -341,6 +347,13 @@ func TestCoalesceValues(t *testing.T) {
 	for _, tt := range tests {
 		if o, err := ttpl(tt.tpl, v); err != nil || o != tt.expect {
 			t.Errorf("Expected %q to expand to %q, got %q", tt.tpl, tt.expect, o)
+		}
+	}
+
+	nullKeys := []string{"bottom", "right", "left", "front"}
+	for _, nullKey := range nullKeys {
+		if _, ok := v[nullKey]; ok {
+			t.Errorf("Expected key %q to be removed, still present", nullKey)
 		}
 	}
 }


### PR DESCRIPTION
Since #1656 Helm deep-merges multiple values files. However, this also means there is currently no way to delete an existing key that may be incompatible with a newly added one.

This PR addresses option 2 in #1966. My Golang fu is not top notch yet, but that said let me know if this is wrong so I can fix it (PS Thanks to @rabellamy for sending me Go map documentation).