### PR TITLE
Add containerized options for tests in Makefile

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -27,7 +27,8 @@ This will build both Helm and Tiller. `make bootstrap` will attempt to
 install certain tools if they are missing.
 
 To run all the tests (without running the tests for `vendor/`), run
-`make test`.
+`make test`. To run all tests in a containerized environment, run `make
+docker-test`.
 
 To run Helm and Tiller locally, you can run `bin/helm` or `bin/tiller`.
 
@@ -209,6 +210,9 @@ We follow the Go coding style standards very closely. Typically, running
 
 We also typically follow the conventions recommended by `go lint` and
 `gometalinter`. Run `make test-style` to test the style conformance.
+If you do not want to install all the linters from `gometalinter` into your
+global Go environment, you can run `make docker-test-style` which will
+run the same tests, but isolated within a docker container.
 
 Read more:
 


### PR DESCRIPTION
Fix #4162 

Add an option to run the `test-unit`, `test-style`, `build`, and `test`
steps from the `Makefile` insides of a docker container. Doing so
isolates this component of helm development from any other aspect of
your global go environment.

These commands all have the name `containerized-*`. Long term, there may
be reproducibility benefits to running all of the Make steps in a
container by default, in which case `containerized-test-unit` could
become `test-unit`.