### PR TITLE
ref(cmd/helm): show grpc error msg from prettyError

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -214,7 +214,7 @@ func prettyError(err error) error {
 	}
 	// If it's grpc's error, make it more user-friendly.
 	if s, ok := status.FromError(err); ok {
-		return s.Err()
+		return fmt.Errorf(s.Message())
 	}
 	// Else return the original error.
 	return err


### PR DESCRIPTION
Changed error output from: 
```
$ helm history test
Error: rpc error: code = Unknown desc = release: "test" not found
``` 

to only show error description like:

```
$ helm history test
Error: release: "test" not found
```
related to #3381 
The output used to only show the grpc error description but this got changed in #3383 because `grpc.ErrorDesc` was deprecated. This PR changes the output to look the way it did before and should probably be included in 2.9.0 so that people's scripts don't break.

cc/ @bacongobbler @mattfarina 