### PR TITLE
Install docs change

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -46,8 +46,8 @@ import (
 const installDesc = `
 This command installs a chart archive.
 
-The install argument must be either a relative path to a chart directory or the
-name of a chart in the current working directory.
+The install argument must be a chart reference, a path to a packaged chart,
+a path to an unpacked chart directory or a URL.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line.

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -47,7 +47,7 @@ const installDesc = `
 This command installs a chart archive.
 
 The install argument must be a chart reference, a path to a packaged chart,
-a path to an unpacked chart directory or a URL.
+a path to an unpacked chart directory or a URL. 
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line.

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -47,7 +47,7 @@ const installDesc = `
 This command installs a chart archive.
 
 The install argument must be a chart reference, a path to a packaged chart,
-a path to an unpacked chart directory or a URL. 
+a path to an unpacked chart directory or a URL.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line.

--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -8,8 +8,8 @@ install a chart archive
 
 This command installs a chart archive.
 
-The install argument must be either a relative path to a chart directory or the
-name of a chart in the current working directory.
+The install argument must be a chart reference, a path to a packaged chart,
+a path to an unpacked chart directory or a URL.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line.

--- a/docs/man/man1/helm_install.1
+++ b/docs/man/man1/helm_install.1
@@ -18,8 +18,8 @@ helm\-install \- install a chart archive
 This command installs a chart archive.
 
 .PP
-The install argument must be either a relative path to a chart directory or the
-name of a chart in the current working directory.
+The install argument must be a chart reference, a path to a packaged chart,
+a path to an unpacked chart directory or a URL.
 
 .PP
 To override values in a chart, use either the '\-\-values' flag and pass in a file


### PR DESCRIPTION
The install docs are misleading about what arguments are allowed. Make them more accurate.

Not sure if some of these copies of the text are automatically generated but I have changed them all.