### PR TITLE
fix(helm): Set template context inside tpl function to outer function.

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -166,19 +166,32 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 
 	// Add the 'tpl' function here
 	funcMap["tpl"] = func(tpl string, vals chartutil.Values) (string, error) {
-		r := renderable{
-			tpl:  tpl,
-			vals: vals,
+		basePath, err := vals.PathValue("Template.BasePath")
+		if err != nil {
+			return "", fmt.Errorf("Cannot retrieve Template.Basepath from values inside tpl function", tpl, err.Error())
 		}
 
+		r := renderable{
+			tpl:      tpl,
+			vals:     vals,
+			basePath: basePath.(string),
+		}
+
+		println(vals.Table)
+
 		templates := map[string]renderable{}
-		templates["aaa_template"] = r
+		templateName, err := vals.PathValue("Template.Name")
+		if err != nil {
+			return "", fmt.Errorf("Cannot retrieve Template.Name from values inside tpl function", tpl, err.Error())
+		}
+
+		templates[templateName.(string)] = r
 
 		result, err := e.render(templates)
 		if err != nil {
 			return "", fmt.Errorf("Error during tpl function execution for %q: %s", tpl, err.Error())
 		}
-		return result["aaa_template"], nil
+		return result[templateName.(string)], nil
 	}
 
 	return funcMap

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -177,8 +177,6 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 			basePath: basePath.(string),
 		}
 
-		println(vals.Table)
-
 		templates := map[string]renderable{}
 		templateName, err := vals.PathValue("Template.Name")
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -168,7 +168,7 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 	funcMap["tpl"] = func(tpl string, vals chartutil.Values) (string, error) {
 		basePath, err := vals.PathValue("Template.BasePath")
 		if err != nil {
-			return "", fmt.Errorf("Cannot retrieve Template.Basepath from values inside tpl function", tpl, err.Error())
+			return "", fmt.Errorf("Cannot retrieve Template.Basepath from values inside tpl function: %s (%s)", tpl, err.Error())
 		}
 
 		r := renderable{
@@ -182,7 +182,7 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 		templates := map[string]renderable{}
 		templateName, err := vals.PathValue("Template.Name")
 		if err != nil {
-			return "", fmt.Errorf("Cannot retrieve Template.Name from values inside tpl function", tpl, err.Error())
+			return "", fmt.Errorf("Cannot retrieve Template.Name from values inside tpl function: %s (%s)", tpl, err.Error())
 		}
 
 		templates[templateName.(string)] = r

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -538,7 +538,7 @@ func TestAlterFuncMap(t *testing.T) {
 		Metadata: &chart.Metadata{Name: "TplFunction"},
 		Templates: []*chart.Template{
 			{Name: "templates/base", Data: []byte(`{{ tpl "{{include ` + "`" + `TplFunction/templates/_partial` + "`" + ` .  | quote }}" .}}`)},
-			{Name: "templates/_partial", Data: []byte(`{{.Release.Name}}`)},
+			{Name: "templates/_partial", Data: []byte(`{{.Template.Name}}`)},
 		},
 		Values:       &chart.Config{Raw: ``},
 		Dependencies: []*chart.Chart{},
@@ -558,7 +558,7 @@ func TestAlterFuncMap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedTplStrWithInclude := "\"TestRelease\""
+	expectedTplStrWithInclude := "\"TplFunction/templates/base\""
 	if gotStrTplWithInclude := outTplWithInclude["TplFunction/templates/base"]; gotStrTplWithInclude != expectedTplStrWithInclude {
 		t.Errorf("Expected %q, got %q (%v)", expectedTplStrWithInclude, gotStrTplWithInclude, outTplWithInclude)
 	}


### PR DESCRIPTION
docs(helm): Added documentation about tpl function

Fix for https://github.com/kubernetes/helm/issues/3054

The Template Name of BasePath of the outer template which calls the tpl function will now be set during the execution of the tpl function. 