### PR TITLE
Remove facebookgo dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0759b118eb4017d612af767460cdec467d6f78013ad1efff1c82676f1df84a75
-updated: 2017-09-26T15:01:33.961357-07:00
+updated: 2017-09-26T15:21:30.833774-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -68,8 +68,6 @@ imports:
   version: ba18e35c5c1b36ef6334cad706eb681153d2d379
 - name: github.com/exponent-io/jsonpath
   version: d6023ce2651d8eafb5c75bb0c7167536102ec9f5
-- name: github.com/facebookgo/symwalk
-  version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/fatih/camelcase
   version: f6a740d52f961c60348ebb109adde9f4635d7540
 - name: github.com/ghodss/yaml

--- a/glide.lock
+++ b/glide.lock
@@ -68,8 +68,6 @@ imports:
   version: ba18e35c5c1b36ef6334cad706eb681153d2d379
 - name: github.com/exponent-io/jsonpath
   version: d6023ce2651d8eafb5c75bb0c7167536102ec9f5
-- name: github.com/facebookgo/atomicfile
-  version: 2de1f203e7d5e386a6833233882782932729f27e
 - name: github.com/facebookgo/symwalk
   version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/fatih/camelcase

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: f66b2182102bb19545353d4168a4a02fc58590eeb75b1a41dec60834aad8c29e
-updated: 2017-09-26T10:27:19.202679689-04:00
+hash: 0759b118eb4017d612af767460cdec467d6f78013ad1efff1c82676f1df84a75
+updated: 2017-09-26T15:01:33.961357-07:00
 imports:
 - name: cloud.google.com/go
-  version: c7cd507af965dbabdcd5611969432dd422f6b628
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
 - name: github.com/aokoli/goutils
-  version: 3391d3790d23d03408670993e957e8f408993c34
+  version: 9c37978a95bd5c709a15883b6242714ea6709e64
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: github.com/Azure/go-autorest
@@ -18,7 +18,7 @@ imports:
 - name: github.com/chai2010/gettext-go
   version: bf70f2a70fb1b1f36d90d671a72795984eab0fcb
 - name: github.com/cpuguy83/go-md2man
-  version: 1d903dcb749992f3741d744c0f8376b4bd7eb3e1
+  version: 71acacd42f85e5e82f70a55327789582a5200a90
   subpackages:
   - md2man
 - name: github.com/davecgh/go-spew
@@ -57,7 +57,7 @@ imports:
 - name: github.com/docker/go-units
   version: e30f1e79f3cd72542f2026ceec18d3bd67ab859c
 - name: github.com/docker/spdystream
-  version: bc6354cbbc295e925e4c611ffe90c1f287ee54db
+  version: 449fdfce4d962303d702fec724ef0ad181c92528
 - name: github.com/emicklei/go-restful
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
@@ -87,7 +87,7 @@ imports:
 - name: github.com/go-openapi/spec
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/strfmt
-  version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
+  version: d65c7fdb29eca313476e529628176fe17e58c488
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gobwas/glob
@@ -141,7 +141,7 @@ imports:
   - ptypes/any
   - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/gosuri/uitable
   version: 36ee7e946282a3fb1cfecd476ddc9b35d8847e42
   subpackages:
@@ -150,11 +150,11 @@ imports:
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
   version: 2500245aa6110c562d17020fb31a2c133d737799
 - name: github.com/hashicorp/golang-lru
-  version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 - name: github.com/howeyc/gopass
-  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
+  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/huandu/xstrings
-  version: d6590c0c31d16526217fa60fbd2067f7afcd78c5
+  version: 3959339b333561bf62a38b424fd41517c2c90f40
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
@@ -174,17 +174,17 @@ imports:
 - name: github.com/Masterminds/vcs
   version: 3084677c2c188840777bff30054f2b553729d329
 - name: github.com/mattn/go-runewidth
-  version: 97311d9f7767e3d6f422ea06661bc2c7a19e8a5d
+  version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: 740c764bc6149d3f1806231418adb9f52c11bcbf
 - name: github.com/naoina/go-stringutil
   version: 6b638e95a32d0c1131db0e7fe83775cbea4a0d0b
 - name: github.com/pborman/uuid
-  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -221,7 +221,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/technosophos/moniker
-  version: ab470f5e105a44d0c87ea21bacd6a335c4816d83
+  version: 9f956786b91d9786ca11aa5be6104542fa911546
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -252,9 +252,9 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/oauth2
-  version: 13449ad91cb26cb47661c1b080790392170385fd
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
 - name: golang.org/x/sys
-  version: 062cd7e4e68206d8bab9b18396626e855c992658
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -296,42 +296,18 @@ imports:
   subpackages:
   - bson
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 926789af7ddda62752e08bc9b93f1d1ebbc7b2de
+  version: 4fe9229aaa9d704f8a2a21cdcd50de2bbb6e1b57
   subpackages:
-  - admissionregistration/v1alpha1
-  - apps/v1beta1
-  - apps/v1beta2
-  - authentication/v1
-  - authentication/v1beta1
-  - authorization/v1
-  - authorization/v1beta1
-  - autoscaling/v1
-  - autoscaling/v2beta1
-  - batch/v1
-  - batch/v1beta1
-  - batch/v2alpha1
-  - certificates/v1beta1
   - core/v1
