### PR TITLE
fix(pkg/tiller): saves all previous computed values on reuseValues

### DIFF
--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -80,7 +80,7 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 		return nil, nil, err
 	}
 
-	// If new values were not supplied in the upgrade, re-use the existing values.
+	// determine if values will be reused
 	if err := s.reuseValues(req, currentRelease); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/tiller/release_update_test.go
+++ b/pkg/tiller/release_update_test.go
@@ -260,7 +260,7 @@ func TestUpdateRelease_ReuseValues(t *testing.T) {
 		t.Errorf("Expected chart values to be %q, got %q", expect, res.Release.Chart.Values.Raw)
 	}
 	// This should have the newly-passed overrides and any other computed values. `name: value` comes from release Config via releaseStub()
-	expect = "name: value\nname2: val2"
+	expect = "name: value\nname2: val2\n"
 	if res.Release.Config != nil && res.Release.Config.Raw != expect {
 		t.Errorf("Expected request config to be %q, got %q", expect, res.Release.Config.Raw)
 	}


### PR DESCRIPTION
Resolves #3655