### PR TITLE
Support Stdin when using downloaders of plugin

### DIFF
--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -69,6 +69,7 @@ func (p *pluginGetter) Get(href string) (*bytes.Buffer, error) {
 	buf := bytes.NewBuffer(nil)
 	prog.Stdout = buf
 	prog.Stderr = os.Stderr
+	prog.Stdin = os.Stdin
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)


### PR DESCRIPTION
Inject os.Stdin into the command of helm plugin's downloaders, this allows the helm plugin to enable interactive mode when downloading files, which makes the plugin more flexible and powerful.

For instance, as we all know, helm plugin support downloaders, which makes it possible to download index or chart files from other protocols. When executing "helm repo add", helm will download the index file. If it is not the http or https protocol, helm will call the plugin's downloader to download the index file, but my repository is private and has its own authentication mechanism, "helm repo add" support "--username" and "--password" parameters for basic auth, but it does not apply to protocols other than http and https. And the local has not yet cached the repo's credentials, In this case, I want helm to inject stdin into the plugin's command to provide an interactive mode for the user to enter credentials, and then the plugin caches and maintains the repo's credentials information for later usage.
