### PR TITLE
toYaml - Fix #3470 and #3410's trailing \n issues

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -175,7 +175,7 @@ func ToYaml(v interface{}) string {
 		// Swallow errors inside of a template.
 		return ""
 	}
-	return string(data)
+	return strings.TrimSuffix(string(data), "\n")
 }
 
 // FromYaml converts a YAML document into a map[string]interface{}.

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -72,10 +72,10 @@ func TestToConfig(t *testing.T) {
 
 	f := NewFiles(getTestFiles())
 	out := f.Glob("**/captain.txt").AsConfig()
-	as.Equal("captain.txt: The Captain\n", out)
+	as.Equal("captain.txt: The Captain", out)
 
 	out = f.Glob("ship/**").AsConfig()
-	as.Equal("captain.txt: The Captain\nstowaway.txt: Legatt\n", out)
+	as.Equal("captain.txt: The Captain\nstowaway.txt: Legatt", out)
 }
 
 func TestToSecret(t *testing.T) {
@@ -84,7 +84,7 @@ func TestToSecret(t *testing.T) {
 	f := NewFiles(getTestFiles())
 
 	out := f.Glob("ship/**").AsSecrets()
-	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0\n", out)
+	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0", out)
 }
 
 func TestLines(t *testing.T) {
@@ -99,7 +99,7 @@ func TestLines(t *testing.T) {
 }
 
 func TestToYaml(t *testing.T) {
-	expect := "foo: bar\n"
+	expect := "foo: bar"
 	v := struct {
 		Foo string `json:"foo"`
 	}{

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -36,7 +36,7 @@ func ToYAML(s string) (string, error) {
 		return "", err
 	}
 	d, err := yaml.Marshal(m)
-	return string(d), err
+	return strings.TrimSuffix(string(d), "\n"), err
 }
 
 // Parse parses a set line.

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -365,7 +365,7 @@ func TestToYAML(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expect := "name: value\n"
+	expect := "name: value"
 	if o != expect {
 		t.Errorf("Expected %q, got %q", expect, o)
 	}


### PR DESCRIPTION
## Summary

`toYaml` is currently introducing a new line, and since the new line it is part of a functions output, it can't be whitespace chomped away but requires a `trimSuffix "\n"`. This commit trims one trailing `\n` from the toYaml output by default as it [seems like the best solution when considering options](https://github.com/kubernetes/helm/issues/3470#issuecomment-378785908).

The PR fixes #3470 and #3410.

## About the new line

```yaml
# values.yaml
myKeys:
  key1: value1
  key2: value2
```

__Situation 1__
A new line is added by toYaml...
```yaml
# my-template.yaml
keys:
  {{- toYaml .Values.myKeys | nindent 2 }}
other:
  irrelevantKey: irrelevantValue

# my-template.yaml (parsed)
keys:
  key1: value1
  key2: value2
  
other:
  irrelevantKey: irrelevantValue
```

__Situation 2__
Okay so we could compensate by not adding another new line after the toYaml output? Well... Then you might get indentation failures instead, this would only work if the next yaml statement was supposed to be indented to the same level as the toYaml content.
```yaml
# my-template.yaml
keys:
  {{- toYaml .Values.myKeys | nindent 2 -}}
other:
  irrelevantKey: irrelevantValue

# my-template.yaml (parsed)
keys:
  key1: value1
  key2: value2
  other:
  irrelevantKey: irrelevantValue
```

__Situation 3__
This works, but it is quite cluttered. Perhaps we can make it built in instead? Hence this PR.
```yaml
# my-template.yaml
keys:
  {{- toYaml .Values.myKeys | trimSuffix "\n" | nindent 2 }}
other:
  irrelevantKey: irrelevantValue

# my-template.yaml (parsed)
keys:
  key1: value1
  key2: value2
other:
  irrelevantKey: irrelevantValue
```

## About toYaml
There are two implementations of toYaml.

https://github.com/kubernetes/helm/blob/be1e974cccec4f5583ef6e67b229f35f9e6edd2e/pkg/chartutil/files.go#L168-L179

https://github.com/kubernetes/helm/blob/1a55161a53345816d724e1df9664f789113e1328/pkg/strvals/parser.go#L32-L40