-  - extensions/v1beta1
-  - networking/v1
-  - policy/v1beta1
-  - rbac/v1
-  - rbac/v1alpha1
-  - rbac/v1beta1
-  - scheduling/v1alpha1
-  - settings/v1alpha1
-  - storage/v1
-  - storage/v1beta1
 - name: k8s.io/apiserver
-  version: 19667a1afc13cc13930c40a20f2c12bbdcaaa246
+  version: 2308857ad3b8b18abf74ff734853973eda9da94d
   subpackages:
   - pkg/admission
   - pkg/apis/apiserver
   - pkg/apis/apiserver/install
   - pkg/apis/apiserver/v1alpha1
-  - pkg/apis/audit
   - pkg/authentication/authenticator
   - pkg/authentication/serviceaccount
   - pkg/authentication/user
@@ -340,7 +316,7 @@ imports:
   - pkg/util/feature
   - pkg/util/flag
 - name: k8s.io/kubernetes
-  version: 4bc5e7f9a6c25dc4c03d4d656f2cefd21540e28c
+  version: d3faa3f8f2e85c8089e80a661955626ae24abf80
   subpackages:
   - cmd/kubeadm/app/apis/kubeadm
   - federation/apis/federation
@@ -532,15 +508,13 @@ imports:
   - plugin/pkg/scheduler/schedulercache
   - plugin/pkg/scheduler/util
 - name: k8s.io/metrics
-  version: 4faa73f37a1635813affc8fbc36ba49a15e81a24
+  version: 8efbc8e22d00b9c600afec5f1c14073fd2412fce
   subpackages:
   - pkg/apis/metrics
   - pkg/apis/metrics/v1alpha1
-  - pkg/apis/metrics/v1beta1
   - pkg/client/clientset_generated/clientset
   - pkg/client/clientset_generated/clientset/scheme
   - pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1
-  - pkg/client/clientset_generated/clientset/typed/metrics/v1beta1
 - name: vbom.ml/util
   version: db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394
   repo: https://github.com/fvbommel/util.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,7 +38,6 @@ import:
 - package: github.com/gobwas/glob
   version: ^0.2.1
 - package: github.com/evanphx/json-patch
-- package: github.com/facebookgo/atomicfile
 - package: github.com/facebookgo/symwalk
 - package: github.com/BurntSushi/toml
   version: ~0.3.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,7 +38,6 @@ import:
 - package: github.com/gobwas/glob
   version: ^0.2.1
 - package: github.com/evanphx/json-patch
-- package: github.com/facebookgo/symwalk
 - package: github.com/BurntSushi/toml
   version: ~0.3.0
 - package: github.com/naoina/go-stringutil
@@ -80,7 +79,6 @@ import:
 ignore:
   - k8s.io/client-go
   - k8s.io/apimachinery
-
 testImports:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -244,7 +244,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 	files := []*BufferedFile{}
 	topdir += string(filepath.Separator)
 
-	err = symwalk.Walk(topdir, func(name string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(topdir, func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
 
 		// Normalize to / since it will also work on Windows

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/facebookgo/symwalk"
 	"github.com/golang/protobuf/ptypes/any"
 
 	"k8s.io/helm/pkg/ignore"

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/facebookgo/atomicfile"
 	"github.com/ghodss/yaml"
 )
 
@@ -135,20 +134,9 @@ func (r *RepoFile) Remove(name string) bool {
 
 // WriteFile writes a repositories file to the given path.
 func (r *RepoFile) WriteFile(path string, perm os.FileMode) error {
-	f, err := atomicfile.New(path, perm)
-	if err != nil {
-		return err
-	}
-
 	data, err := yaml.Marshal(r)
 	if err != nil {
 		return err
 	}
-
-	_, err = f.File.Write(data)
-	if err != nil {
-		return err
-	}
-
-	return f.Close()
+	return ioutil.WriteFile(path, data, perm)
 }

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -201,16 +201,8 @@ func TestWriteFile(t *testing.T) {
 		t.Errorf("failed to create test-file (%v)", err)
 	}
 	defer os.Remove(repoFile.Name())
-
-	fileMode := os.FileMode(0744)
-	if err := sampleRepository.WriteFile(repoFile.Name(), fileMode); err != nil {
+	if err := sampleRepository.WriteFile(repoFile.Name(), 744); err != nil {
 		t.Errorf("failed to write file (%v)", err)
-	}
-
-	info, _ := os.Stat(repoFile.Name())
-	mode := info.Mode()
-	if mode != fileMode {
-		t.Errorf("incorrect file mode: %s (expected %s)", mode, fileMode)
 	}
 
 	repos, err := LoadRepositoriesFile(repoFile.Name())


### PR DESCRIPTION
These dependencies were introduced in both #2010 and #2449. Facebook's BSD+patent license is incompatible with the Apache v2 license. Reverting these two PRs for now so we are OK for compliance purposes, but we will need to re-implement these fixes with our own packages/alternative packages that are Apache v2 compatible.

closes #2933 
closes #2934

re-opens #2449 (we'll have to file a new ticket for this)
re-opens #1639 
