### PR TITLE
fixed flag for tls ca cert option in the documentation

### DIFF
--- a/docs/securing_installation.md
+++ b/docs/securing_installation.md
@@ -95,10 +95,10 @@ If these steps are followed, an example `helm init` command might look something
 $ helm init \
 --tiller-tls \
 --tiller-tls-verify \
---tiller-tls-ca-cert=ca.pem \
 --tiller-tls-cert=cert.pem \
 --tiller-tls-key=key.pem \
---service-account=accountname  
+--tls-ca-cert=ca.pem \
+--service-account=accountname
 ```
 
 This command will start Tiller with both strong authentication over gRPC, and a service account to which RBAC policies have been applied. 


### PR DESCRIPTION
documentation for securing helm had a flag called `tiller-tls-ca-cert` listed, when in fact the correct flag name is simply `tls-ca-cert`


![image](https://user-images.githubusercontent.com/739280/39023327-e9283fa6-4407-11e8-9b57-69d646f63537.png)

