### PR TITLE
set helm client-go user-agent

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/helm/pkg/helm/portforwarder"
 	"k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/tlsutil"
+	"k8s.io/helm/pkg/version"
 )
 
 var (
@@ -220,6 +221,8 @@ func configForContext(context string) (*rest.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get Kubernetes config for context %q: %s", context, err)
 	}
+	config.UserAgent = fmt.Sprintf("%s/%s",
+		os.Args[0], version.FormatVersion(version.GetVersionProto(), true))
 	return config, nil
 }
 

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"k8s.io/helm/pkg/helm"
-	pb "k8s.io/helm/pkg/proto/hapi/version"
 	"k8s.io/helm/pkg/version"
 )
 
@@ -92,7 +91,7 @@ func (v *versionCmd) run() error {
 
 	if v.showClient {
 		cv := version.GetVersionProto()
-		fmt.Fprintf(v.out, "Client: %s\n", formatVersion(cv, v.short))
+		fmt.Fprintf(v.out, "Client: %s\n", version.FormatVersion(cv, v.short))
 	}
 
 	if !v.showServer {
@@ -107,13 +106,6 @@ func (v *versionCmd) run() error {
 		debug("%s", err)
 		return errors.New("cannot connect to Tiller")
 	}
-	fmt.Fprintf(v.out, "Server: %s\n", formatVersion(resp.Version, v.short))
+	fmt.Fprintf(v.out, "Server: %s\n", version.FormatVersion(resp.Version, v.short))
 	return nil
-}
-
-func formatVersion(v *pb.Version, short bool) string {
-	if short {
-		return fmt.Sprintf("%s+g%s", v.SemVer, v.GitCommit[:7])
-	}
-	return fmt.Sprintf("%#v", v)
 }

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -97,7 +97,7 @@ func main() {
 	flag.Parse()
 
 	if *printVersion {
-		fmt.Println(version.GetVersion())
+		fmt.Println(version.FormatVersion(version.GetVersionProto(), true))
 		os.Exit(0)
 	}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/spf13/pflag"
 	apps "k8s.io/api/apps/v1beta2"
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
@@ -41,7 +43,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/helm/pkg/version"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/helper"
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
@@ -65,10 +70,41 @@ type Client struct {
 	Log func(string, ...interface{})
 }
 
+type clientConfig struct {
+	inner clientcmd.ClientConfig
+}
+
+var _ clientcmd.ClientConfig = &clientConfig{}
+
+func (c *clientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.inner.RawConfig()
+}
+
+func (c *clientConfig) ClientConfig() (*rest.Config, error) {
+	cfg, err := c.inner.ClientConfig()
+	if err != nil {
+		return cfg, err
+	}
+	cfg.UserAgent = fmt.Sprintf("%s/%s",
+		os.Args[0], version.FormatVersion(version.GetVersionProto(), true))
+	return cfg, err
+}
+
+func (c *clientConfig) Namespace() (string, bool, error) {
+	return c.inner.Namespace()
+}
+
+func (c *clientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return c.inner.ConfigAccess()
+}
+
 // New creates a new Client.
 func New(config clientcmd.ClientConfig) *Client {
+	if config == nil {
+		config = &clientConfig{cmdutil.DefaultClientConfig(pflag.NewFlagSet("", pflag.ContinueOnError))}
+	}
 	return &Client{
-		Factory:        cmdutil.NewFactory(config),
+		Factory:        cmdutil.NewFactory(&clientConfig{config}),
 		SchemaCacheDir: clientcmd.RecommendedSchemaFile,
 		Log:            func(_ string, _ ...interface{}) {},
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package version // import "k8s.io/helm/pkg/version"
 
-import "k8s.io/helm/pkg/proto/hapi/version"
+import (
+	"fmt"
+
+	"k8s.io/helm/pkg/proto/hapi/version"
+)
 
 var (
 	// Version is the current version of the Helm.
@@ -51,4 +55,12 @@ func GetVersionProto() *version.Version {
 		GitCommit:    GitCommit,
 		GitTreeState: GitTreeState,
 	}
+}
+
+// FormatVersion returns the semver string with git commit
+func FormatVersion(v *version.Version, short bool) string {
+	if short {
+		return fmt.Sprintf("%s+g%s", v.SemVer, v.GitCommit[:7])
+	}
+	return fmt.Sprintf("%#v", v)
 }


### PR DESCRIPTION
set the correct user-agent for access log & monitor

before

```
helm/v1.8.0+$Format:%h$ (linux/amd64) kubernetes/$Format
tiller/v1.8.0+$Format:%h$ (linux/amd64) kubernetes/$Format
```

after

```
/tiller/v2.7+unreleased+g44c34fc
helm/v2.7+unreleased+g44c34fc
```

Signed-off-by: Wei Wei <weiwei.inf@gmail.com>