### PR TITLE
helm create all defined template names should be namespaced …

### DIFF
--- a/docs/chart_best_practices/templates.md
+++ b/docs/chart_best_practices/templates.md
@@ -36,6 +36,7 @@ Incorrect:
 {{/* ... */}}
 {{ end -}}
 ```
+It is highly recommended that new charts are created via `helm create` command as the template names are automatically defined as per this best practice.
 
 ## Formatting Templates
 

--- a/docs/examples/alpine/templates/_helpers.tpl
+++ b/docs/examples/alpine/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "alpine.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "alpine.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/docs/examples/alpine/templates/alpine-pod.yaml
+++ b/docs/examples/alpine/templates/alpine-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "alpine.fullname" . }}
   labels:
     # The "heritage" label is used to track which tool deployed a given chart.
     # It is useful for admins who want to see what releases a particular tool
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     # This makes it easy to audit chart usage.
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "alpine.name" . }}
 spec:
   # This shows how to use a simple value. This will look for a passed-in value called restartPolicy.
   restartPolicy: {{ .Values.restartPolicy }}

--- a/docs/examples/nginx/templates/_helpers.tpl
+++ b/docs/examples/nginx/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "nginx.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "nginx.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/docs/examples/nginx/templates/configmap.yaml
+++ b/docs/examples/nginx/templates/configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "nginx.fullname" . }}
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
 data:
   # When the config map is mounted as a volume, these will be created as files.
   index.html: {{ .Values.index | quote }}

--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   # This uses a "fullname" template (see _helpers)
   # Basing names on .Release.Name means that the same chart can be installed
   # multiple times into the same namespace.
-  name: {{ template "fullname" . }}
+  name: {{ template "nginx.fullname" . }}
   labels:
     # The "heritage" label is used to track which tool deployed a given chart.
     # It is useful for admins who want to see what releases a particular tool
@@ -15,7 +15,7 @@ metadata:
     release: {{ .Release.Name }}
     # This makes it easy to audit chart usage.
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -26,11 +26,11 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "nginx.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "name" . }}
+        - name: {{ template "nginx.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: wwwdata-volume
           configMap:
-            name: {{ template "fullname" . }}
+            name: {{ template "nginx.fullname" . }}

--- a/docs/examples/nginx/templates/post-install-job.yaml
+++ b/docs/examples/nginx/templates/post-install-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "nginx.fullname" . }}
   labels:
     # The "heritage" label is used to track which tool deployed a given chart.
     # It is useful for admins who want to see what releases a particular tool
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     # This makes it easy to audit chart usage.
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -20,10 +20,10 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ template "fullname" . }}
+      name: {{ template "nginx.fullname" . }}
       labels:
         release: {{ .Release.Name }}
-        app: {{ template "name" . }}
+        app: {{ template "nginx.name" . }}
     spec:
       # This shows how to use a simple value. This will look for a passed-in value
       # called restartPolicy. If it is not found, it will use the default value.

--- a/docs/examples/nginx/templates/pre-install-secret.yaml
+++ b/docs/examples/nginx/templates/pre-install-secret.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "nginx.fullname" . }}
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
   # This declares the resource to be a hook. By convention, we also name the
   # file "pre-install-XXX.yaml", but Helm itself doesn't care about file names.
   annotations:

--- a/docs/examples/nginx/templates/service-test.yaml
+++ b/docs/examples/nginx/templates/service-test.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ template "fullname" . }}-service-test"
+  name: "{{ template "nginx.fullname" . }}-service-test"
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
   annotations:
     "helm.sh/hook": test-success
 spec:
@@ -14,5 +14,5 @@ spec:
     - name: curl
       image: radial/busyboxplus:curl
       command: ['curl']
-      args:  ['{{ template "fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ template "nginx.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/docs/examples/nginx/templates/service.yaml
+++ b/docs/examples/nginx/templates/service.yaml
@@ -6,11 +6,11 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "nginx.fullname" . }}
 spec:
 # Provides options for the service so chart users have the full choice
   type: "{{ .Values.service.type }}"
@@ -35,5 +35,5 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "nginx.name" . }}
     release: {{ .Release.Name }}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
@@ -111,14 +112,14 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 `
 
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "fullname" . -}}
+{{- $serviceName := include "<CHARTNAME>.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "<CHARTNAME>.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "<CHARTNAME>.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -147,9 +148,9 @@ spec:
 const defaultDeployment = `apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "<CHARTNAME>.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "<CHARTNAME>.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -158,7 +159,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "<CHARTNAME>.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:
@@ -186,9 +187,9 @@ spec:
 const defaultService = `apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "<CHARTNAME>.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "<CHARTNAME>.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -200,7 +201,7 @@ spec:
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "<CHARTNAME>.name" . }}
     release: {{ .Release.Name }}
 `
 
@@ -210,16 +211,16 @@ const defaultNotes = `1. Get the application URL by running these commands:
   http://{{ . }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "<CHARTNAME>.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "<CHARTNAME>.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "<CHARTNAME>.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "<CHARTNAME>.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}
@@ -229,7 +230,7 @@ const defaultHelpers = `{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "<CHARTNAME>.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -237,7 +238,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "<CHARTNAME>.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -318,27 +319,27 @@ func Create(chartfile *chart.Metadata, dir string) (string, error) {
 		{
 			// ingress.yaml
 			path:    filepath.Join(cdir, TemplatesDir, IngressFileName),
-			content: []byte(defaultIngress),
+			content: []byte(strings.Replace(defaultIngress, "<CHARTNAME>", chartfile.Name, -1)),
 		},
 		{
 			// deployment.yaml
 			path:    filepath.Join(cdir, TemplatesDir, DeploymentName),
-			content: []byte(defaultDeployment),
+			content: []byte(strings.Replace(defaultDeployment, "<CHARTNAME>", chartfile.Name, -1)),
 		},
 		{
 			// service.yaml
 			path:    filepath.Join(cdir, TemplatesDir, ServiceName),
-			content: []byte(defaultService),
+			content: []byte(strings.Replace(defaultService, "<CHARTNAME>", chartfile.Name, -1)),
 		},
 		{
 			// NOTES.txt
 			path:    filepath.Join(cdir, TemplatesDir, NotesName),
-			content: []byte(defaultNotes),
+			content: []byte(strings.Replace(defaultNotes, "<CHARTNAME>", chartfile.Name, -1)),
 		},
 		{
 			// _helpers.tpl
 			path:    filepath.Join(cdir, TemplatesDir, HelpersName),
-			content: []byte(defaultHelpers),
+			content: []byte(strings.Replace(defaultHelpers, "<CHARTNAME>", chartfile.Name, -1)),
 		},
 	}
 


### PR DESCRIPTION
As mentioned [here](https://docs.helm.sh/chart_best_practices/#names-of-defined-templates), the default chart created by `helm create` should contian namespaced template functions. 

```
$helm create foo
Creating foo
```

The helper function now looks like this
```
$cat foo/templates/_helpers.tpl
{{/* vim: set filetype=mustache: */}}
{{/*
Expand the name of the chart.
*/}}
{{- define "foo.name" -}}
{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
{{- end -}}

{{/*
Create a default fully qualified app name.
We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
*/}}
{{- define "foo.fullname" -}}
{{- $name := default .Chart.Name .Values.nameOverride -}}
{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
{{- end -}}
```

[ref 1](https://github.com/kubernetes/charts/issues/1785)
[ref 2](https://github.com/kubernetes/helm/issues/2216)