### PR TITLE
exit zero on non-master branch

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -29,7 +29,8 @@ if [[ -n "${CIRCLE_TAG:-}" ]]; then
 elif [[ "${CIRCLE_BRANCH:-}" == "master" ]]; then
   VERSION="canary"
 else
-  exit 1
+  echo "Skipping deploy step; this is neither master or a tag"
+  exit
 fi
 
 echo "Install docker client"


### PR DESCRIPTION
While we still don't want to upload to GCS/GCR, we also don't want the CI run to fail because we are just skipping the step. This is most usually seen in the `release-X.Y` branches cut every minor release.