### PR TITLE
check if resource is present before adding it to remaining or keep on deletion

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -53,6 +53,11 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
+const (
+	// MissingGetHeader is added to Get's outout when a resource is not found.
+	MissingGetHeader = "==> MISSING\nKIND\t\tNAME\n"
+)
+
 // ErrNoObjectsVisited indicates that during a visit operation, no matching objects were found.
 var ErrNoObjectsVisited = goerrors.New("no objects visited")
 
@@ -217,7 +222,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 		}
 	}
 	if len(missing) > 0 {
-		buf.WriteString("==> MISSING\nKIND\t\tNAME\n")
+		buf.WriteString(MissingGetHeader)
 		for _, s := range missing {
 			fmt.Fprintln(buf, s)
 		}

--- a/pkg/tiller/release_modules.go
+++ b/pkg/tiller/release_modules.go
@@ -159,9 +159,9 @@ func DeleteRelease(rel *release.Release, vs chartutil.VersionSet, kubeClient env
 		return rel.Manifest, []error{fmt.Errorf("corrupted release record. You must manually delete the resources: %s", err)}
 	}
 
-	filesToKeep, filesToDelete := filterManifestsToKeep(files, kubeClient, rel.Namespace)
+	filesToKeep, filesToDelete := filterManifestsToKeep(files)
 	if len(filesToKeep) > 0 {
-		kept = summarizeKeptManifests(filesToKeep)
+		kept = summarizeKeptManifests(filesToKeep, kubeClient, rel.Namespace)
 	}
 
 	errs = []error{}

--- a/pkg/tiller/release_modules.go
+++ b/pkg/tiller/release_modules.go
@@ -159,7 +159,7 @@ func DeleteRelease(rel *release.Release, vs chartutil.VersionSet, kubeClient env
 		return rel.Manifest, []error{fmt.Errorf("corrupted release record. You must manually delete the resources: %s", err)}
 	}
 
-	filesToKeep, filesToDelete := filterManifestsToKeep(files)
+	filesToKeep, filesToDelete := filterManifestsToKeep(files, kubeClient, rel.Namespace)
 	if len(filesToKeep) > 0 {
 		kept = summarizeKeptManifests(filesToKeep)
 	}

--- a/pkg/tiller/resource_policy.go
+++ b/pkg/tiller/resource_policy.go
@@ -33,7 +33,7 @@ const resourcePolicyAnno = "helm.sh/resource-policy"
 //   during an uninstallRelease action.
 const keepPolicy = "keep"
 
-func filterManifestsToKeep(manifests []Manifest, kubeClient environment.KubeClient, namespace string) ([]Manifest, []Manifest) {
+func filterManifestsToKeep(manifests []Manifest) ([]Manifest, []Manifest) {
 	remaining := []Manifest{}
 	keep := []Manifest{}
 
@@ -58,7 +58,7 @@ func filterManifestsToKeep(manifests []Manifest, kubeClient environment.KubeClie
 	return keep, remaining
 }
 
-func summarizeKeptManifests(manifests []Manifest) string {
+func summarizeKeptManifests(manifests []Manifest, kubeClient environment.KubeClient, namespace string) string {
 	message := "These resources were kept due to the resource policy:\n"
 	for _, m := range manifests {
 		// check if m is in fact present from k8s client's POV.

--- a/pkg/tiller/resource_policy.go
+++ b/pkg/tiller/resource_policy.go
@@ -38,12 +38,6 @@ func filterManifestsToKeep(manifests []Manifest, kubeClient environment.KubeClie
 	keep := []Manifest{}
 
 	for _, m := range manifests {
-		// check if m is in fact present from k8s client's POV.
-		output, err := kubeClient.Get(namespace, bytes.NewBufferString(m.Content))
-		if err != nil || strings.Contains(output, kube.MissingGetHeader) {
-			continue
-		}
-
 		if m.Head.Metadata == nil || m.Head.Metadata.Annotations == nil || len(m.Head.Metadata.Annotations) == 0 {
 			remaining = append(remaining, m)
 			continue
@@ -67,6 +61,12 @@ func filterManifestsToKeep(manifests []Manifest, kubeClient environment.KubeClie
 func summarizeKeptManifests(manifests []Manifest) string {
 	message := "These resources were kept due to the resource policy:\n"
 	for _, m := range manifests {
+		// check if m is in fact present from k8s client's POV.
+		output, err := kubeClient.Get(namespace, bytes.NewBufferString(m.Content))
+		if err != nil || strings.Contains(output, kube.MissingGetHeader) {
+			continue
+		}
+
 		details := "[" + m.Head.Kind + "] " + m.Head.Metadata.Name + "\n"
 		message = message + details
 	}

--- a/pkg/tiller/resource_policy.go
+++ b/pkg/tiller/resource_policy.go
@@ -59,7 +59,7 @@ func filterManifestsToKeep(manifests []Manifest) ([]Manifest, []Manifest) {
 }
 
 func summarizeKeptManifests(manifests []Manifest, kubeClient environment.KubeClient, namespace string) string {
-	message := "These resources were kept due to the resource policy:\n"
+	var message string
 	for _, m := range manifests {
 		// check if m is in fact present from k8s client's POV.
 		output, err := kubeClient.Get(namespace, bytes.NewBufferString(m.Content))
@@ -68,6 +68,9 @@ func summarizeKeptManifests(manifests []Manifest, kubeClient environment.KubeCli
 		}
 
 		details := "[" + m.Head.Kind + "] " + m.Head.Metadata.Name + "\n"
+		if message == "" {
+			message = "These resources were kept due to the resource policy:\n"
+		}
 		message = message + details
 	}
 	return message


### PR DESCRIPTION
Closes https://github.com/kubernetes/helm/issues/2745

While checking which resources to keep on deletion, verify if each of them is actually present from k8s client's point of view before adding it to the list of manifests remaining or to keep. The check is done on the output string sent, the client doesn't fail if the resource is not present and instead sends a specific string (now turned into an exported constant) together with the name and kind of the resource.

I've tested these changes using a ResourceQuota that limits the number of secrets, creating a chart that includes a secret with the keep annotation, along with other resources (a namespace included so that it will be created before the secret). On install I get the secret creation error. With the current codebase i get the faulty keep message on deletion of the chart. With these changes the message is not shown while deleting the chart.

This test was performed manually, it would be super nice to be able to write a (probably integration) test for this but haven't found how, pls let me know if that could be possible.

Thx!