### PR TITLE
add SECURITY_CONTACTS

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,20 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://github.com/kubernetes/helm/blob/master/CONTRIBUTING.md#reporting-a-security-issue
+
+adamreese
+bacongobbler
+mattfarina
+michelleN
+prydonius
+SlickNik
+technosophos
+thomastaylor312


### PR DESCRIPTION
resolves #4120 

Needs lgtm from everyone on the list before merge. Lgtm-ing also means that the security contact agrees to [embargo policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy). If are listed here but do not agree to abide by the embargo policy, please comment or let me know privately and I'll remove you from this list.