### PR TITLE
Updating default values.yaml comments

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -82,7 +82,7 @@ resources: {}
   # limits:
   #  cpu: 100m
   #  memory: 128Mi
-  #requests:
+  # requests:
   #  cpu: 100m
   #  memory: 128Mi
 `


### PR DESCRIPTION
Following the instructions to simply uncomment the following lines results in a invalid yaml output, this patch fixes it.