### PR TITLE
Tiller should only enforce what we expect from Helm

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -157,14 +157,15 @@ func start() {
 			logger.Fatalf("Could not create server TLS configuration: %v", err)
 		}
 		opts = append(opts, grpc.Creds(credentials.NewTLS(cfg)))
-		opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
-			MaxConnectionIdle: 10 * time.Minute,
-			// If needed, we can configure the max connection age
-		}))
-		opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime: time.Duration(20) * time.Second, // For compatibility with the client keepalive.ClientParameters
-		}))
 	}
+
+	opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionIdle: 10 * time.Minute,
+		// If needed, we can configure the max connection age
+	}))
+	opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+		MinTime: time.Duration(20) * time.Second, // For compatibility with the client keepalive.ClientParameters
+	}))
 
 	rootServer = tiller.NewServer(opts...)
 

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -161,6 +161,9 @@ func start() {
 			MaxConnectionIdle: 10 * time.Minute,
 			// If needed, we can configure the max connection age
 		}))
+		opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: time.Duration(20) * time.Second, // For compatibility with the client keepalive.ClientParameters
+		}))
 	}
 
 	rootServer = tiller.NewServer(opts...)


### PR DESCRIPTION
https://github.com/kubernetes/helm/pull/3183 added a keepalive to the Helm client of 30s period, while Tiller was never configured to permit this, keeping the default minimum keepalive period of 5 minutes, disconnecting any clients which ping more regularly than this.

This commit enforces a minimum that is lower than what Helm is configured for, preventing these disconnections, and thus fixes #3409.