### PR TITLE
Removes unnecessary if block

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -313,11 +313,6 @@ func mergeValues(dest map[string]interface{}, src map[string]interface{}) map[st
 			dest[k] = v
 			continue
 		}
-		// If the key doesn't exist already, then just set the key to that value
-		if _, exists := dest[k]; !exists {
-			dest[k] = nextMap
-			continue
-		}
 		// Edge case: If the key exists in the destination, but isn't a map
 		destMap, isMap := dest[k].(map[string]interface{})
 		// If the source map has a map for this key, prefer it


### PR DESCRIPTION
I created a [PR](https://github.com/kubernetes/kops/pull/4668) in the Kops project copying the mergeValues from helm to make both tools behave the same way. @justinsb noticed that the if block removed in this PR is not necessary as the same block is already executed earlier in the function.