### PR TITLE
Don't request Tiller version in installer

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -92,7 +92,7 @@ checkDesiredVersion() {
 # if it needs to be changed.
 checkHelmInstalledVersion() {
   if [[ -f "${HELM_INSTALL_DIR}/${PROJECT_NAME}" ]]; then
-    local version=$(helm version | grep '^Client' | cut -d'"' -f2)
+    local version=$(helm version -c | grep '^Client' | cut -d'"' -f2)
     if [[ "$version" == "$TAG" ]]; then
       echo "Helm ${version} is already ${DESIRED_VERSION:-latest}"
       return 0


### PR DESCRIPTION
This makes the script hang for quite a while if it can't connect to Tiller to retrieve this information that isn't being used anyways.