### PR TITLE
Create missing directories when saving files in chartutil.SaveDir

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -70,6 +70,12 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save files
 	for _, f := range c.Files {
 		n := filepath.Join(outdir, f.TypeUrl)
+
+		d := filepath.Dir(n)
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return err
+		}
+
 		if err := ioutil.WriteFile(n, f.Value, 0755); err != nil {
 			return err
 		}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/any"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
@@ -39,6 +40,9 @@ func TestSave(t *testing.T) {
 		},
 		Values: &chart.Config{
 			Raw: "ship: Pequod",
+		},
+		Files: []*any.Any{
+			{TypeUrl: "scheherazade/shahryar.txt", Value: []byte("1,001 Nights")},
 		},
 	}
 
@@ -64,6 +68,9 @@ func TestSave(t *testing.T) {
 	if c2.Values.Raw != c.Values.Raw {
 		t.Fatal("Values data did not match")
 	}
+	if len(c2.Files) != 1 || c2.Files[0].TypeUrl != "scheherazade/shahryar.txt" {
+		t.Fatal("Files data did not match")
+	}
 }
 
 func TestSaveDir(t *testing.T) {
@@ -81,6 +88,9 @@ func TestSaveDir(t *testing.T) {
 		Values: &chart.Config{
 			Raw: "ship: Pequod",
 		},
+		Files: []*any.Any{
+			{TypeUrl: "scheherazade/shahryar.txt", Value: []byte("1,001 Nights")},
+		},
 	}
 
 	if err := SaveDir(c, tmp); err != nil {
@@ -97,5 +107,8 @@ func TestSaveDir(t *testing.T) {
 	}
 	if c2.Values.Raw != c.Values.Raw {
 		t.Fatal("Values data did not match")
+	}
+	if len(c2.Files) != 1 || c2.Files[0].TypeUrl != "scheherazade/shahryar.txt" {
+		t.Fatal("Files data did not match")
 	}
 }


### PR DESCRIPTION
chartutil.SaveDir does not create the directories present in Chart.Files[].TypeUrl.

This prevents draft start packs to contain arbitrary directories.