### PR TITLE
fix(helm): Tunnel closing already closed channel

### DIFF
--- a/pkg/kube/tunnel.go
+++ b/pkg/kube/tunnel.go
@@ -59,7 +59,6 @@ func NewTunnel(client rest.Interface, config *rest.Config, namespace, podName st
 // Close disconnects a tunnel connection
 func (t *Tunnel) Close() {
 	close(t.stopChan)
-	close(t.readyChan)
 }
 
 // ForwardPort opens a tunnel to a kubernetes pod


### PR DESCRIPTION
k8s client-go closes the ready channel that's passed in (see https://github.com/kubernetes/client-go/blob/master/tools/portforward/portforward.go#L171) This means that Tunnel's Close will always panic, as the client-go library will have closed then channel. This isn't reproducible unless helm.Client is externally, as the helm cli runner doesn't actually invoke Close.