### PR TITLE
lets avoid failing if the outdir already exists

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -36,8 +36,10 @@ var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
 func SaveDir(c *chart.Chart, dest string) error {
 	// Create the chart directory
 	outdir := filepath.Join(dest, c.Metadata.Name)
-	if err := os.Mkdir(outdir, 0755); err != nil {
-		return err
+	if _, err := os.Stat(outdir); err != nil && os.IsNotExist(err) {
+		if err := os.Mkdir(outdir, 0755); err != nil {
+			return err
+		}
 	}
 
 	// Save the chart file.


### PR DESCRIPTION
rather than assuming the `outdir` exists and then failing if it doesn't, lets check if it doesn't exist first