### PR TITLE
Increase error message specificity for name reuse

### DIFF
--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -190,7 +190,7 @@ func (s *ReleaseServer) uniqName(start string, reuse bool) (string, error) {
 			s.Log("name %s exists but is not in use, reusing name", start)
 			return start, nil
 		} else if reuse {
-			return "", errors.New("cannot re-use a name that is still in use")
+			return "", fmt.Errorf("a released named %s is in use, cannot re-use a name that is still in use", start)
 		}
 
 		return "", fmt.Errorf("a release named %s already exists.\nRun: helm ls --all %s; to check the status of the release\nOr run: helm del --purge %s; to delete it", start, start, start)


### PR DESCRIPTION
Fix #4174 

If `helm upgrade` fails because a reused name is still in use, the error
message does not specify which name is still in use. Update the error
message.