### PR TITLE
helm install when resources already exist will fail

### DIFF
--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -355,8 +355,7 @@ func TestCreate(t *testing.T) {
 	existingPod := strings.NewReader(fmt.Sprintf(testNewPodFormatString, existingResourceName))
 	err := c.Create("default", existingPod, 3, false)
 	if err == nil {
-		t.Skip("This test is pending. still need to implement exit on existing resource.")
-		t.Errorf("creating a resource which already exists should with proper error, got: %q", err)
+		t.Errorf("creating a resource which already exists should fail with error, got: %q", err)
 	}
 }
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -315,7 +315,7 @@ func (s *testCore) Namespaces() internalversion.NamespaceInterface {
 	return s
 }
 
-func (s *testCore) Get(name string, options apiv1.GetOptions) (*core.Namespace, error) {
+func (s *testCore) Get(name string, options metav1.GetOptions) (*core.Namespace, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This is a PR to fix the issue described here: https://github.com/kubernetes/helm/issues/3319

- the intent here is to make the client smart enough to fail if a `Create` call is not able to complete successfully, due to a conflicting pre-existing resource.

I decided to implement this pre-existing resource check within the kubeclient. Reason being, if a `Create` call can not actually create the resource b/c the resource already exists, then one would expect the call to return an error.

This seemed more appropriate then implementing a check in the tiller package as part of the `InstallRelease` call, as tiller knows only about installing a release, and that it has a client interface upon which it can call `Create`. It shouldn't need to know anything about the expected behavior of the client Create call, and its handling of pre-existing resources.

The kubeclient Create implementation borrows the approach taken in the Update call on the kubeclient. Obvious difference being, update will skip pre-existing resources and create will now fail on pre-existing resources.
