### PR TITLE
fix upgrade of broken install

### DIFF
--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -325,6 +325,31 @@ func TestStorageLast(t *testing.T) {
 	}
 }
 
+func TestStorageFailed(t *testing.T) {
+	storage := Init(driver.NewMemory())
+
+	const name = "angry-bird"
+
+	// Set up storage with test releases.
+	setup := func() {
+		// release records
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.Status_FAILED}.ToRelease()
+
+		// create the release records in the storage
+		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
+	}
+	setup()
+
+	h, err := storage.Failed(name)
+	if err != nil {
+		t.Fatalf("Failed to query for failed release (%v): %v\n", name, err)
+	}
+	if h.Info.Status.Code != rspb.Status_FAILED {
+		t.Errorf("Expected a failed status, got %s", h.Info.Status.Code)
+	}
+
+}
+
 type ReleaseTestData struct {
 	Name      string
 	Version   int32

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -309,6 +309,20 @@ func newHookFailingKubeClient() *hookFailingKubeClient {
 	}
 }
 
+func newInstallFailingKubClient() *installFailingKubeClient {
+	return &installFailingKubeClient{
+		PrintingKubeClient: environment.PrintingKubeClient{Out: os.Stdout},
+	}
+}
+
+type installFailingKubeClient struct {
+	environment.PrintingKubeClient
+}
+
+func (h *installFailingKubeClient) Create(namespace string, reader io.Reader, timeout int64, shouldWait bool) error {
+	return errors.New("Failed create")
+}
+
 type hookFailingKubeClient struct {
 	environment.PrintingKubeClient
 }

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -72,9 +72,12 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 	// finds the deployed release with the given name
 	currentRelease, err := s.env.Releases.Deployed(req.Name)
 	if err != nil {
-		return nil, nil, err
+		// try to find a failed release we can upgrade
+		currentRelease, err = s.env.Releases.Failed(req.Name)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-
 	// If new values were not supplied in the upgrade, re-use the existing values.
 	if err := s.reuseValues(req, currentRelease); err != nil {
 		return nil, nil, err

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -71,16 +71,17 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 
 	// finds the deployed release with the given name
 	currentRelease, err := s.env.Releases.Deployed(req.Name)
-	if err != nil {
+	if err == nil {
+		// If new values were not supplied in the upgrade, re-use the existing values.
+		if err := s.reuseValues(req, currentRelease); err != nil {
+			return nil, nil, err
+		}
+	} else {
 		// try to find a failed release we can upgrade
 		currentRelease, err = s.env.Releases.Failed(req.Name)
 		if err != nil {
 			return nil, nil, err
 		}
-	}
-	// If new values were not supplied in the upgrade, re-use the existing values.
-	if err := s.reuseValues(req, currentRelease); err != nil {
-		return nil, nil, err
 	}
 
 	// finds the non-deleted release with the given name


### PR DESCRIPTION
If the first `upgrade --install` results in a state FAILED, you can not
run the same command `upgrade --install` again without a failure.
This happens becuase we are search only for releases with the status DEPLOYED.
This change will if the search for DEPLOYED fails, then try to search for a release
with the state FAILED, and if found upgrade that.

This fixes issue #3353