### PR TITLE
Download charts to a temporary file

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -97,12 +97,16 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 
 	name := filepath.Base(u.Path)
 	destfile := filepath.Join(dest, name)
-	tempdestfile := destfile + ".part"
-	if err := ioutil.WriteFile(tempdestfile, data.Bytes(), 0644); err != nil {
-		return tempdestfile, nil, err
+	tmpfile, err := ioutil.TempFile(dest, "tmp")
+	if err != nil {
+		return "", nil, err
+	}
+	tmpfilename := tmpfile.Name()
+	if err := ioutil.WriteFile(tmpfilename, data.Bytes(), 0644); err != nil {
+		return tmpfilename, nil, err
 	}
 
-	if err := os.Rename(tempdestfile, destfile); err != nil {
+	if err := os.Rename(tmpfilename, destfile); err != nil {
 		return destfile, nil, err
 	}
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -99,7 +99,10 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 	destfile := filepath.Join(dest, name)
 	tempdestfile := destfile + ".part"
 	if err := ioutil.WriteFile(tempdestfile, data.Bytes(), 0644); err != nil {
-		err = os.Rename(tempdestfile, destfile)
+		return tempdestfile, nil, err
+	}
+
+	if err := os.Rename(tempdestfile, destfile); err != nil {
 		return destfile, nil, err
 	}
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -97,7 +97,9 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 
 	name := filepath.Base(u.Path)
 	destfile := filepath.Join(dest, name)
-	if err := ioutil.WriteFile(destfile, data.Bytes(), 0644); err != nil {
+	tempdestfile := destfile + ".part"
+	if err := ioutil.WriteFile(tempdestfile, data.Bytes(), 0644); err != nil {
+		err = os.Rename(tempdestfile, destfile)
 		return destfile, nil, err
 	}
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -111,8 +111,10 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 	}
 
 	tmpfilename := tmpfile.Name()
-	// 0644 here is ineffective since TempFile creates files with 0600 permission. We'll chmod it later.
-	if err := ioutil.WriteFile(tmpfilename, data.Bytes(), 0644); err != nil {
+	if _, err := tmpfile.Write(data.Bytes()); err != nil {
+		return tmpfilename, nil, err
+	}
+	if err := tmpfile.Close(); err != nil {
 		return tmpfilename, nil, err
 	}
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -102,6 +102,7 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 	defer func() {
 		if tmpfile != nil {
 			if _, err := os.Stat(tmpfile.Name()); err == nil {
+				tmpfile.Close()
 				os.Remove(tmpfile.Name())
 			}
 		}
@@ -111,7 +112,7 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 	}
 
 	tmpfilename := tmpfile.Name()
-	if _, err := tmpfile.Write(data.Bytes()); err != nil {
+	if _, err := io.Copy(tmpfile, data); err != nil {
 		return tmpfilename, nil, err
 	}
 	if err := tmpfile.Close(); err != nil {


### PR DESCRIPTION
Similar to https://github.com/kubernetes/helm/issues/3253 we're using
Helm by directly importing the Go package.

A concurrency issue arises when multiple requests come for the same
package. Currently DownloadTo truncates contents of destination file and
rewrites it.

This patch changes the behaviour so instead of directly writing into the
destination it'll write the content in a temp file and renames it once
download is finished.

This change fixes sporadic issues in
https://github.com/amir/skeg/blob/5c5c6a1c215cf5110843a28f1fa389aa69a3f452/main_test.go