### PR TITLE
Feature/1979 remove dirname constraint

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -139,10 +139,6 @@ func (p *packageCmd) run() error {
 		debug("Setting version to %s", p.version)
 	}
 
-	if filepath.Base(path) != ch.Metadata.Name {
-		return fmt.Errorf("directory name (%s) and Chart.yaml name (%s) must match", filepath.Base(path), ch.Metadata.Name)
-	}
-
 	if reqs, err := chartutil.LoadRequirements(ch); err == nil {
 		if err := checkDependencies(ch, reqs); err != nil {
 			return err


### PR DESCRIPTION
Removes dirname constraint on `helm package`.

Closes #1979 