### PR TITLE
fix typo in docs and fake

### DIFF
--- a/docs/chart_tests.md
+++ b/docs/chart_tests.md
@@ -2,7 +2,7 @@
 
 A chart contains a number of Kubernetes resources and components that work together. As a chart author, you may want to write some tests that validate that your chart works as expected when it is installed. These tests also help the chart consumer understand what your chart is supposed to do.
 
-A **test** in a helm chart lives under the `templates/` directory and is a pod definition that specifies a container with a given command to run. The container should exit successfully (exit 0) for a test to be considered a success. The pod definition must contain one of the helm test hook annotations: `helm.sh/hooks: test-success` or `helm.sh/hooks: test-failure`.
+A **test** in a helm chart lives under the `templates/` directory and is a pod definition that specifies a container with a given command to run. The container should exit successfully (exit 0) for a test to be considered a success. The pod definition must contain one of the helm test hook annotations: `helm.sh/hook: test-success` or `helm.sh/hook: test-failure`.
 
 Example tests:
 - Validate that your configuration from the values.yaml file was properly injected.

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -194,7 +194,7 @@ var MockHookTemplate = `apiVersion: v1
 kind: Job
 metadata:
   annotations:
-    "helm.sh/hooks": pre-install
+    "helm.sh/hook": pre-install
 `
 
 // MockManifest is the manifest used for all mock release objects.


### PR DESCRIPTION
got bitten by this today and spent quite some time debugging why my tests were not getting recognized as hooks.