### PR TITLE
fix helm init --upgrade logic

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -63,8 +63,8 @@ func Upgrade(client kubernetes.Interface, opts *Options) error {
 	if err != nil {
 		return err
 	}
-	existingImage := obj.Spec.Template.Spec.Containers[0].Image
-	if !isNewerVersion(existingImage) && !opts.ForceUpgrade {
+	tillerImage := obj.Spec.Template.Spec.Containers[0].Image
+	if semverCompare(tillerImage) == -1 && !opts.ForceUpgrade {
 		return errors.New("current Tiller version is newer, use --force-upgrade to downgrade")
 	}
 	obj.Spec.Template.Spec.Containers[0].Image = opts.selectImage()
@@ -82,15 +82,24 @@ func Upgrade(client kubernetes.Interface, opts *Options) error {
 	return err
 }
 
-// isNewerVersion returns whether the current version is newer than the give image's version
-func isNewerVersion(image string) bool {
+// semverCompare returns whether the client's version is older, equal or newer than the given image's version.
+func semverCompare(image string) int {
 	split := strings.Split(image, ":")
 	if len(split) < 2 {
-		// If we don't know the version, we consider the current version newer
-		return true
+		// If we don't know the version, we consider the client version newer.
+		return 1
 	}
-	imageVersion := split[1]
-	return semver.MustParse(version.Version).GreaterThan(semver.MustParse(imageVersion))
+	tillerVersion, err := semver.NewVersion(split[1])
+	if err != nil {
+		// same thing with unparsable tiller versions (e.g. canary releases).
+		return 1
+	}
+	clientVersion, err := semver.NewVersion(version.Version)
+	if err != nil {
+		// aaaaaand same thing with unparsable helm versions (e.g. canary releases).
+		return 1
+	}
+	return clientVersion.Compare(tillerVersion)
 }
 
 // createDeployment creates the Tiller Deployment resource.


### PR DESCRIPTION
This change does the following:

- performs an upgrade anytime we're using non-semver-compatible clients or servers (e.g. `helm init --canary-image && helm init --upgrade`, or just by installing a canary client). Beforehand, it would panic when it hit `semver.MustParse`.
- allows upgrades when the clients are identical, as CI systems relied on this to not error out or as a no-op. The system will allow upgrades when the client and server are identical to allow the user to tweak settings

downgrades are still not allowed without the use of `--force-upgrade`.

closes #3392