### PR TITLE
add support for `auth-provider` from kubeconfig files

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -37,6 +37,8 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
+	// Import to initialize client auth plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/proto/hapi/services"
 	"k8s.io/helm/pkg/storage"


### PR DESCRIPTION
addreses #4422, with this fix `Tiller-less` Helm can be used with Kubernetes clusters which use `auth-provider` to authenticate user to the cluster.