### PR TITLE
Updates readme with chocolatey install command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Binary downloads of the Helm client can be found at the following links:
 - [Windows](https://kubernetes-helm.storage.googleapis.com/helm-v2.8.2-windows-amd64.tar.gz)
 
 Unpack the `helm` binary and add it to your PATH and you are good to go!
-macOS/[homebrew](https://brew.sh/) users can also use `brew install kubernetes-helm`.
+
+If you want to use a package manager:
+
+- macOS/[homebrew](https://brew.sh/) users can use `brew install kubernetes-helm`.
+- Windows/[chocolatey](https://chocolatey.org/) users can use `choco install kubernetes-helm`.
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,6 +36,15 @@ brew install kubernetes-helm
 (Note: There is also a formula for emacs-helm, which is a different
 project.)
 
+### From Chocolatey (Windows)
+
+Members of the Kubernetes community have contributed a [Helm package](https://chocolatey.org/packages/kubernetes-helm) build to
+[Chocolatey](https://chocolatey.org/). This package is generally up to date.
+
+```
+choco install kubernetes-helm
+```
+
 ## From Script
 
 Helm now has an installer script that will automatically grab the latest version


### PR DESCRIPTION
I've created a chocolatey helm package and thought it makes sense to update the documentation with this new info. I use appveyor (https://ci.appveyor.com/project/synax/chocolatey-packages) to build the helm package (https://chocolatey.org/packages/kubernetes-helm) from this repo: https://github.com/synax/chocolatey-packages. Is it possible to add a webhook to trigger a build on every release of helm? Or how do you manage this for the brew formula? The appveyor webhook is: https://ci.appveyor.com/api/github/webhook?id=gl9dbj2y8ikvqghr