### PR TITLE
Fix the output leak to stdout during build by tests under pkg/releasetesting

### DIFF
--- a/pkg/releasetesting/environment_test.go
+++ b/pkg/releasetesting/environment_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"os"
+	"io/ioutil"
 	"testing"
 
 	"k8s.io/helm/pkg/proto/hapi/release"
@@ -145,7 +145,7 @@ type getFailingKubeClient struct {
 
 func newGetFailingKubeClient() *getFailingKubeClient {
 	return &getFailingKubeClient{
-		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 
@@ -159,7 +159,7 @@ type deleteFailingKubeClient struct {
 
 func newDeleteFailingKubeClient() *deleteFailingKubeClient {
 	return &deleteFailingKubeClient{
-		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 
@@ -173,7 +173,7 @@ type createFailingKubeClient struct {
 
 func newCreateFailingKubeClient() *createFailingKubeClient {
 	return &createFailingKubeClient{
-		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 

--- a/pkg/releasetesting/test_suite_test.go
+++ b/pkg/releasetesting/test_suite_test.go
@@ -18,7 +18,7 @@ package releasetesting
 
 import (
 	"io"
-	"os"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -320,7 +320,7 @@ type podSucceededKubeClient struct {
 
 func newPodSucceededKubeClient() *podSucceededKubeClient {
 	return &podSucceededKubeClient{
-		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 
@@ -334,7 +334,7 @@ type podFailedKubeClient struct {
 
 func newPodFailedKubeClient() *podFailedKubeClient {
 	return &podFailedKubeClient{
-		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 


### PR DESCRIPTION
Fix the output leak to stdout during build by tests under pkg/releasetesting,
 by redirecting output from mock clients. Fixes #3526 .

Example of output leak from tests during build:

>=== RUN   TestNewTestSuite
>--- PASS: TestNewTestSuite (0.00s)
>=== RUN   TestRun
>apiVersion: v1
>kind: Pod
>metadata:
>  name: finding-nemo,
> annotations:
>"helm.sh/hook": test-success
>spec:
>containers:
>name: nemo-test
>image: fake-image
>cmd: fake-command
>apiVersion: v1
>kind: Pod
>metadata:
>  name: gold-rush,
>  annotations:
>    "helm.sh/hook": test-failure
>spec:
> containers:
>name: gold-finding-test
>   image: fake-gold-finding-image
>   cmd: fake-gold-finding-command
>--- PASS: TestRun (0.00s)
>=== RUN   TestRunEmptyTestSuite
>--- PASS: TestRunEmptyTestSuite (0.00s)


With this PR, the output would change to: (no output leak from the tests):

>ok      k8s.io/helm/pkg/provenance      2.988s
>=== RUN   TestCreateTestPodSuccess
>--- PASS: TestCreateTestPodSuccess (0.00s)
=== RUN   TestCreateTestPodFailure
2018/02/16 16:36:54 We ran out of budget and couldn't create finding-nemo
--- PASS: TestCreateTestPodFailure (0.00s)
=== RUN   TestDeleteTestPods
--- PASS: TestDeleteTestPods (0.00s)
=== RUN   TestDeleteTestPodsFailingDelete
--- PASS: TestDeleteTestPodsFailingDelete (0.00s)
=== RUN   TestStreamMessage
--- PASS: TestStreamMessage (0.00s)
=== RUN   TestNewTestSuite
--- PASS: TestNewTestSuite (0.00s)
=== RUN   TestRun
--- PASS: TestRun (0.00s)
=== RUN   TestRunEmptyTestSuite
--- PASS: TestRunEmptyTestSuite (0.00s)
=== RUN   TestRunSuccessWithTestFailureHook
--- PASS: TestRunSuccessWithTestFailureHook (0.00s)
=== RUN   TestExtractTestManifestsFromHooks
--- PASS: TestExtractTestManifestsFromHooks (0.00s)
PASS
ok      k8s.io/helm/pkg/releasetesting  2.210s


Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>