### PR TITLE
Improvements to FakeClient: support all CRUD operations

### DIFF
--- a/cmd/helm/delete_test.go
+++ b/cmd/helm/delete_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestDelete(t *testing.T) {
@@ -33,28 +34,32 @@ func TestDelete(t *testing.T) {
 			args:     []string{"aeneas"},
 			flags:    []string{},
 			expected: "", // Output of a delete is an empty string and exit 0.
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
 			name:     "delete with timeout",
 			args:     []string{"aeneas"},
 			flags:    []string{"--timeout", "120"},
 			expected: "",
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
 			name:     "delete without hooks",
 			args:     []string{"aeneas"},
 			flags:    []string{"--no-hooks"},
 			expected: "",
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
 			name:     "purge",
 			args:     []string{"aeneas"},
 			flags:    []string{"--purge"},
 			expected: "",
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
 			name: "delete without release",

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestGetHooks(t *testing.T) {
@@ -30,8 +31,9 @@ func TestGetHooks(t *testing.T) {
 		{
 			name:     "get hooks with release",
 			args:     []string{"aeneas"},
-			expected: mockHookTemplate,
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			expected: helm.MockHookTemplate,
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
 			name: "get hooks without args",

--- a/cmd/helm/get_manifest_test.go
+++ b/cmd/helm/get_manifest_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestGetManifest(t *testing.T) {
@@ -30,8 +31,9 @@ func TestGetManifest(t *testing.T) {
 		{
 			name:     "get manifest with release",
 			args:     []string{"juno"},
-			expected: mockManifest,
-			resp:     releaseMock(&releaseOptions{name: "juno"}),
+			expected: helm.MockManifest,
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "juno"}),
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "juno"})},
 		},
 		{
 			name: "get manifest without args",

--- a/cmd/helm/get_test.go
+++ b/cmd/helm/get_test.go
@@ -23,15 +23,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestGetCmd(t *testing.T) {
 	tests := []releaseCase{
 		{
 			name:     "get with a release",
-			resp:     releaseMock(&releaseOptions{name: "thomas-guide"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"}),
 			args:     []string{"thomas-guide"},
-			expected: "REVISION: 1\nRELEASED: (.*)\nCHART: foo-0.1.0-beta.1\nUSER-SUPPLIED VALUES:\nname: \"value\"\nCOMPUTED VALUES:\nname: value\n\nHOOKS:\n---\n# pre-install-hook\n" + mockHookTemplate + "\nMANIFEST:",
+			expected: "REVISION: 1\nRELEASED: (.*)\nCHART: foo-0.1.0-beta.1\nUSER-SUPPLIED VALUES:\nname: \"value\"\nCOMPUTED VALUES:\nname: value\n\nHOOKS:\n---\n# pre-install-hook\n" + helm.MockHookTemplate + "\nMANIFEST:",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"})},
 		},
 		{
 			name: "get requires release name arg",

--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -23,15 +23,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestGetValuesCmd(t *testing.T) {
 	tests := []releaseCase{
 		{
 			name:     "get values with a release",
-			resp:     releaseMock(&releaseOptions{name: "thomas-guide"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"}),
 			args:     []string{"thomas-guide"},
 			expected: "name: \"value\"",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"})},
 		},
 		{
 			name: "get values requires release name arg",

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -27,10 +27,10 @@ import (
 
 func TestHistoryCmd(t *testing.T) {
 	mk := func(name string, vers int32, code rpb.Status_Code) *rpb.Release {
-		return releaseMock(&releaseOptions{
-			name:       name,
-			version:    vers,
-			statusCode: code,
+		return helm.ReleaseMock(&helm.MockReleaseOptions{
+			Name:       name,
+			Version:    vers,
+			StatusCode: code,
 		})
 	}
 

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-
 	"k8s.io/helm/pkg/helm"
 )
 
@@ -36,46 +35,46 @@ func TestInstall(t *testing.T) {
 			args:     []string{"testdata/testcharts/alpine"},
 			flags:    strings.Split("--name aeneas", " "),
 			expected: "aeneas",
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
 		},
 		// Install, no hooks
 		{
 			name:     "install without hooks",
 			args:     []string{"testdata/testcharts/alpine"},
 			flags:    strings.Split("--name aeneas --no-hooks", " "),
-			expected: "juno",
-			resp:     releaseMock(&releaseOptions{name: "juno"}),
+			expected: "aeneas",
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
 		},
 		// Install, values from cli
 		{
 			name:     "install with values",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("--set foo=bar", " "),
-			resp:     releaseMock(&releaseOptions{name: "virgil"}),
+			flags:    strings.Split("--name virgil --set foo=bar", " "),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "virgil",
 		},
 		// Install, values from cli via multiple --set
 		{
 			name:     "install with multiple values",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("--set foo=bar", "--set bar=foo"),
-			resp:     releaseMock(&releaseOptions{name: "virgil"}),
+			flags:    strings.Split("--name virgil --set foo=bar --set bar=foo", " "),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "virgil",
 		},
 		// Install, values from yaml
 		{
 			name:     "install with values",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("-f testdata/testcharts/alpine/extra_values.yaml", " "),
-			resp:     releaseMock(&releaseOptions{name: "virgil"}),
+			flags:    strings.Split("--name virgil -f testdata/testcharts/alpine/extra_values.yaml", " "),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "virgil",
 		},
 		// Install, values from multiple yaml
 		{
 			name:     "install with values",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("-f testdata/testcharts/alpine/extra_values.yaml -f testdata/testcharts/alpine/more_values.yaml", " "),
-			resp:     releaseMock(&releaseOptions{name: "virgil"}),
+			flags:    strings.Split("--name virgil -f testdata/testcharts/alpine/extra_values.yaml -f testdata/testcharts/alpine/more_values.yaml", " "),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "virgil",
 		},
 		// Install, no charts
@@ -90,23 +89,23 @@ func TestInstall(t *testing.T) {
 			args:     []string{"testdata/testcharts/alpine"},
 			flags:    strings.Split("--name aeneas --replace", " "),
 			expected: "aeneas",
-			resp:     releaseMock(&releaseOptions{name: "aeneas"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
 		},
 		// Install, with timeout
 		{
 			name:     "install with a timeout",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("--timeout 120", " "),
+			flags:    strings.Split("--name foobar --timeout 120", " "),
 			expected: "foobar",
-			resp:     releaseMock(&releaseOptions{name: "foobar"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "foobar"}),
 		},
 		// Install, with wait
 		{
 			name:     "install with a wait",
 			args:     []string{"testdata/testcharts/alpine"},
-			flags:    strings.Split("--wait", " "),
+			flags:    strings.Split("--name apollo --wait", " "),
 			expected: "apollo",
-			resp:     releaseMock(&releaseOptions{name: "apollo"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "apollo"}),
 		},
 		// Install, using the name-template
 		{
@@ -114,7 +113,7 @@ func TestInstall(t *testing.T) {
 			args:     []string{"testdata/testcharts/alpine"},
 			flags:    []string{"--name-template", "{{upper \"foobar\"}}"},
 			expected: "FOOBAR",
-			resp:     releaseMock(&releaseOptions{name: "FOOBAR"}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "FOOBAR"}),
 		},
 		// Install, perform chart verification along the way.
 		{

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -36,7 +36,7 @@ func TestListCmd(t *testing.T) {
 		{
 			name: "with a release",
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide"}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"}),
 			},
 			expected: "thomas-guide",
 		},
@@ -44,7 +44,7 @@ func TestListCmd(t *testing.T) {
 			name: "list",
 			args: []string{},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "atlas"}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas"}),
 			},
 			expected: "NAME \tREVISION\tUPDATED                 \tSTATUS  \tCHART           \tNAMESPACE\natlas\t1       \t(.*)\tDEPLOYED\tfoo-0.1.0-beta.1\tdefault  \n",
 		},
@@ -52,8 +52,8 @@ func TestListCmd(t *testing.T) {
 			name: "list, one deployed, one failed",
 			args: []string{"-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_FAILED}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_FAILED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			expected: "thomas-guide\natlas-guide",
 		},
@@ -61,8 +61,8 @@ func TestListCmd(t *testing.T) {
 			name: "with a release, multiple flags",
 			args: []string{"--deleted", "--deployed", "--failed", "-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_DELETED}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_DELETED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			// Note: We're really only testing that the flags parsed correctly. Which results are returned
 			// depends on the backend. And until pkg/helm is done, we can't mock this.
@@ -72,8 +72,8 @@ func TestListCmd(t *testing.T) {
 			name: "with a release, multiple flags",
 			args: []string{"--all", "-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_DELETED}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_DELETED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			// See note on previous test.
 			expected: "thomas-guide\natlas-guide",
@@ -82,8 +82,8 @@ func TestListCmd(t *testing.T) {
 			name: "with a release, multiple flags, deleting",
 			args: []string{"--all", "-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_DELETING}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_DELETING}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			// See note on previous test.
 			expected: "thomas-guide\natlas-guide",
@@ -92,8 +92,8 @@ func TestListCmd(t *testing.T) {
 			name: "namespace defined, multiple flags",
 			args: []string{"--all", "-q", "--namespace test123"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", namespace: "test123"}),
-				releaseMock(&releaseOptions{name: "atlas-guide", namespace: "test321"}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", Namespace: "test123"}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", Namespace: "test321"}),
 			},
 			// See note on previous test.
 			expected: "thomas-guide",
@@ -102,8 +102,8 @@ func TestListCmd(t *testing.T) {
 			name: "with a pending release, multiple flags",
 			args: []string{"--all", "-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_PENDING_INSTALL}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_PENDING_INSTALL}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			expected: "thomas-guide\natlas-guide",
 		},
@@ -111,10 +111,10 @@ func TestListCmd(t *testing.T) {
 			name: "with a pending release, pending flag",
 			args: []string{"--pending", "-q"},
 			resp: []*release.Release{
-				releaseMock(&releaseOptions{name: "thomas-guide", statusCode: release.Status_PENDING_INSTALL}),
-				releaseMock(&releaseOptions{name: "wild-idea", statusCode: release.Status_PENDING_UPGRADE}),
-				releaseMock(&releaseOptions{name: "crazy-maps", statusCode: release.Status_PENDING_ROLLBACK}),
-				releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide", StatusCode: release.Status_PENDING_INSTALL}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "wild-idea", StatusCode: release.Status_PENDING_UPGRADE}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-maps", StatusCode: release.Status_PENDING_ROLLBACK}),
+				helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 			},
 			expected: "thomas-guide\nwild-idea\ncrazy-maps",
 		},

--- a/cmd/helm/reset_test.go
+++ b/cmd/helm/reset_test.go
@@ -107,7 +107,7 @@ func TestReset_deployedReleases(t *testing.T) {
 
 	var buf bytes.Buffer
 	resp := []*release.Release{
-		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+		helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 	}
 	c := &helm.FakeClient{
 		Rels: resp,
@@ -139,7 +139,7 @@ func TestReset_forceFlag(t *testing.T) {
 
 	var buf bytes.Buffer
 	resp := []*release.Release{
-		releaseMock(&releaseOptions{name: "atlas-guide", statusCode: release.Status_DEPLOYED}),
+		helm.ReleaseMock(&helm.MockReleaseOptions{Name: "atlas-guide", StatusCode: release.Status_DEPLOYED}),
 	}
 	c := &helm.FakeClient{
 		Rels: resp,

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -52,7 +52,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\n"),
-			rel: releaseMockWithStatus(&release.Status{
+			rel: ReleaseMockWithStatus(&release.Status{
 				Code: release.Status_DEPLOYED,
 			}),
 		},
@@ -60,7 +60,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release with notes",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\nNOTES:\nrelease notes\n"),
-			rel: releaseMockWithStatus(&release.Status{
+			rel: ReleaseMockWithStatus(&release.Status{
 				Code:  release.Status_DEPLOYED,
 				Notes: "release notes",
 			}),
@@ -69,7 +69,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release with resources",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\nRESOURCES:\nresource A\nresource B\n\n"),
-			rel: releaseMockWithStatus(&release.Status{
+			rel: ReleaseMockWithStatus(&release.Status{
 				Code:      release.Status_DEPLOYED,
 				Resources: "resource A\nresource B\n",
 			}),
@@ -82,7 +82,7 @@ func TestStatusCmd(t *testing.T) {
 					"TEST \tSTATUS \tINFO \tSTARTED \tCOMPLETED \n" +
 					fmt.Sprintf("test run 1\tSUCCESS \textra info\t%s\t%s\n", dateString, dateString) +
 					fmt.Sprintf("test run 2\tFAILURE \t \t%s\t%s\n", dateString, dateString)),
-			rel: releaseMockWithStatus(&release.Status{
+			rel: ReleaseMockWithStatus(&release.Status{
 				Code: release.Status_DEPLOYED,
 				LastTestSuiteRun: &release.TestSuite{
 					StartedAt:   &date,
@@ -138,7 +138,7 @@ func outputWithStatus(status string) string {
 		status)
 }
 
-func releaseMockWithStatus(status *release.Status) *release.Release {
+func ReleaseMockWithStatus(status *release.Status) *release.Release {
 	return &release.Release{
 		Name: "flummoxed-chickadee",
 		Info: &release.Info{

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -52,7 +52,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\n"),
-			rel: ReleaseMockWithStatus(&release.Status{
+			rel: releaseMockWithStatus(&release.Status{
 				Code: release.Status_DEPLOYED,
 			}),
 		},
@@ -60,7 +60,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release with notes",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\nNOTES:\nrelease notes\n"),
-			rel: ReleaseMockWithStatus(&release.Status{
+			rel: releaseMockWithStatus(&release.Status{
 				Code:  release.Status_DEPLOYED,
 				Notes: "release notes",
 			}),
@@ -69,7 +69,7 @@ func TestStatusCmd(t *testing.T) {
 			name:     "get status of a deployed release with resources",
 			args:     []string{"flummoxed-chickadee"},
 			expected: outputWithStatus("DEPLOYED\n\nRESOURCES:\nresource A\nresource B\n\n"),
-			rel: ReleaseMockWithStatus(&release.Status{
+			rel: releaseMockWithStatus(&release.Status{
 				Code:      release.Status_DEPLOYED,
 				Resources: "resource A\nresource B\n",
 			}),
@@ -82,7 +82,7 @@ func TestStatusCmd(t *testing.T) {
 					"TEST \tSTATUS \tINFO \tSTARTED \tCOMPLETED \n" +
 					fmt.Sprintf("test run 1\tSUCCESS \textra info\t%s\t%s\n", dateString, dateString) +
 					fmt.Sprintf("test run 2\tFAILURE \t \t%s\t%s\n", dateString, dateString)),
-			rel: ReleaseMockWithStatus(&release.Status{
+			rel: releaseMockWithStatus(&release.Status{
 				Code: release.Status_DEPLOYED,
 				LastTestSuiteRun: &release.TestSuite{
 					StartedAt:   &date,
@@ -138,7 +138,7 @@ func outputWithStatus(status string) string {
 		status)
 }
 
-func ReleaseMockWithStatus(status *release.Status) *release.Release {
+func releaseMockWithStatus(status *release.Status) *release.Release {
 	return &release.Release{
 		Name: "flummoxed-chickadee",
 		Info: &release.Info{

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestUpgradeCmd(t *testing.T) {
@@ -43,9 +44,9 @@ func TestUpgradeCmd(t *testing.T) {
 		t.Errorf("Error creating chart for upgrade: %v", err)
 	}
 	ch, _ := chartutil.Load(chartPath)
-	_ = releaseMock(&releaseOptions{
-		name:  "funny-bunny",
-		chart: ch,
+	_ = helm.ReleaseMock(&helm.MockReleaseOptions{
+		Name:  "funny-bunny",
+		Chart: ch,
 	})
 
 	// update chart version
@@ -94,61 +95,68 @@ func TestUpgradeCmd(t *testing.T) {
 		{
 			name:     "upgrade a release",
 			args:     []string{"funny-bunny", chartPath},
-			resp:     releaseMock(&releaseOptions{name: "funny-bunny", version: 2, chart: ch}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 2, Chart: ch}),
 			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 2, Chart: ch})},
 		},
 		{
 			name:     "upgrade a release with timeout",
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--timeout", "120"},
-			resp:     releaseMock(&releaseOptions{name: "funny-bunny", version: 3, chart: ch2}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 3, Chart: ch2}),
 			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 3, Chart: ch2})},
 		},
 		{
 			name:     "upgrade a release with --reset-values",
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--reset-values", "true"},
-			resp:     releaseMock(&releaseOptions{name: "funny-bunny", version: 4, chart: ch2}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 4, Chart: ch2}),
 			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 4, Chart: ch2})},
 		},
 		{
 			name:     "upgrade a release with --reuse-values",
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--reuse-values", "true"},
-			resp:     releaseMock(&releaseOptions{name: "funny-bunny", version: 5, chart: ch2}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 5, Chart: ch2}),
 			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 5, Chart: ch2})},
 		},
 		{
 			name:     "install a release with 'upgrade --install'",
 			args:     []string{"zany-bunny", chartPath},
 			flags:    []string{"-i"},
-			resp:     releaseMock(&releaseOptions{name: "zany-bunny", version: 1, chart: ch}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "zany-bunny", Version: 1, Chart: ch}),
 			expected: "Release \"zany-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "zany-bunny", Version: 1, Chart: ch})},
 		},
 		{
 			name:     "install a release with 'upgrade --install' and timeout",
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"-i", "--timeout", "120"},
-			resp:     releaseMock(&releaseOptions{name: "crazy-bunny", version: 1, chart: ch}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch}),
 			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch})},
 		},
 		{
 			name:     "upgrade a release with wait",
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"--wait"},
-			resp:     releaseMock(&releaseOptions{name: "crazy-bunny", version: 2, chart: ch2}),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2}),
 			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2})},
 		},
 		{
 			name: "upgrade a release with missing dependencies",
 			args: []string{"bonkers-bunny", missingDepsPath},
-			resp: releaseMock(&releaseOptions{name: "bonkers-bunny", version: 1, chart: ch3}),
+			resp: helm.ReleaseMock(&helm.MockReleaseOptions{Name: "bonkers-bunny", Version: 1, Chart: ch3}),
 			err:  true,
 		},
 		{
 			name: "upgrade a release with bad dependencies",
 			args: []string{"bonkers-bunny", badDepsPath},
-			resp: releaseMock(&releaseOptions{name: "bonkers-bunny", version: 1, chart: ch3}),
+			resp: helm.ReleaseMock(&helm.MockReleaseOptions{Name: "bonkers-bunny", Version: 1, Chart: ch3}),
 			err:  true,
 		},
 	}

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -104,7 +104,7 @@ func (c *FakeClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.G
 	return nil, fmt.Errorf("No such release: %s", rlsName)
 }
 
-// ReleaseContent returns the configuration for the first release in the fake release client
+// ReleaseContent returns the configuration for the matching release name in the fake release client.
 func (c *FakeClient) ReleaseContent(rlsName string, opts ...ContentOption) (resp *rls.GetReleaseContentResponse, err error) {
 	if len(c.Rels) > 0 {
 		for _, release := range c.Rels {

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -88,15 +88,18 @@ func (c *FakeClient) RollbackRelease(rlsName string, opts ...RollbackOption) (*r
 	return nil, nil
 }
 
-// ReleaseStatus returns a release status response with info from the first release in the fake
-// release client
+// ReleaseStatus returns a release status response with info from the matching release name in the fake release client.
 func (c *FakeClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.GetReleaseStatusResponse, error) {
-	if c.Rels[0] != nil {
-		return &rls.GetReleaseStatusResponse{
-			Name:      c.Rels[0].Name,
-			Info:      c.Rels[0].Info,
-			Namespace: c.Rels[0].Namespace,
-		}, nil
+	if len(c.Rels) > 0 {
+		for _, release := range c.Rels {
+			if release.Name == rlsName {
+				return &rls.GetReleaseStatusResponse{
+					Name:      release.Name,
+					Info:      release.Info,
+					Namespace: release.Namespace,
+				}, nil
+			}
+		}
 	}
 	return nil, fmt.Errorf("No such release: %s", rlsName)
 }
@@ -104,8 +107,12 @@ func (c *FakeClient) ReleaseStatus(rlsName string, opts ...StatusOption) (*rls.G
 // ReleaseContent returns the configuration for the first release in the fake release client
 func (c *FakeClient) ReleaseContent(rlsName string, opts ...ContentOption) (resp *rls.GetReleaseContentResponse, err error) {
 	if len(c.Rels) > 0 {
-		resp = &rls.GetReleaseContentResponse{
-			Release: c.Rels[0],
+		for _, release := range c.Rels {
+			if release.Name == rlsName {
+				resp = &rls.GetReleaseContentResponse{
+					Release: release,
+				}
+			}
 		}
 	}
 	return resp, c.Err

--- a/pkg/helm/fake_test.go
+++ b/pkg/helm/fake_test.go
@@ -79,8 +79,8 @@ func TestFakeClient_ReleaseStatus(t *testing.T) {
 			name: "Get a single release that exists from list",
 			fields: fields{
 				Rels: []*release.Release{
-					&release.Release{Name: "angry-dolphin", Namespace: "default"},
-					&release.Release{Name: "trepid-tapir", Namespace: "default"},
+					{Name: "angry-dolphin", Namespace: "default"},
+					{Name: "trepid-tapir", Namespace: "default"},
 					releasePresent,
 				},
 			},

--- a/pkg/helm/fake_test.go
+++ b/pkg/helm/fake_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/helm/pkg/proto/hapi/release"
+	rls "k8s.io/helm/pkg/proto/hapi/services"
+)
+
+func TestFakeClient_ReleaseStatus(t *testing.T) {
+	releasePresent := &release.Release{Name: "release-present", Namespace: "default"}
+	releaseNotPresent := &release.Release{Name: "release-not-present", Namespace: "default"}
+
+	type fields struct {
+		Rels []*release.Release
+	}
+	type args struct {
+		rlsName string
+		opts    []StatusOption
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *rls.GetReleaseStatusResponse
+		wantErr bool
+	}{
+		{
+			name: "Get a single release that exists",
+			fields: fields{
+				Rels: []*release.Release{
+					releasePresent,
+				},
+			},
+			args: args{
+				rlsName: releasePresent.Name,
+				opts:    nil,
+			},
+			want: &rls.GetReleaseStatusResponse{
+				Name:      releasePresent.Name,
+				Info:      releasePresent.Info,
+				Namespace: releasePresent.Namespace,
+			},
+
+			wantErr: false,
+		},
+		{
+			name: "Get a release that does not exist",
+			fields: fields{
+				Rels: []*release.Release{
+					releasePresent,
+				},
+			},
+			args: args{
+				rlsName: releaseNotPresent.Name,
+				opts:    nil,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Get a single release that exists from list",
+			fields: fields{
+				Rels: []*release.Release{
+					&release.Release{Name: "angry-dolphin", Namespace: "default"},
+					&release.Release{Name: "trepid-tapir", Namespace: "default"},
+					releasePresent,
+				},
+			},
+			args: args{
+				rlsName: releasePresent.Name,
+				opts:    nil,
+			},
+			want: &rls.GetReleaseStatusResponse{
+				Name:      releasePresent.Name,
+				Info:      releasePresent.Info,
+				Namespace: releasePresent.Namespace,
+			},
+
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &FakeClient{
+				Rels: tt.fields.Rels,
+			}
+			got, err := c.ReleaseStatus(tt.args.rlsName, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FakeClient.ReleaseStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FakeClient.ReleaseStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/helm/fake_test.go
+++ b/pkg/helm/fake_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestFakeClient_ReleaseStatus(t *testing.T) {
-	releasePresent := &release.Release{Name: "release-present", Namespace: "default"}
-	releaseNotPresent := &release.Release{Name: "release-not-present", Namespace: "default"}
+	releasePresent := ReleaseMock(&MockReleaseOptions{Name: "release-present"})
+	releaseNotPresent := ReleaseMock(&MockReleaseOptions{Name: "release-not-present"})
 
 	type fields struct {
 		Rels []*release.Release
@@ -80,8 +80,8 @@ func TestFakeClient_ReleaseStatus(t *testing.T) {
 			name: "Get a single release that exists from list",
 			fields: fields{
 				Rels: []*release.Release{
-					{Name: "angry-dolphin", Namespace: "default"},
-					{Name: "trepid-tapir", Namespace: "default"},
+					ReleaseMock(&MockReleaseOptions{Name: "angry-dolphin", Namespace: "default"}),
+					ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir", Namespace: "default"}),
 					releasePresent,
 				},
 			},
@@ -143,13 +143,10 @@ func TestFakeClient_InstallReleaseFromChart(t *testing.T) {
 				opts: []InstallOption{ReleaseName("new-release")},
 			},
 			want: &rls.InstallReleaseResponse{
-				Release: &release.Release{
-					Name:      "new-release",
-					Namespace: "default",
-				},
+				Release: ReleaseMock(&MockReleaseOptions{Name: "new-release"}),
 			},
 			relsAfter: []*release.Release{
-				{Name: "new-release", Namespace: "default"},
+				ReleaseMock(&MockReleaseOptions{Name: "new-release"}),
 			},
 			wantErr: false,
 		},
@@ -157,10 +154,7 @@ func TestFakeClient_InstallReleaseFromChart(t *testing.T) {
 			name: "Try to add a release where the name already exists.",
 			fields: fields{
 				Rels: []*release.Release{
-					&release.Release{
-						Name:      "new-release",
-						Namespace: "default",
-					},
+					ReleaseMock(&MockReleaseOptions{Name: "new-release"}),
 				},
 			},
 			args: args{
@@ -168,10 +162,7 @@ func TestFakeClient_InstallReleaseFromChart(t *testing.T) {
 				opts: []InstallOption{ReleaseName("new-release")},
 			},
 			relsAfter: []*release.Release{
-				{
-					Name:      "new-release",
-					Namespace: "default",
-				},
+				ReleaseMock(&MockReleaseOptions{Name: "new-release"}),
 			},
 			want:    nil,
 			wantErr: true,
@@ -217,12 +208,8 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 			name: "Delete a release that exists.",
 			fields: fields{
 				Rels: []*release.Release{
-					{
-						Name: "angry-dolphin",
-					},
-					{
-						Name: "trepid-tapir",
-					},
+					ReleaseMock(&MockReleaseOptions{Name: "angry-dolphin"}),
+					ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 				},
 			},
 			args: args{
@@ -230,12 +217,10 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 				opts:    []DeleteOption{},
 			},
 			relsAfter: []*release.Release{
-				{
-					Name: "angry-dolphin",
-				},
+				ReleaseMock(&MockReleaseOptions{Name: "angry-dolphin"}),
 			},
 			want: &rls.UninstallReleaseResponse{
-				Release: &release.Release{Name: "trepid-tapir"},
+				Release: ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 			},
 			wantErr: false,
 		},
@@ -243,12 +228,8 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 			name: "Delete a release that does not exist.",
 			fields: fields{
 				Rels: []*release.Release{
-					{
-						Name: "angry-dolphin",
-					},
-					{
-						Name: "trepid-tapir",
-					},
+					ReleaseMock(&MockReleaseOptions{Name: "angry-dolphin"}),
+					ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 				},
 			},
 			args: args{
@@ -256,12 +237,8 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 				opts:    []DeleteOption{},
 			},
 			relsAfter: []*release.Release{
-				{
-					Name: "angry-dolphin",
-				},
-				{
-					Name: "trepid-tapir",
-				},
+				ReleaseMock(&MockReleaseOptions{Name: "angry-dolphin"}),
+				ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 			},
 			want:    nil,
 			wantErr: true,
@@ -270,9 +247,7 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 			name: "Delete when only 1 item exists.",
 			fields: fields{
 				Rels: []*release.Release{
-					{
-						Name: "trepid-tapir",
-					},
+					ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 				},
 			},
 			args: args{
@@ -281,7 +256,7 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 			},
 			relsAfter: []*release.Release{},
 			want: &rls.UninstallReleaseResponse{
-				Release: &release.Release{Name: "trepid-tapir"},
+				Release: ReleaseMock(&MockReleaseOptions{Name: "trepid-tapir"}),
 			},
 			wantErr: false,
 		},

--- a/pkg/helm/fake_test.go
+++ b/pkg/helm/fake_test.go
@@ -266,6 +266,25 @@ func TestFakeClient_DeleteRelease(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "Delete when only 1 item exists.",
+			fields: fields{
+				Rels: []*release.Release{
+					{
+						Name: "trepid-tapir",
+					},
+				},
+			},
+			args: args{
+				rlsName: "trepid-tapir",
+				opts:    []DeleteOption{},
+			},
+			relsAfter: []*release.Release{},
+			want: &rls.UninstallReleaseResponse{
+				Release: &release.Release{Name: "trepid-tapir"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I'm using the helm packages in some custom code and came across the FakeClient. It's excellent to have for unit-testing purposes, but it'd be nice if it worked just a bit more like the real thing. Since it has an internal []Rels slice to track releases, we should be able to make it support all CRUD operations.

This PR adds support for all CRUD operations, and adds tests for the following methods:

- InstallRelease()
- ReleaseStatus()
- DeleteRelease()

I did not add tests for UpdateRelease(), since it felt pretty low value to me. I'm happy to add those if requested, though.

There are a few ways this mock client falls short:

- Validation. There is some copied logic from the tiller release server for creating release names, but overall there is much less validation in the mock client than the real thing. I wanted to create a reasonable mock without duplicating tons of code.
- Errors. I did my best to maintain the semantics of the methods, but in most cases, the errors returned will not be exact matches for what tiller would return. From what I could tell none of the errors were exported, and I wanted to avoid making this PR any larger than I needed.

This is my first PR to helm and I'm not super familiar with the codebase. I'm sure there are lots of things could be doing better, so I'm happy to accept suggestions for improvements.