### PR TITLE
v2.6 Docker container was not found. updated to v2.6.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
 	// Increment patch number for critical fixes to existing releases.
-	Version = "v2.6"
+	Version = "v2.6.0"
 
 	// BuildMetadata is extra build time data
 	BuildMetadata = "unreleased"


### PR DESCRIPTION
After running `helm init` I saw that my Kube cluster had trouble pulling down v2.6 of the Tiller container. I tried pulling manually on my local machine, and it failed too. I then tried to pull down v2.6.0 and this worked. I updated version.go, rebuilt, and ran `helm init` again which resulted in the Tiller container starting up correctly.