### PR TITLE
return a non 0 exit code when lint fails due to missing Chart.yaml

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -97,10 +97,14 @@ func (l *lintCmd) run() error {
 
 	var total int
 	var failures int
+	rc := 0
 	for _, path := range l.paths {
 		if linter, err := lintChart(path, rvals, l.namespace, l.strict); err != nil {
 			fmt.Println("==> Skipping", path)
 			fmt.Println(err)
+			if err == errLintNoChart {
+				rc = 1
+			}
 		} else {
 			fmt.Println("==> Linting", path)
 
@@ -126,6 +130,10 @@ func (l *lintCmd) run() error {
 	}
 
 	fmt.Fprintf(l.out, "%s, no failures\n", msg)
+
+	if rc != 0 {
+		os.Exit(rc)
+	}
 
 	return nil
 }

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -97,13 +97,12 @@ func (l *lintCmd) run() error {
 
 	var total int
 	var failures int
-	rc := 0
 	for _, path := range l.paths {
 		if linter, err := lintChart(path, rvals, l.namespace, l.strict); err != nil {
 			fmt.Println("==> Skipping", path)
 			fmt.Println(err)
 			if err == errLintNoChart {
-				rc = 1
+				failures = failures + 1
 			}
 		} else {
 			fmt.Println("==> Linting", path)
@@ -130,10 +129,6 @@ func (l *lintCmd) run() error {
 	}
 
 	fmt.Fprintf(l.out, "%s, no failures\n", msg)
-
-	if rc != 0 {
-		os.Exit(rc)
-	}
 
 	return nil
 }

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -28,6 +28,7 @@ var (
 	archivedChartPathWithHyphens = "testdata/testcharts/compressedchart-with-hyphens-0.1.0.tgz"
 	invalidArchivedChartPath     = "testdata/testcharts/invalidcompressedchart0.1.0.tgz"
 	chartDirPath                 = "testdata/testcharts/decompressedchart/"
+	chartMissingManifest         = "testdata/testcharts/chart-missing-manifest"
 )
 
 func TestLintChart(t *testing.T) {
@@ -44,6 +45,10 @@ func TestLintChart(t *testing.T) {
 	}
 
 	if _, err := lintChart(invalidArchivedChartPath, values, namespace, strict); err == nil {
+		t.Errorf("Expected a chart parsing error")
+	}
+
+	if _, err := lintChart(chartMissingManifest, values, namespace, strict); err == nil {
 		t.Errorf("Expected a chart parsing error")
 	}
 }


### PR DESCRIPTION
This PR aims to address #3769.

Currently, if a chart directory is missing a Chart.yaml (required), the linter returns a 0 exit code. 
It seems appropriate to return a non-0 return code so that people can put lint commands in CI scripts or mechanism of their choosing, failing if someone submits a chart without a Chart.yaml file.  