### PR TITLE
revert back to /tiller

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -18,10 +18,10 @@ RUN apk update && apk add ca-certificates socat && rm -rf /var/cache/apk/*
 
 ENV HOME /tmp
 
-COPY helm /bin/helm
-COPY tiller /bin/tiller
+COPY helm /helm
+COPY tiller /tiller
 
 EXPOSE 44134
 USER nobody
-ENTRYPOINT ["/bin/tiller"]
+ENTRYPOINT ["/tiller"]
 

--- a/rootfs/Dockerfile.experimental
+++ b/rootfs/Dockerfile.experimental
@@ -18,9 +18,9 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ENV HOME /tmp
 
-COPY tiller /bin/tiller
+COPY tiller /tiller
 
 EXPOSE 44134
 USER nobody
-ENTRYPOINT ["/bin/tiller", "--experimental-release"]
+ENTRYPOINT ["/tiller", "--experimental-release"]
 


### PR DESCRIPTION
when running `helm init --upgrade`, the entrypoint since v2.9.1 changed which
caused tiller to never start. Kubernetes may be holding onto the same entrypoint
during upgrades.

introduced in #3965 
closes #4413 