### PR TITLE
Adds the tip that you can pass custom objects

### DIFF
--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -36,6 +36,12 @@ is required, and will print an error message when that entry is missing:
 value: {{required "A valid .Values.who entry required!" .Values.who }}
 ```
 
+When using the `include` function, you can pass it a custom object tree built from the current context by using the `dict` function:
+
+```yaml
+{{- include "mytpl" (dict "key1" .Values.originalKey1 "key2" .Values.originalKey2) }}
+```
+
 ## Quote Strings, Don't Quote Integers
 
 When you are working with string data, you are always safer quoting the


### PR DESCRIPTION
This has come up in the offiicial Helm Slack Channel and was something I wish I knew sooner. I have modified the example [given by John McGowan](https://kubernetes.slack.com/archives/C0NH30761/p1523974759000058?thread_ts=1523970885.000492&cid=C0NH30761) slightly for this PR.