### PR TITLE
docs(helm): Added double quotes to example

### DIFF
--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -285,7 +285,7 @@ servers:
 ```
 
 Sometimes you need to use special characters in your `--set` lines. You can use
-a backslash to escape the characters; `--set name=value1\,value2` will become:
+a backslash to escape the characters; `--set name="value1\,value2"` will become:
 
 ```yaml
 name: "value1,value2"


### PR DESCRIPTION
In the current version of helm (2.8.2), there needs to be double quotes around the value to support escaping special characters.