### PR TITLE
fix lint warning

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -99,11 +99,7 @@ func (m *Manager) Build() error {
 	}
 
 	// Now we need to fetch every package here into charts/
-	if err := m.downloadAll(lock.Dependencies); err != nil {
-		return err
-	}
-
-	return nil
+	return m.downloadAll(lock.Dependencies)
 }
 
 // Update updates a local charts directory.


### PR DESCRIPTION
fixes following warning:

pkg/downloader/manager.go:102:2:warning: redundant if ...; err != nil check, just return error instead. (golint)
