### PR TITLE
docs(quickstart): add clarifications about RBAC, TLS

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,9 @@ $ kubectl config current-context
 my-cluster
 ```
 
+If your cluster has Role-Based Access Control (RBAC) enabled, you may want
+to [configure a service account and rules](service_account.md) before proceeding.
+
 ## Install Helm
 
 Download a binary release of the Helm client. You can use tools like
@@ -44,6 +47,10 @@ This will install Tiller into the Kubernetes cluster you saw with
 `--kube-context` flag.
 
 **TIP:** When you want to upgrade Tiller, just run `helm init --upgrade`.
+
+By default, when Tiller is installed,it does not have authentication enabled.
+To learn more about configuring strong TLS authentication for Tiller, consult
+[the Tiller TLS guide](tiller_ssl.md).
 
 ## Install an Example Chart
 


### PR DESCRIPTION
This puts pointers to RBAC and TLS docs in the quickstart guide.