### PR TITLE
escape tilde in docs

### DIFF
--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -22,11 +22,12 @@ Common actions from this point include:
 - helm list:      list releases of charts
 
 Environment:
-  $HELM_HOME          set an alternative location for Helm files. By default, these are stored in ~/.helm
-  $HELM_HOST          set an alternative Tiller host. The format is host:port
-  $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
-  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-system")
-  $KUBECONFIG         set an alternative Kubernetes configuration file (default "~/.kube/config")
+
+  $HELM_HOME          set an alternative location for Helm files. By default, these are stored in \~/.helm  
+  $HELM_HOST          set an alternative Tiller host. The format is host:port  
+  $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.  
+  $TILLER_NAMESPACE   set an alternative Tiller namespace (default "kube-system")  
+  $KUBECONFIG         set an alternative Kubernetes configuration file (default "\~/.kube/config")
 
 
 ### Options


### PR DESCRIPTION
If the `~` is not escaped, it strikes through the text between the 2 tildes. I don't see this on the official docs, but the formatting is messed up there.

Also added 2 blank spaces after each line so that it will render with every env variable on its own line.