### PR TITLE
Make build-cross TARGETS configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_REGISTRY   ?= gcr.io
 IMAGE_PREFIX      ?= kubernetes-helm
 SHORT_NAME        ?= tiller
 SHORT_NAME_RUDDER ?= rudder
-TARGETS           = darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64
+TARGETS           ?= darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64
 DIST_DIRS         = find * -type d -exec
 APP               = helm
 


### PR DESCRIPTION
Lets us build a subset of the targets while still using build-cross

To build for multiple linux archs:
TARGETS="linux/amd64 linux/386" make clean build-cross dist APP=helm VERSION=v25.12.2