### PR TITLE
UnmarshalChartfile never return (nil, nil)

### DIFF
--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -35,6 +35,9 @@ const ApiVersionV1 = "v1"
 
 // UnmarshalChartfile takes raw Chart.yaml data and unmarshals it.
 func UnmarshalChartfile(data []byte) (*chart.Metadata, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
 	y := &chart.Metadata{}
 	err := yaml.Unmarshal(data, y)
 	if err != nil {

--- a/pkg/chartutil/chartfile_test.go
+++ b/pkg/chartutil/chartfile_test.go
@@ -24,6 +24,16 @@ import (
 
 const testfile = "testdata/chartfiletest.yaml"
 
+func TestUnmarshalChartfile(t *testing.T) {
+	metadata, err := UnmarshalChartfile([]byte{})
+	if err != nil {
+		t.Error(err)
+	}
+	if err == nil && metadata != nil {
+		t.Errorf("Want nil, but got %t", metadata)
+	}
+}
+
 func TestLoadChartfile(t *testing.T) {
 	f, err := LoadChartfile(testfile)
 	if err != nil {


### PR DESCRIPTION
I found the UnmarshalChartfile never return (nil, nil)

```go
// LoadFiles loads from in-memory files.
func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
	c := &chart.Chart{}
	subcharts := map[string][]*BufferedFile{}

	for _, f := range files {
		if f.Name == "Chart.yaml" {
			m, err := UnmarshalChartfile(f.Data)
			if err != nil {
				return c, err
			}
			c.Metadata = m
          ...
      }

	// Ensure that we got a Chart.yaml file
	if c.Metadata == nil {
		return c, errors.New("chart metadata (Chart.yaml) missing")
	}
      ...
}
```
