### PR TITLE
Fix #2937 - helm always appends /index.yaml at the end of URL

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -7,6 +7,7 @@ Helm and Tiller.
 
 - Go 1.6.0 or later
 - Glide 0.12.0 or later
+- Gometalinter
 - kubectl 1.2 or later
 - A Kubernetes cluster (optional)
 - The gRPC toolchain

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -7,7 +7,6 @@ Helm and Tiller.
 
 - Go 1.6.0 or later
 - Glide 0.12.0 or later
-- Gometalinter
 - kubectl 1.2 or later
 - A Kubernetes cluster (optional)
 - The gRPC toolchain

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -82,7 +82,6 @@ type ChartDownloader struct {
 // (if provenance was verified), or an error if something bad happened.
 func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *provenance.Verification, error) {
 	u, g, err := c.ResolveChartVersion(ref, version)
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -212,7 +211,6 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 
 	// TODO: Seems that picking first URL is not fully correct
 	u, err = url.Parse(cv.URLs[0])
-
 	if err != nil {
 		return u, r.Client, fmt.Errorf("invalid chart URL format: %s", ref)
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -220,7 +220,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 		path := u.Path
 		u, err = url.Parse(rc.URL)
 		if err != nil {
-			return nil, r.Client, err
+			return u, r.Client, err
 		}
 		u.Path = u.Path + path
 		return u, r.Client, err

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -43,6 +43,7 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "reference, testing repo", ref: "testing/alpine", expect: "http://example.com/alpine-1.2.3.tgz"},
 		{name: "reference, version, testing repo", ref: "testing/alpine", version: "0.2.0", expect: "http://example.com/alpine-0.2.0.tgz"},
 		{name: "reference, version, malformed repo", ref: "malformed/alpine", version: "1.2.3", expect: "http://dl.example.com/alpine-1.2.3.tgz"},
+		{name: "reference, querystring repo", ref: "testing-querystring/alpine", expect: "http://example.com/alpine-1.2.3.tgz?key=value"},
 		{name: "full URL, HTTPS, irrelevant version", ref: "https://example.com/foo-1.2.3.tgz", version: "0.1.0", expect: "https://example.com/foo-1.2.3.tgz", fail: true},
 		{name: "full URL, file", ref: "file:///foo-1.2.3.tgz", fail: true},
 		{name: "invalid", ref: "invalid-1.2.3", fail: true},

--- a/pkg/downloader/testdata/helmhome/repository/cache/testing-querystring-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/testing-querystring-index.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      urls:
+        - alpine-1.2.3.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      home: https://k8s.io/helm
+      sources:
+      - https://github.com/kubernetes/helm
+      version: 1.2.3
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      engine: ""
+      icon: ""

--- a/pkg/downloader/testdata/helmhome/repository/repositories.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/repositories.yaml
@@ -10,3 +10,5 @@ repositories:
     url: "http://example.com/charts"
   - name: malformed
     url: "http://dl.example.com"
+  - name: testing-querystring
+    url: "http://example.com?key=value"

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -110,8 +110,13 @@ func (r *ChartRepository) Load() error {
 // is for pre-2.2.0 repo files.
 func (r *ChartRepository) DownloadIndexFile(cachePath string) error {
 	var indexURL string
+	parsedURL, err := url.Parse(r.Config.URL)
+	if err != nil {
+		return err
+	}
+	parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/") + "/index.yaml"
 
-	indexURL = strings.TrimSuffix(r.Config.URL, "/") + "/index.yaml"
+	indexURL = parsedURL.String()
 	resp, err := r.Client.Get(indexURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
- closes #2937 