### PR TITLE
docs(OWNERS): add rimusz as emeritus maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -28,3 +28,4 @@ emeritus:
   - migmartri
   - seh
   - vaikas-google
+  - rimusz


### PR DESCRIPTION
This PR was approved by vote of the core maintainers. It adds Rimus, one
of the project's founders, as an emeritus Helm maintainer.

/cc @rimusz 