### PR TITLE
Add 'name' label to created namespaces

### DIFF
--- a/pkg/kube/namespace.go
+++ b/pkg/kube/namespace.go
@@ -27,6 +27,9 @@ func createNamespace(client internalclientset.Interface, namespace string) error
 	ns := &core.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
+			Labels: map[string]string{
+				"name": namespace,
+			},
 		},
 	}
 	_, err := client.Core().Namespaces().Create(ns)


### PR DESCRIPTION
This pull request changes Helm to add a 'name' label to namespaces it creates.

This is useful because a number of Kubernetes extension points allow configuring whether webhook/policy applies to a namespace based only on labels, and not namespace name (e.g. NetworkPolicy & Validating/MutatingWebhookConfiguration).

This PR will allow me to selectively disable resource validation on the namespace that my controller/application is deployed into.

This has been requested in #3503 (although that issue requests *more* metadata). Custom labels have been requested in #4178.

Given the security considerations with custom labels, and the complication in complexity with adding more metadata, for now, I have opted to add a simple 'name' label.