### PR TITLE
Accept .yml files as well as .yaml for templates.

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -101,7 +101,7 @@ func Templates(linter *support.Linter, values []byte, namespace string, strict b
 		linter.RunLinterRule(support.ErrorSev, path, validateAllowedExtension(fileName))
 
 		// We only apply the following lint rules to yaml files
-		if filepath.Ext(fileName) != ".yaml" {
+		if filepath.Ext(fileName) != ".yaml" || filepath.Ext(fileName) == ".yml" {
 			continue
 		}
 
@@ -138,7 +138,7 @@ func validateTemplatesDir(templatesPath string) error {
 
 func validateAllowedExtension(fileName string) error {
 	ext := filepath.Ext(fileName)
-	validExtensions := []string{".yaml", ".tpl", ".txt"}
+	validExtensions := []string{".yaml", ".yml", ".tpl", ".txt"}
 
 	for _, b := range validExtensions {
 		if b == ext {
@@ -146,7 +146,7 @@ func validateAllowedExtension(fileName string) error {
 		}
 	}
 
-	return fmt.Errorf("file extension '%s' not valid. Valid extensions are .yaml, .tpl, or .txt", ext)
+	return fmt.Errorf("file extension '%s' not valid. Valid extensions are .yaml, .yml, .tpl, or .txt", ext)
 }
 
 func validateYamlContent(err error) error {

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -28,11 +28,11 @@ import (
 const templateTestBasedir = "./testdata/albatross"
 
 func TestValidateAllowedExtension(t *testing.T) {
-	var failTest = []string{"/foo", "/test.yml", "/test.toml", "test.yml"}
+	var failTest = []string{"/foo", "/test.toml"}
 	for _, test := range failTest {
 		err := validateAllowedExtension(test)
-		if err == nil || !strings.Contains(err.Error(), "Valid extensions are .yaml, .tpl, or .txt") {
-			t.Errorf("validateAllowedExtension('%s') to return \"Valid extensions are .yaml, .tpl, or .txt\", got no error", test)
+		if err == nil || !strings.Contains(err.Error(), "Valid extensions are .yaml, .yml, .tpl, or .txt") {
+			t.Errorf("validateAllowedExtension('%s') to return \"Valid extensions are .yaml, .yml, .tpl, or .txt\", got no error", test)
 		}
 	}
 	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt"}


### PR DESCRIPTION
See https://github.com/helm/helm-classic/pull/306 for helm classic
and
https://kubernetes.slack.com/archives/C51E88VDG/p1520588964000061

This means charts can be made with `.yml` files. It's backwards compatible as `helm install` doesn't care about the contents of the package, and so older versions of `helm` can still install the packaged chart.