### PR TITLE
Fixed SIGSEGV when running helm create with -p and no values.yaml file

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -305,8 +305,9 @@ func CreateFrom(chartfile *chart.Metadata, dest string, src string) error {
 	}
 
 	schart.Templates = updatedTemplates
-	schart.Values = &chart.Config{Raw: string(Transform(schart.Values.Raw, "<CHARTNAME>", schart.Metadata.Name))}
-
+	if schart.Values != nil {
+		schart.Values = &chart.Config{Raw: string(Transform(schart.Values.Raw, "<CHARTNAME>", schart.Metadata.Name))}
+	}
 	return SaveDir(schart, dest)
 }
 


### PR DESCRIPTION
If there no values.yaml file in the starter the schart.Values is always nil.