### PR TITLE
fix circle not building tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,11 @@ jobs:
       - deploy:
           name: deploy
           command: .circleci/deploy.sh
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
CircleCI recently skipped building tags by default, so we need to explicitly enable it.

This should be cherry-picked into the 2.7.0 release so we don't have to make API calls to manually kick off the job.

See https://circleci.com/docs/2.0/configuration-reference/#tags