### PR TITLE
fix(pkg/kube): make internal cache miss not an error

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -277,7 +277,7 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 		originalInfo := original.Get(info)
 		if originalInfo == nil {
 			kind := info.Mapping.GroupVersionKind.Kind
-			return fmt.Errorf("no %s with the name %q found", kind, info.Name)
+			c.Log("Warning: no %s with the name %q found in internal state", kind, info.Name)
 		}
 
 		if err := updateResource(c, info, originalInfo.Object, force, recreate); err != nil {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -278,6 +278,9 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 		if originalInfo == nil {
 			kind := info.Mapping.GroupVersionKind.Kind
 			c.Log("Warning: no %s with the name %q found in internal state", kind, info.Name)
+
+			originalInfo = &resource.Info{}
+			originalInfo.Object = info.Object
 		}
 
 		if err := updateResource(c, info, originalInfo.Object, force, recreate); err != nil {


### PR DESCRIPTION
This fixes #1193 by not making an internal cache miss an error, and instead making it a warning. It will default to the original object, if one exists, instead. This should fix at least one scenario of when helm loses track of the real state of the a config.

This could have issues since it uses the existing object in place of the cached one. Let me know if there are better ways of handling this, since my comment on the issue didn't have anything I decided to propose my fix but am open to any better way of fixing this!

Thanks! :sparkles: 