### PR TITLE
fix output leak from tiller release install test

### DIFF
--- a/pkg/tiller/release_install_test.go
+++ b/pkg/tiller/release_install_test.go
@@ -468,7 +468,6 @@ func TestInstallRelease_KubeVersion(t *testing.T) {
 		},
 	}
 	_, err := rs.InstallRelease(c, req)
-	fmt.Println(err)
 	if err != nil {
 		t.Fatalf("Expected valid range. Got %q", err)
 	}


### PR DESCRIPTION
A very small PR to fix the output leaked from the tiller release installer test:

```
=== RUN   TestInstallRelease_KubeVersion
<nil>
--- PASS: TestInstallRelease_KubeVersion (0.00s)
```

This PR cleans up the output:

```
=== RUN   TestInstallRelease_KubeVersion
--- PASS: TestInstallRelease_KubeVersion (0.00s)
```

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>