### PR TITLE
[WIP] feat(functional_tests): add functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,27 @@ test-style:
 	@scripts/validate-go.sh
 	@scripts/validate-license.sh
 
+.PHONY: build-test-functional
+build-test-functional: TARGETS = linux/amd64
+build-test-functional: build-cross
+build-test-functional: APP = tiller
+build-test-functional: build-cross
+build-test-functional:
+	docker build -f _functional_tests/Dockerfile -t helm-functional-tests:latest .
+
+.PHONY: run-test-functional
+run-test-functional:
+	# FIXME: Have to do a little path hackery to get minikube to work.
+	docker run \
+		-v $(HOME)/.kube/:/kube \
+		-v $(HOME)/.minikube/:$(HOME)/.minikube \
+		helm-functional-tests:latest
+
+
+.PHONY: test-functional
+test-functional: build-test-functional
+test-functional: run-test-functional
+
 .PHONY: protoc
 protoc:
 	$(MAKE) -C _proto/ all

--- a/_functional_tests/Dockerfile
+++ b/_functional_tests/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:stretch-slim
+
+RUN apt-get update && apt-get install -y curl ca-certificates procps
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && mv kubectl /usr/local/bin && chmod 755 /usr/local/bin/kubectl
+
+
+ENV HELM_HOME=/helmhome
+ENV HELM_HOST=127.0.0.1:44134
+ENV KUBECONFIG=/kube/config
+
+COPY _functional_tests/run.sh /run.sh
+# Copy the scripts
+COPY _functional_tests/tests /tests
+# Copy the charts
+#COPY _functional_tests/tests/chart* /tests/
+COPY _dist/linux-amd64/helm /usr/bin/helm
+COPY _dist/linux-amd64/tiller /usr/bin/tiller
+
+RUN chmod 755 /tests/*.sh
+
+ENTRYPOINT /run.sh

--- a/_functional_tests/run.sh
+++ b/_functional_tests/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test organization:
+# 0XX: Basic commands (init, version, completion, etc)
+# 1XX: Local commands (create, package)
+# 2XX: Install/delete commands (helm install XXX)
+# 3XX: Commands that work with releases (list, get, status, test)
+# 4XX: Repository commands (search, fetch)
+# 5XX: RESERVED
+# 6XX: Advanced commands (plugins, serve, dependency)
+# 7XX: Signing and verification (helm package --sign)
+# 8XX: RESERVED
+# 9XX: Teardown
+
+set -e -o pipefail
+export NAMESPACE="helm-functional-tests"
+
+# We store Tiller's data in the testing namespace.
+export TILLER_NAMESPACE=${NAMESPACE}
+
+# Run a tiller locally, and point all Helm operations to that
+# tiller.
+#2>/dev/null 1>&2 tiller &
+tiller &
+sleep 3
+
+for s in tests/*.sh; do
+  echo "+++ Running " $s
+  echo $s
+  echo "--- Finished " $s " with code " $?
+done
+
+function cleanup {
+  echo "Cleaning up"
+  pkill tiller || true
+  kubectl delete namespace $NAMESPACE || true
+}
+
+trap cleanup EXIT

--- a/_functional_tests/tests/000-helm-init.sh
+++ b/_functional_tests/tests/000-helm-init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+helm init --client-only

--- a/_functional_tests/tests/010-helm-version.sh
+++ b/_functional_tests/tests/010-helm-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+helm version --client
+helm version --server

--- a/_functional_tests/tests/020-helm-completion.sh
+++ b/_functional_tests/tests/020-helm-completion.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# test that command works
+helm completion bash > /dev/null
+helm completion zsh > /dev/null
+
+# test that generate code is readable by Bash
+#source < (helm completion bash)

--- a/_functional_tests/tests/030-helm-home.sh
+++ b/_functional_tests/tests/030-helm-home.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+helm home
+
+cd $(helm home)
+cd -

--- a/_functional_tests/tests/100-helm-create.sh
+++ b/_functional_tests/tests/100-helm-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+helm create test-1xx

--- a/_functional_tests/tests/110-helm-package.sh
+++ b/_functional_tests/tests/110-helm-package.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+helm create test110
+helm package --version 1.0.0 test110
+
+expect="test110-1.0.0.tgz"
+if [ ! -f $expect ]; then
+  echo "Cannot find $expect"
+  ls -1
+  exit 1
+fi

--- a/_functional_tests/tests/200-helm-install-empty.sh
+++ b/_functional_tests/tests/200-helm-install-empty.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source "common.bash"
+
+set -e -o pipefail
+
+install_chart chart200
+sleep 10
+uninstall_chart chart200

--- a/_functional_tests/tests/210-helm-install-pod.sh
+++ b/_functional_tests/tests/210-helm-install-pod.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source "common.bash"
+
+install_chart chart210
+sleep 30
+uninstall_chart chart210

--- a/_functional_tests/tests/220-helm-install-replicaset.sh
+++ b/_functional_tests/tests/220-helm-install-replicaset.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source "common.bash"
+
+install_chart chart220
+sleep 30
+uninstall_chart chart220

--- a/_functional_tests/tests/221-helm-install-deployment.sh
+++ b/_functional_tests/tests/221-helm-install-deployment.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source "common.bash"
+
+install_chart chart221
+sleep 30
+uninstall_chart chart221

--- a/_functional_tests/tests/222-helm-install-daemonset.sh
+++ b/_functional_tests/tests/222-helm-install-daemonset.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source "common.bash"
+
+install_chart chart222
+sleep 30
+uninstall_chart chart222

--- a/_functional_tests/tests/chart200/Chart.yaml
+++ b/_functional_tests/tests/chart200/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: test200
+version: 0.1.0

--- a/_functional_tests/tests/chart200/README.md
+++ b/_functional_tests/tests/chart200/README.md
@@ -1,0 +1,3 @@
+# Min: A minimal helm chart
+
+Create a minimal helm chart.

--- a/_functional_tests/tests/chart200/templates/NOTES.txt
+++ b/_functional_tests/tests/chart200/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name: {{ .Release.Name }}

--- a/_functional_tests/tests/chart200/templates/secret.yaml
+++ b/_functional_tests/tests/chart200/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.Release.Name}}
+type: Opaque
+data:
+  key: {{ b64enc "value" }}

--- a/_functional_tests/tests/chart200/values.yaml
+++ b/_functional_tests/tests/chart200/values.yaml
@@ -1,0 +1,1 @@
+# Add values here

--- a/_functional_tests/tests/chart210/Chart.yaml
+++ b/_functional_tests/tests/chart210/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart210
+version: 0.1.0

--- a/_functional_tests/tests/chart210/README.md
+++ b/_functional_tests/tests/chart210/README.md
@@ -1,0 +1,3 @@
+# Min: A minimal helm chart
+
+Create a minimal helm chart.

--- a/_functional_tests/tests/chart210/templates/NOTES.txt
+++ b/_functional_tests/tests/chart210/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name: {{ .Release.Name }}

--- a/_functional_tests/tests/chart210/templates/pod.yaml
+++ b/_functional_tests/tests/chart210/templates/pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name . }}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: waiter
+    image: "alpine:3.3"
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sleep", "500"]

--- a/_functional_tests/tests/chart210/values.yaml
+++ b/_functional_tests/tests/chart210/values.yaml
@@ -1,0 +1,1 @@
+# Add values here

--- a/_functional_tests/tests/chart220/Chart.yaml
+++ b/_functional_tests/tests/chart220/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart220
+version: 0.1.0

--- a/_functional_tests/tests/chart220/README.md
+++ b/_functional_tests/tests/chart220/README.md
@@ -1,0 +1,3 @@
+# Min: A minimal helm chart
+
+Create a minimal helm chart.

--- a/_functional_tests/tests/chart220/templates/NOTES.txt
+++ b/_functional_tests/tests/chart220/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name: {{ .Release.Name }}

--- a/_functional_tests/tests/chart220/templates/replicaset.yaml
+++ b/_functional_tests/tests/chart220/templates/replicaset.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: {{.Release.Name}}-replicaset
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      tier: frontend
+    matchExpressions:
+      - {key: tier, operator: In, values: [frontend]}
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: alpine:3.3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+

--- a/_functional_tests/tests/chart220/values.yaml
+++ b/_functional_tests/tests/chart220/values.yaml
@@ -1,0 +1,1 @@
+# Add values here

--- a/_functional_tests/tests/chart221/Chart.yaml
+++ b/_functional_tests/tests/chart221/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart221
+version: 0.1.0

--- a/_functional_tests/tests/chart221/README.md
+++ b/_functional_tests/tests/chart221/README.md
@@ -1,0 +1,3 @@
+# Min: A minimal helm chart
+
+Create a minimal helm chart.

--- a/_functional_tests/tests/chart221/templates/NOTES.txt
+++ b/_functional_tests/tests/chart221/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name: {{ .Release.Name }}

--- a/_functional_tests/tests/chart221/templates/deployment.yaml
+++ b/_functional_tests/tests/chart221/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{.Release.Name}}-deployment
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{.Release.Name}}-deployment
+        tier: frontend
+    spec:
+      containers:
+      - name: name
+        image: alpine:3.3
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 8080

--- a/_functional_tests/tests/chart221/values.yaml
+++ b/_functional_tests/tests/chart221/values.yaml
@@ -1,0 +1,1 @@
+# Add values here

--- a/_functional_tests/tests/chart222/Chart.yaml
+++ b/_functional_tests/tests/chart222/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart222
+version: 0.1.0

--- a/_functional_tests/tests/chart222/README.md
+++ b/_functional_tests/tests/chart222/README.md
@@ -1,0 +1,3 @@
+# Min: A minimal helm chart
+
+Create a minimal helm chart.

--- a/_functional_tests/tests/chart222/templates/NOTES.txt
+++ b/_functional_tests/tests/chart222/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Release name: {{ .Release.Name }}

--- a/_functional_tests/tests/chart222/templates/daemonset.yaml
+++ b/_functional_tests/tests/chart222/templates/daemonset.yaml
@@ -1,0 +1,17 @@
+iapiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name . }}
+      name: {{ .Release.Name . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "alpine:3.3"
+        imagePullPolicy: IfNotPresent

--- a/_functional_tests/tests/chart222/values.yaml
+++ b/_functional_tests/tests/chart222/values.yaml
@@ -1,0 +1,1 @@
+# Add values here

--- a/_functional_tests/tests/common.bash
+++ b/_functional_tests/tests/common.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function install_chart {
+  helm install tests/$1 -n $1 --namespace $NAMESPACE
+}
+
+function uninstall_chart {
+  helm delete $1
+}
+


### PR DESCRIPTION
This adds a series of functional tests that are implemented as Bash
scripts and run inside of a Docker container.

The idea is to create an intuitive but useful set of functional tests
that we can run against an existing Kubermetes cluster as acceptance
tests for a Helm release.

Scripts are spaced out and organized thematically, with basic tests
preceding more sophisticated tests. Emphasis falls on testing different
Kubernetes resource kinds, as well as testing all of Helm's commands.

The test runs with configmap storage since that is the default, even
though in-memory storage would be faster and easier to clean up.

The test suite is run inside of a namespace, and the namespace is
destroyed at the end of a test run.