### PR TITLE
Adding output for the created repos when `helm init`

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -295,11 +295,11 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewRepoFile()
-		sr, err := initStableRepo(home.CacheIndex(stableRepository), skipRefresh)
+		sr, err := initStableRepo(home.CacheIndex(stableRepository), out, skipRefresh)
 		if err != nil {
 			return err
 		}
-		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheIndex("local"))
+		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheIndex("local"), out)
 		if err != nil {
 			return err
 		}
@@ -314,7 +314,8 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 	return nil
 }
 
-func initStableRepo(cacheFile string, skipRefresh bool) (*repo.Entry, error) {
+func initStableRepo(cacheFile string, out io.Writer, skipRefresh bool) (*repo.Entry, error) {
+	fmt.Fprintf(out, "Adding %s repo with URL: %s \n", stableRepository, stableRepositoryURL)
 	c := repo.Entry{
 		Name:  stableRepository,
 		URL:   stableRepositoryURL,
@@ -338,8 +339,9 @@ func initStableRepo(cacheFile string, skipRefresh bool) (*repo.Entry, error) {
 	return &c, nil
 }
 
-func initLocalRepo(indexFile, cacheFile string) (*repo.Entry, error) {
+func initLocalRepo(indexFile, cacheFile string, out io.Writer) (*repo.Entry, error) {
 	if fi, err := os.Stat(indexFile); err != nil {
+		fmt.Fprintf(out, "Adding %s repo with URL: %s \n", localRepository, localRepositoryURL)
 		i := repo.NewIndexFile()
 		if err := i.WriteFile(indexFile, 0644); err != nil {
 			return nil, err


### PR DESCRIPTION
Adding output for the created repos when `helm init`. Fixing issue [2810](https://github.com/kubernetes/helm/issues/2810)