### PR TITLE
Remove spurious field in Tiller kind sorter test

### DIFF
--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -118,9 +118,8 @@ func TestKindSorter(t *testing.T) {
 			Head: &util.SimpleHead{Kind: "StatefulSet"},
 		},
 		{
-			Name:    "w",
-			Content: "",
-			Head:    &util.SimpleHead{Kind: "APIService"},
+			Name: "w",
+			Head: &util.SimpleHead{Kind: "APIService"},
 		},
 	}
 


### PR DESCRIPTION
Following up on #2666, cover the new case added in #2650 by @scottrigby, but missed in the otherwise clean merge.