### PR TITLE
feat(helm): added support for windows build 

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -87,6 +87,44 @@ The `bootstrap` target will attempt to install dependencies, rebuild the
 The `build` target will compile `helm` and place it in `bin/helm`.
 Tiller is also compiled, and is placed in `bin/tiller`.
 
+### From Source (Windows)
+
+From powershell run:
+
+```console
+$ cd $GOPATH
+$ mkdir -p src/k8s.io
+$ cd src/k8s.io
+$ git clone https://github.com/kubernetes/helm.git
+$ cd helm
+$ ./scripts/devenv.ps1
+```
+
+This will prepare Docker container with properly setup git, Mercurial and Go. Helm directory will be share with container so it can access your changes to helm as well as produce binaries you can access from Windows environment.
+
+From within this container run:
+
+```console
+$ make bootstrap build
+```
+
+to produce linux assembly. Or
+
+```console
+$ make bootstrap build-cross
+```
+
+to cross compile and produce windows assemblies which you will find in _dist/windows-amd64.
+
+In case you have troubles with line endings on some script files, you can use 'dos2unix' utility to make them right.
+
+Usage: 
+
+```console
+$ dos2unix scripts/{script_filename.sh}
+```
+
+
 ## Installing Tiller
 
 Tiller, the server portion of Helm, typically runs inside of your

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,44 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+	&& apt-get -y install make curl vim mercurial git dos2unix 
+
+# Install golang using godeb which transforms golang tar.gz archive into deb package
+ENV GO_VERSION 1.9
+RUN mkdir /tmp/godeb \
+	&& curl "https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz" > /tmp/godeb/godeb.tar.gz \
+	&& (cd /tmp/godeb; tar zvxf godeb.tar.gz; ./godeb install "${GO_VERSION}") \
+	&& rm -rf /tmp/godeb \
+	&& mkdir -p /usr/local/go/bin \	
+
+ENV GOPATH /root/go 
+ENV PATH "${PATH}:/root/go/bin:/usr/local/go/src/k8s.io/helm/bin"
+
+# Install glide to handle dependencies 
+RUN mkdir -p /usr/local/go/src/github.com/Masterminds \
+	&& cd /usr/local/go/src/github.com/Masterminds \
+	&& git clone https://github.com/Masterminds/glide.git \
+	&& cd glide \
+	&& make build \
+	&& mv glide $GOPATH/bin/glide
+
+# Prepare for work
+WORKDIR /usr/local/go/src/k8s.io/helm
+
+ADD . /usr/local/go/src/k8s.io/helm
+
+RUN dos2unix /usr/local/go/src/k8s.io/helm/scripts/*

--- a/scripts/devenv.ps1
+++ b/scripts/devenv.ps1
@@ -1,0 +1,4 @@
+$pwd = (Get-Location).Path
+
+docker build --pull -t helm-devenv $pwd/scripts 
+docker run -it -v ${pwd}:/usr/local/go/src/k8s.io/helm  -w /usr/local/go/src/k8s.io/helm helm-devenv /bin/bash


### PR DESCRIPTION
Allows building and cross building on windows host using docker container with go, mercurial and glide prepared.