### PR TITLE
update google.golang.org/grpc to 1.7.2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 397d714c3a444071879981d3e6575931bd637166e845c6577eaea08ffde7e33d
-updated: 2017-10-27T11:04:22.887120936-04:00
+hash: 3d0ff2a6cf119f719abbd2606da14a00073627972be81a6e68404ad92c2d4cd5
+updated: 2017-11-04T13:04:46.410949815+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -320,18 +320,27 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/grpc
-  version: 8050b9cbc271307e5a716a9d782803d09b0d6f2d
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
   subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 5ffe3083946d5603a0578721101dc8165b1d5b5f
+  subpackages:
+  - balancer
   - codes
+  - connectivity
   - credentials
+  - grpclb/grpc_lb_v1/messages
   - grpclog
   - internal
   - keepalive
   - metadata
   - naming
   - peer
+  - resolver
   - stats
+  - status
   - tap
   - transport
 - name: gopkg.in/inf.v0

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
   - ptypes/any
   - ptypes/timestamp
 - package: google.golang.org/grpc
-  version: 1.2.1
+  version: 1.7.2
   # 1.8.1 libs are hosed and need some manual intervention, so pinning to 1.8.0 for now
   # so others aren't getting errors when running `glide up`
 - package: k8s.io/kubernetes

--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -426,7 +426,7 @@ func WithMaxHistory(max int32) HistoryOption {
 // NewContext creates a versioned context.
 func NewContext() context.Context {
 	md := metadata.Pairs("x-helm-api-client", version.GetVersion())
-	return metadata.NewContext(context.TODO(), md)
+	return metadata.NewOutgoingContext(context.TODO(), md)
 }
 
 // ReleaseTestOption allows configuring optional request data for

--- a/pkg/tiller/server.go
+++ b/pkg/tiller/server.go
@@ -78,7 +78,7 @@ func splitMethod(fullMethod string) (string, string) {
 }
 
 func versionFromContext(ctx context.Context) string {
-	if md, ok := metadata.FromContext(ctx); ok {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		if v, ok := md["x-helm-api-client"]; ok && len(v) > 0 {
 			return v[0]
 		}


### PR DESCRIPTION
Versions after 13 July 2017 of grpc-go require context to be explicitly set to outgoing or incoming, for security reasons.  This is a breaking change, and the only one preventing from bumping to 1.7.2.

This PR allows repositories that flatten all their dependencies (e.g., with Bazel) to depend on the latest versions of gRPC and Helm in a sane way.

See https://github.com/grpc/grpc-go/issues/1219 for an explanation