### PR TITLE
bug(tiller): sort unknown but different kinds alphabetically based on kind name

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -116,8 +116,12 @@ func (k *kindSorter) Less(i, j int) bool {
 	b := k.manifests[j]
 	first, aok := k.ordering[a.Head.Kind]
 	second, bok := k.ordering[b.Head.Kind]
+	// if same kind (including unknown) sub sort alphanumeric
 	if first == second {
-		// same kind (including unknown) so sub sort alphanumeric
+		// if both are unknown and of different kind sort by kind alphabetically
+		if !aok && !bok && a.Head.Kind != b.Head.Kind {
+			return a.Head.Kind < b.Head.Kind
+		}
 		return a.Name < b.Name
 	}
 	// unknown kind is last

--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -175,7 +175,7 @@ func TestKindSorterSubSort(t *testing.T) {
 			Head: &util.SimpleHead{Kind: "ClusterRoleBinding"},
 		},
 		{
-			Name: "u3",
+			Name: "u2",
 			Head: &util.SimpleHead{Kind: "Unknown"},
 		},
 		{
@@ -183,8 +183,8 @@ func TestKindSorterSubSort(t *testing.T) {
 			Head: &util.SimpleHead{Kind: "Unknown"},
 		},
 		{
-			Name: "u2",
-			Head: &util.SimpleHead{Kind: "Unknown"},
+			Name: "t3",
+			Head: &util.SimpleHead{Kind: "Unknown2"},
 		},
 	}
 	for _, test := range []struct {
@@ -193,7 +193,7 @@ func TestKindSorterSubSort(t *testing.T) {
 		expected    string
 	}{
 		// expectation is sorted by kind (unknown is last) and then sub sorted alphabetically within each group
-		{"cm,clusterRole,clusterRoleBinding,Unknown", InstallOrder, "01Aa!zu1u2u3"},
+		{"cm,clusterRole,clusterRoleBinding,Unknown,Unknown2", InstallOrder, "01Aa!zu1u2t3"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
Adds additional manifest sorting logic so that different unknown kinds
are sorted alphabetically so that manifest order is more deterministic.