### PR TITLE
docs(chart_template_guide): Fix link to Charts Guide

### DIFF
--- a/docs/chart_template_guide/getting_started.md
+++ b/docs/chart_template_guide/getting_started.md
@@ -6,7 +6,7 @@ To get going, let's take a brief look at a Helm chart.
 
 ## Charts
 
-As described in the [Charts Guide](../charts.md), Helm charts are structured like
+As described in the [Charts Guide](charts.md), Helm charts are structured like
 this:
 
 ```


### PR DESCRIPTION
The link to the charts guide is currently broken on docs.helm.sh.  It's
possible that the `..` is confusing things.  Try it without.