### PR TITLE
fix(helm): pass os.stdin when executing a plugin

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -81,6 +81,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 
 				prog := exec.Command(main, argv...)
 				prog.Env = os.Environ()
+				prog.Stdin = os.Stdin
 				prog.Stdout = out
 				prog.Stderr = os.Stderr
 				if err := prog.Run(); err != nil {


### PR DESCRIPTION
It fixes the problem with an editor opened by a plugin (Vim returns _Input is not from a terminal_ warning and the TTY is broken).