### PR TITLE
use kubectl's UniversalDecoder to decode objects into versioned objects

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/client/conditions"
@@ -613,7 +614,7 @@ func (c *Client) AsVersionedObject(obj runtime.Object) (runtime.Object, error) {
 		return nil, err
 	}
 	versions := &runtime.VersionedObjects{}
-	decoder := unstructured.UnstructuredJSONScheme
+	decoder := legacyscheme.Codecs.UniversalDecoder()
 	err = runtime.DecodeInto(decoder, json, versions)
 	return versions.First(), err
 }


### PR DESCRIPTION
as of #3721, `AsVersionedObject` was using the unstructured JSON scheme decoder, causing it to return an object of type `Unstructured` which broke `getSelectorFromObject` since it was expecting the versioned objects.

cc @adamreese, would love to :pear: on this so I can gain some form of understanding behind this change

fixes #3826