### PR TITLE
[issue1957] print out log of failing test pod

### DIFF
--- a/pkg/releasetesting/environment.go
+++ b/pkg/releasetesting/environment.go
@@ -62,6 +62,12 @@ func (env *Environment) getTestPodStatus(test *test) (core.PodPhase, error) {
 	return status, err
 }
 
+func (env *Environment) getTestPodsLogs(test *test) error {
+	b := bytes.NewBufferString(test.manifest)
+	err := env.KubeClient.GetPodLogs(env.Namespace, b, time.Duration(env.Timeout)*time.Second)
+	return err
+}
+
 func (env *Environment) streamResult(r *release.TestRun) error {
 	switch r.Status {
 	case release.TestRun_SUCCESS:

--- a/pkg/releasetesting/environment_test.go
+++ b/pkg/releasetesting/environment_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/proto/hapi/services"
 	tillerEnv "k8s.io/helm/pkg/tiller/environment"
+	"time"
 )
 
 func TestCreateTestPodSuccess(t *testing.T) {
@@ -143,6 +144,10 @@ type getFailingKubeClient struct {
 	tillerEnv.PrintingKubeClient
 }
 
+func (p *getFailingKubeClient) GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error {
+	return nil
+}
+
 func newGetFailingKubeClient() *getFailingKubeClient {
 	return &getFailingKubeClient{
 		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
@@ -157,6 +162,10 @@ type deleteFailingKubeClient struct {
 	tillerEnv.PrintingKubeClient
 }
 
+func (p *deleteFailingKubeClient) GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error {
+	return nil
+}
+
 func newDeleteFailingKubeClient() *deleteFailingKubeClient {
 	return &deleteFailingKubeClient{
 		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
@@ -169,6 +178,10 @@ func (p *deleteFailingKubeClient) Delete(ns string, r io.Reader) error {
 
 type createFailingKubeClient struct {
 	tillerEnv.PrintingKubeClient
+}
+
+func (p *createFailingKubeClient) GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error {
+	return nil
 }
 
 func newCreateFailingKubeClient() *createFailingKubeClient {

--- a/pkg/releasetesting/test_suite.go
+++ b/pkg/releasetesting/test_suite.go
@@ -95,7 +95,12 @@ func (ts *TestSuite) Run(env *Environment) error {
 			status, err = env.getTestPodStatus(test)
 			if err != nil {
 				resourceCleanExit = false
-				if streamErr := env.streamError(test.result.Info); streamErr != nil {
+				streamErr := env.streamError(test.result.Info)
+				logErr := env.getTestPodsLogs(test)
+				if logErr != nil {
+					fmt.Println("Fail to get log for the failing test")
+				}
+				if streamErr != nil {
 					return streamErr
 				}
 			}

--- a/pkg/releasetesting/test_suite_test.go
+++ b/pkg/releasetesting/test_suite_test.go
@@ -318,6 +318,10 @@ type podSucceededKubeClient struct {
 	tillerEnv.PrintingKubeClient
 }
 
+func (p *podSucceededKubeClient) GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error {
+	return nil
+}
+
 func newPodSucceededKubeClient() *podSucceededKubeClient {
 	return &podSucceededKubeClient{
 		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
@@ -336,6 +340,10 @@ func newPodFailedKubeClient() *podFailedKubeClient {
 	return &podFailedKubeClient{
 		PrintingKubeClient: tillerEnv.PrintingKubeClient{Out: ioutil.Discard},
 	}
+}
+
+func (p *podFailedKubeClient) GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error {
+	return nil
 }
 
 func (p *podFailedKubeClient) WaitAndGetCompletedPodPhase(ns string, r io.Reader, timeout time.Duration) (core.PodPhase, error) {

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -143,12 +143,21 @@ type KubeClient interface {
 	// WaitAndGetCompletedPodPhase waits up to a timeout until a pod enters a completed phase
 	// and returns said phase (PodSucceeded or PodFailed qualify).
 	WaitAndGetCompletedPodPhase(namespace string, reader io.Reader, timeout time.Duration) (core.PodPhase, error)
+
+	// GetPodLogs gets the log of a pod and print it out to standard output
+	GetPodLogs(namespace string, reader io.Reader, timeout time.Duration) error
 }
 
 // PrintingKubeClient implements KubeClient, but simply prints the reader to
 // the given output.
 type PrintingKubeClient struct {
 	Out io.Writer
+}
+
+//GetPodLogs prints the values of what would be created with a real KubeClient.
+func (p *PrintingKubeClient) GetPodLogs(namespace string, r io.Reader, timeout time.Duration) error {
+	_, err := io.Copy(p.Out, r)
+	return err
 }
 
 // Create prints the values of what would be created with a real KubeClient.

--- a/pkg/tiller/environment/environment_test.go
+++ b/pkg/tiller/environment/environment_test.go
@@ -40,6 +40,10 @@ func (e *mockEngine) Render(chrt *chart.Chart, v chartutil.Values) (map[string]s
 
 type mockKubeClient struct{}
 
+func (k *mockKubeClient) GetPodLogs(namespace string, r io.Reader, timeout time.Duration) error {
+	return nil
+}
+
 func (k *mockKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	return nil
 }

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -363,6 +363,10 @@ type mockHooksKubeClient struct {
 	Resources map[string]*mockHooksManifest
 }
 
+func (kc *mockHooksKubeClient) GetPodLogs(namespace string, r io.Reader, timeout time.Duration) error {
+	return nil
+}
+
 var errResourceExists = errors.New("resource already exists")
 
 func (kc *mockHooksKubeClient) makeManifest(r io.Reader) (*mockHooksManifest, error) {


### PR DESCRIPTION
This is a fix to issue https://github.com/kubernetes/helm/issues/1957
The implementation is to print out the log of the test pod when it is fails
