### PR TITLE
fix(helm): Don't crash on bad --values arg

### DIFF
--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -63,10 +63,10 @@ func TestInitCmd(t *testing.T) {
 	if len(actions) != 2 {
 		t.Errorf("Expected 2 actions, got %d", len(actions))
 	}
-	if !actions[0].Matches("create", "deployments") {
+	if len(actions) >= 1 && !actions[0].Matches("create", "deployments") {
 		t.Errorf("unexpected action: %v, expected create deployment", actions[0])
 	}
-	if !actions[1].Matches("create", "services") {
+	if len(actions) >= 2 && !actions[1].Matches("create", "services") {
 		t.Errorf("unexpected action: %v, expected create service", actions[1])
 	}
 	expected := "Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster."

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -491,9 +491,12 @@ func checkDependencies(ch *chart.Chart, reqs *chartutil.Requirements) error {
 
 //readFile load a file from the local directory or a remote file with a url.
 func readFile(filePath string) ([]byte, error) {
-	u, _ := url.Parse(filePath)
-	p := getter.All(settings)
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return ioutil.ReadFile(filePath)
+	}
 
+	p := getter.All(settings)
 	// FIXME: maybe someone handle other protocols like ftp.
 	getterConstructor, err := p.ByScheme(u.Scheme)
 

--- a/cmd/helm/testdata/testcharts/alpine/extra_values.yaml
+++ b/cmd/helm/testdata/testcharts/alpine/extra_values.yaml
@@ -1,2 +1,1 @@
-test:
-  Name: extra-values
+foo: bar

--- a/cmd/helm/testdata/testcharts/alpine/more_values.yaml
+++ b/cmd/helm/testdata/testcharts/alpine/more_values.yaml
@@ -1,2 +1,1 @@
-test:
-  Name: more-values
+foo: baz

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -77,6 +77,9 @@ func (c *FakeClient) InstallReleaseFromChart(chart *chart.Chart, ns string, opts
 	}
 
 	release := ReleaseMock(&MockReleaseOptions{Name: releaseName, Namespace: ns})
+	if c.Opts.instReq.Values != nil {
+		release.Config = c.Opts.instReq.Values
+	}
 	c.Rels = append(c.Rels, release)
 
 	return &rls.InstallReleaseResponse{


### PR DESCRIPTION
Closes #3679.

Note that I have also made a small fix in `init_test.go` to prevent a potential `index out of range` panic when `TestInitCmd` fails in a certain way. This was preventing me from running the full test suite locally on my Mac, where I have some certificate issues due to a proxy.