### PR TITLE
Fixed error in docs for file access

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -130,7 +130,7 @@ Or
 
 ```yaml
 {{ range $path, $bytes := .Files.Glob "foo/*" }}
-{{ $path.base }}: '{{ $root.Files.Get $path | b64enc }}'
+{{ base $path }}: '{{ $root.Files.Get $path | b64enc }}'
 {{ end }}
 ```
 


### PR DESCRIPTION
$path.base gives the error "can't evaluate field base in type string" in this instance, it should be "base $path" which works without problems.