### PR TITLE
fix(tiller): delete Job objects when CronJob object deleted

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -374,7 +374,14 @@ func deleteResource(c *Client, info *resource.Info) error {
 	if err != nil {
 		// If there is no reaper for this resources, delete it.
 		if kubectl.IsNoSuchReaperError(err) {
-			return resource.NewHelper(info.Client, info.Mapping).Delete(info.Namespace, info.Name)
+			propagationPolicy := metav1.DeletePropagationBackground
+			return resource.NewHelper(info.Client, info.Mapping).DeleteWithOptions(
+				info.Namespace,
+				info.Name,
+				&metav1.DeleteOptions{
+					PropagationPolicy: &propagationPolicy,
+				},
+			)
 		}
 		return err
 	}


### PR DESCRIPTION
`CronJob` object will create `Job` object(s) to run and when the `CronJob` object is
deleted, the related `Job` objects should be deleted cascade.