### PR TITLE
fix(files): including file path in the config / secret keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rootfs/rudder
 vendor/
 *.exe
 .idea/
+*.iml

--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -162,6 +162,10 @@ metadata:
 type: Opaque
 data:
 {{ (.Files.Glob "bar/*").AsSecrets | indent 2 }}
+
+In above example, `AsSecrets` and `AsConfig` convert the files in `foo/` directory to
+Kubernetes ConfigMap and Secret definition. Both `AsSecrets` and `AsConfig` methods respect the
+path of the file and include the path in the key. For example, `foo/boo.txt` generates a key of `foo_boo.txt`.
 ```
 
 ## Encoding

--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -19,12 +19,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"path"
 	"strings"
 
 	"github.com/ghodss/yaml"
 
-	"fmt"
 	"github.com/BurntSushi/toml"
 	"github.com/gobwas/glob"
 	"github.com/golang/protobuf/ptypes/any"
@@ -96,8 +96,12 @@ func (f Files) Glob(pattern string) Files {
 
 // AsConfig turns a Files group and flattens it to a YAML map suitable for
 // including in the 'data' section of a Kubernetes ConfigMap definition.
-// Duplicate keys will be overwritten, so be aware that your file names
-// (regardless of path) should be unique.
+// Duplicate keys under the same path will be overwritten, so be aware that
+// your file names should be unique.
+//
+// AsConfig respects the path of the file and converts `/` to `_`:
+//
+// `ship/captain.txt` will be `ship_captain.txt` in the ConfigMap definition.
 //
 // This is designed to be called from a template, and will return empty string
 // (via ToYaml function) if it cannot be serialized to YAML, or if the Files
@@ -144,8 +148,12 @@ func AsConfigKey(k string) string {
 
 // AsSecrets returns the base64-encoded value of a Files object suitable for
 // including in the 'data' section of a Kubernetes Secret definition.
-// Duplicate keys will be overwritten, so be aware that your file names
-// (regardless of path) should be unique.
+// Duplicate keys under the same path will be overwritten, so be aware that
+// your file names should be unique.
+//
+// AsSecrets respects the path of the file and converts `/` to `_`:
+//
+// `ship/captain.txt` will be `ship_captain.txt` in the Secret definition.
 //
 // This is designed to be called from a template, and will return empty string
 // (via ToYaml function) if it cannot be serialized to YAML, or if the Files

--- a/pkg/chartutil/files_test.go
+++ b/pkg/chartutil/files_test.go
@@ -27,6 +27,7 @@ var cases = []struct {
 }{
 	{"ship/captain.txt", "The Captain"},
 	{"ship/stowaway.txt", "Legatt"},
+	{"ship/cabin/helm.txt", "Helm"},
 	{"story/name.txt", "The Secret Sharer"},
 	{"story/author.txt", "Joseph Conrad"},
 	{"multiline/test.txt", "bar\nfoo"},
@@ -72,10 +73,10 @@ func TestToConfig(t *testing.T) {
 
 	f := NewFiles(getTestFiles())
 	out := f.Glob("**/captain.txt").AsConfig()
-	as.Equal("captain.txt: The Captain\n", out)
+	as.Equal("ship_captain.txt: The Captain\n", out)
 
 	out = f.Glob("ship/**").AsConfig()
-	as.Equal("captain.txt: The Captain\nstowaway.txt: Legatt\n", out)
+	as.Equal("ship_cabin_helm.txt: Helm\nship_captain.txt: The Captain\nship_stowaway.txt: Legatt\n", out)
 }
 
 func TestToSecret(t *testing.T) {
@@ -84,7 +85,7 @@ func TestToSecret(t *testing.T) {
 	f := NewFiles(getTestFiles())
 
 	out := f.Glob("ship/**").AsSecrets()
-	as.Equal("captain.txt: VGhlIENhcHRhaW4=\nstowaway.txt: TGVnYXR0\n", out)
+	as.Equal("ship_cabin_helm.txt: SGVsbQ==\nship_captain.txt: VGhlIENhcHRhaW4=\nship_stowaway.txt: TGVnYXR0\n", out)
 }
 
 func TestLines(t *testing.T) {


### PR DESCRIPTION
To include the path of files when calling `.AsConfig()` and `.AsSecret()` methods. For instance:

`boo/**`:
- `boo_nested_nested2_file.txt`
- `boo_nested_nested3_file.txt`

Also avoid conflicts when there are files with the same name in different sub folders.