### PR TITLE
feat Making starter templates more versatile

### DIFF
--- a/docs/charts.md
+++ b/docs/charts.md
@@ -849,6 +849,8 @@ considerations in mind:
 - The `Chart.yaml` will be overwritten by the generator.
 - Users will expect to modify such a chart's contents, so documentation
   should indicate how users can do so.
+- All occurances of `<CHARTNAME>` will be replaced with the specified chart
+  name so that starter charts can be used as templates.
 
 Currently the only way to add a chart to `$HELM_HOME/starters` is to manually
 copy it there. In your chart's documentation, you may want to explain that

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/helm/pkg/proto/hapi/chart"
@@ -124,5 +125,10 @@ func TestCreateFrom(t *testing.T) {
 		} else if fi.IsDir() {
 			t.Errorf("Expected %s to be a file.", f)
 		}
+	}
+
+	// Ensure we replace `<CHARTNAME>`
+	if strings.Contains(mychart.Values.Raw, "<CHARTNAME>") {
+		t.Errorf("Did not expect %s to be present in %s", "<CHARTNAME>", mychart.Values.Raw)
 	}
 }

--- a/pkg/chartutil/testdata/mariner/values.yaml
+++ b/pkg/chartutil/testdata/mariner/values.yaml
@@ -1,4 +1,7 @@
-# Default values for mariner.
+# Default values for <CHARTNAME>.
 # This is a YAML-formatted file. https://github.com/toml-lang/toml
 # Declare name/value pairs to be passed into your templates.
 # name: "value"
+
+<CHARTNAME>:
+  test: true

--- a/pkg/chartutil/transform.go
+++ b/pkg/chartutil/transform.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chartutil
+
+import "strings"
+
+// Transform performs a string replacement of the specified source for
+// a given key with the replacement string
+func Transform(src string, key string, replacement string) []byte {
+	return []byte(strings.Replace(src, key, replacement, -1))
+}


### PR DESCRIPTION
This adds support for changing `'<CHARTNAME>'`
occurances in starter chart to the destination
chart name