### PR TITLE
add newline after header

### DIFF
--- a/docs/securing_installation.md
+++ b/docs/securing_installation.md
@@ -41,6 +41,7 @@ Helm and Tiller are designed to install, remove, and modify logical applications
 Specific users and teams -- developers, operators, system and network administrators -- will need their own portion of the cluster in which they can use Helm and Tiller without risking other portions of the cluster. This means using a Kubernetes cluster with RBAC enabled and Tiller configured to enforce them. For more information about using RBAC in Kubernetes, see [Using RBAC Authorization](rbac.md).
 
 #### Tiller and User Permissions
+
 Tiller in its current form does not provide a way to map user credentials to specific permissions within Kubernetes. When Tiller is running inside of the cluster, it operates with the permissions of its service account. If no service account name is supplied to Tiller, it runs with the default service account for that namespace. This means that all Tiller operations on that server are executed using the Tiller pod's credentials and permissions. 
 
 To properly limit what Tiller itself can do, the standard Kubernetes RBAC mechanisms must be attached to Tiller, including Roles and RoleBindings that place explicit limits on what things a Tiller instance can install, and where. 


### PR DESCRIPTION
Doesn't change the rendered markdown, but it makes the styling consistent with the rest of the docs.