### PR TITLE
Automount serviceaccount tokens into tiller pod

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -189,7 +189,8 @@ func generateDeployment(opts *Options) (*v1beta1.Deployment, error) {
 					Labels: labels,
 				},
 				Spec: v1.PodSpec{
-					ServiceAccountName: opts.ServiceAccount,
+					ServiceAccountName:           opts.ServiceAccount,
+					AutomountServiceAccountToken: &[]bool{true}[0],
 					Containers: []v1.Container{
 						{
 							Name:            "tiller",


### PR DESCRIPTION
This is especially helpful when serviceaccounts are created with automountServiceAccountToken=false
and the expectation is on the pods to define the security restrictions around token mounts.