### PR TITLE
Added autodetection of YAML/JSON values

### DIFF
--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -98,6 +98,13 @@ func TestTemplateCmd(t *testing.T) {
 			expectValue: "name: apache",
 		},
 		{
+			name:        "check_values_files_json",
+			desc:        "verify --values files values exist",
+			args:        []string{chartPath, "--values", chartPath + "/charts/subchartA/values.json"},
+			expectKey:   "subchart1/templates/service.yaml",
+			expectValue: "name: apache",
+		},
+		{
 			name:        "check_name_template",
 			desc:        "verify --name-template result exists",
 			args:        []string{chartPath, "--name-template", "foobar-{{ b64enc \"abc\" }}-baz"},

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.json
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.json
@@ -1,0 +1,17 @@
+{
+  "service": {
+    "name": "apache",
+    "type": "ClusterIP",
+    "externalPort": 80,
+    "internalPort": 80
+  },
+  "SCAdata": {
+    "SCAbool": false,
+    "SCAfloat": 3.1,
+    "SCAint": 55,
+    "SCAstring": "jabba",
+    "SCAnested1": {
+      "SCAnested2": true
+    }
+  }
+}


### PR DESCRIPTION
This is a PR associated with kubernetes/helm#3225

This implements autodetection of YAML/JSON values for helm install/upgrade/template comands. As as result, you can execute these commands using whichever format you prefer or a combination of both, such as below:

```
helm install -f values1.yaml -f values2.json stable/mychart
```

It is reusing the detection functionality used by kubernetes (more specifically from `k8s.io/apimachinery/pkg/util/yaml`)
