### PR TITLE
Fix inaccurate comment in `tiller`

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -85,7 +85,7 @@ var (
 
 	// rootServer is the root gRPC server.
 	//
-	// Each gRPC service registers itself to this server during init().
+	// Each gRPC service registers itself to this server during start().
 	rootServer *grpc.Server
 
 	// env is the default environment.


### PR DESCRIPTION
When reading through `cmd/tiller/tiller.go`, I noticed a comment around
`rootServer` mentions the usage of an `init` function. However, there is
no `init` function in this package. Update the comment to be more
accurate.