### PR TITLE
Disambiguate encoding from secrets

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -18,7 +18,7 @@ Helm provides access to files through the `.Files` object. Before we get going w
 - [Path helpers](#path-helpers)
 - [Glob patterns](#glob-patterns)
 - [ConfigMap and Secrets utility functions](#configmap-and-secrets-utility-functions)
-- [Secrets](#secrets)
+- [Encoding](#encoding)
 - [Lines](#lines)
 
 <!-- tocstop -->
@@ -163,9 +163,9 @@ data:
 {{ (.Files.Glob "bar/*").AsSecrets | indent 2 }}
 ```
 
-## Secrets
+## Encoding
 
-When working with a Secret resource, you can import a file and have the template base-64 encode it for you:
+You can import a file and have the template base-64 encode it to ensure successful transmission:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
The use of the term secrets adds confusion here. Base64 encoding is a common data transmission practice, and can be used without referencing secrets. Those less familiar with software engineering will be confused between encoding and encryption. Therefore, I've left the example as a `Secret`, but I removed the references to secrets in the surrounding text.

Closes #2679.