### PR TITLE
Adds 'Annotations' field to Release

### DIFF
--- a/pkg/hapi/release/release.go
+++ b/pkg/hapi/release/release.go
@@ -22,6 +22,10 @@ import "k8s.io/helm/pkg/hapi/chart"
 type Release struct {
 	// Name is the name of the release
 	Name string `json:"name,omitempty"`
+	// Annotations is an unstructured key value map stored with a resource that may be
+	// set by external tools to store and retrieve arbitrary metadata. They are not
+	// queryable and should be preserved when modifying objects.
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Info provides information about a release
 	Info *Info `json:"info,omitempty"`
 	// Chart is the chart that was released.

--- a/pkg/hapi/tiller.go
+++ b/pkg/hapi/tiller.go
@@ -93,6 +93,8 @@ type GetReleaseContentRequest struct {
 
 // UpdateReleaseRequest updates a release.
 type UpdateReleaseRequest struct {
+	// Annotations used by external tools.
+	Annotations map[string]string
 	// The name of the release
 	Name string `json:"name,omitempty"`
 	// Chart is the protobuf representation of a chart.
@@ -143,6 +145,8 @@ type RollbackReleaseRequest struct {
 
 // InstallReleaseRequest is the request for an installation of a chart.
 type InstallReleaseRequest struct {
+	// Annotations used by external tools.
+	Annotations map[string]string
 	// Chart is the protobuf representation of a chart.
 	Chart *chart.Chart `json:"chart,omitempty"`
 	// Values is a string containing (unparsed) YAML values.

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -90,6 +90,7 @@ func (c *Client) InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...
 	req.DryRun = reqOpts.dryRun
 	req.DisableHooks = reqOpts.disableHooks
 	req.ReuseName = reqOpts.reuseName
+	req.Annotations = reqOpts.annotations
 
 	if err := reqOpts.runBefore(req); err != nil {
 		return nil, err
@@ -160,6 +161,7 @@ func (c *Client) UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts
 	req.Force = reqOpts.force
 	req.ResetValues = reqOpts.resetValues
 	req.ReuseValues = reqOpts.reuseValues
+	req.Annotations = reqOpts.annotations
 
 	if err := reqOpts.runBefore(req); err != nil {
 		return nil, err

--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -31,6 +31,8 @@ type Option func(*options)
 
 // options specify optional settings used by the helm client.
 type options struct {
+	// if set, annotations will be applied to a release
+	annotations map[string]string
 	// if set dry-run helm client calls
 	dryRun bool
 	// if set, re-use an existing name
@@ -268,6 +270,13 @@ func InstallReuseName(reuse bool) InstallOption {
 	}
 }
 
+// InstallAnnotations will add annotations to a Helm release.
+func InstallAnnotations(annoations map[string]string) InstallOption {
+	return func(opts *options) {
+		opts.annotations = annoations
+	}
+}
+
 // RollbackDisableHooks will disable hooks for a rollback operation
 func RollbackDisableHooks(disable bool) RollbackOption {
 	return func(opts *options) {
@@ -343,6 +352,13 @@ func UpgradeRecreate(recreate bool) UpdateOption {
 func UpgradeForce(force bool) UpdateOption {
 	return func(opts *options) {
 		opts.force = force
+	}
+}
+
+// UpdateAnnotations will assign annotations to a Helm release.
+func UpdateAnnotations(annoations map[string]string) UpdateOption {
+	return func(opts *options) {
+		opts.annotations = annoations
 	}
 }
 

--- a/pkg/tiller/release_install.go
+++ b/pkg/tiller/release_install.go
@@ -81,10 +81,11 @@ func (s *ReleaseServer) prepareRelease(req *hapi.InstallReleaseRequest) (*releas
 		// Return a release with partial data so that client can show debugging
 		// information.
 		rel := &release.Release{
-			Name:      name,
-			Namespace: req.Namespace,
-			Chart:     req.Chart,
-			Config:    req.Values,
+			Name:        name,
+			Namespace:   req.Namespace,
+			Annotations: req.Annotations,
+			Chart:       req.Chart,
+			Config:      req.Values,
 			Info: &release.Info{
 				FirstDeployed: ts,
 				LastDeployed:  ts,
@@ -101,10 +102,11 @@ func (s *ReleaseServer) prepareRelease(req *hapi.InstallReleaseRequest) (*releas
 
 	// Store a release.
 	rel := &release.Release{
-		Name:      name,
-		Namespace: req.Namespace,
-		Chart:     req.Chart,
-		Config:    req.Values,
+		Name:        name,
+		Namespace:   req.Namespace,
+		Annotations: req.Annotations,
+		Chart:       req.Chart,
+		Config:      req.Values,
 		Info: &release.Info{
 			FirstDeployed: ts,
 			LastDeployed:  ts,


### PR DESCRIPTION
Adds annotations so that external tools can have easy integrations.

eg. Add deployment author information

```
external.io/deployer: Nick Schuch
```