### PR TITLE
feat(helm):  use openssl sha1 command in Helm get script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -130,7 +130,7 @@ downloadFile() {
 # installs it.
 installFile() {
   HELM_TMP="/tmp/$PROJECT_NAME"
-  local sum=$(openssl sha -sha256 ${HELM_TMP_FILE} | awk '{print $2}')
+  local sum=$(openssl sha1 -sha256 ${HELM_TMP_FILE} | awk '{print $2}')
   local expected_sum=$(cat ${HELM_SUM_FILE})
   if [ "$sum" != "$expected_sum" ]; then
     echo "SHA sum of $HELM_TMP does not match. Aborting."


### PR DESCRIPTION
Currently the bash script that installs Helm is hard-coded to use
openssl sha command but some distros like Debian 9 only have sha1.
~This patch hackily detects if sha1 is available and falls back to sha.~
This patch changes the get script to just use sha1.

Closes(#2859)