### PR TITLE
docs/developers.md: add notes for `k8s.io` dir

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -22,7 +22,7 @@ $ make bootstrap build
 ```
 
 NOTE: This will fail if not running from the path `$GOPATH/src/k8s.io/helm`. The
-directory `k8s.io` should not be a symlink or `build` couldn't find the relevant
+directory `k8s.io` should not be a symlink or `build` will not find the relevant
 packages.
 
 This will build both Helm and Tiller. `make bootstrap` will attempt to

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -21,7 +21,9 @@ We use Make to build our programs. The simplest way to get started is:
 $ make bootstrap build
 ```
 
-NOTE: This will fail if not run from the path: `$GOPATH/src/k8s.io/helm`.
+NOTE: This will fail if not running from the path `$GOPATH/src/k8s.io/helm`. The
+directory `k8s.io` should not be a symlink or `build` couldn't find the relevant
+packages.
 
 This will build both Helm and Tiller. `make bootstrap` will attempt to
 install certain tools if they are missing.


### PR DESCRIPTION
Projects related to kubernetes are hosted on github.com and they use `k8s.io` in package imports. Many people will clone golang projects on github.com under `$GOPATH/src/github.com/` and may use symlinks to this directory when needed to develop.

It will have no effects when building helm if it is located in `$GOPATH/src/github.com/kubernetes/` and `$GOPATH/src/k8s.io` is just a symlink to `$GOPATH/src/github.com/kubernetes/`.

Making this clear in `developers.md` may reduce surprise when developing helm.