### PR TITLE
Make --set-string flag parse booleans and null as strings

### DIFF
--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -325,6 +325,11 @@ func inMap(k rune, m map[rune]bool) bool {
 
 func typedVal(v []rune, st bool) interface{} {
 	val := string(v)
+
+	if st {
+		return val
+	}
+
 	if strings.EqualFold(val, "true") {
 		return true
 	}
@@ -337,8 +342,8 @@ func typedVal(v []rune, st bool) interface{} {
 		return nil
 	}
 
-	// If this value does not start with zero, and not returnString, try parsing it to an int
-	if !st && len(val) != 0 && val[0] != '0' {
+	// If this value does not start with zero, try parsing it to an int
+	if len(val) != 0 && val[0] != '0' {
 		if iv, err := strconv.ParseInt(val, 10, 64); err == nil {
 			return iv
 		}

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -75,6 +75,11 @@ func TestParseSet(t *testing.T) {
 			expect: map[string]interface{}{"long_int_string": "1234567890"},
 			err:    false,
 		},
+		{
+			str:    "boolean=true",
+			expect: map[string]interface{}{"boolean": "true"},
+			err:    false,
+		},
 	}
 	tests := []struct {
 		str    string
@@ -116,6 +121,10 @@ func TestParseSet(t *testing.T) {
 		{
 			str:    "long_int=1234567890",
 			expect: map[string]interface{}{"long_int": 1234567890},
+		},
+		{
+			str:    "boolean=true",
+			expect: map[string]interface{}{"boolean": true},
 		},
 		{
 			str: "name1,name2=",

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -132,6 +132,11 @@ func TestParseSet(t *testing.T) {
 			expect: map[string]interface{}{"boolean": true},
 		},
 		{
+			str:    "is_null=null",
+			expect: map[string]interface{}{"is_null": nil},
+			err:    false,
+		},
+		{
 			str: "name1,name2=",
 			err: true,
 		},

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -80,6 +80,11 @@ func TestParseSet(t *testing.T) {
 			expect: map[string]interface{}{"boolean": "true"},
 			err:    false,
 		},
+		{
+			str:    "is_null=null",
+			expect: map[string]interface{}{"is_null": "null"},
+			err:    false,
+		},
 	}
 	tests := []struct {
 		str    string


### PR DESCRIPTION
This makes the `--set-string` flag behave more intuitively. With this change, the values `true`, `false` and `null` are no longer interpreted as booleans but as strings if `--set-string` is used.

Closes #2848 
Relates to #4006 