### PR TITLE
fix(helm): add `--tls-hostname` flag to tls flags

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -40,6 +40,7 @@ import (
 )
 
 var (
+	tlsServerName string // overrides the server name used to verify the hostname on the returned certificates from the server.
 	tlsCaCertFile string // path to TLS CA certificate file
 	tlsCertFile   string // path to TLS certificate file
 	tlsKeyFile    string // path to TLS key file
@@ -280,8 +281,13 @@ func newClient() helm.Interface {
 		if tlsKeyFile == "" {
 			tlsKeyFile = settings.Home.TLSKey()
 		}
-		debug("Key=%q, Cert=%q, CA=%q\n", tlsKeyFile, tlsCertFile, tlsCaCertFile)
-		tlsopts := tlsutil.Options{KeyFile: tlsKeyFile, CertFile: tlsCertFile, InsecureSkipVerify: true}
+		debug("Host=%q, Key=%q, Cert=%q, CA=%q\n", tlsKeyFile, tlsCertFile, tlsCaCertFile)
+		tlsopts := tlsutil.Options{
+			ServerName:         tlsServerName,
+			KeyFile:            tlsKeyFile,
+			CertFile:           tlsCertFile,
+			InsecureSkipVerify: true,
+		}
 		if tlsVerify {
 			tlsopts.CaCertFile = tlsCaCertFile
 			tlsopts.InsecureSkipVerify = false
@@ -301,6 +307,7 @@ func newClient() helm.Interface {
 func addFlagsTLS(cmd *cobra.Command) *cobra.Command {
 
 	// add flags
+	cmd.Flags().StringVar(&tlsServerName, "tls-hostname", settings.TillerHost, "the server name used to verify the hostname on the returned certificates from the server")
 	cmd.Flags().StringVar(&tlsCaCertFile, "tls-ca-cert", tlsCaCertDefault, "path to TLS CA certificate file")
 	cmd.Flags().StringVar(&tlsCertFile, "tls-cert", tlsCertDefault, "path to TLS certificate file")
 	cmd.Flags().StringVar(&tlsKeyFile, "tls-key", tlsKeyDefault, "path to TLS key file")

--- a/pkg/tlsutil/cfg.go
+++ b/pkg/tlsutil/cfg.go
@@ -33,6 +33,9 @@ type Options struct {
 	CertFile string
 	// Client-only options
 	InsecureSkipVerify bool
+	// Overrides the server name used to verify the hostname on the returned
+	// certificates from the server.
+	ServerName string
 	// Server-only options
 	ClientAuth tls.ClientAuthType
 }
@@ -55,8 +58,12 @@ func ClientConfig(opts Options) (cfg *tls.Config, err error) {
 			return nil, err
 		}
 	}
-
-	cfg = &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify, Certificates: []tls.Certificate{*cert}, RootCAs: pool}
+	cfg = &tls.Config{
+		InsecureSkipVerify: opts.InsecureSkipVerify,
+		Certificates:       []tls.Certificate{*cert},
+		ServerName:         opts.ServerName,
+		RootCAs:            pool,
+	}
 	return cfg, nil
 }
 


### PR DESCRIPTION
fix(helm): add `--tls-hostname` flag to tls flags

docs(*): update tiller_ssl.md to reflect IP SAN usage.
When using helm/tiller in tls-verify mode, 127.0.0.1 should
be listed as an IP SAN in the tiller certificate to pass
hostname verficiation of the TLS handshake.

Closes #4149