### PR TITLE
Recover from a tiller pod crash caused due to errors in values.yaml

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"path"
 	"sort"
 	"strings"
@@ -204,6 +205,11 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 	// The idea with this process is to make it possible for more complex templates
 	// to share common blocks, but to make the entire thing feel like a file-based
 	// template engine.
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("rendering template failed: %v\n", err)
+		}
+	}()
 	t := template.New("gotpl")
 	if e.Strict {
 		t.Option("missingkey=error")

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,7 +19,6 @@ package engine
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"path"
 	"sort"
 	"strings"
@@ -197,7 +196,7 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 }
 
 // render takes a map of templates/values and renders them.
-func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
+func (e *Engine) render(tpls map[string]renderable) (rendered map[string]string, err error) {
 	// Basically, what we do here is start with an empty parent template and then
 	// build up a list of templates -- one for each file. Once all of the templates
 	// have been parsed, we loop through again and execute every template.
@@ -206,8 +205,8 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 	// to share common blocks, but to make the entire thing feel like a file-based
 	// template engine.
 	defer func() {
-		if err := recover(); err != nil {
-			log.Printf("rendering template failed: %v\n", err)
+		if r := recover(); r != nil {
+			err = fmt.Errorf("rendering template failed: %v", r)
 		}
 	}()
 	t := template.New("gotpl")
@@ -247,7 +246,7 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 		}
 	}
 
-	rendered := make(map[string]string, len(files))
+	rendered = make(map[string]string, len(files))
 	var buf bytes.Buffer
 	for _, file := range files {
 		// Don't render partials. We don't care out the direct output of partials.


### PR DESCRIPTION
Towards #3290
#### Problem
Tiller pod was crashing with a panic when `values.yaml` had an issue and the template rendering fails.
refer [this comment](https://github.com/kubernetes/helm/issues/3290#issuecomment-371243089) for a detailed description of the issue.[This](https://github.com/kubernetes/helm/files/1790435/helm-template-crash-0.0.1.tar.gz) is a sample chart which can cause a crash.

#### Proposed solution
quoting @technosophos [comment](https://github.com/kubernetes/helm/issues/3290#issuecomment-356083598)
>To prevent this, we should probably place a recover outside of the template rendering code to trap the panic and handle/log it.
<!-- Fixes #3290 -->