### PR TITLE
Set proxy for all connections, fixes #4326

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -83,6 +83,7 @@ func NewHTTPGetter(URL, CertFile, KeyFile, CAFile string) (*HttpGetter, error) {
 	var client HttpGetter
 	tr := &http.Transport{
 		DisableCompression: true,
+		Proxy:              http.ProxyFromEnvironment,
 	}
 	if (CertFile != "" && KeyFile != "") || CAFile != "" {
 		tlsConf, err := tlsutil.NewTLSConfig(URL, CertFile, KeyFile, CAFile)
@@ -90,7 +91,6 @@ func NewHTTPGetter(URL, CertFile, KeyFile, CAFile string) (*HttpGetter, error) {
 			return &client, fmt.Errorf("can't create TLS config: %s", err.Error())
 		}
 		tr.TLSClientConfig = tlsConf
-		tr.Proxy = http.ProxyFromEnvironment
 	}
 	client.client = &http.Client{Transport: tr}
 	return &client, nil


### PR DESCRIPTION
Commit 3eaa1bfd3b040cb644c7974d32047dc70037cf95 removed the use of `http.DefaultClient` and created the client with a new transport - this removed the default setting for using a proxy (`http.ProxyFromEnvironment`).

This PR changes the `http.Transport` to use `http.ProxyFromEnvironment` again.

Signed-off-by: Christian Koeberl <christian.koeberl@gmail.com>