### PR TITLE
Make ping() request a specific image

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -68,7 +68,7 @@ func Upgrade(client kubernetes.Interface, opts *Options) error {
 	if semverCompare(tillerImage) == -1 && !opts.ForceUpgrade {
 		return errors.New("current Tiller version is newer, use --force-upgrade to downgrade")
 	}
-	obj.Spec.Template.Spec.Containers[0].Image = opts.selectImage()
+	obj.Spec.Template.Spec.Containers[0].Image = opts.SelectImage()
 	obj.Spec.Template.Spec.Containers[0].ImagePullPolicy = opts.pullPolicy()
 	obj.Spec.Template.Spec.ServiceAccountName = opts.ServiceAccount
 	if _, err := client.ExtensionsV1beta1().Deployments(opts.Namespace).Update(obj); err != nil {
@@ -223,7 +223,7 @@ func generateDeployment(opts *Options) (*v1beta1.Deployment, error) {
 					Containers: []v1.Container{
 						{
 							Name:            "tiller",
-							Image:           opts.selectImage(),
+							Image:           opts.SelectImage(),
 							ImagePullPolicy: opts.pullPolicy(),
 							Ports: []v1.ContainerPort{
 								{ContainerPort: 44134, Name: "tiller"},

--- a/cmd/helm/installer/options.go
+++ b/cmd/helm/installer/options.go
@@ -99,7 +99,8 @@ type Options struct {
 	Values []string
 }
 
-func (opts *Options) selectImage() string {
+// SelectImage returns the image according to whether UseCanary is true or not
+func (opts *Options) SelectImage() string {
 	switch {
 	case opts.UseCanary:
 		return defaultImage + ":canary"

--- a/pkg/helm/portforwarder/portforwarder.go
+++ b/pkg/helm/portforwarder/portforwarder.go
@@ -54,6 +54,21 @@ func GetTillerPodName(client corev1.PodsGetter, namespace string) (string, error
 	return pod.ObjectMeta.GetName(), nil
 }
 
+// GetTillerPodImage fetches the image of tiller pod running in the given namespace.
+func GetTillerPodImage(client corev1.PodsGetter, namespace string) (string, error) {
+	selector := tillerPodLabels.AsSelector()
+	pod, err := getFirstRunningPod(client, namespace, selector)
+	if err != nil {
+		return "", err
+	}
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "tiller" {
+			return c.Image, nil
+		}
+	}
+	return "", fmt.Errorf("could not find a tiller pod")
+}
+
 func getFirstRunningPod(client corev1.PodsGetter, namespace string, selector labels.Selector) (*v1.Pod, error) {
 	options := metav1.ListOptions{LabelSelector: selector.String()}
 	pods, err := client.Pods(namespace).List(options)


### PR DESCRIPTION
This fixes a potential race condition when upgrading tiller.

The current code does not ensure that the first running tiller pod is for the upgraded image. 
It can (and does) happen that the old pod may still be around by the time ping() is called.
When that happens setupConnection() fails because it tries to open a connection for proxying to a dying pod (which will be replaced shortly by the new one).

This PR changes ping() to look for a specific image (i.e. that of the new deployment) so that it will ignore the old pods when looking for the first running pod.

Fixes #4031 

Signed-off-by: Louis Munro <lm@louismunro.com>