### PR TITLE
chore(sprig): bump sprig to 2.15.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4023a1644d60060fbf2fdbbe5b73cbb4b957eb686ce925640d102db2d1858676
-updated: 2018-04-14T11:27:34.604716498-04:00
+hash: 41304a2eabc68608507c034304ce87cbf76924c90caaafbe42a9be16e6265868
+updated: 2018-06-19T14:50:56.238468981-05:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -89,7 +89,7 @@ imports:
   subpackages:
   - spdy
 - name: github.com/evanphx/json-patch
-  version: 944e07253867aacae43c04b2e6a239005443f33a
+  version: 94e38aa1586e8a6c8a75770bddf5ff84c48a106b
 - name: github.com/exponent-io/jsonpath
   version: d6023ce2651d8eafb5c75bb0c7167536102ec9f5
 - name: github.com/fatih/camelcase
@@ -250,7 +250,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/technosophos/moniker
-  version: ab470f5e105a44d0c87ea21bacd6a335c4816d83
+  version: a5dbd03a2245d554160e3ae6bfdcf969fe58b431
 - name: golang.org/x/crypto
   version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
@@ -359,9 +359,9 @@ imports:
   - json
   - jwt
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: c699ec51538f0cfd4afa8bfcfe1e0779cafbe666
+  version: 8b7507fac302640dd5f1efbf9643199952cc58db
   subpackages:
   - admission/v1beta1
   - admissionregistration/v1alpha1
@@ -398,7 +398,7 @@ imports:
   subpackages:
   - pkg/features
 - name: k8s.io/apimachinery
-  version: 54101a56dda9a0962bc48751c058eb4c546dcbb9
+  version: f6313580a4d36c7c74a3d845dda6e116642c4f90
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -455,7 +455,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: ea53f8588c655568158b4ff53f5ec6fa4ebfc332
+  version: f7914ed3085badf66a1b6f3a5218ada28f7bd084
   subpackages:
   - pkg/apis/audit
   - pkg/authentication/authenticator
@@ -640,12 +640,12 @@ imports:
   - util/retry
   - util/workqueue
 - name: k8s.io/kube-openapi
-  version: 50ae88d24ede7b8bad68e23c805b5d3da5c8abaf
+  version: 39cb288412c48cb533ba4be5d6c28620b9a0c1b4
   subpackages:
   - pkg/util/proto
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: baab3992147260d47cb59b9c485a24fdeff2e457
+  version: 32ac1c9073b132b8ba18aa830f46b77dcceb0723
   subpackages:
   - pkg/api/events
   - pkg/api/legacyscheme
@@ -767,7 +767,6 @@ imports:
   - pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/fake
   - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
   - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/fake
-  - pkg/client/conditions
   - pkg/cloudprovider
   - pkg/controller
   - pkg/controller/daemon

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - package: github.com/Masterminds/sprig
-  version: ^2.14.1
+  version: ^2.15.0
 - package: github.com/ghodss/yaml
 - package: github.com/Masterminds/semver
   version: ~1.3.1


### PR DESCRIPTION
This change updates sprig to 2.15, which has support for generating
SSL certificates in charts from user defined CA certificates.