### PR TITLE
fix(circle): fix download link to download.docker.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 17.11.0-ce
+          version: 17.09.0-ce
       - restore_cache:
           keys:
             - glide-{{ checksum "glide.yaml" }}-{{ checksum "glide.lock" }}

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -34,8 +34,8 @@ else
 fi
 
 echo "Install docker client"
-VER="17.11.0-ce"
-curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
+VER="17.09.0-ce"
+curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
 tar -xz -C /tmp -f /tmp/docker-$VER.tgz
 mv /tmp/docker/* /usr/bin
 


### PR DESCRIPTION
Docker stopped releasing binaries to get.docker.com as of 17.03.0-ce. They are all hosted at download.docker.com now.

I also had to downgrade docker to 17.09.0-ce because that's the only version that both download.docker.com and CircleCI support.

https://download.docker.com/linux/static/stable/x86_64/
https://circleci.com/docs/2.0/building-docker-images/#docker-version