### PR TITLE
Revert "toYaml - Fix #3470 and #3410's trailing \n issues"

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -175,7 +175,7 @@ func ToYaml(v interface{}) string {
 		// Swallow errors inside of a template.
 		return ""
 	}
-	return strings.TrimSuffix(string(data), "\n")
+	return string(data)
 }
 
 // FromYaml converts a YAML document into a map[string]interface{}.

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -72,10 +72,10 @@ func TestToConfig(t *testing.T) {
 
 	f := NewFiles(getTestFiles())
 	out := f.Glob("**/captain.txt").AsConfig()
-	as.Equal("captain.txt: The Captain", out)
+	as.Equal("captain.txt: The Captain\n", out)
 
 	out = f.Glob("ship/**").AsConfig()
-	as.Equal("captain.txt: The Captain\nstowaway.txt: Legatt", out)
+	as.Equal("captain.txt: The Captain\nstowaway.txt: Legatt\n", out)
 }
 
 func TestToSecret(t *testing.T) {
@@ -84,7 +84,7 @@ func TestToSecret(t *testing.T) {
 	f := NewFiles(getTestFiles())
 
 	out := f.Glob("ship/**").AsSecrets()
-	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0", out)
+	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0\n", out)
 }
 
 func TestLines(t *testing.T) {
@@ -99,7 +99,7 @@ func TestLines(t *testing.T) {
 }
 
 func TestToYaml(t *testing.T) {
-	expect := "foo: bar"
+	expect := "foo: bar\n"
 	v := struct {
 		Foo string `json:"foo"`
 	}{

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -36,7 +36,7 @@ func ToYAML(s string) (string, error) {
 		return "", err
 	}
 	d, err := yaml.Marshal(m)
-	return strings.TrimSuffix(string(d), "\n"), err
+	return string(d), err
 }
 
 // Parse parses a set line.

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -370,7 +370,7 @@ func TestToYAML(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expect := "name: value"
+	expect := "name: value\n"
 	if o != expect {
 		t.Errorf("Expected %q, got %q", expect, o)
 	}


### PR DESCRIPTION
Reverts kubernetes/helm#3837

closes #3981 