### PR TITLE
docs(chart_template_guide): Fix link

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -144,7 +144,7 @@ couple utility methods on the `Files` type.
 For further organization, it is especially useful to use these methods in
 conjunction with the `Glob` method.
 
-Given the directory structure from the [Glob][Glob patterns] example above:
+Given the directory structure from the [Glob](#glob-patterns) example above:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Fix a Glob link floating around with some invalid markdown and an invalid
target.