### PR TITLE
Add actionable message in the error

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -443,7 +443,7 @@ func locateChartPath(repoURL, name, version string, verify bool, keyring,
 		return filename, err
 	}
 
-	return filename, fmt.Errorf("failed to download %q", name)
+	return filename, fmt.Errorf("failed to download %q (hint: running `helm repo update` may help)", name)
 }
 
 func generateName(nameTemplate string) (string, error) {


### PR DESCRIPTION
This PR  adds a small help message when `helm install` fails. This does not help if/when the user has entered the wrong chart name, but does help when charts under `stable/*` fails to install when everything else seems to be correct and should be working.

See #3697 
