### PR TITLE
refactor release_testing unit tests to utilize runReleaseCases

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -43,7 +43,10 @@ func runReleaseCases(t *testing.T, tests []releaseCase, rcmd releaseCmd) {
 	var buf bytes.Buffer
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &helm.FakeClient{Rels: tt.rels}
+			c := &helm.FakeClient{
+				Rels:      tt.rels,
+				Responses: tt.responses,
+			}
 			cmd := rcmd(c, &buf)
 			cmd.ParseFlags(tt.flags)
 			err := cmd.RunE(cmd, tt.args)
@@ -69,7 +72,8 @@ type releaseCase struct {
 	err      bool
 	resp     *release.Release
 	// Rels are the available releases at the start of the test.
-	rels []*release.Release
+	rels      []*release.Release
+	responses map[string]release.TestRun_Status
 }
 
 // tempHelmHome sets up a Helm Home in a temp dir.

--- a/cmd/helm/release_testing_test.go
+++ b/cmd/helm/release_testing_test.go
@@ -17,55 +17,50 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
+	"io"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 func TestReleaseTesting(t *testing.T) {
-	tests := []struct {
-		name      string
-		args      []string
-		flags     []string
-		responses map[string]release.TestRun_Status
-		fail      bool
-	}{
+	tests := []releaseCase{
 		{
 			name:      "basic test",
 			args:      []string{"example-release"},
 			flags:     []string{},
 			responses: map[string]release.TestRun_Status{"PASSED: green lights everywhere": release.TestRun_SUCCESS},
-			fail:      false,
+			err:       false,
 		},
 		{
 			name:      "test failure",
 			args:      []string{"example-fail"},
 			flags:     []string{},
 			responses: map[string]release.TestRun_Status{"FAILURE: red lights everywhere": release.TestRun_FAILURE},
-			fail:      true,
+			err:       true,
 		},
 		{
 			name:      "test unknown",
 			args:      []string{"example-unknown"},
 			flags:     []string{},
 			responses: map[string]release.TestRun_Status{"UNKNOWN: yellow lights everywhere": release.TestRun_UNKNOWN},
-			fail:      false,
+			err:       false,
 		},
 		{
 			name:      "test error",
 			args:      []string{"example-error"},
 			flags:     []string{},
 			responses: map[string]release.TestRun_Status{"ERROR: yellow lights everywhere": release.TestRun_FAILURE},
-			fail:      true,
+			err:       true,
 		},
 		{
 			name:      "test running",
 			args:      []string{"example-running"},
 			flags:     []string{},
 			responses: map[string]release.TestRun_Status{"RUNNING: things are happpeningggg": release.TestRun_RUNNING},
-			fail:      false,
+			err:       false,
 		},
 		{
 			name:  "multiple tests example",
@@ -78,29 +73,11 @@ func TestReleaseTesting(t *testing.T) {
 				"FAILURE: good thing u checked :)":            release.TestRun_FAILURE,
 				"RUNNING: things are happpeningggg yet again": release.TestRun_RUNNING,
 				"PASSED: feel free to party again":            release.TestRun_SUCCESS},
-			fail: true,
+			err: true,
 		},
 	}
 
-	for _, tt := range tests {
-		c := &helm.FakeClient{Responses: tt.responses}
-
-		buf := bytes.NewBuffer(nil)
-		cmd := newReleaseTestCmd(c, buf)
-		cmd.ParseFlags(tt.flags)
-
-		err := cmd.RunE(cmd, tt.args)
-		if err == nil && tt.fail {
-			t.Errorf("%q did not fail but should have failed", tt.name)
-		}
-
-		if err != nil {
-			if tt.fail {
-				continue
-			} else {
-				t.Errorf("%q reported error: %s", tt.name, err)
-			}
-		}
-
-	}
+	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
+		return newReleaseTestCmd(c, out)
+	})
 }


### PR DESCRIPTION
fix(helm) refactor `release_testing` command unit tests to utilize `runReleaseCases` function and the corresponding struct `releaseCase` for testing. Fixes #3807 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>