### PR TITLE
Add ChartMuseum to related.md

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -57,6 +57,7 @@ Tools layered on top of Helm or Tiller.
 - [Monocular](https://github.com/helm/monocular) - Web UI for Helm Chart repositories
 - [Helm Chart Publisher](https://github.com/luizbafilho/helm-chart-publisher) - HTTP API for publishing Helm Charts in an easy way
 - [Armada](https://github.com/att-comdev/armada) - Manage prefixed releases throughout various Kubernetes namespaces, and removes completed jobs for complex deployments. Used by the [Openstack-Helm](https://github.com/openstack/openstack-helm) team.
+- [ChartMuseum](https://github.com/chartmuseum/chartmuseum) - Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 
 ## Helm Included
 


### PR DESCRIPTION
Adding _ChartMuseum_ to the "Additional Tools" section following a chat with @jascott1 in #helm-users
https://github.com/chartmuseum/chartmuseum