### PR TITLE
#3221 Accept dependency in requirements.yaml  from charts directory. 

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -690,11 +690,11 @@ func copyFile(source string, destination string) (err error) {
 	_, err = io.Copy(destinationFile, sourceFile)
 	if err == nil {
 		stats, err := os.Stat(source)
-		if err != nil {
-			err = os.Chmod(destination, stats.Mode())
+		if err == nil {
+			return os.Chmod(destination, stats.Mode())
 		}
 	}
-	return
+	return err
 }
 
 func copyDir(source string, destination string) (err error) {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -53,6 +53,19 @@ func (r *Resolver) Resolve(reqs *chartutil.Requirements, repoNames map[string]st
 	locked := make([]*chartutil.Dependency, len(reqs.Dependencies))
 	missing := []string{}
 	for i, d := range reqs.Dependencies {
+		if d.Repository == "" {
+			// Local chart subfolder
+			if _, err := GetLocalPath(filepath.Join("charts", d.Name), r.chartpath); err != nil {
+				return nil, err
+			}
+
+			locked[i] = &chartutil.Dependency{
+				Name:       d.Name,
+				Repository: "",
+				Version:    d.Version,
+			}
+			continue
+		}
 		if strings.HasPrefix(d.Repository, "file://") {
 
 			if _, err := GetLocalPath(d.Repository, r.chartpath); err != nil {


### PR DESCRIPTION
This change allow the use of charts from the charts sub-directory of the current chart in requirements.yaml. It checks the version. It leaves the chart in place.