### PR TITLE
add short-output flag to search

### DIFF
--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -84,6 +84,18 @@ func TestSearchCmd(t *testing.T) {
 			flags: []string{"--regexp"},
 			err:   true,
 		},
+		{
+			name:     "search for 'maria', expect one match, expect to be the short version",
+			args:     []string{"maria"},
+			flags:    []string{"--short-output"},
+			expected: "testing/mariadb\t0.3.0        \t           \tChart for MariaDB",
+		},
+		{
+			name:     "search for 'maria', expect one match, expect to be the short version",
+			args:     []string{"maria"},
+			flags:    []string{"-s"},
+			expected: "testing/mariadb\t0.3.0        \t           \tChart for MariaDB",
+		},
 	}
 
 	cleanup := resetEnv()


### PR DESCRIPTION
Add a --short-output flag to search.
The option prevent some the details from appearing -> NAME CHART VERSION APP VERSION	DESCRIPTION.