### PR TITLE
Adds nameOverride/fullnameOverride to values.yaml

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -93,6 +93,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Override chart app names with caution, here be dragons!
+nameOverride: ""
+fullnameOverride: ""
 `
 
 const defaultIgnore = `# Patterns to ignore when building packages.


### PR DESCRIPTION
**Version**: Helm v2.8.0

The chart skeleton generated by the `create` commands does not pass the checks enforced by `helm lint --strict`.

**Console Output**
```console
$ helm create my-chart
Creating my-chart

$ helm lint --strict my-chart/
==> Linting my-chart/
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: render error in "my-chart/templates/service.yaml": template: my-chart/templates/_helpers.tpl:15:14: executing "my-chart.fullname" at <.Values.fullnameOver...>: map has no entry for key "fullnameOverride"
Error: 1 chart(s) linted, 1 chart(s) failed

$ egrep 'nameOverride|fullnameOverride' my-chart/templates/_helpers.tpl
{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
{{- if .Values.fullnameOverride -}}
{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
{{- $name := default .Chart.Name .Values.nameOverride -}}

$ egrep 'nameOverride|fullnameOverride' my-chart/values.yaml # nothing
```

As you can see, `_helpers.tpl` optionally tries to use values that are not defined in the `values.yaml`. From a _strict_ linting standpoint, I think this error makes sense because it seems like a poor practice to blindly reference a value variable.

Does it make sense to add the 2 variables listed above to the `values.yaml` template?