### PR TITLE
Fix(helm): fix the bug of helm search --regexp

### DIFF
--- a/cmd/helm/search/search.go
+++ b/cmd/helm/search/search.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-
 	"k8s.io/helm/pkg/repo"
 )
 
@@ -147,6 +146,8 @@ func (i *Index) SearchLiteral(term string, threshold int) []*Result {
 	term = strings.ToLower(term)
 	buf := []*Result{}
 	for k, v := range i.lines {
+		k = strings.ToLower(k)
+		v = strings.ToLower(v)
 		res := strings.Index(v, term)
 		if score := i.calcScore(res, v); res != -1 && score < threshold {
 			parts := strings.Split(k, verSep) // Remove version, if it is there.
@@ -231,5 +232,5 @@ func (s scoreSorter) Less(a, b int) bool {
 func indstr(name string, ref *repo.ChartVersion) string {
 	i := ref.Name + sep + name + "/" + ref.Name + sep +
 		ref.Description + sep + strings.Join(ref.Keywords, " ")
-	return strings.ToLower(i)
+	return i
 }

--- a/cmd/helm/search/search_test.go
+++ b/cmd/helm/search/search_test.go
@@ -135,7 +135,7 @@ func TestAll(t *testing.T) {
 
 func TestAddRepo_Sort(t *testing.T) {
 	i := loadTestIndex(t, true)
-	sr, err := i.Search("testing/santa-maria", 100, false)
+	sr, err := i.Search("TESTING/SANTA-MARIA", 100, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,13 +203,21 @@ func TestSearchByName(t *testing.T) {
 			},
 		},
 		{
+			name:  "description upper search, two results",
+			query: "TWO",
+			expect: []*Result{
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
+			},
+		},
+		{
 			name:   "nothing found",
 			query:  "mayflower",
 			expect: []*Result{},
 		},
 		{
 			name:  "regexp, one result",
-			query: "th[ref]*",
+			query: "Th[ref]*",
 			expect: []*Result{
 				{Name: "testing/santa-maria"},
 			},


### PR DESCRIPTION
helm search cannot search for upper case by --regexp, because it
lowers all the letters when build repo index.

Closes #2865