### PR TITLE
fix(downloader): use plugin getters instead of a hardcoded HttpGetter

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"k8s.io/helm/pkg/getter"
@@ -243,9 +242,8 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 
 // If HttpGetter is used, this method sets the configured repository credentials on the HttpGetter.
 func (c *ChartDownloader) setCredentials(r *repo.ChartRepository) {
-	var t *getter.HttpGetter
-	if reflect.TypeOf(r.Client) == reflect.TypeOf(t) {
-		r.Client.(*getter.HttpGetter).SetCredentials(c.getRepoCredentials(r))
+	if t, ok := r.Client.(*getter.HttpGetter); ok {
+		t.SetCredentials(c.getRepoCredentials(r))
 	}
 }
 

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -152,9 +151,8 @@ func (r *ChartRepository) DownloadIndexFile(cachePath string) error {
 
 // If HttpGetter is used, this method sets the configured repository credentials on the HttpGetter.
 func (r *ChartRepository) setCredentials() {
-	var t *getter.HttpGetter
-	if reflect.TypeOf(r.Client) == reflect.TypeOf(t) {
-		r.Client.(*getter.HttpGetter).SetCredentials(r.Config.Username, r.Config.Password)
+	if t, ok := r.Client.(*getter.HttpGetter); ok {
+		t.SetCredentials(r.Config.Username, r.Config.Password)
 	}
 }
 


### PR DESCRIPTION
builds upon https://github.com/kubernetes/helm/pull/3962 to remove the need for type reflection.

closes #3938 
closes #3962