### PR TITLE
Clean up temporary "helm-repotest-*" directories left behind by tests under cmd/helm

### DIFF
--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -36,7 +36,7 @@ func TestRepoAddCmd(t *testing.T) {
 	cleanup := resetEnv()
 	defer func() {
 		srv.Stop()
-		os.Remove(thome.String())
+		os.RemoveAll(thome.String())
 		cleanup()
 	}()
 	if err := ensureTestHome(thome, t); err != nil {
@@ -72,7 +72,7 @@ func TestRepoAdd(t *testing.T) {
 	hh := thome
 	defer func() {
 		ts.Stop()
-		os.Remove(thome.String())
+		os.RemoveAll(thome.String())
 		cleanup()
 	}()
 	if err := ensureTestHome(hh, t); err != nil {

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -37,7 +37,7 @@ func TestRepoRemove(t *testing.T) {
 	cleanup := resetEnv()
 	defer func() {
 		ts.Stop()
-		os.Remove(thome.String())
+		os.RemoveAll(thome.String())
 		cleanup()
 	}()
 	if err := ensureTestHome(hh, t); err != nil {

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -75,7 +75,7 @@ func TestUpdateCharts(t *testing.T) {
 	cleanup := resetEnv()
 	defer func() {
 		ts.Stop()
-		os.Remove(thome.String())
+		os.RemoveAll(thome.String())
 		cleanup()
 	}()
 	if err := ensureTestHome(hh, t); err != nil {


### PR DESCRIPTION
fix(helm): fix the bug in multiple tests (cmd/helm/repo_*_test.go) which leaves behind temporary directories named "helm-repotest-*" during build. Part of work on #3485 

Example of such directories left behind by the build:

>drwx------ 5 ab ab  4096 Feb 19 12:59 helm-repotest-473135226
drwx------ 5 ab ab  4096 Feb 19 12:59 helm-repotest-956265361
drwx------ 5 ab ab  4096 Feb 19 12:59 helm-repotest-070488043
drwx------ 5 ab ab  4096 Feb 19 12:59 helm-repotest-763010901

This PR results in no remaining temporary "helm-repotest-*" directories after build.



Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>