### PR TITLE
ref(pkg/chartutil): replace use of 'fmt.Efforf'

### DIFF
--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -391,7 +391,7 @@ func istable(v interface{}) bool {
 // PathValue takes a yaml path with . notation and returns the value if exists
 func (v Values) PathValue(ypath string) (interface{}, error) {
 	if len(ypath) == 0 {
-		return nil, errors.New("yaml path string cannot be zero length")
+		return nil, errors.New("YAML path string cannot be zero length")
 	}
 	yps := strings.Split(ypath, ".")
 	if len(yps) == 1 {

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chartutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -390,7 +391,7 @@ func istable(v interface{}) bool {
 // PathValue takes a yaml path with . notation and returns the value if exists
 func (v Values) PathValue(ypath string) (interface{}, error) {
 	if len(ypath) == 0 {
-		return nil, fmt.Errorf("yaml path string cannot be zero length")
+		return nil, errors.New("yaml path string cannot be zero length")
 	}
 	yps := strings.Split(ypath, ".")
 	if len(yps) == 1 {

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -388,7 +388,13 @@ func istable(v interface{}) bool {
 	return ok
 }
 
-// PathValue takes a yaml path with . notation and returns the value if exists
+// PathValue takes a path that traverses a YAML structure and returns the value at the end of that path.
+// The path starts at the root of the YAML structure and is comprised of YAML keys separated by periods.
+// Given the following YAML data the value at path "chapter.one.title" is "Loomings".
+//
+// 		chapter:
+//		  one:
+//		    title: "Loomings"
 func (v Values) PathValue(ypath string) (interface{}, error) {
 	if len(ypath) == 0 {
 		return nil, errors.New("YAML path string cannot be zero length")

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -392,9 +392,9 @@ func istable(v interface{}) bool {
 // The path starts at the root of the YAML structure and is comprised of YAML keys separated by periods.
 // Given the following YAML data the value at path "chapter.one.title" is "Loomings".
 //
-// 		chapter:
-//		  one:
-//		    title: "Loomings"
+//	chapter:
+//	  one:
+//	    title: "Loomings"
 func (v Values) PathValue(ypath string) (interface{}, error) {
 	if len(ypath) == 0 {
 		return nil, errors.New("YAML path string cannot be zero length")

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -447,10 +447,12 @@ chapter:
 	if _, err := d.PathValue("chapter.doesntexist.one"); err == nil {
 		t.Errorf("Non-existent key in middle of path should return error: %s\n%v", err, d)
 	}
+	if _, err := d.PathValue(""); err == nil {
+		t.Errorf("Empty path should return error: %s\n%v", err, d)
+	}
 	if v, err := d.PathValue("title"); err == nil {
 		if v != "Moby Dick" {
 			t.Errorf("Failed to return values for root key title")
 		}
 	}
-
 }

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -447,8 +447,8 @@ chapter:
 	if _, err := d.PathValue("chapter.doesntexist.one"); err == nil {
 		t.Errorf("Non-existent key in middle of path should return error: %s\n%v", err, d)
 	}
-	if _, err := d.PathValue(""); err != nil {
-		t.Errorf("Empty path should return error: \n%v", d)
+	if _, err := d.PathValue(""); err == nil {
+		t.Error("Asking for the value from an empty path should yield an error")
 	}
 	if v, err := d.PathValue("title"); err == nil {
 		if v != "Moby Dick" {

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -447,8 +447,8 @@ chapter:
 	if _, err := d.PathValue("chapter.doesntexist.one"); err == nil {
 		t.Errorf("Non-existent key in middle of path should return error: %s\n%v", err, d)
 	}
-	if _, err := d.PathValue(""); err == nil {
-		t.Errorf("Empty path should return error: %s\n%v", err, d)
+	if _, err := d.PathValue(""); err != nil {
+		t.Errorf("Empty path should return error: \n%v", d)
 	}
 	if v, err := d.PathValue("title"); err == nil {
 		if v != "Moby Dick" {


### PR DESCRIPTION
'fmt.Errorf' is unnecessary when checking for 0 length path in Values.PathValue
due to the lack of formatting. Add test covering changes.