### PR TITLE
Changed the format of setting list as was getting an error

### DIFF
--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -259,7 +259,7 @@ outer:
 ```
 
 Lists can be expressed by enclosing values in `{` and `}`. For example,
-`--set name={a, b, c}` translates to:
+`--set name="{a, b, c}"` translates to:
 
 ```yaml
 name:


### PR DESCRIPTION
Give then docs, I attempted to run:

``` zsh
helm install ./website --debug --dry-run --set args={ npm, start, -p, 80 }
```
However, the response was in zsh:

```zsh
zsh: parse error near `}'
```
and bash:

``` bash
Error: unknown shorthand flag: 'p' in -p,
```

Quoting the parameter enables sufficient interpolation into the yaml. Hence the change of the docs.
