### PR TITLE
Expand Helm v3 predefined values to match Helm 2

### DIFF
--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestStatusCmd(t *testing.T) {
 	releasesMockWithStatus := func(info *release.Info) []*release.Release {
-		info.LastDeployed = time.Unix(1452902400, 0)
+		info.LastDeployed = time.Unix(1452902400, 0).UTC()
 		return []*release.Release{{
 			Name: "flummoxed-chickadee",
 			Info: info,

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -334,8 +335,11 @@ func coalesceTables(dst, src map[string]interface{}) map[string]interface{} {
 // for the composition of the final values struct
 type ReleaseOptions struct {
 	Name      string
+	Time      time.Time
+	Namespace string
 	IsUpgrade bool
 	IsInstall bool
+	Revision  int
 }
 
 // ToRenderValues composes the struct from the data coming from the Releases, Charts and Values files
@@ -357,8 +361,11 @@ func ToRenderValuesCaps(chrt *chart.Chart, chrtVals []byte, options ReleaseOptio
 	top := map[string]interface{}{
 		"Release": map[string]interface{}{
 			"Name":      options.Name,
+			"Time":      options.Time,
+			"Namespace": options.Namespace,
 			"IsUpgrade": options.IsUpgrade,
 			"IsInstall": options.IsInstall,
+			"Revision":  options.Revision,
 			"Service":   "Helm",
 		},
 		"Chart":        chrt.Metadata,

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 	"text/template"
+	"time"
 
 	kversion "k8s.io/apimachinery/pkg/version"
 
@@ -101,8 +102,16 @@ where:
 	}
 	v := []byte(overideValues)
 
+	ts, err := time.Parse(time.RFC3339, "2017-08-14T10:00:00+00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	o := ReleaseOptions{
 		Name:      "Seven Voyages",
+		Namespace: "my-namespace",
+		Time: ts,
+		Revision: 0,
 		IsInstall: true,
 	}
 
@@ -124,6 +133,15 @@ where:
 	relmap := res["Release"].(map[string]interface{})
 	if name := relmap["Name"]; name.(string) != "Seven Voyages" {
 		t.Errorf("Expected release name 'Seven Voyages', got %q", name)
+	}
+	if namespace := relmap["Namespace"]; namespace.(string) != "my-namespace" {
+		t.Errorf("Expected namespace 'my-namespace', got %q", namespace)
+	}
+	if relts := relmap["Time"]; relts.(time.Time) != ts {
+		t.Errorf("Expected time '2017-08-14T10:00:00z', got %q", relts)
+	}
+	if revision := relmap["Revision"]; revision.(int) != 0 {
+		t.Errorf("Expected revision '0', got %q", revision)
 	}
 	if relmap["IsUpgrade"].(bool) {
 		t.Error("Expected upgrade to be false.")

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -187,7 +187,7 @@ type MockReleaseOptions struct {
 
 // ReleaseMock creates a mock release object based on options set by MockReleaseOptions. This function should typically not be used outside of testing.
 func ReleaseMock(opts *MockReleaseOptions) *release.Release {
-	date := time.Unix(242085845, 0)
+	date := time.Unix(242085845, 0).UTC()
 
 	name := opts.Name
 	if name == "" {

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -19,6 +19,7 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -50,7 +51,7 @@ func Templates(linter *support.Linter, values []byte, namespace string, strict b
 		return
 	}
 
-	options := chartutil.ReleaseOptions{Name: "testRelease"}
+	options := chartutil.ReleaseOptions{Name: "testRelease", Time: time.Now(), Namespace: "testNamespace"}
 	caps := &chartutil.Capabilities{
 		APIVersions: chartutil.DefaultVersionSet,
 		KubeVersion: chartutil.DefaultKubeVersion,

--- a/pkg/tiller/release_install.go
+++ b/pkg/tiller/release_install.go
@@ -69,6 +69,9 @@ func (s *ReleaseServer) prepareRelease(req *hapi.InstallReleaseRequest) (*releas
 	ts := time.Now()
 	options := chartutil.ReleaseOptions{
 		Name:      name,
+		Namespace: req.Namespace,
+		Revision: revision,
+		Time: ts,
 		IsInstall: true,
 	}
 	valuesToRender, err := chartutil.ToRenderValuesCaps(req.Chart, req.Values, options, caps)

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -98,6 +98,9 @@ func (s *ReleaseServer) prepareUpdate(req *hapi.UpdateReleaseRequest) (*release.
 	ts := time.Now()
 	options := chartutil.ReleaseOptions{
 		Name:      req.Name,
+		Namespace: currentRelease.Namespace,
+		Revision: revision,
+		Time: ts,
 		IsUpgrade: true,
 	}
 


### PR DESCRIPTION
Adds the predefined values:

 * Release.Namespace
 * Release.Revision
 * Release.Time

which exist in Helm 2.x