### PR TITLE
remove tiller/environment dependency from plugin package

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	helm_env "k8s.io/helm/pkg/helm/environment"
-	tiller_env "k8s.io/helm/pkg/tiller/environment"
 
 	"github.com/ghodss/yaml"
 )
@@ -189,8 +188,8 @@ func SetupPluginEnv(settings helm_env.EnvSettings,
 		"HELM_PATH_LOCAL_REPOSITORY": settings.Home.LocalRepository(),
 		"HELM_PATH_STARTER":          settings.Home.Starters(),
 
-		"TILLER_HOST":                    settings.TillerHost,
-		tiller_env.TillerNamespaceEnvVar: settings.TillerNamespace,
+		"TILLER_HOST":      settings.TillerHost,
+		"TILLER_NAMESPACE": settings.TillerNamespace,
 	} {
 		os.Setenv(key, val)
 	}


### PR DESCRIPTION
This might be controversial. I'm putting this PR out to get some feedback on this.

While writing the [helm-diff](https://github.com/databus23/helm-diff) plugin starting with helm 2.3 I suddenly pulled in a dependency on `github.com/kubernetes/kubernetes` which as you all know is quite a heavy cross to bear.
Needless to say this is totally unnecessary because the plugin just want to talk to tiller via grpc and does not interact with kubernetes directly.
It also inflates the resulting binary from 13MB to 63MB which is at least a little annoying.

I looked into this a little and turns it is because of a dependency from `k8s.io/helm/pkg/plugin` to `k8s.io/helm/pkg/tiller/environment`. Its only used to access the `TillerNamespaceEnvVar` constant.

`k8s.io/helm/pkg/plugin` is used by `k8s.io/helm/pkg/downloader` which is the package I need to import to reproduce the downloading of charts. Arguably these things have nothing todo with kubernetes und having a lighter dependency graph would improve the usability of these packages as libraries considerably.

What do you think?