### PR TITLE
Remove Mercurial build-time dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,6 @@ coverage:
 HAS_GLIDE := $(shell command -v glide;)
 HAS_GOX := $(shell command -v gox;)
 HAS_GIT := $(shell command -v git;)
-HAS_HG := $(shell command -v hg;)
 
 .PHONY: bootstrap
 bootstrap:
@@ -133,9 +132,6 @@ endif
 
 ifndef HAS_GIT
 	$(error You must install Git)
-endif
-ifndef HAS_HG
-	$(error You must install Mercurial)
 endif
 	glide install --strip-vendor
 	go build -o bin/protoc-gen-go ./vendor/github.com/golang/protobuf/protoc-gen-go

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -10,7 +10,6 @@ Helm and Tiller.
 - A Kubernetes cluster w/ kubectl (optional)
 - The gRPC toolchain
 - Git
-- Mercurial
 
 ## Building Helm/Tiller
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,7 @@ Building Helm from source is slightly more work, but is the best way to
 go if you want to test the latest (pre-release) Helm version.
 
 You must have a working Go environment with
-[glide](https://github.com/Masterminds/glide) and Mercurial installed.
+[glide](https://github.com/Masterminds/glide) installed.
 
 ```console
 $ cd $GOPATH


### PR DESCRIPTION
Since the only dep (bitbucket.org/ww/goautoneg) that required it is gone in
https://github.com/kubernetes/helm/commit/845e99014362983d01179a411ae664b104e6c1f7#diff-f16a80eae23d5b298c2652448ec420cfL4