### PR TITLE
fixing nested interface type parsing for --set

### DIFF
--- a/pkg/strvals/testdata/parser_val_nested.yaml
+++ b/pkg/strvals/testdata/parser_val_nested.yaml
@@ -1,0 +1,8 @@
+toplevel:
+   env:
+   - key: abckey
+     value: abcval
+   - key: defkey
+     value: defval
+   flatlevel1: abc
+   flatlevel2: def


### PR DESCRIPTION
I was using helm as a library from another go project that injects values through the `--set install.go#vals/mergeValues` mechanism and I encountered an issue while reading the following values.yaml:

```yaml
toplevel:
   env:
   - key: abckey
     value: abcval
   - key: defkey
     value: defval
   flatlevel1: abc
   flatlevel2: def
```

It has a nested array of maps, on the same level as normal string values. 
Now simply injecting `"toplevel.flatlevel1=overwritefl1"` will cause the cast:

> inner = data[string(k)].(map[string]interface{})

to crash the process, since it is a `map[interface{}]interface{}`. 
I patched it by casting the keys to strings- if possible, giving an error otherwise.
