### PR TITLE
Add fullnameOverride

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -240,7 +240,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "<CHARTNAME>.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- $default := printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- default $default .Values.fullnameOverride -}}
 {{- end -}}
 `
 


### PR DESCRIPTION
This adds .Values.fullnameOverride in the default starter generated by `helm create foo`.

It allows users to override the fullname with: `helm install foo --set fullnameOverride bar`