### PR TITLE
Fix link in plugins page that results in a 404

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,7 +4,7 @@ Helm 2.1.0 introduced the concept of a client-side Helm _plugin_. A plugin is a
 tool that can be accessed through the `helm` CLI, but which is not part of the
 built-in Helm codebase.
 
-Existing plugins can be found on [related](related.md#helm-plugins) section or by searching [Github](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
+Existing plugins can be found on [related](https://docs.helm.sh/related#helm-plugins) section or by searching [Github](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
 
 This guide explains how to use and create plugins.
 


### PR DESCRIPTION
Clicking the link will work when viewing docs in GitHub but when viewing via https://docs.helm.sh I get a 404. I have explicitly applied the full address which is the same format used in the README.md e.g. [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide) 