### PR TITLE
Quote hostnames in default ingress YAML

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -143,14 +143,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}


### PR DESCRIPTION
Wildcard hostnames such as *.example.com break the default ingress because YAML treats elements starting with an asterisk specially.

The values therefore need to be quoted in order to be recognised as strings.