### PR TITLE
Allow zsh completion to be autoloaded by compinit

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -82,6 +82,8 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	zshInitialization := `
+#compdef helm
+
 __helm_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand


### PR DESCRIPTION
This will allow helm zsh autocompletion to work with compinit, same as [kubectl](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/completion.go#L142) does.