### PR TITLE
add appveyor for testing on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+version: "{build}"
+clone_folder: c:\go\src\k8s.io\helm
+environment:
+  GOPATH: c:\go
+  PATH: c:\ProgramData\bin;$(PATH)
+install:
+  - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fishworks/gofish/master/scripts/install.ps1'))
+  - gofish init
+  - gofish install dep
+  - dep ensure -v
+cache:
+  - vendor -> Gopkg.lock
+build: "off"
+deploy: "off"
+test_script:
+  - go build .\cmd\...
+  - go test .\...


### PR DESCRIPTION
We've been using a similar appveyor manifest for testing Draft on Windows, so I figure I'd drop this here in case there's interest.

The intent is just to test that helm compiles and tests successfully on Windows, but doesn't actually deploy any assets since that's handled through CircleCI.

closes #1606