### PR TITLE
fix(tiller): upgrade last deployed release

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -18,6 +18,7 @@ package storage // import "k8s.io/helm/pkg/storage"
 
 import (
 	"fmt"
+	"strings"
 
 	rspb "k8s.io/helm/pkg/proto/hapi/release"
 	relutil "k8s.io/helm/pkg/releaseutil"
@@ -127,14 +128,13 @@ func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 		"OWNER":  "TILLER",
 		"STATUS": "DEPLOYED",
 	})
-	switch {
-	case err != nil:
-		return nil, err
-	case len(ls) == 0:
-		return nil, fmt.Errorf("%q has no deployed releases", name)
-	default:
+	if err == nil {
 		return ls[0], nil
 	}
+	if strings.Contains(err.Error(), "not found") {
+		return nil, fmt.Errorf("%q has no deployed releases", name)
+	}
+	return nil, err
 }
 
 // History returns the revision history for the release with the provided name, or

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -69,8 +69,8 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 		return nil, nil, errMissingChart
 	}
 
-	// finds the non-deleted release with the given name
-	currentRelease, err := s.env.Releases.Last(req.Name)
+	// finds the deployed release with the given name
+	currentRelease, err := s.env.Releases.Deployed(req.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,9 +80,15 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 		return nil, nil, err
 	}
 
+	// finds the non-deleted release with the given name
+	lastRelease, err := s.env.Releases.Last(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Increment revision count. This is passed to templates, and also stored on
 	// the release object.
-	revision := currentRelease.Version + 1
+	revision := lastRelease.Version + 1
 
 	ts := timeconv.Now()
 	options := chartutil.ReleaseOptions{
@@ -151,7 +157,6 @@ func (s *ReleaseServer) performUpdate(originalRelease, updatedRelease *release.R
 	if err := s.ReleaseModule.Update(originalRelease, updatedRelease, req, s.env); err != nil {
 		msg := fmt.Sprintf("Upgrade %q failed: %s", updatedRelease.Name, err)
 		s.Log("warning: %s", msg)
-		originalRelease.Info.Status.Code = release.Status_SUPERSEDED
 		updatedRelease.Info.Status.Code = release.Status_FAILED
 		updatedRelease.Info.Description = msg
 		s.recordRelease(originalRelease, true)

--- a/pkg/tiller/release_update_test.go
+++ b/pkg/tiller/release_update_test.go
@@ -234,8 +234,8 @@ func TestUpdateReleaseFailure(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected to be able to get previous release")
 	}
-	if oldStatus := oldRelease.Info.Status.Code; oldStatus != release.Status_SUPERSEDED {
-		t.Errorf("Expected SUPERSEDED status on previous Release version. Got %v", oldStatus)
+	if oldStatus := oldRelease.Info.Status.Code; oldStatus != release.Status_DEPLOYED {
+		t.Errorf("Expected Deployed status on previous Release version. Got %v", oldStatus)
 	}
 }
 


### PR DESCRIPTION
Fixes #2437

Two bugs were causing this behavior

- Tiller was marking the previous release superseded when an upgrade
failed.
- Upgrade was diffing against failed releases