### PR TITLE
docs(helm): add helm-cos to related helm plugins

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -39,6 +39,7 @@ or [pull request](https://github.com/kubernetes/helm/pulls).
 - [helm-secrets](https://github.com/futuresimple/helm-secrets) - Plugin to manage and store secrets safely
 - [helm-edit](https://github.com/mstrzele/helm-edit) - Plugin for editing release's values
 - [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories on Google Cloud Storage
+- [helm-cos](https://github.com/imroc/helm-cos) - Plugin to manage repositories on Tencent Cloud Object Storage
 - [helm-github](https://github.com/sagansystems/helm-github) - Plugin to install Helm Charts from Github repositories
 - [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to monitor a release and rollback based on Prometheus/ElasticSearch query
 - [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm Charts from hiera using k8comp


### PR DESCRIPTION
Just like helm-gcs, helm-cos is a helm plugin that manage helm repositories on Tencent COS, so I added it to the list of related helm plugins.