### PR TITLE
Fix --tiller-namespace flag for plugins

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -131,7 +131,7 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 		switch a := args[i]; a {
 		case "--debug":
 			known = append(known, a)
-		case "--host", "--kube-context", "--home":
+		case "--host", "--kube-context", "--home", "--tiller-namespace":
 			known = append(known, a, args[i+1])
 			i++
 		default:


### PR DESCRIPTION
This fixes using `--tiller-namespace $namespace` flag (without the equal sign) flag for helm plugins.

This was originally raised here: https://github.com/databus23/helm-diff/pull/44