### PR TITLE
chore(sprig): bump sprig to 2.14.0

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
 - package: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - package: github.com/Masterminds/sprig
-  version: ^2.13
+  version: ^2.14
 - package: github.com/ghodss/yaml
 - package: github.com/Masterminds/semver
   version: ~1.3.1


### PR DESCRIPTION
This adds Sprig 2.14, which has support for generating SSL certificates in charts.

If possible, it would be nice to get this in for 2.7.0