### PR TITLE
Correctly persists Release upgrade failure

### DIFF
--- a/pkg/storage/driver/records.go
+++ b/pkg/storage/driver/records.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/golang/protobuf/proto"
+
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -129,5 +131,5 @@ func newRecord(key string, rls *rspb.Release) *record {
 	lbs.set("STATUS", rspb.Status_Code_name[int32(rls.Info.Status.Code)])
 	lbs.set("VERSION", strconv.Itoa(int(rls.Version)))
 
-	return &record{key: key, lbs: lbs, rls: rls}
+	return &record{key: key, lbs: lbs, rls: proto.Clone(rls).(*rspb.Release)}
 }

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -155,7 +155,7 @@ func (s *ReleaseServer) performUpdate(originalRelease, updatedRelease *release.R
 		updatedRelease.Info.Status.Code = release.Status_FAILED
 		updatedRelease.Info.Description = msg
 		s.recordRelease(originalRelease, true)
-		s.recordRelease(updatedRelease, false)
+		s.recordRelease(updatedRelease, true)
 		return res, err
 	}
 


### PR DESCRIPTION
When release upgrade fails, updatedRelease is already created
in a storage by *ReleaseServer.UpdateRelease, therefore we should
be updating it's status, not creating it again.