### PR TITLE
Revert "Fix tiller deployment on RBAC clusters"

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -176,7 +176,6 @@ func generateDeployment(opts *Options) (*v1beta1.Deployment, error) {
 			return nil, err
 		}
 	}
-	automountServiceAccountToken := opts.ServiceAccount != ""
 	d := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: opts.Namespace,
@@ -190,8 +189,7 @@ func generateDeployment(opts *Options) (*v1beta1.Deployment, error) {
 					Labels: labels,
 				},
 				Spec: v1.PodSpec{
-					ServiceAccountName:           opts.ServiceAccount,
-					AutomountServiceAccountToken: &automountServiceAccountToken,
+					ServiceAccountName: opts.ServiceAccount,
 					Containers: []v1.Container{
 						{
 							Name:            "tiller",

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -96,9 +96,6 @@ func TestDeploymentManifestForServiceAccount(t *testing.T) {
 		if got := d.Spec.Template.Spec.ServiceAccountName; got != tt.serviceAccount {
 			t.Errorf("%s: expected service account value %q, got %q", tt.name, tt.serviceAccount, got)
 		}
-		if got := *d.Spec.Template.Spec.AutomountServiceAccountToken; got != (tt.serviceAccount != "") {
-			t.Errorf("%s: unexpected automountServiceAccountToken = %t for serviceAccount %q", tt.name, got, tt.serviceAccount)
-		}
 	}
 }
 


### PR DESCRIPTION
Reverts kubernetes/helm#3784

This change broke `helm init` as seen in #2464, #3985, and #3986 by setting the default value of `autoMountServiceAccount` to `false`, whereas by default we want it to be unset (nil).

closes #2464 
closes #3985 
closes #3986