### PR TITLE
fix the bug in test code  that leaves behind temp directories during build

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -33,7 +33,7 @@ func TestCreateCmd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tdir)
+	defer os.RemoveAll(tdir)
 
 	// CD into it
 	pwd, err := os.Getwd()
@@ -79,7 +79,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tdir)
+	defer os.RemoveAll(tdir)
 
 	thome, err := tempHelmHome(t)
 	if err != nil {


### PR DESCRIPTION
fix the bug in test code 'cmd/helm/create_test.go' that leaves behind temp directories during build
With this PR, the build process no longer leaves behind 'helm-create-*' temp directories. Part of work on #3485 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>