### PR TITLE
Fix concurrency issues with helm install

### DIFF
--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -98,8 +98,6 @@ type Engine interface {
 type KubeClient interface {
 	// Create creates one or more resources.
 	//
-	// namespace must contain a valid existing namespace.
-	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
 	Create(namespace string, reader io.Reader, timeout int64, shouldWait bool) error


### PR DESCRIPTION
Fix #4086 

Address a race condition that arises when running two `helm install`
commands, both of which specify a namespace that does not already exist.

In this specific instance, attempting to create a `namespace` which
already exists should not be a failure which causes `helm install` to
terminate.