### PR TITLE
Update OWNERS file to use approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
 
 approvers:
-  - sig-apps-leads
   - helm-admins
   - helm-maintainers
 reviewers:

--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,9 @@
-maintainers:
-  - adamreese
-  - bacongobbler
-  - jascott1
-  - michelleN
-  - migmartri
-  - nebril
-  - prydonius
-  - seh
-  - technosophos
-  - thomastaylor312
-  - vaikas-google
-  - viglesiasce
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+approvers:
+  - sig-apps-leads
+  - helm-admins
+  - helm-maintainers
 reviewers:
   - adamreese
   - bacongobbler

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+aliases:
+  sig-apps-leads:
+    - michelleN
+    - mattfarina
+    - prydonius
+    - kow3ns
+  helm-admins:
+    - sgoings
+    - technosophos
+    - vaikas-google
+  helm-maintainers:
+    - technosophos
+    - sgoings
+    - sparkprime
+    - michelleN
+    - sebgoa
+    - adamreese
+    - bmelville
+    - vaikas-google

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
 
 aliases:
-  sig-apps-leads:
-    - michelleN
-    - mattfarina
-    - prydonius
-    - kow3ns
   helm-admins:
     - sgoings
     - technosophos


### PR DESCRIPTION
ref https://github.com/kubernetes/helm/issues/3333

Not sure our automation has ever used a field called "maintainers"

Base approvers on existing github teams that have write or admin
access to this repo, plus SIG leads