### PR TITLE
feat(helm):Allow remote values.yaml with -f

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -111,7 +111,7 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.VarP(&upgrade.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
+	f.VarP(&upgrade.valueFiles, "values", "f", "specify values in a YAML file or a URL(can specify multiple)")
 	f.BoolVar(&upgrade.dryRun, "dry-run", false, "simulate an upgrade")
 	f.BoolVar(&upgrade.recreate, "recreate-pods", false, "performs pods restart for the resource if applicable")
 	f.BoolVar(&upgrade.force, "force", false, "force resource update through delete/recreate if needed")

--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -87,7 +87,7 @@ helm install [CHART]
       --tls-cert string        path to TLS certificate file (default "$HELM_HOME/cert.pem")
       --tls-key string         path to TLS key file (default "$HELM_HOME/key.pem")
       --tls-verify             enable TLS for request and verify remote
-  -f, --values valueFiles      specify values in a YAML file (can specify multiple) (default [])
+  -f, --values valueFiles      specify values in a YAML file or a URL(can specify multiple) (default [])
       --verify                 verify the package before installing it
       --version string         specify the exact chart version to install. If this is not specified, the latest version is installed
       --wait                   if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful. It will wait for as long as --timeout

--- a/docs/helm/helm_upgrade.md
+++ b/docs/helm/helm_upgrade.md
@@ -57,7 +57,7 @@ helm upgrade [RELEASE] [CHART]
       --tls-cert string      path to TLS certificate file (default "$HELM_HOME/cert.pem")
       --tls-key string       path to TLS key file (default "$HELM_HOME/key.pem")
       --tls-verify           enable TLS for request and verify remote
-  -f, --values valueFiles    specify values in a YAML file (can specify multiple) (default [])
+  -f, --values valueFiles    specify values in a YAML file or a URL(can specify multiple) (default [])
       --verify               verify the provenance of the chart before upgrading
       --version string       specify the exact chart version to use. If this is not specified, the latest version is used
       --wait                 if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful. It will wait for as long as --timeout

--- a/docs/man/man1/helm_install.1
+++ b/docs/man/man1/helm_install.1
@@ -192,7 +192,7 @@ charts in a repository, use 'helm search'.
 
 .PP
 \fB\-f\fP, \fB\-\-values\fP=[]
-    specify values in a YAML file (can specify multiple)
+    specify values in a YAML file or a URL(can specify multiple)
 
 .PP
 \fB\-\-verify\fP[=false]

--- a/docs/man/man1/helm_upgrade.1
+++ b/docs/man/man1/helm_upgrade.1
@@ -143,7 +143,7 @@ $ helm upgrade \-\-set foo=bar \-\-set foo=newbar redis ./redis
 
 .PP
 \fB\-f\fP, \fB\-\-values\fP=[]
-    specify values in a YAML file (can specify multiple)
+    specify values in a YAML file or a URL(can specify multiple)
 
 .PP
 \fB\-\-verify\fP[=false]


### PR DESCRIPTION
In this feature, we can use -f option with remote files, same as kubectl
accepted URLs. I add an option to send a 'get' request when read the local
file failed.

Closes #2642