### PR TITLE
Fix race in helm list when partitioning

### DIFF
--- a/pkg/tiller/release_list.go
+++ b/pkg/tiller/release_list.go
@@ -140,7 +140,7 @@ func (s *ReleaseServer) partition(rels []*release.Release, cap int) <-chan []*re
 				s.Log("partitioned at %d with %d releases (cap=%d)", fill, len(chunk), cap)
 				chunks <- chunk
 				// reset paritioning state
-				chunk = chunk[:0]
+				chunk = nil
 				fill = 0
 			}
 			chunk = append(chunk, rls)


### PR DESCRIPTION
Problem:
The chunks slice that is passed through the channel is reused for each
partition. This means that encoding the release into a message is racing with
populating the next partition, causing the results to sometimes not fit in the
message, and the release list to be incorrect

Solution:
Allocate a new slice for each partition

Issue #3322 

Since the root cause has the side effect of making `helm list` sometimes return the wrong result, I think this should be back-ported. I don't know what the process for that is.