### PR TITLE
Resolve warning from golint on template command unit test

### DIFF
--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -160,9 +160,8 @@ func TestTemplateCmd(t *testing.T) {
 					// had the error we were looking for, this test case is
 					// done
 					return
-				} else {
-					t.Fatalf("expected err: %q, got: %q", tt.expectError, err)
 				}
+				t.Fatalf("expected err: %q, got: %q", tt.expectError, err)
 			} else if err != nil {
 				t.Errorf("expected no error, got %v", err)
 			}


### PR DESCRIPTION
fix(helm): resolve golint warning on template command unit tests. Closes #3896 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>