### PR TITLE
bump k8s version in helm lint to 1.7

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -58,7 +58,7 @@ func Templates(linter *support.Linter) {
 		APIVersions: chartutil.DefaultVersionSet,
 		KubeVersion: &version.Info{
 			Major:     "1",
-			Minor:     "6",
+			Minor:     "7",
 			GoVersion: runtime.Version(),
 			Compiler:  runtime.Compiler,
 			Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),


### PR DESCRIPTION
Helm in master targets k8s 1.7 so it makes sense to target that release for linters.