### PR TITLE
Relative home path part3

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -374,7 +375,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewRepoFile()
-		sr, err := initStableRepo(home.CacheRelativeIndex(stableRepository), out, skipRefresh, home)
+		sr, err := initStableRepo(filepath.Rel(home.Cache(), home.CacheIndex(stableRepository)), out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -374,7 +374,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewRepoFile()
-		sr, err := initStableRepo(home.CacheIndex(stableRepository), out, skipRefresh, home)
+		sr, err := initStableRepo(home.CacheRelativeIndex(stableRepository), out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -409,9 +409,7 @@ func initStableRepo(cacheFile string, out io.Writer, skipRefresh bool, home helm
 		return &c, nil
 	}
 
-	// In this case, the cacheFile is always absolute. So passing empty string
-	// is safe.
-	if err := r.DownloadIndexFile(""); err != nil {
+	if err := r.DownloadIndexFile(home.Cache()); err != nil {
 		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
 	}
 

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -375,7 +375,11 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewRepoFile()
-		sr, err := initStableRepo(filepath.Rel(home.Cache(), home.CacheIndex(stableRepository)), out, skipRefresh, home)
+		sif, err := filepath.Rel(home.Cache(), home.CacheIndex(stableRepository))
+		if err != nil {
+			return err
+		}
+		sr, err := initStableRepo(sif, out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -203,13 +203,13 @@ func TestEnsureHome(t *testing.T) {
 		t.Error(err)
 	}
 
-	rr, err := repo.LoadRepositoriesFile(hh.RepositoryFile())
+	rf, err := repo.LoadRepositoriesFile(hh.RepositoryFile())
 	if err != nil {
 		t.Error(err)
 	}
 
 	foundStable := false
-	for _, rr := range rr.Repositories {
+	for _, rr := range rf.Repositories {
 		if rr.Name == stableRepository {
 			foundStable = true
 			if err != nil {

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -215,7 +215,7 @@ func TestEnsureHome(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if !filepath.IsAbs(rr.Cache) {
+			if filepath.IsAbs(rr.Cache) {
 				t.Errorf("%s stable repo cache path is an absolute path", rr.Cache)
 			}
 			absCache, err := filepath.Abs(filepath.Join(hh.Cache(), rr.Cache))


### PR DESCRIPTION
makes the stable repo add a relative path from the cache directory to `repositories.yaml` and downloads to that location.

part3 of #3327