### PR TITLE
Fixed bad link to Issues page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The Kubernetes Helm project accepts contributions via GitHub pull requests. This
 ## Reporting a Security Issue
 
 Most of the time, when you find a bug in Helm, it should be reported
-using [GitHub issues](github.com/kubernetes/helm/issues). However, if
+using [GitHub issues](https://github.com/kubernetes/helm/issues). However, if
 you are reporting a _security vulnerability_, please email a report to
 [helm-security@deis.com](mailto:helm-security@deis.com). This will give
 us a chance to try to fix the issue before it is exploited in the wild.


### PR DESCRIPTION
The link to the issues page was giving a 404 due to a malformed URL.