### PR TITLE
fix(helm): Non-zero exit code on failed chart repository update

### DIFF
--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -46,7 +46,7 @@ func TestUpdateCmd(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer, hh helmpath.Home) error {
+	updater := func(repos []*repo.ChartRepository, out io.Writer, hh helmpath.Home, strict bool) error {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
@@ -95,7 +95,7 @@ func TestUpdateCharts(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	updateCharts([]*repo.ChartRepository{r}, b, hh)
+	updateCharts([]*repo.ChartRepository{r}, b, hh, false)
 
 	got := b.String()
 	if strings.Contains(got, "Unable to get an update") {

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -46,10 +46,11 @@ func TestUpdateCmd(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer, hh helmpath.Home) {
+	updater := func(repos []*repo.ChartRepository, out io.Writer, hh helmpath.Home) error {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
+		return nil
 	}
 	uc := &repoUpdateCmd{
 		update: updater,


### PR DESCRIPTION
Returns non-zero exit code when one of chart repositories failed to update. I think it might be useful for CI processes.

Before:

```
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "stable" chart repository
Error: Get https://charts.gke/app/index.yaml: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
...Unable to get an update from the "app" chart repository (https://charts.gke/app/):
	plugin "bin/helmpush" exited with error
Update Complete. ⎈ Happy Helming!⎈ 
```

After:

```
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "stable" chart repository
Error: Get https://charts.gke/app/index.yaml: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
...Unable to get an update from the "app" chart repository (https://charts.gke/app/):
	plugin "bin/helmpush" exited with error
Error: Update Failed. Check log for details
```

Is it looks fine? Please comment.
