### PR TITLE
feat(search): Expose AppVersion in search results

### DIFF
--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -125,9 +125,9 @@ func (s *searchCmd) formatSearchResults(res []*search.Result) string {
 	}
 	table := uitable.New()
 	table.MaxColWidth = 50
-	table.AddRow("NAME", "VERSION", "DESCRIPTION")
+	table.AddRow("NAME", "CHART VERSION", "APP VERSION", "DESCRIPTION")
 	for _, r := range res {
-		table.AddRow(r.Name, r.Chart.Version, r.Chart.Description)
+		table.AddRow(r.Name, r.Chart.Version, r.Chart.AppVersion, r.Chart.Description)
 	}
 	return table.String()
 }

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -34,18 +34,18 @@ func TestSearchCmd(t *testing.T) {
 		{
 			name:   "search for 'maria', expect one match",
 			args:   []string{"maria"},
-			expect: "NAME           \tVERSION\tDESCRIPTION      \ntesting/mariadb\t0.3.0  \tChart for MariaDB",
+			expect: "NAME           \tCHART VERSION\tAPP VERSION\tDESCRIPTION      \ntesting/mariadb\t0.3.0        \t           \tChart for MariaDB",
 		},
 		{
 			name:   "search for 'alpine', expect two matches",
 			args:   []string{"alpine"},
-			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod",
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod",
 		},
 		{
 			name:   "search for 'alpine' with versions, expect three matches",
 			args:   []string{"alpine"},
 			flags:  []string{"--versions"},
-			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod\ntesting/alpine\t0.1.0  \tDeploy a basic Alpine Linux pod",
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod\ntesting/alpine\t0.1.0        \t1.2.3      \tDeploy a basic Alpine Linux pod",
 		},
 		{
 			name:   "search for 'syzygy', expect no matches",
@@ -56,7 +56,7 @@ func TestSearchCmd(t *testing.T) {
 			name:   "search for 'alp[a-z]+', expect two matches",
 			args:   []string{"alp[a-z]+"},
 			flags:  []string{"--regexp"},
-			expect: "NAME          \tVERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0  \tDeploy a basic Alpine Linux pod",
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod",
 			regexp: true,
 		},
 		{

--- a/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
@@ -8,6 +8,7 @@ entries:
       sources:
       - https://github.com/kubernetes/helm
       version: 0.1.0
+      appVersion: 1.2.3
       description: Deploy a basic Alpine Linux pod
       keywords: []
       maintainers: []
@@ -20,6 +21,7 @@ entries:
       sources:
       - https://github.com/kubernetes/helm
       version: 0.2.0
+      appVersion: 2.3.4
       description: Deploy a basic Alpine Linux pod
       keywords: []
       maintainers: []


### PR DESCRIPTION
Some would like to expose and see the application version in the
search results. This change displays it.

Closes #3010 

An example of the change...
Before:
```
$ helm search wordpress
NAME            	VERSION	DESCRIPTION
stable/wordpress	0.6.13 	Web publishing platform for building blogs and ...
```

After:
```
$ helm search wordpress
NAME            	CHART VERSION	APP VERSION	DESCRIPTION
stable/wordpress	0.6.13       	4.8.2      	Web publishing platform for building blogs and ...
```