### PR TITLE
Moving from CLA to DCO in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,21 +10,75 @@ you are reporting a _security vulnerability_, please email a report to
 [cncf-kubernetes-helm-security@lists.cncf.io](mailto:cncf-kubernetes-helm-security@lists.cncf.io). This will give
 us a chance to try to fix the issue before it is exploited in the wild.
 
-## Contributor License Agreements
+## Sign Your Work
 
-We'd love to accept your patches! Before we can take them, we have to jump a
-couple of legal hurdles.
+The sign-off is a simple line at the end of the explanation for a commit. All 
+commits needs to be signed. Your signature certifies that you wrote the patch or
+otherwise have the right to contribute the material. The rules are pretty simple,
+if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
 
-The Cloud Native Computing Foundation (CNCF) CLA [must be signed](https://github.com/kubernetes/community/blob/master/CLA.md) by all contributors.
-Please fill out either the individual or corporate Contributor License
-Agreement (CLA).
+```
+Developer Certificate of Origin
+Version 1.1
 
-Once you are CLA'ed, we'll be able to accept your pull requests. For any issues that you face during this process,
-please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796) explaining the issue and we will help get it sorted out.
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
 
-***NOTE***: Only original source code from you and other people that have
-signed the CLA can be accepted into the repository. This policy does not
-apply to [third_party](third_party/) and [vendor](vendor/).
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.
+
+Note: If your git config information is set properly then viewing the
+ `git log` information for your commit will look something like this:
+
+```
+Author: Joe Smith <joe.smith@example.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+
+    Update README
+
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't
+your PR will be rejected by the automated DCO check.
 
 ## Support Channels
 
@@ -215,8 +269,6 @@ The following tables define all label types used for Helm. It is split up by cat
 | ----- | ----------- |
 | `awaiting review` | The PR has been triaged and is ready for someone to review |
 | `breaking` | The PR has breaking changes (such as API changes) |
-| `cncf-cla: no` | The PR submitter has **not** signed the project CLA. |
-| `cncf-cla: yes` | The PR submitter has signed the project CLA. This is required to merge. |
 | `in progress` | Indicates that a maintainer is looking at the PR, even if no review has been posted yet |
 | `needs pick` | Indicates that the PR needs to be picked into a feature branch (generally bugfix branches). Once it has been, the `picked` label should be applied and this one removed |
 | `needs rebase` | A helper label used to indicate that the PR needs to be rebased before it can be merged. Used for easy filtering |


### PR DESCRIPTION
**DO NOT MERGE UNTIL THE SWITCH TAKES PLACE.**

When the DCO switch takes place this should be merged. Not before. This PR is prep for that change.

This is based on the wonderful write-up in CloudEvents.