### PR TITLE
Fix the unit tests to avoid leaving behind 'helm_home*' temporary directories during build

### DIFF
--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -46,7 +46,7 @@ func TestInitCmd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(home)
+	defer os.RemoveAll(home)
 
 	var buf bytes.Buffer
 	fc := fake.NewSimpleClientset()
@@ -80,7 +80,7 @@ func TestInitCmd_exists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(home)
+	defer os.RemoveAll(home)
 
 	var buf bytes.Buffer
 	fc := fake.NewSimpleClientset(&v1beta1.Deployment{
@@ -113,7 +113,7 @@ func TestInitCmd_clientOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(home)
+	defer os.RemoveAll(home)
 
 	var buf bytes.Buffer
 	fc := fake.NewSimpleClientset()
@@ -184,7 +184,7 @@ func TestEnsureHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(home)
+	defer os.RemoveAll(home)
 
 	b := bytes.NewBuffer(nil)
 	hh := helmpath.Home(home)

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -37,7 +37,7 @@ func TestUpdateCmd(t *testing.T) {
 
 	cleanup := resetEnv()
 	defer func() {
-		os.Remove(thome.String())
+		os.RemoveAll(thome.String())
 		cleanup()
 	}()
 


### PR DESCRIPTION
fix(helm): fix the bug in test code 'cmd/helm/init_test.go' and 'cmd/helm/repo_update_test.go' that leave behind temporary helm home directories during build. With this fix, the build process no longer leaves behind 'helm_home-*' temp directories.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>