### PR TITLE
ref(pkg/version): allow comparison of pre-releases

### DIFF
--- a/pkg/version/compatible_test.go
+++ b/pkg/version/compatible_test.go
@@ -56,6 +56,10 @@ func TestIsCompatibleRange(t *testing.T) {
 		{"v2", "v2.0.0", true},
 		{">2.0.0", "v2.1.1", true},
 		{"v2.1.*", "v2.1.1", true},
+		{">=1.8.0", "v1.9.4-gke.1", true},
+		{">=1.8.0", "v1.7.4-gke.1", false},
+		{"<=1.8.0", "v1.7.4-gke.1", true},
+		{"~v2.0.0", "v2.0.1-gke1", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Allows you to compare pre-releases to a version constraint as long as that constraint does not also contain a pre-release in it using the `-r0` hack mentioned on the dev call today. 

Feels kinda hacky. Wondering what other folks think about this.

Resolves #3810 