### PR TITLE
added warning and set default image for unreleased versions of helm for #3770

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -325,7 +324,7 @@ func (i *initCmd) run() error {
 		fmt.Fprintln(i.out, "Not installing Tiller due to 'client-only' flag having been set")
 	}
 
-	if !(len(strings.Split(version.Version, ".")) > 2) && !i.opts.UseCanary && len(i.opts.ImageSpec) == 0 {
+	if version.BuildMetadata == "unreleased" && !i.opts.UseCanary && len(i.opts.ImageSpec) == 0 {
 		fmt.Fprintf(i.out, "\nWarning: You appear to be using an unreleased version of Helm. Please either use the\n"+
 			"--canary-image flag, or specify your desired tiller version with --tiller-image.\n\n"+
 			"Ex:\n"+

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -324,7 +324,8 @@ func (i *initCmd) run() error {
 		fmt.Fprintln(i.out, "Not installing Tiller due to 'client-only' flag having been set")
 	}
 
-	if version.BuildMetadata == "unreleased" && !i.opts.UseCanary && len(i.opts.ImageSpec) == 0 {
+	needsDefaultImage := !i.clientOnly && !i.opts.UseCanary && len(i.opts.ImageSpec) == 0 && version.BuildMetadata == "unreleased"
+	if needsDefaultImage {
 		fmt.Fprintf(i.out, "\nWarning: You appear to be using an unreleased version of Helm. Please either use the\n"+
 			"--canary-image flag, or specify your desired tiller version with --tiller-image.\n\n"+
 			"Ex:\n"+

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/helm/portforwarder"
 	"k8s.io/helm/pkg/repo"
+	"k8s.io/helm/pkg/version"
 )
 
 const initDesc = `
@@ -321,6 +323,13 @@ func (i *initCmd) run() error {
 		}
 	} else {
 		fmt.Fprintln(i.out, "Not installing Tiller due to 'client-only' flag having been set")
+	}
+
+	if !(len(strings.Split(version.Version, ".")) > 2) && !i.opts.UseCanary && len(i.opts.ImageSpec) == 0 {
+		fmt.Fprintf(i.out, "\nWarning: You appear to be using an unreleased version of Helm. Please either use the\n"+
+			"--canary-image flag, or specify your desired tiller version with --tiller-image.\n\n"+
+			"Ex:\n"+
+			"$ helm init --tiller-image gcr.io/kubernetes-helm/tiller:v2.8.2\n\n")
 	}
 
 	fmt.Fprintln(i.out, "Happy Helming!")

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -59,7 +58,7 @@ func TestDeploymentManifest(t *testing.T) {
 		}
 
 		// Unreleased versions of helm don't have a release image. See issue 3370
-		if tt.name == "default" && !(len(strings.Split(version.Version, ".")) > 2) {
+		if tt.name == "default" && version.BuildMetadata == "unreleased" {
 			tt.expect = "gcr.io/kubernetes-helm/tiller:canary"
 		}
 		if got := dep.Spec.Template.Spec.Containers[0].Image; got != tt.expect {

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -57,6 +58,10 @@ func TestDeploymentManifest(t *testing.T) {
 			t.Fatalf("%s: error %q", tt.name, err)
 		}
 
+		// Unreleased versions of helm don't have a release image. See issue 3370
+		if tt.name == "default" && !(len(strings.Split(version.Version, ".")) > 2) {
+			tt.expect = "gcr.io/kubernetes-helm/tiller:canary"
+		}
 		if got := dep.Spec.Template.Spec.Containers[0].Image; got != tt.expect {
 			t.Errorf("%s: expected image %q, got %q", tt.name, tt.expect, got)
 		}

--- a/cmd/helm/installer/options.go
+++ b/cmd/helm/installer/options.go
@@ -18,6 +18,7 @@ package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/helm/pkg/strvals"
@@ -101,6 +102,9 @@ func (opts *Options) selectImage() string {
 	case opts.UseCanary:
 		return defaultImage + ":canary"
 	case opts.ImageSpec == "":
+		if !(len(strings.Split(version.Version, ".")) > 2) {
+			return defaultImage + ":canary"
+		}
 		return fmt.Sprintf("%s:%s", defaultImage, version.Version)
 	default:
 		return opts.ImageSpec

--- a/cmd/helm/installer/options.go
+++ b/cmd/helm/installer/options.go
@@ -18,7 +18,6 @@ package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/helm/pkg/strvals"
@@ -102,7 +101,7 @@ func (opts *Options) selectImage() string {
 	case opts.UseCanary:
 		return defaultImage + ":canary"
 	case opts.ImageSpec == "":
-		if !(len(strings.Split(version.Version, ".")) > 2) {
+		if version.BuildMetadata == "unreleased" {
 			return defaultImage + ":canary"
 		}
 		return fmt.Sprintf("%s:%s", defaultImage, version.Version)


### PR DESCRIPTION
I setup something in cmd/helm/installer/options.go to use the canary image in the event that the BuildMetaData for helm was "unreleased" and that UseCanary wasn't set, and the tiller-image flag wasn't used.

I separately repeated this logic in cmd/helm/init.go for the sake of keeping warnings and other output together. 