### PR TITLE
Build tiller image for various architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LDFLAGS   := -w -s
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := helm tiller
+GO_ARCH   := amd64
 
 # Required for globs to work correctly
 SHELL=/bin/bash
@@ -60,8 +61,8 @@ check-docker:
 docker-binary: BINDIR = ./rootfs
 docker-binary: GOFLAGS += -a -installsuffix cgo
 docker-binary:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/helm $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/tiller $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
+	GOOS=linux GOARCH=$(GO_ARCH) CGO_ENABLED=0 $(GO) build -o $(BINDIR)/helm $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
+	GOOS=linux GOARCH=$(GO_ARCH) CGO_ENABLED=0 $(GO) build -o $(BINDIR)/tiller $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
 
 .PHONY: docker-build
 docker-build: check-docker docker-binary
@@ -72,7 +73,7 @@ docker-build: check-docker docker-binary
 docker-binary-rudder: BINDIR = ./rootfs
 docker-binary-rudder: GOFLAGS += -a -installsuffix cgo
 docker-binary-rudder:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(BINDIR)/rudder $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/rudder
+	GOOS=linux GOARCH=$(GO_ARCH) CGO_ENABLED=0 $(GO) build -o $(BINDIR)/rudder $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/rudder
 
 .PHONY: docker-build-experimental
 docker-build-experimental: check-docker docker-binary docker-binary-rudder

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,12 +14,14 @@
 
 FROM alpine:3.7
 
-RUN apk update && apk add ca-certificates socat && rm -rf /var/cache/apk/*
+ARG BIN_DIR
+
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ENV HOME /tmp
 
-COPY helm /bin/helm
-COPY tiller /bin/tiller
+COPY ${BIN_DIR}helm /bin/helm
+COPY ${BIN_DIR}tiller /bin/tiller
 
 EXPOSE 44134
 USER nobody


### PR DESCRIPTION
Helm already supports cross-compiling and the parent image `alpine:3.7` is multi-arch. Therefore, building the `tiller` image for other architectures rather than x86_64 is straightforward. The docker images can be builti by using `make docker-build-images `

I also generalized the building process of a single docker image. The default target architecture remains `amd64`. However, another architecture could be set as the target. For example
```sh
$ make GO_ARCH=s390x docker-build
```