### PR TITLE
Support values files on remote servers with self-signed certs / client cert authentication

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -218,7 +218,7 @@ func (i *installCmd) run() error {
 		i.namespace = defaultNamespace()
 	}
 
-	rawVals, err := vals(i.valueFiles, i.values, i.stringValues)
+	rawVals, err := vals(i.valueFiles, i.values, i.stringValues, i.certFile, i.keyFile, i.caFile)
 	if err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func mergeValues(dest map[string]interface{}, src map[string]interface{}) map[st
 
 // vals merges values from files specified via -f/--values and
 // directly via --set or --set-string, marshaling them to YAML
-func vals(valueFiles valueFiles, values []string, stringValues []string) ([]byte, error) {
+func vals(valueFiles valueFiles, values []string, stringValues []string, CertFile, KeyFile, CAFile string) ([]byte, error) {
 	base := map[string]interface{}{}
 
 	// User specified a values files via -f/--values
@@ -340,7 +340,7 @@ func vals(valueFiles valueFiles, values []string, stringValues []string) ([]byte
 		if strings.TrimSpace(filePath) == "-" {
 			bytes, err = ioutil.ReadAll(os.Stdin)
 		} else {
-			bytes, err = readFile(filePath)
+			bytes, err = readFile(filePath, CertFile, KeyFile, CAFile)
 		}
 
 		if err != nil {
@@ -505,7 +505,7 @@ func checkDependencies(ch *chart.Chart, reqs *chartutil.Requirements) error {
 }
 
 //readFile load a file from the local directory or a remote file with a url.
-func readFile(filePath string) ([]byte, error) {
+func readFile(filePath, CertFile, KeyFile, CAFile string) ([]byte, error) {
 	u, _ := url.Parse(filePath)
 	p := getter.All(settings)
 
@@ -516,7 +516,7 @@ func readFile(filePath string) ([]byte, error) {
 		return ioutil.ReadFile(filePath)
 	}
 
-	getter, err := getterConstructor(filePath, "", "", "")
+	getter, err := getterConstructor(filePath, CertFile, KeyFile, CAFile)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -130,7 +130,7 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 		t.namespace = defaultNamespace()
 	}
 	// get combined values and create config
-	rawVals, err := vals(t.valueFiles, t.values, t.stringValues)
+	rawVals, err := vals(t.valueFiles, t.values, t.stringValues, "", "", "")
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -195,7 +195,7 @@ func (u *upgradeCmd) run() error {
 		}
 	}
 
-	rawVals, err := vals(u.valueFiles, u.values, u.stringValues)
+	rawVals, err := vals(u.valueFiles, u.values, u.stringValues, "", "", "")
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -195,7 +195,7 @@ func (u *upgradeCmd) run() error {
 		}
 	}
 
-	rawVals, err := vals(u.valueFiles, u.values, u.stringValues, "", "", "")
+	rawVals, err := vals(u.valueFiles, u.values, u.stringValues, u.certFile, u.keyFile, u.caFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have values files on servers that authenticate with client certs.

`helm install` and `upgrade` already provide the `--ca-file`, `--cert-file` and `--key-file` options, so using these for values as well as charts seems sane.

`helm template` does not provide these command line options but maybe should?