### PR TITLE
return recordRelease error and check for it on install and update

### DIFF
--- a/pkg/tiller/release_install.go
+++ b/pkg/tiller/release_install.go
@@ -162,7 +162,9 @@ func (s *ReleaseServer) performRelease(r *release.Release, req *services.Install
 
 		// update old release status
 		old.Info.Status.Code = release.Status_SUPERSEDED
-		s.recordRelease(old, true)
+		if err := s.recordRelease(old, true); err != nil {
+			return res, err
+		}
 
 		// update new release with next revision number
 		// so as to append to the old release's history
@@ -172,7 +174,9 @@ func (s *ReleaseServer) performRelease(r *release.Release, req *services.Install
 			Recreate: false,
 			Timeout:  req.Timeout,
 		}
-		s.recordRelease(r, false)
+		if err := s.recordRelease(r, false); err != nil {
+			return res, err
+		}
 		if err := s.ReleaseModule.Update(old, r, updateReq, s.env); err != nil {
 			msg := fmt.Sprintf("Release replace %q failed: %s", r.Name, err)
 			s.Log("warning: %s", msg)
@@ -187,7 +191,9 @@ func (s *ReleaseServer) performRelease(r *release.Release, req *services.Install
 	default:
 		// nothing to replace, create as normal
 		// regular manifests
-		s.recordRelease(r, false)
+		if err := s.recordRelease(r, false); err != nil {
+			return res, err
+		}
 		if err := s.ReleaseModule.Create(r, req, s.env); err != nil {
 			msg := fmt.Sprintf("Release %q failed: %s", r.Name, err)
 			s.Log("warning: %s", msg)

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -307,14 +307,17 @@ func (s *ReleaseServer) renderResources(ch *chart.Chart, values chartutil.Values
 	return hooks, b, notes, nil
 }
 
-func (s *ReleaseServer) recordRelease(r *release.Release, reuse bool) {
+func (s *ReleaseServer) recordRelease(r *release.Release, reuse bool) error {
 	if reuse {
 		if err := s.env.Releases.Update(r); err != nil {
 			s.Log("warning: Failed to update release %s: %s", r.Name, err)
+			return err
 		}
 	} else if err := s.env.Releases.Create(r); err != nil {
 		s.Log("warning: Failed to record release %s: %s", r.Name, err)
+		return err
 	}
+	return nil
 }
 
 func (s *ReleaseServer) execHook(hs []*release.Hook, name, namespace, hook string, timeout int64) error {


### PR DESCRIPTION
Closes #1996

These changes make `recordRelease` return an eventual error, and its consumer code at install and update check for it and return the actual error. I've added some unit tests checking for the returned error (both on update and install) and also tried the functionality using the repro case linked in the issue https://github.com/streamplace/weird-chart-bug, without the fix:
```
$ helm install --name test .
NAME:   test
Error: getting deployed release "test": release: "test" not found
```
With the fix:
```
$ helm install --name test .
Error: ConfigMap "test.v1" is invalid: data: Too long: must have at most 1048576 characters
```

As an additional note, these changes only address the error message part of #1996, the additional problems mentioned about partially installed charts are not taken into account, please let me know if I should try to extend the solution.

Cheers!