### PR TITLE
fixed linter warnings due to Json function names

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -207,11 +207,11 @@ func ToToml(v interface{}) string {
 	return b.String()
 }
 
-// ToJson takes an interface, marshals it to json, and returns a string. It will
+// ToJSON takes an interface, marshals it to json, and returns a string. It will
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func ToJson(v interface{}) string {
+func ToJSON(v interface{}) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.
@@ -220,13 +220,13 @@ func ToJson(v interface{}) string {
 	return string(data)
 }
 
-// FromJson converts a JSON document into a map[string]interface{}.
+// FromJSON converts a JSON document into a map[string]interface{}.
 //
 // This is not a general-purpose JSON parser, and will not parse all valid
 // JSON documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string into
 // m["Error"] in the returned map.
-func FromJson(str string) map[string]interface{} {
+func FromJSON(str string) map[string]interface{} {
 	m := map[string]interface{}{}
 
 	if err := json.Unmarshal([]byte(str), &m); err != nil {

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -167,7 +167,7 @@ one:
 	}
 }
 
-func TestToJson(t *testing.T) {
+func TestToJSON(t *testing.T) {
 	expect := `{"foo":"bar"}`
 	v := struct {
 		Foo string `json:"foo"`
@@ -175,12 +175,12 @@ func TestToJson(t *testing.T) {
 		Foo: "bar",
 	}
 
-	if got := ToJson(v); got != expect {
+	if got := ToJSON(v); got != expect {
 		t.Errorf("Expected %q, got %q", expect, got)
 	}
 }
 
-func TestFromJson(t *testing.T) {
+func TestFromJSON(t *testing.T) {
 	doc := `{
   "hello": "world",
   "one": {
@@ -188,7 +188,7 @@ func TestFromJson(t *testing.T) {
   }
 }
 `
-	dict := FromJson(doc)
+	dict := FromJSON(doc)
 	if err, ok := dict["Error"]; ok {
 		t.Fatalf("Parse error: %s", err)
 	}
@@ -210,7 +210,7 @@ func TestFromJson(t *testing.T) {
  "three"
 ]
 `
-	dict = FromJson(doc2)
+	dict = FromJSON(doc2)
 	if _, ok := dict["Error"]; !ok {
 		t.Fatal("Expected parser error")
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -79,8 +79,8 @@ func FuncMap() template.FuncMap {
 		"toToml":   chartutil.ToToml,
 		"toYaml":   chartutil.ToYaml,
 		"fromYaml": chartutil.FromYaml,
-		"toJson":   chartutil.ToJson,
-		"fromJson": chartutil.FromJson,
+		"toJson":   chartutil.ToJSON,
+		"fromJson": chartutil.FromJSON,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the


### PR DESCRIPTION
fix(helm): fixed linter warnings due to Json function names:

```
==> Running linters <==
```

```
pkg/chartutil/files.go:214:6:warning: func ToJson should be ToJSON (golint)
pkg/chartutil/files.go:229:6:warning: func FromJson should be FromJSON (golint)
```
This PR resolves the above warnings.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>