### PR TITLE
Fix "no kind registered for version" when executing hooks

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -346,7 +346,7 @@ func (c *Client) watchTimeout(t time.Duration) ResourceActorFunc {
 //
 // Handling for other kinds will be added as necessary.
 func (c *Client) WatchUntilReady(namespace string, reader io.Reader, timeout int64, shouldWait bool) error {
-	infos, err := c.Build(namespace, reader)
+	infos, err := c.BuildUnstructured(namespace, reader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses an issue waiting on certain resources instantiated by hooks.

I ran into this while creating a Helm chart for the [Kubernetes Metrics Server](https://github.com/kubernetes-incubator/metrics-server)

It's trivial to reproduce by creating a Helm chart with a template for an APIService resource with the appropriate annotations for a `pre-install` hook:
```
# /path/to/helm/charts/metrics-server/templates/apiService.yaml
apiVersion: apiregistration.k8s.io/v1beta1
kind: APIService
metadata:
  name: v1beta1.metrics.k8s.io
  labels:
    app: {{ .Chart.Name }}
    release: {{ .Release.Name }}
  annotations:
    "helm.sh/hook": pre-install
    "helm.sh/hook-delete-policy": hook-failed
spec:
  service:
    name: {{ .Release.Name }}
    namespace: {{ .Release.Namespace }}
  group: metrics.k8s.io
  version: v1beta1
  insecureSkipTLSVerify: true
  groupPriorityMinimum: 100
  versionPriority: 100
```

When I try to install the Helm Chart with the above APIService, I run into an error, and the release is never created:
```
$ helm upgrade --install --namespace kube-system metrics-server /path/to/helm/charts/metrics-server
Release "metrics-server" does not exist. Installing it now.
Error: unable to decode "": no kind "APIService" is registered for version "apiregistration.k8s.io/v1beta1"
```

The corresponding logs for Tiller provide a little more information:
```
[tiller] 2018/03/22 12:21:15 getting history for release metrics-server
[storage] 2018/03/22 12:21:15 getting release history for "metrics-server"
[tiller] 2018/03/22 12:21:15 preparing install for metrics-server
[storage] 2018/03/22 12:21:15 getting release history for "metrics-server"
[tiller] 2018/03/22 12:21:15 rendering metrics-server chart using values
[tiller] 2018/03/22 12:21:16 performing install for metrics-server
[tiller] 2018/03/22 12:21:16 executing 1 pre-install hooks for metrics-server
[kube] 2018/03/22 12:21:16 building resources from manifest
[kube] 2018/03/22 12:21:16 creating 1 resource(s)
[tiller] 2018/03/22 12:21:16 warning: Release metrics-server pre-install metrics-server/templates/apiService.yaml could not complete: unable to decode "": no kind "APIService" is registered for version "apiregistration.k8s.io/v1beta1"
[tiller] 2018/03/22 12:21:16 deleting pre-install hook v1beta1.metrics.k8s.io for release metrics-server due to "hook-failed" policy
[kube] 2018/03/22 12:21:16 Starting delete for "v1beta1.metrics.k8s.io" APIService
[tiller] 2018/03/22 12:21:16 failed install perform step: unable to decode "": no kind "APIService" is registered for version "apiregistration.k8s.io/v1beta1"
```

(For what it's worth, if I omit the `helm.sh/hook` annotation, the APIService resource is created without issue. It's only during the `pre-install` hook that this is an issue.)

For reference, here are my Helm and Kubernetes versions:
```
$ helm version
Client: &version.Version{SemVer:"v2.8.2", GitCommit:"a80231648a1473929271764b920a8e346f6de844", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.8.1", GitCommit:"6af75a8fd72e2aa18a2b278cfe5c7a1c5feca7f2", GitTreeState:"clean"}
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-09T21:50:44Z", GoVersion:"go1.9.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-07T11:55:20Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
```