### PR TITLE
Remove executable permission bit for charts downloaded from remote repos

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -93,7 +93,7 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 
 	name := filepath.Base(u.Path)
 	destfile := filepath.Join(dest, name)
-	if err := ioutil.WriteFile(destfile, data.Bytes(), 0655); err != nil {
+	if err := ioutil.WriteFile(destfile, data.Bytes(), 0644); err != nil {
 		return destfile, nil, err
 	}
 
@@ -109,7 +109,7 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 			return destfile, ver, nil
 		}
 		provfile := destfile + ".prov"
-		if err := ioutil.WriteFile(provfile, body.Bytes(), 0655); err != nil {
+		if err := ioutil.WriteFile(provfile, body.Bytes(), 0644); err != nil {
 			return destfile, nil, err
 		}
 


### PR DESCRIPTION
Chart files downloaded from repo in `helm dependency build <chart>` are stored with mode `0655`. For example:

```
$ ls -l path/to/charts/ 
total 16
-rw-r-xr-x 1 user staff 3611 Nov 10 15:28 alertmanager-0.0.3.tgz
-rw-r-xr-x 1 user staff 2673 Nov 10 15:28 exporter-kube-state-0.1.0.tgz
-rw-r-xr-x 1 user staff 4961 Nov 10 15:28 prometheus-0.0.1.tgz
```

I believe there's no reason to make theses files executable for group & others.