### PR TITLE
Bump client side grpc max msg size

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -30,6 +30,10 @@ import (
 	rls "k8s.io/helm/pkg/proto/hapi/services"
 )
 
+// maxMsgSize use 20MB as the default message size limit.
+// grpc library default is 4MB
+const maxMsgSize = 1024 * 1024 * 20
+
 // Client manages client side of the Helm-Tiller protocol.
 type Client struct {
 	opts options
@@ -310,6 +314,7 @@ func (h *Client) connect(ctx context.Context) (conn *grpc.ClientConn, err error)
 			// getting closed by upstreams
 			Time: time.Duration(30) * time.Second,
 		}),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
 	}
 	switch {
 	case h.opts.useTLS:

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -307,7 +307,6 @@ func (h *Client) PingTiller() error {
 // are constructed here.
 func (h *Client) connect(ctx context.Context) (conn *grpc.ClientConn, err error) {
 	opts := []grpc.DialOption{
-		grpc.WithTimeout(5 * time.Second),
 		grpc.WithBlock(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			// Send keepalive every 30 seconds to prevent the connection from
@@ -322,7 +321,9 @@ func (h *Client) connect(ctx context.Context) (conn *grpc.ClientConn, err error)
 	default:
 		opts = append(opts, grpc.WithInsecure())
 	}
-	if conn, err = grpc.Dial(h.opts.host, opts...); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if conn, err = grpc.DialContext(ctx, h.opts.host, opts...); err != nil {
 		return nil, err
 	}
 	return conn, nil

--- a/pkg/tiller/server.go
+++ b/pkg/tiller/server.go
@@ -31,7 +31,7 @@ import (
 
 // maxMsgSize use 20MB as the default message size limit.
 // grpc library default is 4MB
-var maxMsgSize = 1024 * 1024 * 20
+const maxMsgSize = 1024 * 1024 * 20
 
 // DefaultServerOpts returns the set of default grpc ServerOption's that Tiller requires.
 func DefaultServerOpts() []grpc.ServerOption {


### PR DESCRIPTION
Set  grpc max message size to match the server side, or the default limit
of 4MB will still apply when upgrading charts.

Unrelated changes:
- const instead of var on max size setting
- deprecated grpc dial timeout fix
- ~~mute default namespace warnings on `upgrade --install`~~

Fixes #3512