### PR TITLE
Added support for export-values in requirements

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -186,6 +186,10 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	err = chartutil.ProcessRequirementsExportValues(c)
+	if err != nil {
+		return err
+	}
 
 	// Set up engine.
 	renderer := engine.New()

--- a/pkg/chartutil/requirements_test.go
+++ b/pkg/chartutil/requirements_test.go
@@ -279,11 +279,19 @@ func TestProcessRequirementsImportValues(t *testing.T) {
 	e["SCBexported2A"] = "blaster"
 	e["global.SC1exported2.all.SC1exported3"] = "SC1expstr"
 
+	// `imports`
+	e["subchart1.mytags.back-end"] = "false"
+	e["subchart1.mytags.front-end"] = "true"
+
 	verifyRequirementsImportValues(t, c, v, e)
 }
 func verifyRequirementsImportValues(t *testing.T, c *chart.Chart, v *chart.Config, e map[string]string) {
 
 	err := ProcessRequirementsImportValues(c)
+	if err != nil {
+		t.Errorf("Error processing import values requirements %v", err)
+	}
+	err = ProcessRequirementsExportValues(c)
 	if err != nil {
 		t.Errorf("Error processing import values requirements %v", err)
 	}

--- a/pkg/chartutil/testdata/subpop/requirements.yaml
+++ b/pkg/chartutil/testdata/subpop/requirements.yaml
@@ -21,6 +21,9 @@ dependencies:
             parent: .
           - SCBexported2
           - SC1exported1
+        export-values:
+          - child: mytags
+            parent: tags
 
       - name: subchart2
         repository: http://localhost:10191


### PR DESCRIPTION
See issue #3242 

There is a need for an `export-values` method when working with requirements.

The attached PR approaches this by mimicking the `import-values` functionality but in the other direction - allowing you to specify the tree in the parent chart you wish to export into the values of the child chart.It also allows you to _ringfence_ settings to a duplicate (aliased) subchart, as can be seen in the example below:

```
dependencies:
      - name: subchart1
        repository: http://localhost:10191
        version: 0.1.0
        tags:
          - front-end
          - subchart1
        export-values:
          - child: release
            parent: release.old

      - name: subchart1
        repository: http://localhost:10191
        version: 0.1.0
        export-values:
          - child: release
            parent: release.new
        alias: subchart1a
```
Obviously, this simple use case can be achieved through other methods - it's when there are many requirements using a mix & match of various parent values that this change become effective.
