### PR TITLE
docs(alpine): quote release label value

### DIFF
--- a/docs/examples/alpine/templates/alpine-pod.yaml
+++ b/docs/examples/alpine/templates/alpine-pod.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     # This makes it easy to audit chart usage.
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "alpine.name" . }}


### PR DESCRIPTION
Labels should be quoted so that values such as "true" or "1" are not
interpolated to the wrong type.