### PR TITLE
fix(tiller): remove locking system from storage and rely on backend

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -173,7 +173,7 @@ func (cfgmaps *ConfigMaps) Create(key string, rls *rspb.Release) error {
 	// push the configmap object out into the kubiverse
 	if _, err := cfgmaps.impl.Create(obj); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			return ErrReleaseExists(rls.Name)
+			return ErrReleaseExists(key)
 		}
 
 		cfgmaps.Log("create: failed to create: %s", err)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -272,31 +272,3 @@ func assertErrNil(eh func(args ...interface{}), err error, message string) {
 		eh(fmt.Sprintf("%s: %q", message, err))
 	}
 }
-
-func TestReleaseLocksNotExist(t *testing.T) {
-	s := Init(driver.NewMemory())
-
-	err := s.LockRelease("no-such-release")
-
-	if err == nil {
-		t.Errorf("Exptected error when trying to lock non-existing release, got nil")
-	}
-}
-
-func TestReleaseLocks(t *testing.T) {
-	s := Init(driver.NewMemory())
-
-	releaseName := "angry-beaver"
-	rls := ReleaseTestData{
-		Name:    releaseName,
-		Version: 1,
-	}.ToRelease()
-
-	s.Create(rls)
-
-	err := s.LockRelease(releaseName)
-	if err != nil {
-		t.Errorf("Exptected nil err when locking existing release")
-	}
-	s.UnlockRelease(releaseName)
-}

--- a/pkg/tiller/release_rollback.go
+++ b/pkg/tiller/release_rollback.go
@@ -29,12 +29,6 @@ import (
 
 // RollbackRelease rolls back to a previous version of the given release.
 func (s *ReleaseServer) RollbackRelease(c ctx.Context, req *services.RollbackReleaseRequest) (*services.RollbackReleaseResponse, error) {
-	err := s.env.Releases.LockRelease(req.Name)
-	if err != nil {
-		return nil, err
-	}
-	defer s.env.Releases.UnlockRelease(req.Name)
-
 	s.Log("preparing rollback of %s", req.Name)
 	currentRelease, targetRelease, err := s.prepareRollback(req)
 	if err != nil {

--- a/pkg/tiller/release_uninstall.go
+++ b/pkg/tiller/release_uninstall.go
@@ -36,12 +36,6 @@ func (s *ReleaseServer) UninstallRelease(c ctx.Context, req *services.UninstallR
 		return nil, err
 	}
 
-	err := s.env.Releases.LockRelease(req.Name)
-	if err != nil {
-		return nil, err
-	}
-	defer s.env.Releases.UnlockRelease(req.Name)
-
 	rels, err := s.env.Releases.History(req.Name)
 	if err != nil {
 		s.Log("uninstall: Release not loaded: %s", req.Name)

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -34,13 +34,6 @@ func (s *ReleaseServer) UpdateRelease(c ctx.Context, req *services.UpdateRelease
 		s.Log("updateRelease: Release name is invalid: %s", req.Name)
 		return nil, err
 	}
-
-	err := s.env.Releases.LockRelease(req.Name)
-	if err != nil {
-		return nil, err
-	}
-	defer s.env.Releases.UnlockRelease(req.Name)
-
 	s.Log("preparing update for %s", req.Name)
 	currentRelease, updatedRelease, err := s.prepareUpdate(req)
 	if err != nil {


### PR DESCRIPTION

Tiller currently hangs indefinitely when deadlocks arise from certain
concurrent operations. This commit removes the nested mutex locking
system from pkg/Storage and relies on resource contention controls in k8s.

Closes #2560