### PR TITLE
Avoid to call 'go' with empty -tags argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
-	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/$(APP)
+	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/$(APP)
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
go1.10.1 linux/amd64 complains: flag provided but not defined: -tags
when compiling with: "make build-cross dist". This seems to fix it.