### PR TITLE
fix(helm): fix the build-time golint warning on 'cmd/helm/install.go'

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -499,12 +499,12 @@ func readFile(filePath string) ([]byte, error) {
 
 	if err != nil {
 		return ioutil.ReadFile(filePath)
-	} else {
-		getter, err := getterConstructor(filePath, "", "", "")
-		if err != nil {
-			return []byte{}, err
-		}
-		data, err := getter.Get(filePath)
-		return data.Bytes(), err
 	}
+
+	getter, err := getterConstructor(filePath, "", "", "")
+	if err != nil {
+		return []byte{}, err
+	}
+	data, err := getter.Get(filePath)
+	return data.Bytes(), err
 }


### PR DESCRIPTION
When building helm, golint no longer generates the following warning:

cmd/helm/install.go:502:9: warning: if block ends with a return statement, so drop this else and outdent its block (golint)

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>