### PR TITLE
feat(tiller): exposes port 44135 in tiller deployment

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -168,6 +168,7 @@ func generateDeployment(opts *Options) (*v1beta1.Deployment, error) {
 							ImagePullPolicy: opts.pullPolicy(),
 							Ports: []v1.ContainerPort{
 								{ContainerPort: 44134, Name: "tiller"},
+								{ContainerPort: 44135, Name: "http"},
 							},
 							Env: []v1.EnvVar{
 								{Name: "TILLER_NAMESPACE", Value: opts.Namespace},

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -207,6 +207,10 @@ func TestInstall(t *testing.T) {
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
 		}
+		ports := len(obj.Spec.Template.Spec.Containers[0].Ports)
+		if ports != 2 {
+			t.Errorf("expected ports = 2, got '%d'", ports)
+		}
 		return true, obj, nil
 	})
 	fc.AddReactor("create", "services", func(action testcore.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
Tiller exposes probes and metrics in 44135. With this change, we don't have to manually expose that port in order to Prometheus to scrape it.

Closes #2985 