### PR TITLE
Support for json output in helm get values

### DIFF
--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -45,3 +45,24 @@ func TestGetValuesCmd(t *testing.T) {
 	}
 	runReleaseCases(t, tests, cmd)
 }
+
+func TestGetValuesCmdJson(t *testing.T) {
+	tests := []releaseCase{
+		{
+			name:     "get values with a release in JSON",
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"}),
+			flags:    []string{"--output", "json"},
+			args:     []string{"thomas-guide"},
+			expected: "{\n    \"name\": \"value\"\n}\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "thomas-guide"})},
+		},
+		{
+			name: "get values requires release name arg",
+			err:  true,
+		},
+	}
+	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
+		return newGetValuesCmd(c, out)
+	}
+	runReleaseCases(t, tests, cmd)
+}

--- a/docs/helm/helm_get_values.md
+++ b/docs/helm/helm_get_values.md
@@ -17,6 +17,7 @@ helm get values [flags] RELEASE_NAME
 
 ```
   -a, --all                  dump all (computed) values
+  -o, --output string        output the status in the specified format (json or yaml) (default "yaml")
       --revision int32       get the named release with revision
       --tls                  enable TLS for request
       --tls-ca-cert string   path to TLS CA certificate file (default "$HELM_HOME/ca.pem")


### PR DESCRIPTION
This is a PR associated with kubernetes/helm#3225

This implements the `--output` flag for `helm get values` and provides for both the default YAML rendering and a pretty printed JSON rendering.

As a side note, there doesn't seem to be any handling of flags which are enumerated strings at present, and there doesn't seem to be a 'validate' hook available in each command, so implemented a yaml/json parameter check at the start of `run()` - not sure this is ideal going forward.

