### PR TITLE
Do not fail linting because of missing 'required' template values

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"path"
 	"sort"
 	"strings"
@@ -39,6 +40,8 @@ type Engine struct {
 	// a value that was not passed in.
 	Strict           bool
 	CurrentTemplates map[string]renderable
+	// In LintMode, some 'required' template values may be missing, so don't fail
+	LintMode bool
 }
 
 // New creates a new Go template Engine instance.
@@ -155,9 +158,19 @@ func (e *Engine) alterFuncMap(t *template.Template) template.FuncMap {
 	// Add the 'required' function here
 	funcMap["required"] = func(warn string, val interface{}) (interface{}, error) {
 		if val == nil {
+			if e.LintMode {
+				// Don't fail on missing required values when linting
+				log.Printf("[INFO] Missing required value: %s", warn)
+				return val, nil
+			}
 			return val, fmt.Errorf(warn)
 		} else if _, ok := val.(string); ok {
 			if val == "" {
+				if e.LintMode {
+					// Don't fail on missing required values when linting
+					log.Printf("[INFO] Missing required value: %s", warn)
+					return val, nil
+				}
 				return val, fmt.Errorf(warn)
 			}
 		}

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -76,6 +76,7 @@ func Templates(linter *support.Linter, values []byte, namespace string, strict b
 		return
 	}
 	e := engine.New()
+	e.LintMode = true
 	if strict {
 		e.Strict = true
 	}


### PR DESCRIPTION
Addresses #2347 by adding a `LintMode` flag, which logs `[INFO]` messages instead of `Error` when required template values are missing.