### PR TITLE
fix(helm): Init not creating local-index symlink on Windows

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -390,7 +390,7 @@ func initLocalRepo(indexFile, cacheFile string, out io.Writer) (*repo.Entry, err
 		}
 
 		//TODO: take this out and replace with helm update functionality
-		os.Symlink(indexFile, cacheFile)
+		createLink(indexFile, cacheFile)
 	} else if fi.IsDir() {
 		return nil, fmt.Errorf("%s must be a file, not a directory", indexFile)
 	}

--- a/cmd/helm/init_unix.go
+++ b/cmd/helm/init_unix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+)
+
+func createLink(indexFile, cacheFile string) {
+	os.Symlink(indexFile, cacheFile)
+}

--- a/cmd/helm/init_windows.go
+++ b/cmd/helm/init_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+)
+
+func createLink(indexFile, cacheFile string) {
+	os.Link(indexFile, cacheFile)
+}


### PR DESCRIPTION
os.Symlink required additional permissions on Windows, and init is not currently identifying the failed creation.

Related to #2071