### PR TITLE
fix(pkg/strvals): preserve leading zeros in vals

### DIFF
--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -308,8 +308,11 @@ func typedVal(v []rune) interface{} {
 		return false
 	}
 
-	if iv, err := strconv.ParseInt(val, 10, 64); err == nil {
-		return iv
+	// If this value does not start with zero, try parsing it to an int
+	if len(val) != 0 && val[0] != 48 {
+		if iv, err := strconv.ParseInt(val, 10, 64); err == nil {
+			return iv
+		}
 	}
 
 	return val

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -309,7 +309,7 @@ func typedVal(v []rune) interface{} {
 	}
 
 	// If this value does not start with zero, try parsing it to an int
-	if len(val) != 0 && val[0] != 48 {
+	if len(val) != 0 && val[0] != '0' {
 		if iv, err := strconv.ParseInt(val, 10, 64); err == nil {
 			return iv
 		}

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -94,6 +94,10 @@ func TestParseSet(t *testing.T) {
 			expect: map[string]interface{}{"name1": "", "name2": "value2"},
 		},
 		{
+			str:    "leading_zeros=00009",
+			expect: map[string]interface{}{"leading_zeros": "00009"},
+		},
+		{
 			str: "name1,name2=",
 			err: true,
 		},


### PR DESCRIPTION
When passing values with "helm install --set" values with leading zeros are
preserved and not parsed as ints.

Closes #2693