### PR TITLE
tiller grpc message size opt

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -177,8 +177,7 @@ func start() {
 
 	// If set, configure gRPC max msg size
 	if *maxMsgSize > 0 {
-		opts = append(opts, grpc.MaxRecvMsgSize(*maxMsgSize))
-		opts = append(opts, grpc.MaxSendMsgSize(*maxMsgSize))
+		opts = append(opts, grpc.MaxRecvMsgSize(*maxMsgSize), grpc.MaxSendMsgSize(*maxMsgSize))
 	}
 
 	rootServer = tiller.NewServer(opts...)

--- a/pkg/tiller/server.go
+++ b/pkg/tiller/server.go
@@ -29,15 +29,15 @@ import (
 	"k8s.io/helm/pkg/version"
 )
 
-// maxMsgSize use 20MB as the default message size limit.
+// DefaultMaxMsgSize use 20MB as the default message size limit.
 // grpc library default is 4MB
-const maxMsgSize = 1024 * 1024 * 20
+const DefaultMaxMsgSize = 1024 * 1024 * 20
 
 // DefaultServerOpts returns the set of default grpc ServerOption's that Tiller requires.
 func DefaultServerOpts() []grpc.ServerOption {
 	return []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(maxMsgSize),
-		grpc.MaxSendMsgSize(maxMsgSize),
+		grpc.MaxRecvMsgSize(DefaultMaxMsgSize),
+		grpc.MaxSendMsgSize(DefaultMaxMsgSize),
 		grpc.UnaryInterceptor(newUnaryInterceptor()),
 		grpc.StreamInterceptor(newStreamInterceptor()),
 	}


### PR DESCRIPTION
We have a lot of releases and in our cluster `helm ls` fails yet:
```
✗ helm ls 
Error: trying to send message larger than max (30334253 vs. 20971520)
✗ helm ls -m 10
	next: api-gateway
NAME                 	REVISION	UPDATED                 	STATUS  	CHART           	NAMESPACE
.... <list of releases>
```

We need to make maxMsgSize configurable.
Fixes #3322
