### PR TITLE
purge plugin directory on `helm plugin remove plug`

### DIFF
--- a/cmd/helm/plugin_remove.go
+++ b/cmd/helm/plugin_remove.go
@@ -82,7 +82,7 @@ func (o *pluginRemoveOptions) run(out io.Writer) error {
 }
 
 func removePlugin(p *plugin.Plugin) error {
-	if err := os.Remove(p.Dir); err != nil {
+	if err := os.RemoveAll(p.Dir); err != nil {
 		return err
 	}
 	return runHook(p, plugin.Delete)


### PR DESCRIPTION
    ><> ./bin/helm plugin remove lintr
    Error: Failed to remove plugin lintr, got error (remove /home/bacongobbler/.helm/plugins/helm-lintr: directory not empty)