### PR TITLE
Fix for checking helm version slice bounds out of range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BINDIR    := $(CURDIR)/bin
 BINARIES  := helm tiller
 
 # Required for globs to work correctly
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 .PHONY: all
 all: build

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -144,7 +144,7 @@ func getK8sVersion() (*apiVersion.Info, error) {
 }
 
 func formatVersion(v *pb.Version, short bool) string {
-	if short {
+	if short && v.GitCommit != "" {
 		return fmt.Sprintf("%s+g%s", v.SemVer, v.GitCommit[:7])
 	}
 	return fmt.Sprintf("%#v", v)

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -57,6 +57,12 @@ func TestVersion(t *testing.T) {
 			flags:    []string{"--template", "{{ .Client.SemVer }} {{ .Server.SemVer }}"},
 			expected: lver + " " + sver,
 		},
+		{
+			name:     "client short empty git",
+			args:     []string{},
+			flags:    []string{"-c", "--short"},
+			expected: lver,
+		},
 	}
 	settings.TillerHost = "fake-localhost"
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {


### PR DESCRIPTION
# Issues
Running `helm version --short` causes the following error if GitCommit is empty:
```
$ helm version --client --short
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
main.formatVersion(0xc42040d470, 0xc42040d401, 0x0, 0x0)
        /wrkdirs/usr/ports/sysutils/helm/work/src/k8s.io/helm/cmd/helm/version.go:148 +0x19e
main.(*versionCmd).run(0xc42003a6c0, 0x0, 0x0)
        /wrkdirs/usr/ports/sysutils/helm/work/src/k8s.io/helm/cmd/helm/version.go:97 +0x6ee
main.newVersionCmd.func1(0xc4207286c0, 0xc42074aaa0, 0x0, 0x2, 0x0, 0x0)
        /wrkdirs/usr/ports/sysutils/helm/work/src/k8s.io/helm/cmd/helm/version.go:76 +0x32
github.com/spf13/cobra.(*Command).execute(0xc4207286c0, 0xc42074a940, 0x2, 0x2, 0xc4207286c0, 0xc42074a940)
        /wrkdirs/usr/ports/sysutils/helm/work/src/github.com/spf13/cobra/command.go:599 +0x3db
github.com/spf13/cobra.(*Command).ExecuteC(0xc4207b4240, 0xc42070c000, 0xc42070cd80, 0xc42070db00)
        /wrkdirs/usr/ports/sysutils/helm/work/src/github.com/spf13/cobra/command.go:689 +0x2d4
github.com/spf13/cobra.(*Command).Execute(0xc4207b4240, 0x3, 0x3)
        /wrkdirs/usr/ports/sysutils/helm/work/src/github.com/spf13/cobra/command.go:648 +0x2b
main.main()
        /wrkdirs/usr/ports/sysutils/helm/work/src/k8s.io/helm/cmd/helm/helm.go:161 +0x79
```

This is due to the FreeBSD helm port being built on the release tarball: https://github.com/helm/helm/archive/v2.10.0.tar.gz as seen in the ports tree source: https://github.com/freebsd/freebsd-ports/blob/master/sysutils/helm/Makefile#L44 This should be an issue for anyone else trying to build off the tarball.

Additionally I ran into an issue with `gnu make` looking for `/bin/bash` which on FreeBSD is located in `/usr/local/bin/bash` since it comes from the portstree and not in the base system:
```
$ GOCACHE=off gmake test-unit
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: /bin/bash: Command not found
gmake: *** [Makefile:99: test-unit] Error 127
```

# Fixes
* Check when `sha` is empty and just output `version` like normal
* Leverage `/usr/bin/env bash` when looking for shell in `make` for portability

# Tests
* Added test for case when version --short is passed to empty sha
* Also manually tested with `go build` which 

# Configuration
```
$ uname -a
FreeBSD robs-desktop 11.2-RELEASE-p1 FreeBSD 11.2-RELEASE-p1 #2 6d554063ca8(releng/11.2): Thu Aug  9 20:53:12 PDT 2018     root@robs-desktop:/usr/obj/usr/src/sys/GENERIC  amd64
$ pkg info | grep helm
helm-2.10.0                    Kubernetes Package Manager
$ helm version
Client: &version.Version{SemVer:"v2.10.0", GitCommit:"", GitTreeState:""}
Server: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
 $ pkg info | grep glide
go-glide-0.13.1                Package Management for Golang    
```