### PR TITLE
 Add chart name check to lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ rootfs/rudder
 vendor/
 *.exe
 .idea/
+*.iml

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -46,7 +46,8 @@ func Chartfile(linter *support.Linter) {
 		return
 	}
 
-	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartName(chartFile))
+	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartNamePresence(chartFile))
+	linter.RunLinterRule(support.WarningSev, chartFileName, validateChartNameFormat(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartNameDirMatch(linter.ChartDir, chartFile))
 
 	// Chart metadata
@@ -74,9 +75,16 @@ func validateChartYamlFormat(chartFileError error) error {
 	return nil
 }
 
-func validateChartName(cf *chart.Metadata) error {
+func validateChartNamePresence(cf *chart.Metadata) error {
 	if cf.Name == "" {
 		return errors.New("name is required")
+	}
+	return nil
+}
+
+func validateChartNameFormat(cf *chart.Metadata) error {
+	if strings.Contains(cf.Name, ".") {
+		return errors.New("name should be lower case letters and numbers. Words may be separated with dashes")
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -29,17 +29,20 @@ import (
 )
 
 const (
-	badChartDir  = "testdata/badchartfile"
-	goodChartDir = "testdata/goodone"
+	badChartDir     = "testdata/badchartfile"
+	badNameChartDir = "testdata/badnamechart"
+	goodChartDir    = "testdata/goodone"
 )
 
 var (
 	badChartFilePath         = filepath.Join(badChartDir, "Chart.yaml")
+	badNameChartFilePath     = filepath.Join(badNameChartDir, "Chart.yaml")
 	goodChartFilePath        = filepath.Join(goodChartDir, "Chart.yaml")
 	nonExistingChartFilePath = filepath.Join(os.TempDir(), "Chart.yaml")
 )
 
 var badChart, chatLoadRrr = chartutil.LoadChartfile(badChartFilePath)
+var badNameChart, _ = chartutil.LoadChartfile(badNameChartFilePath)
 var goodChart, _ = chartutil.LoadChartfile(goodChartFilePath)
 
 // Validation functions Test
@@ -66,9 +69,16 @@ func TestValidateChartYamlFormat(t *testing.T) {
 }
 
 func TestValidateChartName(t *testing.T) {
-	err := validateChartName(badChart)
+	err := validateChartNamePresence(badChart)
 	if err == nil {
 		t.Errorf("validateChartName to return a linter error, got no error")
+	}
+}
+
+func TestValidateChartNameFormat(t *testing.T) {
+	err := validateChartNameFormat(badNameChart)
+	if err == nil {
+		t.Errorf("validateChartNameFormat to return a linter error, got no error")
 	}
 }
 

--- a/pkg/lint/rules/testdata/badnamechart/Chart.yaml
+++ b/pkg/lint/rules/testdata/badnamechart/Chart.yaml
@@ -1,0 +1,4 @@
+name: bad.chart.name
+description: A Helm chart for Kubernetes
+version: 0.1.0
+icon: http://riverrun.io

--- a/pkg/lint/rules/testdata/badnamechart/values.yaml
+++ b/pkg/lint/rules/testdata/badnamechart/values.yaml
@@ -1,0 +1,1 @@
+# Default values for badchartname.


### PR DESCRIPTION
I run into an issue with a chart which contained a dot in the name. Thought it would be nice to get this reported when performing a lint.