### PR TITLE
stream releases when listing

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -148,7 +148,7 @@ func (l *listCmd) run() error {
 		return prettyError(err)
 	}
 
-	if len(res.Releases) == 0 {
+	if len(res.GetReleases()) == 0 {
 		return nil
 	}
 
@@ -239,12 +239,16 @@ func formatList(rels []*release.Release, colWidth uint) string {
 	table.MaxColWidth = colWidth
 	table.AddRow("NAME", "REVISION", "UPDATED", "STATUS", "CHART", "NAMESPACE")
 	for _, r := range rels {
-		c := fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
-		t := timeconv.String(r.Info.LastDeployed)
-		s := r.Info.Status.Code.String()
-		v := r.Version
-		n := r.Namespace
-		table.AddRow(r.Name, v, t, s, c, n)
+		md := r.GetChart().GetMetadata()
+		c := fmt.Sprintf("%s-%s", md.GetName(), md.GetVersion())
+		t := "-"
+		if tspb := r.GetInfo().GetLastDeployed(); tspb != nil {
+			t = timeconv.String(tspb)
+		}
+		s := r.GetInfo().GetStatus().GetCode().String()
+		v := r.GetVersion()
+		n := r.GetNamespace()
+		table.AddRow(r.GetName(), v, t, s, c, n)
 	}
 	return table.String()
 }

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -346,8 +346,22 @@ func (h *Client) list(ctx context.Context, req *rls.ListReleasesRequest) (*rls.L
 	if err != nil {
 		return nil, err
 	}
-
-	return s.Recv()
+	var resp *rls.ListReleasesResponse
+	for {
+		r, err := s.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			resp = r
+			continue
+		}
+		resp.Releases = append(resp.Releases, r.GetReleases()[0])
+	}
+	return resp, nil
 }
 
 // Executes tiller.InstallRelease RPC.

--- a/pkg/tiller/release_list.go
+++ b/pkg/tiller/release_list.go
@@ -108,13 +108,18 @@ func (s *ReleaseServer) ListReleases(req *services.ListReleasesRequest, stream s
 		l = int64(len(rels))
 	}
 
-	res := &services.ListReleasesResponse{
-		Next:     next,
-		Count:    l,
-		Total:    total,
-		Releases: rels,
+	for i := 0; i < min(len(rels), int(req.Limit)); i++ {
+		res := &services.ListReleasesResponse{
+			Next:     next,
+			Count:    l,
+			Total:    total,
+			Releases: []*release.Release{rels[i]},
+		}
+		if err := stream.Send(res); err != nil {
+			return err
+		}
 	}
-	return stream.Send(res)
+	return nil
 }
 
 func filterByNamespace(namespace string, rels []*release.Release) ([]*release.Release, error) {


### PR DESCRIPTION
This PR addresses:

1. In `cmd/list.go`: Use proto Getters to avoid potential panics on accessing nil fields directly.

2. In `pkg/tiller/release_list.go`: Stream releases. Prior, we sent one ListReleasesResponse per ListReleasesRequest containing all releases. However, there are situations where the gRPC max payload limit is exceeded. `ListReleases` was already defined (in proto) to return a stream. Now,
per ListReleasesRequest, one ListReleaseResponse is streamed per release constrained to the caveats of the request.

3. In `pkg/helm/client.go`: Aggregate the ListReleasesResponse's from the stream before returning.