### PR TITLE
Fix deadlock on UnlockRelease

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -193,8 +193,6 @@ func (s *Storage) LockRelease(name string) error {
 // If release doesn't exist or wasn't previously locked - the unlock will pass
 func (s *Storage) UnlockRelease(name string) {
 	s.Log("unlocking release %s", name)
-	s.releaseLocksLock.Lock()
-	defer s.releaseLocksLock.Unlock()
 
 	var lock *sync.Mutex
 	lock, exists := s.releaseLocks[name]


### PR DESCRIPTION
Locking release map is not needed in UnlockRelease as the goroutine
releasing the lock must first acquire it.

More importantly it resulted in deadlocks, which got investigated by
Justin Scott (justin.a.scott@intel.com).

fixes #2560 