### PR TITLE
Adding APIService to the sort order

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -49,12 +49,14 @@ var InstallOrder SortOrder = []string{
 	"Job",
 	"CronJob",
 	"Ingress",
+	"APIService",
 }
 
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
 //
 // Those occurring earlier in the list get uninstalled before those occurring later in the list.
 var UninstallOrder SortOrder = []string{
+	"APIService",
 	"Ingress",
 	"Service",
 	"CronJob",

--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -140,6 +140,11 @@ func TestKindSorter(t *testing.T) {
 			content: "",
 			head:    &util.SimpleHead{Kind: "StatefulSet"},
 		},
+		{
+			name:    "w",
+			content: "",
+			head:    &util.SimpleHead{Kind: "APIService"},
+		},
 	}
 
 	for _, test := range []struct {
@@ -147,8 +152,8 @@ func TestKindSorter(t *testing.T) {
 		order       SortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "abcdefghijklmnopqrstuv!"},
-		{"uninstall", UninstallOrder, "vmutsrqponlkjihgfedcba!"},
+		{"install", InstallOrder, "abcdefghijklmnopqrstuvw!"},
+		{"uninstall", UninstallOrder, "wvmutsrqponlkjihgfedcba!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
This ensures that APIService resources are installed last and uninstalled first.

This is still a work in progress.

Fixes #2641