### PR TITLE
Add AppVersion to initial chart

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -90,6 +90,7 @@ func (c *createCmd) run() error {
 		Name:        chartname,
 		Description: "A Helm chart for Kubernetes",
 		Version:     "0.1.0",
+		AppVersion:  "1.0",
 		ApiVersion:  chartutil.ApiVersionV1,
 	}
 


### PR DESCRIPTION
Most new charts published at the charts repo don't have `AppVersion`. Setting it initially will reduce our review efforts there.

The version `1.0` I chose is arbitrary. I purposely set it to a different version than `Version` to make it kind of explicit that it's not the same thing.