### PR TITLE
Increase script portability

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #


### PR DESCRIPTION
Instead of presuming that bash is installed at /bin/bash, use `$PATH`.  The official [bash docker container](https://hub.docker.com/_/bash/) installs bash at `/usr/local/bin` and recommends the use of `env`