### PR TITLE
Ignore Apiversion, use Kind and Name only to search for original resource on update/delete

### DIFF
--- a/pkg/kube/result.go
+++ b/pkg/kube/result.go
@@ -83,5 +83,5 @@ func (r Result) Intersect(rs Result) Result {
 
 // isMatchingInfo returns true if infos match on Name and GroupVersionKind.
 func isMatchingInfo(a, b *resource.Info) bool {
-	return a.Name == b.Name && a.Mapping.GroupVersionKind == b.Mapping.GroupVersionKind
+	return a.Name == b.Name && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind
 }


### PR DESCRIPTION
Kind can change it's APIVersion with time, such as "Deployment" which was
"extensions/v1beta1" and then migrated to "apps/v1beta1" in Kube 1.6.

Name, Kind and optinally Namespace are used to find relevant Info
object for a original resource which is being upgraded, it safe enough,
as it is uniquely identifies an object.

Fixes: #2885 