### PR TITLE
fix(tiller): fix a warning bug in hook annotation

### DIFF
--- a/pkg/tiller/hooks.go
+++ b/pkg/tiller/hooks.go
@@ -171,17 +171,18 @@ func (file *manifestFile) sort(result *result) error {
 			DeletePolicies: []release.Hook_DeletePolicy{},
 		}
 
-		isKnownHook := false
+		isUnknownHook := false
 		for _, hookType := range strings.Split(hookTypes, ",") {
 			hookType = strings.ToLower(strings.TrimSpace(hookType))
 			e, ok := events[hookType]
-			if ok {
-				isKnownHook = true
-				h.Events = append(h.Events, e)
+			if !ok {
+				isUnknownHook = true
+				break
 			}
+			h.Events = append(h.Events, e)
 		}
 
-		if !isKnownHook {
+		if isUnknownHook {
 			log.Printf("info: skipping unknown hook: %q", hookTypes)
 			continue
 		}


### PR DESCRIPTION
Fix the bug that tiller will omit the warning information for unkonwn hook type annotations when the first hook type in the annotation list is known.