### PR TITLE
Typo fix: mach->match

### DIFF
--- a/pkg/chartutil/requirements.go
+++ b/pkg/chartutil/requirements.go
@@ -45,7 +45,7 @@ var (
 type Dependency struct {
 	// Name is the name of the dependency.
 	//
-	// This must mach the name in the dependency's Chart.yaml.
+	// This must match the name in the dependency's Chart.yaml.
 	Name string `json:"name"`
 	// Version is the version (range) of this chart.
 	//


### PR DESCRIPTION
Line 48: It's very obvious that "mach" should be misspelling of "match".
mach->match