### PR TITLE
Fix(helm): fix the bug of the charts not deployed after downloaded in helm install --dep-up

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -258,6 +258,12 @@ func (i *installCmd) run() error {
 				if err := man.Update(); err != nil {
 					return prettyError(err)
 				}
+
+				// Update all dependencies which are present in /charts.
+				chartRequested, err = chartutil.Load(i.chartPath)
+				if err != nil {
+					return prettyError(err)
+				}
 			} else {
 				return prettyError(err)
 			}


### PR DESCRIPTION

helm install --dep-up does not deploy the charts downloaded by itself.
I reload the charts path after downloading the missing charts.

Closes #3423