### PR TITLE
Reform indentation practices using nindent

### DIFF
--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -6,12 +6,13 @@ metadata:
   # multiple times into the same namespace.
   name: {{ template "nginx.fullname" . }}
   labels:
-    # The "app.kubernetes.io/managed-by" label is used to track which tool deployed a given chart.
-    # It is useful for admins who want to see what releases a particular tool
-    # is responsible for.
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    # The "app.kubernetes.io/instance" convention makes it easy to tie a release to all of the
-    # Kubernetes resources that were created as part of that release.
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
     app.kubernetes.io/instance: {{ .Release.Name }}
     # This makes it easy to audit chart usage.
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -20,11 +21,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       # Allows custom annotations to be specified
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "nginx.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -42,15 +43,16 @@ spec:
             - mountPath: /usr/share/nginx/html
               name: wwwdata-volume
           resources:
-# Allow chart users to specify resources. Usually, no default should be set, so this is left to be a conscious
-# choice to the chart users and avoids that charts don't run out of the box on, e. g., Minikube when high resource
-# requests are specified by default.
-{{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
+            # Allow chart users to specify resources. Usually, no default should
+            # be set, so this is left to be a conscious choice to the chart
+            # users and avoids that charts don't run out of the box on, e. g.,
+            # Minikube when high resource requests are specified by default.
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-      # Node selectors can be important on mixed Windows/Linux clusters.
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+        # Node selectors can be important on mixed Windows/Linux clusters.
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       volumes:
         - name: wwwdata-volume
           configMap:

--- a/docs/examples/nginx/templates/service.yaml
+++ b/docs/examples/nginx/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "nginx.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -15,17 +15,17 @@ spec:
 # Provides options for the service so chart users have the full choice
   type: "{{ .Values.service.type }}"
   clusterIP: "{{ .Values.service.clusterIP }}"
-{{- if .Values.service.externalIPs }}
+  {{- if .Values.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.service.loadBalancerIP }}
+    {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
-{{- end }}
-{{- if .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -133,10 +133,10 @@ metadata:
     helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:
@@ -199,18 +199,18 @@ spec:
               path: /
               port: http
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
 `
 


### PR DESCRIPTION
## About
The `helm create` command comes with some indentation practices that I think can be improved. The essence of this commit is to help people get started with a better indentation practice than this:

```yaml
spec:
  labels:
{{ toYaml .Values.labels | indent 4 }}
```

The previous indentation practice is harder to read. Instead this commit introduces an indentation practice using `nindent` like this:

```yaml
spec:
  labels:
    {{- toYaml .Values.labels | nindent 4 }}
```

It does its work by first whitespace chomp to the left, and then creating a newline (this is the `n` in `nindent`), and then indents all content 4 spaces.