### PR TITLE
Add instruction to support new GnuGP version

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -52,6 +52,12 @@ $ helm package --sign --key 'helm signing key' --keyring path/to/keyring.secret 
 **TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You can
 use `gpg --list-secret-keys` to list the keys you have.
 
+**Warning:**  the latest GnuPG version store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
+
+```
+$ gpg --export-secret-keys >~/.gnupg/secring.gpg
+```
+
 At this point, you should see both `mychart-0.1.0.tgz` and `mychart-0.1.0.tgz.prov`.
 Both files should eventually be uploaded to your desired chart repository.
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -52,7 +52,7 @@ $ helm package --sign --key 'helm signing key' --keyring path/to/keyring.secret 
 **TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You can
 use `gpg --list-secret-keys` to list the keys you have.
 
-**Warning:**  the latest GnuPG version store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
+**Warning:**  the GnuPG v2 store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
 
 ```
 $ gpg --export-secret-keys >~/.gnupg/secring.gpg


### PR DESCRIPTION
The latest GnuGP tool (https://gnupg.org/download/)  is now storing keyring in a new format file 'kbx' instead of 'gpg' which make the current documentation incomplete for a new user. The propose pull request consists of adding documentation to explain how to generate a gpg using the latest GnuGP tool