### PR TITLE
The defined role does not allow Tiller to launch Kubernetes jobs

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -71,7 +71,7 @@ metadata:
   name: tiller-manager
   namespace: tiller-world
 rules:
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "batch", "extensions", "apps"]
   resources: ["*"]
   verbs: ["*"]
 ```


### PR DESCRIPTION
The current documentation does not include "batch" this means if you are trying to use the example role you will be unable to launch Kubernetes jobs.