### PR TITLE
Fix helm search command error on index search failures

### DIFF
--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -83,7 +83,7 @@ func (s *searchCmd) run(args []string) error {
 		q := strings.Join(args, " ")
 		res, err = index.Search(q, searchMaxScore, s.regexp)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
fix(helm): The search command returns error if the index search fails. This PR also refactors the tests on search command to remove some duplication. Fixes #3687 

Signed-off-by: Arash Deshmeh adeshmeh@ca.ibm.com