### PR TITLE
fix the output leak from test code under pkg/tiller

### DIFF
--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -19,6 +19,7 @@ package tiller
 import (
 	"errors"
 	"io"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -284,7 +285,7 @@ func releaseWithKeepStub(rlsName string) *release.Release {
 func MockEnvironment() *environment.Environment {
 	e := environment.New()
 	e.Releases = storage.Init(driver.NewMemory())
-	e.KubeClient = &environment.PrintingKubeClient{Out: os.Stdout}
+	e.KubeClient = &environment.PrintingKubeClient{Out: ioutil.Discard}
 	return e
 }
 
@@ -305,7 +306,7 @@ func (u *updateFailingKubeClient) Update(namespace string, originalReader, modif
 
 func newHookFailingKubeClient() *hookFailingKubeClient {
 	return &hookFailingKubeClient{
-		PrintingKubeClient: environment.PrintingKubeClient{Out: os.Stdout},
+		PrintingKubeClient: environment.PrintingKubeClient{Out: ioutil.Discard},
 	}
 }
 


### PR DESCRIPTION
fix(helm): fix the bug in test code under pkg/tiller that leaks output to stdout during build
Fixes #3534 

Example of output leaked by tests under pkg/tiller:
 
>TestUpdateReleaseNoHooks
>\---
>\# Source: hello/templates/hello
hello: world--- PASS: TestUpdateReleaseNoHooks (0.01s)
=== RUN   TestUpdateReleaseNoChanges
2018/02/14 08:56:59 info: manifest "hello/templates/empty" is empty. Skipping.
>
>\---
>\# Source: hello/templates/goodbye
>goodbye: world
>\---
>\# Source: hello/templates/hello
hello: world
>\---
>\# Source: hello/templates/with-partials
hello: Earth--- PASS: TestUpdateReleaseNoChanges (0.02s)
PASS
ok      k8s.io/helm/pkg/tiller  2.240s


This PR cleans up the output:

>=== RUN   TestUpdateReleaseNoHooks
--- PASS: TestUpdateReleaseNoHooks (0.01s)
=== RUN   TestUpdateReleaseNoChanges
2018/02/19 13:01:00 info: manifest "hello/templates/empty" is empty. Skipping.
--- PASS: TestUpdateReleaseNoChanges (0.02s)
PASS
ok      k8s.io/helm/pkg/tiller  2.659s



Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>