### PR TITLE
Fix(helm): Fix the bug of dependency update deleting subcharts

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -217,9 +217,16 @@ func (m *Manager) downloadAll(deps []*chartutil.Dependency) error {
 	}
 
 	fmt.Fprintln(m.Out, "Deleting outdated charts")
+	c, _ := m.loadChartDir()
+	req, _ := chartutil.LoadRequirements(c)
 	for _, dep := range deps {
-		if err := m.safeDeleteDep(dep.Name, destPath); err != nil {
-			return err
+		for _, r := range req.Dependencies {
+			if dep.Name == r.Name {
+				if err := m.safeDeleteDep(dep.Name, destPath); err != nil {
+					return err
+				}
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
In Helm 2.6.0, the new delete feature that deletes old versions of charts is deleting subcharts that aren't in requirements.yaml.
In this patch, I move subcharts not included in requirements.yaml to charts dir before remove tmpcharts.

Closes #2830