### PR TITLE
docs(chart): add notes regarding `.helmignore` and `.Files`

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -7,6 +7,7 @@ Helm provides access to files through the `.Files` object. Before we get going w
 - It is okay to add extra files to your Helm chart. These files will be bundled and sent to Tiller. Be careful, though. Charts must be smaller than 1M because of the storage limitations of Kubernetes objects.
 - Some files cannot be accessed through the `.Files` object, usually for security reasons.
 	- Files in `templates/` cannot be accessed.
+	- Files excluded using `.helmignore` cannot be accessed.
 - Charts do not preserve UNIX mode information, so file-level permissions will have no impact on the availability of a file when it comes to the `.Files` object.
 
 <!-- (see https://github.com/jonschlinkert/markdown-toc) -->

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -589,9 +589,10 @@ sensitive_.
   `Chart.Maintainers`.
 - `Files`: A map-like object containing all non-special files in the chart. This
   will not give you access to templates, but will give you access to additional
-  files that are present. Files can be accessed using `{{index .Files "file.name"}}`
-  or using the `{{.Files.Get name}}` or `{{.Files.GetString name}}` functions. You can
-  also access the contents of the file as `[]byte` using `{{.Files.GetBytes}}`
+  files that are present (unless they are excluded using `.helmignore`). Files can be
+  accessed using `{{index .Files "file.name"}}` or using the `{{.Files.Get name}}` or
+  `{{.Files.GetString name}}` functions. You can also access the contents of the file
+  as `[]byte` using `{{.Files.GetBytes}}`
 - `Capabilities`: A map-like object that contains information about the versions
   of Kubernetes (`{{.Capabilities.KubeVersion}}`, Tiller
   (`{{.Capabilities.TillerVersion}}`, and the supported Kubernetes API versions


### PR DESCRIPTION
This PR makes more explicit in the docs that files excluded through `.helmignore` are not accessible using the `.Files` variable.

See issue #3050.