### PR TITLE
Add check for nil in template control structure tutorial 

### DIFF
--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -53,10 +53,10 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{ if eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
+  {{ if (.Values.favorite.drink) and eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
 ```
 
-Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:
+Note that `.Values.favorite.drink` must be defined or else it will throw an error when comparing it to "coffee". Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml


### PR DESCRIPTION
Fixes https://github.com/kubernetes/helm/issues/3627

In the template conditional tutorial running `helm install --dry-run --debug` would throw an error because it tries to compare `nil` and a string. Added check for nil and a note referencing why the check is necessary. 