### PR TITLE
fix(helm):Fix dependency aliaes not working

### DIFF
--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/ghodss/yaml"
 	"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/version"
+
 )
 
 const (
@@ -230,7 +232,7 @@ func getAliasDependency(charts []*chart.Chart, aliasChart *Dependency) *chart.Ch
 		if existingChart.Metadata.Name != aliasChart.Name {
 			continue
 		}
-		if existingChart.Metadata.Version != aliasChart.Version {
+		if  !version.IsCompatibleRange(aliasChart.Version, existingChart.Metadata.Version) {
 			continue
 		}
 		chartFound = *existingChart
@@ -266,7 +268,7 @@ func ProcessRequirementsEnabled(c *chart.Chart, v *chart.Config) error {
 	for _, existingDependency := range c.Dependencies {
 		var dependencyFound bool
 		for _, req := range reqs.Dependencies {
-			if existingDependency.Metadata.Name == req.Name && existingDependency.Metadata.Version == req.Version {
+			if existingDependency.Metadata.Name == req.Name && version.IsCompatibleRange(req.Version, existingDependency.Metadata.Version)  {
 				dependencyFound = true
 				break
 			}


### PR DESCRIPTION
The alias functionality only works when a hardcoded version
is used. Any use of semver logic causes unexpected behavior.
I use version.IsCompatibleRange to check the dependency version.
Closes #2794