### PR TITLE
Fix helm repo list example

### DIFF
--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -227,7 +227,7 @@ packaged chart to that directory.
 $ helm package docs/examples/alpine/
 $ mkdir fantastic-charts
 $ mv alpine-0.1.0.tgz fantastic-charts/
-$ helm repo index fantastic-charts --url https://fantastic-charts.storage.googleapis.com
+$ helm repo index --url https://fantastic-charts.storage.googleapis.com fantastic-charts
 ```
 
 The last command takes the path of the local directory that you just created and

--- a/docs/chart_repository_sync_example.md
+++ b/docs/chart_repository_sync_example.md
@@ -19,9 +19,9 @@ $ mv alpine-0.1.0.tgz fantastic-charts/
 Use helm to generate an updated index.yaml file by passing in the directory path and the url of the remote repository to the `helm repo index` command like this:
 
 ```console
-$ helm repo index fantastic-charts/ --url https://fantastic-charts.storage.googleapis.com
+$ helm repo index --url https://fantastic-charts.storage.googleapis.com fantastic-charts
 ```
-This will generate an updated index.yaml file and place in the `fantastic-charts/` directory.
+This will generate an updated index.yaml file and place in the `fantastic-charts` directory.
 
 ## Sync your local and remote chart repositories
 Upload the contents of the directory to your GCS bucket by running `scripts/sync-repo.sh` and pass in the local directory name and the GCS bucket name.


### PR DESCRIPTION
The flags to the command must be provided before the directory: `helm repo index [flags] [DIR]` or an error is given: `Error: This command needs 1 argument: path to a directory`