### PR TITLE
Fix test failure message

### DIFF
--- a/pkg/releasetesting/test_suite_test.go
+++ b/pkg/releasetesting/test_suite_test.go
@@ -134,7 +134,7 @@ func TestRun(t *testing.T) {
 	}
 
 	if result2.Status != release.TestRun_FAILURE {
-		t.Errorf("Expected test result to be successful, got: %v", result2.Status)
+		t.Errorf("Expected test result to be failure, got: %v", result2.Status)
 	}
 
 }


### PR DESCRIPTION
The error message we reported if the test failed was incorrect.