### PR TITLE
cmd/helm,docs/helm: amend default namespace of tiller

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -69,7 +69,7 @@ Environment:
   $HELM_HOME          set an alternative location for Helm files. By default, these are stored in ~/.helm
   $HELM_HOST          set an alternative Tiller host. The format is host:port
   $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
-  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-namespace")
+  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-system")
   $KUBECONFIG         set an alternative Kubernetes configuration file (default "~/.kube/config")
 `
 

--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -25,7 +25,7 @@ Environment:
   $HELM_HOME          set an alternative location for Helm files. By default, these are stored in ~/.helm
   $HELM_HOST          set an alternative Tiller host. The format is host:port
   $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
-  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-namespace")
+  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-system")
   $KUBECONFIG         set an alternative Kubernetes configuration file (default "~/.kube/config")
 
 


### PR DESCRIPTION
From [this code](https://github.com/kubernetes/helm/blob/master/pkg/tiller/environment/environment.go#L41), the default namespace for tiller should be `kube-system`.