### PR TITLE
Some small typos:

### DIFF
--- a/_proto/hapi/services/tiller.proto
+++ b/_proto/hapi/services/tiller.proto
@@ -89,7 +89,7 @@ service ReleaseService {
 //
 // Releases can be retrieved in chunks by setting limit and offset.
 //
-// Releases can be sorted according to a few pre-determined sort stategies.
+// Releases can be sorted according to a few pre-determined sort strategies.
 message ListReleasesRequest {
 	// Limit is the maximum number of releases to be returned.
 	int64 limit  = 1;
@@ -260,10 +260,10 @@ message InstallReleaseRequest {
 	// DisableHooks causes the server to skip running any hooks for the install.
 	bool disable_hooks = 5;
 
-	// Namepace is the kubernetes namespace of the release.
+	// Namespace is the kubernetes namespace of the release.
 	string namespace = 6;
 
-	// ReuseName requests that Tiller re-uses a name, instead of erroring out.
+	// Reuse_name requests that Tiller re-uses a name, instead of erroring out.
 	bool reuse_name = 7;
 
 	// timeout specifies the max amount of time any kubernetes client command can run.


### PR DESCRIPTION
Some small typos:
Line 92: stategies->strategies
Line 263: namepace->namespace
Line 266: ReuseName->Reuse_name