### PR TITLE
Suggested edit to simple conditional example

### DIFF
--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -53,7 +53,7 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{ if eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
+  {{ if ( .Values.favorite.drink ) and eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
 ```
 
 Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:


### PR DESCRIPTION
If drink is null or commented out in values.yaml, you need to check for existence or helm will throw an error as below:

error calling eq: invalid type for comparison

This change handles null or missing dring attribute in values.yaml which is commented out in a previous step in the quick start.