### PR TITLE
feat(helm): hiding password input on terminal

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/repo"
+	"syscall"
 )
 
 type repoAddCmd struct {
@@ -73,11 +75,29 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 }
 
 func (a *repoAddCmd) run() error {
+	if a.username != "" && a.password == "" {
+		fmt.Fprint(a.out, "Password:")
+		password, err := readPassword()
+		fmt.Fprintln(a.out)
+		if err != nil {
+			return err
+		}
+		a.password = password
+	}
+
 	if err := addRepository(a.name, a.url, a.username, a.password, a.home, a.certFile, a.keyFile, a.caFile, a.noupdate); err != nil {
 		return err
 	}
 	fmt.Fprintf(a.out, "%q has been added to your repositories\n", a.name)
 	return nil
+}
+
+func readPassword() (string, error) {
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	return string(password), nil
 }
 
 func addRepository(name, url, username, password string, home helmpath.Home, certFile, keyFile, caFile string, noUpdate bool) error {

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,6 +33,7 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - openpgp
+  - ssh/terminal
 # pin version of golang.org/x/sys that is compatible with golang.org/x/crypto
 - package: golang.org/x/sys
   version: 43eea11


### PR DESCRIPTION
When using "helm repo add" with "--username" and without "--password",
hide user's input with a password prompt. This allows users to not
expose their passwords to the command line history.