### PR TITLE
added a RelativeIndex() func to helmhome to return a relative path to…

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -86,7 +86,7 @@ func addRepository(name, url string, home helmpath.Home, certFile, keyFile, caFi
 		return fmt.Errorf("repository name (%s) already exists, please specify a different name", name)
 	}
 
-	cif := home.CacheIndex(name)
+	cif := home.RelativeIndex(name)
 	c := repo.Entry{
 		Name:     name,
 		Cache:    cif,

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -86,7 +86,7 @@ func addRepository(name, url string, home helmpath.Home, certFile, keyFile, caFi
 		return fmt.Errorf("repository name (%s) already exists, please specify a different name", name)
 	}
 
-	cif := home.RelativeIndex(name)
+	cif := home.CacheRelativeIndex(name)
 	c := repo.Entry{
 		Name:     name,
 		Cache:    cif,

--- a/pkg/helm/helmpath/helmhome.go
+++ b/pkg/helm/helmpath/helmhome.go
@@ -61,6 +61,12 @@ func (h Home) CacheIndex(name string) string {
 	return h.Path("repository", "cache", target)
 }
 
+// RelativeIndex returns the relative path to an index for the given named repository.
+func (h Home) RelativeIndex(name string) string {
+	target := fmt.Sprintf("%s-index.yaml", name)
+	return filepath.Join(target)
+}
+
 // Starters returns the path to the Helm starter packs.
 func (h Home) Starters() string {
 	return h.Path("starters")

--- a/pkg/helm/helmpath/helmhome.go
+++ b/pkg/helm/helmpath/helmhome.go
@@ -57,12 +57,11 @@ func (h Home) Cache() string {
 
 // CacheIndex returns the path to an index for the given named repository.
 func (h Home) CacheIndex(name string) string {
-	target := fmt.Sprintf("%s-index.yaml", name)
-	return h.Path("repository", "cache", target)
+	return h.Path("repository", "cache", h.CacheRelativeIndex(name))
 }
 
-// RelativeIndex returns the relative path to an index for the given named repository.
-func (h Home) RelativeIndex(name string) string {
+// CacheRelativeIndex returns the relative path to an index for the given named repository from the cache path.
+func (h Home) CacheRelativeIndex(name string) string {
 	target := fmt.Sprintf("%s-index.yaml", name)
 	return filepath.Join(target)
 }

--- a/pkg/helm/helmpath/helmhome_unix_test.go
+++ b/pkg/helm/helmpath/helmhome_unix_test.go
@@ -36,6 +36,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.LocalRepository(), "/r/repository/local")
 	isEq(t, hh.Cache(), "/r/repository/cache")
 	isEq(t, hh.CacheIndex("t"), "/r/repository/cache/t-index.yaml")
+	isEq(t, hh.RelativeIndex("t"), "t-index.yaml")
 	isEq(t, hh.Starters(), "/r/starters")
 	isEq(t, hh.Archive(), "/r/cache/archive")
 	isEq(t, hh.TLSCaCert(), "/r/ca.pem")

--- a/pkg/helm/helmpath/helmhome_unix_test.go
+++ b/pkg/helm/helmpath/helmhome_unix_test.go
@@ -36,7 +36,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.LocalRepository(), "/r/repository/local")
 	isEq(t, hh.Cache(), "/r/repository/cache")
 	isEq(t, hh.CacheIndex("t"), "/r/repository/cache/t-index.yaml")
-	isEq(t, hh.RelativeIndex("t"), "t-index.yaml")
+	isEq(t, hh.CacheRelativeIndex("t"), "t-index.yaml")
 	isEq(t, hh.Starters(), "/r/starters")
 	isEq(t, hh.Archive(), "/r/cache/archive")
 	isEq(t, hh.TLSCaCert(), "/r/ca.pem")

--- a/pkg/helm/helmpath/helmhome_windows_test.go
+++ b/pkg/helm/helmpath/helmhome_windows_test.go
@@ -33,6 +33,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.LocalRepository(), "r:\\repository\\local")
 	isEq(t, hh.Cache(), "r:\\repository\\cache")
 	isEq(t, hh.CacheIndex("t"), "r:\\repository\\cache\\t-index.yaml")
+	isEq(t, hh.RelativeIndex("t"), "t-index.yaml")
 	isEq(t, hh.Starters(), "r:\\starters")
 	isEq(t, hh.Archive(), "r:\\cache\\archive")
 	isEq(t, hh.TLSCaCert(), "r:\\ca.pem")

--- a/pkg/helm/helmpath/helmhome_windows_test.go
+++ b/pkg/helm/helmpath/helmhome_windows_test.go
@@ -33,7 +33,7 @@ func TestHelmHome(t *testing.T) {
 	isEq(t, hh.LocalRepository(), "r:\\repository\\local")
 	isEq(t, hh.Cache(), "r:\\repository\\cache")
 	isEq(t, hh.CacheIndex("t"), "r:\\repository\\cache\\t-index.yaml")
-	isEq(t, hh.RelativeIndex("t"), "t-index.yaml")
+	isEq(t, hh.CacheRelativeIndex("t"), "t-index.yaml")
 	isEq(t, hh.Starters(), "r:\\starters")
 	isEq(t, hh.Archive(), "r:\\cache\\archive")
 	isEq(t, hh.TLSCaCert(), "r:\\ca.pem")


### PR DESCRIPTION
… the index files. Also updated repo_add.go to use this new fun

part 2 of #3327: this makes `repo add` write a path relative to the cache directory into `repositories.yaml`