### PR TITLE
WIP: support output-dir for 'helm template' cmd

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -261,11 +261,11 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if t.outputDir != nil {
-			writeToFile(t.outputDir, name, data)
+		if t.outputDir != "" {
+			writeToFile(t.outputDir, m.name, data)
 			continue
 		}
-		fmt.Printf("---\n# Source: %s\n", name)
+		fmt.Printf("---\n# Source: %s\n", m.name)
 		fmt.Printf(data)
 	}
 	return nil

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -262,10 +262,10 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 		}
 
 		if t.outputDir != "" {
-			writeToFile(t.outputDir, m.name, data)
+			writeToFile(t.outputDir, m.Name, data)
 			continue
 		}
-		fmt.Printf("---\n# Source: %s\n", m.name)
+		fmt.Printf("---\n# Source: %s\n", m.Name)
 		fmt.Printf(data)
 	}
 	return nil


### PR DESCRIPTION
Its a work in progress right now.

if --output-dir provided, helm template will create the files instead of printing on stdout.

while doing so, the directory structure of the output files will be same as directory structure of input template files.