### PR TITLE
Add more idiomatic approach to provide certificates to installer

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -355,18 +355,23 @@ func generateSecret(opts *Options) (*v1.Secret, error) {
 		},
 	}
 	var err error
-	if secret.Data["tls.key"], err = read(opts.TLSKeyFile); err != nil {
+	if secret.Data["tls.key"], err = read(opts.TLSKeyFile, opts.TLSKeyData); err != nil {
 		return nil, err
 	}
-	if secret.Data["tls.crt"], err = read(opts.TLSCertFile); err != nil {
+	if secret.Data["tls.crt"], err = read(opts.TLSCertFile, opts.TLSCertData); err != nil {
 		return nil, err
 	}
 	if opts.VerifyTLS {
-		if secret.Data["ca.crt"], err = read(opts.TLSCaCertFile); err != nil {
+		if secret.Data["ca.crt"], err = read(opts.TLSCaCertFile, opts.TLSCaCertFile); err != nil {
 			return nil, err
 		}
 	}
 	return secret, nil
 }
 
-func read(path string) (b []byte, err error) { return ioutil.ReadFile(path) }
+func read(path string, override []byte) (b []byte, err error) {
+	if len(override) > 0 {
+		return override, nil
+	}
+	return ioutil.ReadFile(path)
+}

--- a/cmd/helm/installer/options.go
+++ b/cmd/helm/installer/options.go
@@ -73,6 +73,15 @@ type Options struct {
 	// Required and valid if and only if VerifyTLS is set.
 	TLSCaCertFile string
 
+	// TLSKeyData contains raw PEM encoded data instead of TLSKeyFile path.
+	TLSKeyData []byte
+
+	// TLSCertData contains raw PEM encoded data instead of TLSCertFile path.
+	TLSCertData []byte
+
+	// TLSCaCertData contains raw PEM encoded data instead of TLSKeyFile path.
+	TLSCaCertData []byte
+
 	// EnableHostNetwork installs Tiller with net=host.
 	EnableHostNetwork bool
 


### PR DESCRIPTION
This PR adds a way to provide TLS certificates to the installer without needing them to be on the file system. This is useful for  a third party utilities (e.g. terraform-provider-helm) in cases when certificate data is not available on the local filesystem (e.g. vault).