### PR TITLE
Template comment in docs - syntax error fix

### DIFF
--- a/docs/chart_best_practices/templates.md
+++ b/docs/chart_best_practices/templates.md
@@ -155,7 +155,7 @@ Template comments should be used when documenting features of a template, such a
 ```yaml
 {{- /*
 mychart.shortname provides a 6 char truncated version of the release name.
-*/ }}
+*/ -}}
 {{ define "mychart.shortname" -}}
 {{ .Release.Name | trunc 6 }}
 {{- end -}}


### PR DESCRIPTION
`*/ }}` would cause an error actually, one must use `*/}}` or `*/ -}}`. Not obvious at all.