### PR TITLE
docs: Messages are encrypted when using client-tiller TLS

### DIFF
--- a/docs/securing_installation.md
+++ b/docs/securing_installation.md
@@ -57,7 +57,7 @@ Shared and production clusters -- for the most part -- should use Helm 2.7.2 at 
 
 For more information about the proper steps to configure Tiller and use Helm properly with TLS configured, see [Using SSL between Helm and Tiller](tiller_ssl.md).
 
-When Helm clients are connecting from outside of the cluster, the security between the Helm client and the API server is managed by Kubernetes itself. You may want to ensure that this link is secure. Note that if you are using the TLS configuration recommended above, not even the Kubernetes API server has access to the unencrypted messages between the client and Tiller.
+When Helm clients are connecting from outside of the cluster, the security between the Helm client and the API server is managed by Kubernetes itself. You may want to ensure that this link is secure. Note that if you are using the TLS configuration recommended above, not even the Kubernetes API server has access to the encrypted messages between the client and Tiller.
 
 ### Tiller's Release Information
 


### PR DESCRIPTION
When helm client and tiller use TLS their messages are encrypted, not unencrypted ;)