### PR TITLE
defer in loop may cause resource leak

### DIFF
--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -193,10 +193,11 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 			if err != nil {
 				return err
 			}
-			defer outFile.Close()
 			if _, err := io.Copy(outFile, tarReader); err != nil {
+				outFile.Close()
 				return err
 			}
+			outFile.Close()
 		default:
 			return fmt.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
 		}


### PR DESCRIPTION
defer statement executes only when function return, and the resource still be hold during loop. Release the resource manually when not needed.