### PR TITLE
fix(semver): fixed edge cases that do not match prerelease

### DIFF
--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -79,8 +79,8 @@ func newFetchCmd(out io.Writer) *cobra.Command {
 			}
 
 			if fch.version == "" && fch.devel {
-				debug("setting version to >0.0.0-a")
-				fch.version = ">0.0.0-a"
+				debug("setting version to >0.0.0-0")
+				fch.version = ">0.0.0-0"
 			}
 
 			for i := 0; i < len(args); i++ {
@@ -105,7 +105,7 @@ func newFetchCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&fch.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&fch.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&fch.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
-	f.BoolVar(&fch.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.")
+	f.BoolVar(&fch.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 
 	return cmd
 }

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -159,8 +159,8 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 
 			debug("Original chart version: %q", inst.version)
 			if inst.version == "" && inst.devel {
-				debug("setting version to >0.0.0-a")
-				inst.version = ">0.0.0-a"
+				debug("setting version to >0.0.0-0")
+				inst.version = ">0.0.0-0"
 			}
 
 			cp, err := locateChartPath(inst.repoURL, args[0], inst.version, inst.verify, inst.keyring,
@@ -192,7 +192,7 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&inst.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&inst.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
-	f.BoolVar(&inst.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.")
+	f.BoolVar(&inst.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 
 	return cmd
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -98,8 +98,8 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 			}
 
 			if upgrade.version == "" && upgrade.devel {
-				debug("setting version to >0.0.0-a")
-				upgrade.version = ">0.0.0-a"
+				debug("setting version to >0.0.0-0")
+				upgrade.version = ">0.0.0-0"
 			}
 
 			upgrade.release = args[0]
@@ -131,7 +131,7 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f.StringVar(&upgrade.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&upgrade.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&upgrade.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
-	f.BoolVar(&upgrade.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.")
+	f.BoolVar(&upgrade.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 
 	f.MarkDeprecated("disable-hooks", "use --no-hooks instead")
 

--- a/docs/helm/helm_fetch.md
+++ b/docs/helm/helm_fetch.md
@@ -30,7 +30,7 @@ helm fetch [flags] [chart URL | repo/chartname] [...]
       --ca-file string       verify certificates of HTTPS-enabled servers using this CA bundle
       --cert-file string     identify HTTPS client using this SSL certificate file
   -d, --destination string   location to write the chart. If this and tardir are specified, tardir is appended to this (default ".")
-      --devel                use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.
+      --devel                use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
       --key-file string      identify HTTPS client using this SSL key file
       --keyring string       keyring containing public keys (default "~/.gnupg/pubring.gpg")
       --prov                 fetch the provenance file, but don't perform verification

--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -70,7 +70,7 @@ helm install [CHART]
 ```
       --ca-file string         verify certificates of HTTPS-enabled servers using this CA bundle
       --cert-file string       identify HTTPS client using this SSL certificate file
-      --devel                  use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.
+      --devel                  use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
       --dry-run                simulate an install
       --key-file string        identify HTTPS client using this SSL key file
       --keyring string         location of public keys used for verification (default "~/.gnupg/pubring.gpg")

--- a/docs/helm/helm_upgrade.md
+++ b/docs/helm/helm_upgrade.md
@@ -38,7 +38,7 @@ helm upgrade [RELEASE] [CHART]
 ```
       --ca-file string       verify certificates of HTTPS-enabled servers using this CA bundle
       --cert-file string     identify HTTPS client using this SSL certificate file
-      --devel                use development versions, too. Equivalent to version '>0.0.0-a'. If --version is set, this is ignored.
+      --devel                use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
       --dry-run              simulate an upgrade
       --force                force resource update through delete/recreate if needed
   -i, --install              if a release by this name doesn't already exist, run an install


### PR DESCRIPTION
\>0.0.0-a does not match pre-releases on 0.0.0 that start with a
capital letter or number. This has to do with the ordering of
code points. Numbers and capital letters come before lowercase
letters.

\>0.0.0-0 should match all valid pre-releases on 0.0.0. According
to the spec, "Numeric identifiers MUST NOT include leading zeroes."
A 0 is also the lowest code point for all the allowed characters
in a pre-release

Note, I fully admit that this is a bug I introduced.