### PR TITLE
Add an option which builds recursively the dependent charts

### DIFF
--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -41,6 +41,7 @@ type dependencyBuildCmd struct {
 	chartpath string
 	verify    bool
 	keyring   string
+	recursive bool
 	helmhome  helmpath.Home
 }
 
@@ -65,6 +66,7 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&dbc.verify, "verify", false, "verify the packages against signatures")
 	f.StringVar(&dbc.keyring, "keyring", defaultKeyring(), "keyring containing public keys")
+	f.BoolVar(&dbc.recursive, "recursive", false, "run build recursively for the dependent charts")
 
 	return cmd
 }
@@ -75,11 +77,16 @@ func (d *dependencyBuildCmd) run() error {
 		ChartPath: d.chartpath,
 		HelmHome:  d.helmhome,
 		Keyring:   d.keyring,
+		Recursive: d.recursive,
 		Getters:   getter.All(settings),
 	}
 	if d.verify {
 		man.Verify = downloader.VerifyIfPossible
 	}
 
-	return man.Build()
+	if d.recursive {
+		return man.BuildRecursively()
+	}
+	_, err := man.Build()
+	return err
 }

--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -87,6 +87,5 @@ func (d *dependencyBuildCmd) run() error {
 	if d.recursive {
 		return man.BuildRecursively()
 	}
-	_, err := man.Build()
-	return err
+	return man.Build()
 }

--- a/cmd/helm/dependency_build_test.go
+++ b/cmd/helm/dependency_build_test.go
@@ -162,7 +162,7 @@ func TestDependencyRecursiveBuildCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expect = filepath.Join(hh.String(), chartname, "charts/rectest1/charts/rectest2-0.1.0.tgz")
+	expect = filepath.Join(hh.String(), chartname, "charts/rectest2-0.1.0.tgz")
 	if _, err := os.Stat(expect); err != nil {
 		t.Fatal(err)
 	}

--- a/docs/helm/helm_dependency_build.md
+++ b/docs/helm/helm_dependency_build.md
@@ -24,6 +24,7 @@ helm dependency build [flags] CHART
 ```
   -h, --help             help for build
       --keyring string   keyring containing public keys (default "~/.gnupg/pubring.gpg")
+      --recursive        run build recursively for the dependent charts
       --verify           verify the packages against signatures
 ```
 

--- a/docs/man/man1/helm_dependency_build.1
+++ b/docs/man/man1/helm_dependency_build.1
@@ -32,6 +32,9 @@ of 'helm dependency update'.
 \fB\-\-keyring\fP="~/.gnupg/pubring.gpg"
     keyring containing public keys
 
+\fB\-\-recursive\fP[=false]
+    run build recursively for the dependent charts
+
 .PP
 \fB\-\-verify\fP[=false]
     verify the packages against signatures

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -126,7 +126,11 @@ func (m *Manager) BuildRecursively() error {
 		return err
 	}
 
+	// The local repositories are already updated by the root build. Skip the update
+	// for each dependent chart to improve performance.
+	prevSkipUpdate := m.SkipUpdate
 	m.SkipUpdate = true
+
 	baseChartPath := filepath.Join(m.ChartPath, "charts")
 
 	// Do a Breadth-first traversal over the chart dependencies and
@@ -160,6 +164,9 @@ func (m *Manager) BuildRecursively() error {
 			}
 		}
 	}
+
+	// Restore to the original value before running the recursive build
+	m.SkipUpdate = prevSkipUpdate
 
 	return nil
 }

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -66,7 +66,12 @@ type Manager struct {
 // If the lockfile is not present, this will run a Manager.Update()
 //
 // If SkipUpdate is set, this will not update the repository.
-func (m *Manager) Build() ([]*chartutil.Dependency, error) {
+func (m *Manager) Build() error {
+	_, err := m.build()
+	return err
+}
+
+func (m *Manager) build() ([]*chartutil.Dependency, error) {
 	c, err := m.loadChartDir()
 	if err != nil {
 		return nil, err
@@ -121,7 +126,7 @@ func (m *Manager) Build() ([]*chartutil.Dependency, error) {
 // If SkipUpdate is set, this will not update the repository.
 func (m *Manager) BuildRecursively() error {
 	// Build the main chart
-	dependencies, err := m.Build()
+	dependencies, err := m.build()
 	if err != nil {
 		return err
 	}
@@ -152,7 +157,7 @@ func (m *Manager) BuildRecursively() error {
 		for _, dep := range currChartDep.deps {
 			chartPath := filepath.Join(currChartDep.path, dep.Name)
 			m.ChartPath = chartPath
-			newDeps, err := m.Build()
+			newDeps, err := m.build()
 			if err != nil {
 				return err
 			}

--- a/scripts/completions.bash
+++ b/scripts/completions.bash
@@ -327,6 +327,8 @@ _helm_dependency_build()
 
     flags+=("--keyring=")
     local_nonpersistent_flags+=("--keyring=")
+    flags+=("--recursive")
+    local_nonpersistent_flags+=("--recursive")
     flags+=("--verify")
     local_nonpersistent_flags+=("--verify")
     flags+=("--debug")


### PR DESCRIPTION
This is based on PR #2278. 

The recursive build is now implemented iteratively and also some tests are added.

It was also tested manually on a more complex chart https://github.com/ccojocar/environment-scalewalnut-staging/tree/master/env.

fixes #2247

cc @jstrachan