### PR TITLE
Delete all releases regardless of failures

### DIFF
--- a/cmd/helm/delete.go
+++ b/cmd/helm/delete.go
@@ -64,15 +64,20 @@ func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			}
 			del.client = ensureHelmClient(del.client)
 
+			var err error = nil
 			for i := 0; i < len(args); i++ {
 				del.name = args[i]
-				if err := del.run(); err != nil {
-					return err
+				if relErr := del.run(); relErr != nil {
+					if err != nil {
+						err = fmt.Errorf("%s, %s", err, relErr)
+					} else {
+						err = fmt.Errorf("%s", relErr)
+					}
+				} else {
+					fmt.Fprintf(out, "release \"%s\" deleted\n", del.name)
 				}
-
-				fmt.Fprintf(out, "release \"%s\" deleted\n", del.name)
 			}
-			return nil
+			return err
 		},
 	}
 

--- a/cmd/helm/delete_test.go
+++ b/cmd/helm/delete_test.go
@@ -61,6 +61,13 @@ func TestDelete(t *testing.T) {
 			args: []string{},
 			err:  true,
 		},
+		{
+			name:     "delete after failure",
+			args:     []string{"return-error", "aeneas"},
+			flags:    []string{},
+			expected: "release \"aeneas\" deleted\n",
+			err:      true,
+		},
 	}
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
 		return newDeleteCmd(c, out)

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -61,6 +61,9 @@ func (c *FakeClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts
 
 // DeleteRelease returns nil, nil
 func (c *FakeClient) DeleteRelease(rlsName string, opts ...DeleteOption) (*rls.UninstallReleaseResponse, error) {
+	if rlsName == "return-error" {
+		return nil, fmt.Errorf("No such release: %s", rlsName)
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
`helm delete` was aborting as soon as the attempt to delete a release caused an error. This changes the command to continue attempting to delete each provided release even if a previous release failed to be deleted, while still returning an error for failed deletions.

Closes #1665 
