### PR TITLE
fix(capabilities): Adding GitVersion to default set

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -203,6 +203,7 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 		}
 		caps.KubeVersion.Major = fmt.Sprint(kv.Major())
 		caps.KubeVersion.Minor = fmt.Sprint(kv.Minor())
+		caps.KubeVersion.GitVersion = fmt.Sprintf("v%d.%d.0", kv.Major(), kv.Minor())
 	}
 	vals, err := chartutil.ToRenderValuesCaps(c, config, options, caps)
 	if err != nil {

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -109,7 +109,7 @@ func TestTemplateCmd(t *testing.T) {
 			desc:        "verify --kube-version overrides the kubernetes version",
 			args:        []string{chartPath, "--kube-version", "1.6"},
 			expectKey:   "subchart1/templates/service.yaml",
-			expectValue: "kube-version/major: \"1\"\n    kube-version/minor: \"6\"",
+			expectValue: "kube-version/major: \"1\"\n    kube-version/minor: \"6\"\n    kube-version/gitversion: \"v1.6.0\"",
 		},
 	}
 

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -29,11 +29,12 @@ var (
 
 	// DefaultKubeVersion is the default kubernetes version
 	DefaultKubeVersion = &version.Info{
-		Major:     "1",
-		Minor:     "9",
-		GoVersion: runtime.Version(),
-		Compiler:  runtime.Compiler,
-		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Major:      "1",
+		Minor:      "9",
+		GitVersion: "v1.9.0",
+		GoVersion:  runtime.Version(),
+		Compiler:   runtime.Compiler,
+		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 )
 

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     release-name: "{{ .Release.Name }}"
     kube-version/major: "{{ .Capabilities.KubeVersion.Major }}"
     kube-version/minor: "{{ .Capabilities.KubeVersion.Minor }}"
+    kube-version/gitversion: "v{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}.0"
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Prior to this, using the semver template functions with the full
version, which is represented in the GitVersion, was not possible
for helm template and lint commands because the property was not
populated by default. This update adds default handling.

Closes #3349