### PR TITLE
feat(helm): add better error message to 'dep up'

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -354,7 +354,7 @@ func (m *Manager) hasAllRepos(deps []*chartutil.Dependency) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("no repository definition for %s. Try 'helm repo add'", strings.Join(missing, ", "))
+		return fmt.Errorf("no repository definition for %s. Please add the missing repos via 'helm repo add'", strings.Join(missing, ", "))
 	}
 	return nil
 }
@@ -406,7 +406,24 @@ func (m *Manager) getRepoNames(deps []*chartutil.Dependency) (map[string]string,
 		}
 	}
 	if len(missing) > 0 {
-		return nil, fmt.Errorf("no repository definition for %s. Try 'helm repo add'", strings.Join(missing, ", "))
+		if len(missing) > 0 {
+			errorMessage := fmt.Sprintf("no repository definition for %s. Please add them via 'helm repo add'", strings.Join(missing, ", "))
+			// It is common for people to try to enter "stable" as a repository instead of the actual URL.
+			// For this case, let's give them a suggestion.
+			containsNonURL := false
+			for _, repo := range missing {
+				if !strings.Contains(repo, "//") && !strings.HasPrefix(repo, "@") && !strings.HasPrefix(repo, "alias:") {
+					containsNonURL = true
+				}
+			}
+			if containsNonURL {
+				errorMessage += `
+Note that repositories must be URLs or aliases. For example, to refer to the stable
+repository, use "https://kubernetes-charts.storage.googleapis.com/" or "@stable" instead of
+"stable". Don't forget to add the repo, too ('helm repo add').`
+			}
+			return nil, errors.New(errorMessage)
+		}
 	}
 	return reposMap, nil
 }

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -107,6 +107,13 @@ func TestGetRepoNames(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "no repo definition failure -- stable repo",
+			req: []*chartutil.Dependency{
+				{Name: "oedipus-rex", Repository: "stable"},
+			},
+			err: true,
+		},
+		{
 			name: "no repo definition failure",
 			req: []*chartutil.Dependency{
 				{Name: "oedipus-rex", Repository: "http://example.com"},


### PR DESCRIPTION
When a user enters a non-URL (such as stable)
in requirements.yaml and tries to `helm dep up`,
they get a potentially confusing error message.
This tries to make the error message clearer.

Closes #2672