### PR TITLE
feat(repo): Improve error message for missing repositories.yaml

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -55,6 +55,13 @@ func NewRepoFile() *RepoFile {
 func LoadRepositoriesFile(path string) (*RepoFile, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"Couldn't load repositories file (%s).\n"+
+					"You might need to run `helm init` (or "+
+					"`helm init --client-only` if tiller is "+
+					"already installed)", path)
+		}
 		return nil, err
 	}
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -19,6 +19,7 @@ package repo
 import "testing"
 import "io/ioutil"
 import "os"
+import "strings"
 
 const testRepositoriesFile = "testdata/repositories.yaml"
 
@@ -213,5 +214,14 @@ func TestWriteFile(t *testing.T) {
 		if !repos.Has(repo.Name) {
 			t.Errorf("expected repository %s not found", repo.Name)
 		}
+	}
+}
+
+func TestRepoNotExists(t *testing.T) {
+	_, err := LoadRepositoriesFile("/this/path/does/not/exist.yaml")
+	if err == nil {
+		t.Errorf("expected err to be non-nil when path does not exist")
+	} else if !strings.Contains(err.Error(), "You might need to run `helm init`") {
+		t.Errorf("expected prompt to run `helm init` when repositories file does not exist")
 	}
 }


### PR DESCRIPTION
New users to helm don't always run `helm init` (e.g. if their cluster
already has helm installed).  The user's initial interaction with any of
helm's repository commands (e.g. `helm repo list`) will then be an error
message due to a missing repositories.yaml in their local config.

Give the user a little hint about how to fix the error without them having
to hunt through the man/help pages.