### PR TITLE
Change permission of index.yaml generated by a command `helm repo index`

### DIFF
--- a/cmd/helm/repo_index.go
+++ b/cmd/helm/repo_index.go
@@ -91,7 +91,7 @@ func index(dir, url, mergeTo string) error {
 		var i2 *repo.IndexFile
 		if _, err := os.Stat(mergeTo); os.IsNotExist(err) {
 			i2 = repo.NewIndexFile()
-			i2.WriteFile(mergeTo, 0755)
+			i2.WriteFile(mergeTo, 0644)
 		} else {
 			i2, err = repo.LoadIndexFile(mergeTo)
 			if err != nil {
@@ -101,5 +101,5 @@ func index(dir, url, mergeTo string) error {
 		i.Merge(i2)
 	}
 	i.SortEntries()
-	return i.WriteFile(out, 0755)
+	return i.WriteFile(out, 0644)
 }


### PR DESCRIPTION
I think `index.yaml` generated by a command `helm repo index` shouldn't be executable because we don't execute it.

However, current helm's implementation makes it an executable file.
Thus, I changed the permission of `index.yaml` to `0644` :)