### PR TITLE
fix(helm): Fixed semantic version constraints on 'search' command

### DIFF
--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -109,10 +109,17 @@ func (s *searchCmd) applyConstraint(res []*search.Result) ([]*search.Result, err
 	}
 
 	data := res[:0]
+	foundNames := map[string]bool{}
 	for _, r := range res {
+		if _, found := foundNames[r.Name]; found {
+			continue
+		}
 		v, err := semver.NewVersion(r.Chart.Version)
 		if err != nil || constraint.Check(v) {
 			data = append(data, r)
+			if !s.versions {
+				foundNames[r.Name] = true // If user hasn't requested all versions, only show the latest that matches
+			}
 		}
 	}
 
@@ -149,7 +156,7 @@ func (s *searchCmd) buildIndex() (*search.Index, error) {
 			continue
 		}
 
-		i.AddRepo(n, ind, s.versions)
+		i.AddRepo(n, ind, s.versions || len(s.version) > 0)
 	}
 	return i, nil
 }

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -48,6 +48,30 @@ func TestSearchCmd(t *testing.T) {
 			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod\ntesting/alpine\t0.1.0        \t1.2.3      \tDeploy a basic Alpine Linux pod",
 		},
 		{
+			name:   "search for 'alpine' with version constraint, expect one match with version 0.1.0",
+			args:   []string{"alpine"},
+			flags:  []string{"--version", ">= 0.1, < 0.2"},
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.1.0        \t1.2.3      \tDeploy a basic Alpine Linux pod",
+		},
+		{
+			name:   "search for 'alpine' with version constraint, expect one match with version 0.1.0",
+			args:   []string{"alpine"},
+			flags:  []string{"--versions", "--version", ">= 0.1, < 0.2"},
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.1.0        \t1.2.3      \tDeploy a basic Alpine Linux pod",
+		},
+		{
+			name:   "search for 'alpine' with version constraint, expect one match with version 0.2.0",
+			args:   []string{"alpine"},
+			flags:  []string{"--version", ">= 0.1"},
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod",
+		},
+		{
+			name:   "search for 'alpine' with version constraint and --versions, expect two matches",
+			args:   []string{"alpine"},
+			flags:  []string{"--versions", "--version", ">= 0.1"},
+			expect: "NAME          \tCHART VERSION\tAPP VERSION\tDESCRIPTION                    \ntesting/alpine\t0.2.0        \t2.3.4      \tDeploy a basic Alpine Linux pod\ntesting/alpine\t0.1.0        \t1.2.3      \tDeploy a basic Alpine Linux pod",
+		},
+		{
 			name:   "search for 'syzygy', expect no matches",
 			args:   []string{"syzygy"},
 			expect: "No results found",


### PR DESCRIPTION
This addresses #3115. I have illustrated the change in a comment there.

