### PR TITLE
fixed output leak from template command unit tests

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -91,6 +91,7 @@ func newTemplateCmd(out io.Writer) *cobra.Command {
 		RunE:  t.run,
 	}
 
+	cmd.SetOutput(out)
 	f := cmd.Flags()
 	f.BoolVar(&t.showNotes, "notes", false, "show the computed NOTES.txt file as well")
 	f.StringVarP(&t.releaseName, "name", "n", "release-name", "release name")
@@ -241,20 +242,20 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 			if whitespaceRegex.MatchString(data) {
 				continue
 			}
-			err = writeToFile(t.outputDir, m.Name, data)
+			err = writeToFile(t.outputDir, m.Name, data, t.out)
 			if err != nil {
 				return err
 			}
 			continue
 		}
-		fmt.Printf("---\n# Source: %s\n", m.Name)
-		fmt.Println(data)
+		fmt.Fprintf(t.out, "---\n# Source: %s\n", m.Name)
+		fmt.Fprintln(t.out, data)
 	}
 	return nil
 }
 
 // write the <data> to <output-dir>/<name>
-func writeToFile(outputDir string, name string, data string) error {
+func writeToFile(outputDir string, name string, data string, out io.Writer) error {
 	outfileName := strings.Join([]string{outputDir, name}, string(filepath.Separator))
 
 	err := ensureDirectoryForFile(outfileName)
@@ -275,7 +276,7 @@ func writeToFile(outputDir string, name string, data string) error {
 		return err
 	}
 
-	fmt.Printf("wrote %s\n", outfileName)
+	fmt.Fprintf(out, "wrote %s\n", outfileName)
 	return nil
 }
 

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,14 +177,9 @@ func TestTemplateCmd(t *testing.T) {
 		},
 	}
 
-	var buf bytes.Buffer
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			// capture stdout
-			old := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
 			// execute template command
 			out := bytes.NewBuffer(nil)
 			cmd := newTemplateCmd(out)
@@ -206,14 +200,8 @@ func TestTemplateCmd(t *testing.T) {
 			} else if err != nil {
 				t.Errorf("expected no error, got %v", err)
 			}
-			// restore stdout
-			w.Close()
-			os.Stdout = old
-			var b bytes.Buffer
-			io.Copy(&b, r)
-			r.Close()
 			// scan yaml into map[<path>]yaml
-			scanner := bufio.NewScanner(&b)
+			scanner := bufio.NewScanner(out)
 			next := false
 			lastKey := ""
 			m := map[string]string{}
@@ -239,7 +227,6 @@ func TestTemplateCmd(t *testing.T) {
 			} else {
 				t.Errorf("could not find key %s", tt.expectKey)
 			}
-			buf.Reset()
 		})
 	}
 }


### PR DESCRIPTION
fix(helm): fixed output leak from template command unit tests

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

Current output:
```
=== RUN   TestTemplateCmd/check_execute_non_existent
Error: could not find template /home/adeshmeh/dev/go/src/k8s.io/helm/pkg/chartutil/testdata/subpop/charts/subchart1/templates/thisdoesntexist.yaml in chart
Usage:
  template [flags] CHART

Flags:
  -x, --execute stringArray      only execute the given templates
      --kube-version string      kubernetes version used as Capabilities.KubeVersion.Major/Minor (default "1.9")
  -n, --name string              release name (default "RELEASE-NAME")
      --name-template string     specify template used to name the release
      --namespace string         namespace to install the release into
      --notes                    show the computed NOTES.txt file as well
      --output-dir string        writes the executed templates to files in output-dir instead of stdout
      --set stringArray          set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      --set-string stringArray   set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
  -f, --values valueFiles        specify values in a YAML file (can specify multiple) (default [])

=== RUN   TestTemplateCmd/check_execute_absolute

```


Output with this PR:

```
--- PASS: TestTemplateCmd (0.82s)
    --- PASS: TestTemplateCmd/check_name (0.06s)
    --- PASS: TestTemplateCmd/check_set_name (0.08s)
    --- PASS: TestTemplateCmd/check_execute (0.06s)
    --- PASS: TestTemplateCmd/check_execute_non_existent (0.06s)
    --- PASS: TestTemplateCmd/check_execute_absolute (0.07s)
    --- PASS: TestTemplateCmd/check_execute_subchart_template (0.06s)
    --- PASS: TestTemplateCmd/check_execute_subchart_template_for_tgz_subchart (0.03s)
    --- PASS: TestTemplateCmd/check_namespace (0.05s)
    --- PASS: TestTemplateCmd/check_release_name (0.08s)
    --- PASS: TestTemplateCmd/check_notes (0.06s)
    --- PASS: TestTemplateCmd/check_values_files (0.06s)
    --- PASS: TestTemplateCmd/check_name_template (0.08s)
    --- PASS: TestTemplateCmd/check_kube_version (0.06s)
```