### PR TITLE
pin golang.org/x/sys to master

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f5e472b397d20aaa131c8eada3966fdbbf65457073bd1ee8fb8b349bf39c522a
-updated: 2017-10-09T13:32:53.067503253-07:00
+hash: 650f1d4cd9e9dc5ba76480a5465923ce1bbd11b8fa956b644aaf975e8f7e1f33
+updated: 2017-10-12T13:08:50.435765-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -285,7 +285,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 43eea11bc92608addb41b8a406b0407495c106f6
   subpackages:
   - unix
   - windows

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,13 +28,19 @@ import:
 - package: google.golang.org/grpc
   version: 1.2.1
 - package: k8s.io/kubernetes
-  version: ~1.8.0
+  version: 1.8.0
 - package: github.com/gosuri/uitable
 - package: github.com/asaskevich/govalidator
   version: ^4.0.0
 - package: golang.org/x/crypto
   subpackages:
   - openpgp
+  # pin version of golang.org/x/sys that is compatible with golang.org/x/crypto
+- package: golang.org/x/sys
+  version: 43eea11
+  subpackages:
+  - unix
+  - windows
 - package: github.com/gobwas/glob
   version: ^0.2.1
 - package: github.com/evanphx/json-patch

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,8 @@ import:
   - ptypes/timestamp
 - package: google.golang.org/grpc
   version: 1.2.1
+  # 1.8.1 libs are hosed and need some manual intervention, so pinning to 1.8.0 for now
+  # so others aren't getting errors when running `glide up`
 - package: k8s.io/kubernetes
   version: 1.8.0
 - package: github.com/gosuri/uitable


### PR DESCRIPTION
fixes issues seen in master with `make build-cross` for windows

I had to pin kubernetes to 1.8.0 because running `glide up` without that had some lib breakages