### PR TITLE
make HELM_HOME portable

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -386,7 +386,11 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 		if err != nil {
 			return err
 		}
-		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), filepath.Rel(home.Cache(), home.CacheIndex("local")), out, home)
+		lif, err := filepath.Rel(home.Cache(), home.CacheIndex("local"))
+		if err != nil {
+			return err
+		}
+		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), lif, out, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -386,7 +386,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 		if err != nil {
 			return err
 		}
-		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheIndex("local"), out, home)
+		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheRelativeIndex("local"), out, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -386,7 +386,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) err
 		if err != nil {
 			return err
 		}
-		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheRelativeIndex("local"), out, home)
+		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), filepath.Rel(home.Cache(), home.CacheIndex("local")), out, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init_unix.go
+++ b/cmd/helm/init_unix.go
@@ -20,10 +20,15 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"k8s.io/helm/pkg/helm/helmpath"
 )
 
 func createLink(indexFile, cacheFile string, home helmpath.Home) error {
-	return os.Symlink(indexFile, cacheFile)
+	fp, err := filepath.Rel(home.Cache(), indexFile)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(fp, filepath.Join(home.Cache(), cacheFile))
 }

--- a/cmd/helm/init_windows.go
+++ b/cmd/helm/init_windows.go
@@ -20,10 +20,11 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"k8s.io/helm/pkg/helm/helmpath"
 )
 
 func createLink(indexFile, cacheFile string, home helmpath.Home) error {
-	return os.Link(indexFile, cacheFile)
+	return os.Link(indexFile, filepath.Join(home.Cache(), cacheFile))
 }


### PR DESCRIPTION
allow cacheFile to be relative for local index
uses a symlink with a relative path on unix

final (part4) piece of https://github.com/kubernetes/helm/pull/3327