### PR TITLE
Documentation on RBAC privileges needed for a helm client

### DIFF
--- a/docs/service_accounts.md
+++ b/docs/service_accounts.md
@@ -122,7 +122,7 @@ In this example, we will assume tiller is running in a namespace called `tiller-
 and that the helm client is running in a namespace called `helm-world`  By default,
 tiller is running in the `kube-system` namespace.
 
-In helm-user.yaml:
+In `helm-user.yaml`:
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -164,7 +164,7 @@ subjects:
   namespace: helm-world
 ```
 
-Please note that the role and rolebindings must be placed in the namespace
+Please note that the `role` and `rolebinding` must be placed in the namespace
 that tiller is running in, while the service account must be in the namespace
 that the helm client is to be run in.  (the pod using the helm client must
 be using the service account created here)


### PR DESCRIPTION
If a user wants to run helm in a pod on a cluster (or even outside of the cluster) certain privileges are needed to be granted to the client.  Often the person calling helm has the necessary rights, but I struggled to find documentation on what _exactly_ the rights were.

This PR documents what is needed for a helm client to talk to a tiller.  I figured it belonged in the same file that tiller service accounts and RBAC are discussed.

Thanks