### PR TITLE
Mute upgrade --install default namespace warning

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -154,9 +154,15 @@ func (u *upgradeCmd) run() error {
 		releaseHistory, err := u.client.ReleaseHistory(u.release, helm.WithMaxHistory(1))
 
 		if err == nil {
+			if u.namespace == "" {
+				u.namespace = defaultNamespace()
+			}
 			previousReleaseNamespace := releaseHistory.Releases[0].Namespace
 			if previousReleaseNamespace != u.namespace {
-				fmt.Fprintf(u.out, "WARNING: Namespace doesn't match with previous. Release will be deployed to %s\n", previousReleaseNamespace)
+				fmt.Fprintf(u.out,
+					"WARNING: Namespace %q doesn't match with previous. Release will be deployed to %s\n",
+					u.namespace, previousReleaseNamespace,
+				)
 			}
 		}
 


### PR DESCRIPTION
Initialize empty selection like in the install command to prevent:
WARNING: Namespace doesn't match with previous

Rebased as suggested in #3514 by @bacongobbler 