### PR TITLE
fix TLS default path

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -268,13 +268,13 @@ func newClient() helm.Interface {
 
 	if tlsVerify || tlsEnable {
 		if tlsCaCertFile == "" {
-			tlsCaCertFile = os.ExpandEnv(tlsCaCertDefault)
+			tlsCaCertFile = settings.Home.TLSCaCert()
 		}
 		if tlsCertFile == "" {
-			tlsCertFile = os.ExpandEnv(tlsCertDefault)
+			tlsCertFile = settings.Home.TLSCert()
 		}
 		if tlsKeyFile == "" {
-			tlsKeyFile = os.ExpandEnv(tlsKeyDefault)
+			tlsKeyFile = settings.Home.TLSKey()
 		}
 		debug("Key=%q, Cert=%q, CA=%q\n", tlsKeyFile, tlsCertFile, tlsCaCertFile)
 		tlsopts := tlsutil.Options{KeyFile: tlsKeyFile, CertFile: tlsCertFile, InsecureSkipVerify: true}

--- a/pkg/helm/helmpath/helmhome.go
+++ b/pkg/helm/helmpath/helmhome.go
@@ -82,7 +82,22 @@ func (h Home) Plugins() string {
 	return h.Path("plugins")
 }
 
-// Archive returns the path to download chart archives
+// Archive returns the path to download chart archives.
 func (h Home) Archive() string {
 	return h.Path("cache", "archive")
+}
+
+// TLSCaCert returns the path to fetch the CA certificate.
+func (h Home) TLSCaCert() string {
+	return h.Path("ca.pem")
+}
+
+// TLSCert returns the path to fetch the client certificate.
+func (h Home) TLSCert() string {
+	return h.Path("cert.pem")
+}
+
+// TLSKey returns the path to fetch the client public key.
+func (h Home) TLSKey() string {
+	return h.Path("key.pem")
 }

--- a/pkg/helm/helmpath/helmhome_unix_test.go
+++ b/pkg/helm/helmpath/helmhome_unix_test.go
@@ -38,6 +38,9 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.CacheIndex("t"), "/r/repository/cache/t-index.yaml")
 	isEq(t, hh.Starters(), "/r/starters")
 	isEq(t, hh.Archive(), "/r/cache/archive")
+	isEq(t, hh.TLSCaCert(), "/r/ca.pem")
+	isEq(t, hh.TLSCert(), "/r/cert.pem")
+	isEq(t, hh.TLSKey(), "/r/key.pem")
 }
 
 func TestHelmHome_expand(t *testing.T) {

--- a/pkg/helm/helmpath/helmhome_windows_test.go
+++ b/pkg/helm/helmpath/helmhome_windows_test.go
@@ -35,4 +35,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.CacheIndex("t"), "r:\\repository\\cache\\t-index.yaml")
 	isEq(t, hh.Starters(), "r:\\starters")
 	isEq(t, hh.Archive(), "r:\\cache\\archive")
+	isEq(t, hh.TLSCaCert(), "r:\\ca.pem")
+	isEq(t, hh.TLSCert(), "r:\\cert.pem")
+	isEq(t, hh.TLSKey(), "r:\\key.pem")
 }


### PR DESCRIPTION
Without this change, running `helm list --tls` without setting $HELM_HOME causes helm to look for TLS certificates under /.

A workaround for this is to explicitly set $HELM_HOME to ~/.helm, e.g.

```
$ export HELM_HOME=$HOME/.helm
$ helm list --tls
```