### PR TITLE
docs: fix grammer errors

### DIFF
--- a/docs/chart_tests.md
+++ b/docs/chart_tests.md
@@ -8,7 +8,7 @@ Example tests:
 - Validate that your configuration from the values.yaml file was properly injected.
   - Make sure your username and password work correctly
   - Make sure an incorrect username and password does not work
-- Assert that your services are up and correctly load balancing
+- Assert that your services are up and correctly loadbalanced.
 - etc.
 
 You can run the pre-defined tests in Helm on a release using the command `helm test <RELEASE_NAME>`. For a chart consumer, this is a great way to sanity check that their release of a chart (or application) works as expected.


### PR DESCRIPTION
This PR fixes a grammer error found in `docs/chart_tests.md`.