### PR TITLE
Update charts_tips_and_tricks.md

### DIFF
--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -52,6 +52,16 @@ many cases, cause parsing errors inside of Kubernetes.
 port: {{ .Values.Port }}
 ```
 
+This remark does not apply to env variables values which are expected to be string, even if they represent integers:
+
+```
+env:
+  -name: HOST
+    value: "http://host"
+  -name: PORT
+    value: "1234"
+```
+
 ## Using the 'include' Function
 
 Go provides a way of including one template in another using a built-in


### PR DESCRIPTION
Add a sentence to balance the advice about not quoting integers as it can cause headaches when applied to env variables.

As per the [JSON schema definitions](https://github.com/garethr/kubernetes-json-schema/blob/master/v1.9.0-local/_definitions.json#L731), env variable values are expected to be strings:

<img width="934" alt="screen shot 2018-01-29 at 22 49 42" src="https://user-images.githubusercontent.com/228886/35552003-bbe749e2-0546-11e8-904c-5f86b6ed6a97.png">

Following the advice of not quoting integers, one might try to set an unquoted number as an env variable. Trying to apply something similar to the following example has bitten us a few times:

```
env:
  -name: HOST
    value: "http://host"
  -name: PORT
    value: 1234
```

While the actual correct way is to quote the integer:

```
env:
  -name: HOST
    value: "http://host"
  -name: PORT
    value: "1234"
```