### PR TITLE
fix output leak from unit tests of helm create command

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -46,7 +46,7 @@ func TestCreateCmd(t *testing.T) {
 	defer os.Chdir(pwd)
 
 	// Run a create
-	cmd := newCreateCmd(os.Stdout)
+	cmd := newCreateCmd(ioutil.Discard)
 	if err := cmd.RunE(cmd, []string{cname}); err != nil {
 		t.Errorf("Failed to run create: %s", err)
 		return
@@ -117,7 +117,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	defer os.Chdir(pwd)
 
 	// Run a create
-	cmd := newCreateCmd(os.Stdout)
+	cmd := newCreateCmd(ioutil.Discard)
 	cmd.ParseFlags([]string{"--starter", "starterchart"})
 	if err := cmd.RunE(cmd, []string{cname}); err != nil {
 		t.Errorf("Failed to run create: %s", err)


### PR DESCRIPTION
fix(helm): fix output leak from unit tests of helm create command. Fixes #3788 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>