### PR TITLE
Show kind in resource-not-found-in-release error

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -274,7 +274,8 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 
 		originalInfo := original.Get(info)
 		if originalInfo == nil {
-			return fmt.Errorf("no resource with the name %q found", info.Name)
+			kind := info.Mapping.GroupVersionKind.Kind
+			return fmt.Errorf("no %s with the name %q found", kind, info.Name)
 		}
 
 		if err := updateResource(c, info, originalInfo.Object, force, recreate); err != nil {


### PR DESCRIPTION
This error occures when resource is not found in helm release:
`Error: UPGRADE FAILED: no resource with the name "redis-cluster-sentinel" found`

Changed to:
`Error: UPGRADE FAILED: no ConfigMap with the name "redis-cluster-sentinel" found`

Related to the issue: https://github.com/kubernetes/helm/issues/3275. It is not a solution to the problem, but at least now that resource can easily be found in cluster.