### PR TITLE
fix(helm): fix `helm get` subcommands

### DIFF
--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -44,9 +44,10 @@ func newGetHooksCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		client: client,
 	}
 	cmd := &cobra.Command{
-		Use:   "hooks [flags] RELEASE_NAME",
-		Short: "download all hooks for a named release",
-		Long:  getHooksHelp,
+		Use:     "hooks [flags] RELEASE_NAME",
+		Short:   "download all hooks for a named release",
+		Long:    getHooksHelp,
+		PreRunE: setupConnection,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errReleaseRequired

--- a/cmd/helm/get_manifest.go
+++ b/cmd/helm/get_manifest.go
@@ -46,9 +46,10 @@ func newGetManifestCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		client: client,
 	}
 	cmd := &cobra.Command{
-		Use:   "manifest [flags] RELEASE_NAME",
-		Short: "download the manifest for a named release",
-		Long:  getManifestHelp,
+		Use:     "manifest [flags] RELEASE_NAME",
+		Short:   "download the manifest for a named release",
+		Long:    getManifestHelp,
+		PreRunE: setupConnection,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errReleaseRequired

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -44,9 +44,10 @@ func newGetValuesCmd(client helm.Interface, out io.Writer) *cobra.Command {
 		client: client,
 	}
 	cmd := &cobra.Command{
-		Use:   "values [flags] RELEASE_NAME",
-		Short: "download the values file for a named release",
-		Long:  getValuesHelp,
+		Use:     "values [flags] RELEASE_NAME",
+		Short:   "download the values file for a named release",
+		Long:    getValuesHelp,
+		PreRunE: setupConnection,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errReleaseRequired


### PR DESCRIPTION
This correctly sets up the tunnel for `helm get values`, `helm get
manifest`, and `helm get hooks`.

Closes #2617