### PR TITLE
Fix 'Namesapce' typo

### DIFF
--- a/_proto/hapi/services/tiller.proto
+++ b/_proto/hapi/services/tiller.proto
@@ -165,7 +165,7 @@ message GetReleaseStatusResponse {
 	// Info contains information about the release.
 	hapi.release.Info info = 2;
 
-  // Namesapce the release was released into
+  // Namespace the release was released into
   string namespace = 3;
 }
 


### PR DESCRIPTION
A minor typo but it caught my attention, so here's a fix for it.