### PR TITLE
swallow the error when returning the default HTTP client

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -183,7 +183,7 @@ func (c *ChartDownloader) ResolveChartVersionAndGetRepo(ref, version string) (*u
 				r := &repo.ChartRepository{}
 				r.Client = g
 				g.SetCredentials(c.getRepoCredentials(r))
-				return u, r, g, err
+				return u, r, g, nil
 			}
 			return u, nil, nil, err
 		}


### PR DESCRIPTION
https://github.com/kubernetes/helm/blob/c90b0a8197db0e305d3a375aa94aa4f10136fafc/pkg/downloader/chart_downloader.go#L180-L181

closes #3881