### PR TITLE
include the name of the missing object in release uninstall error

### DIFF
--- a/pkg/tiller/release_modules.go
+++ b/pkg/tiller/release_modules.go
@@ -18,7 +18,6 @@ package tiller
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -174,7 +173,11 @@ func DeleteRelease(rel *release.Release, vs chartutil.VersionSet, kubeClient env
 			log.Printf("uninstall: Failed deletion of %q: %s", rel.Name, err)
 			if err == kube.ErrNoObjectsVisited {
 				// Rewrite the message from "no objects visited"
-				err = errors.New("object not found, skipping delete")
+				obj := ""
+				if file.Head != nil && file.Head.Metadata != nil {
+					obj = "[" + file.Head.Kind + "] " + file.Head.Metadata.Name
+				}
+				err = fmt.Errorf("release %q: object %q not found, skipping delete", rel.Name, obj)
 			}
 			errs = append(errs, err)
 		}

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -441,6 +441,20 @@ func (h *hookFailingKubeClient) WatchUntilReady(ns string, r io.Reader, timeout 
 	return errors.New("Failed watch")
 }
 
+func newDeleteFailingKubeClient() *deleteFailingKubeClient {
+	return &deleteFailingKubeClient{
+		PrintingKubeClient: environment.PrintingKubeClient{Out: ioutil.Discard},
+	}
+}
+
+type deleteFailingKubeClient struct {
+	environment.PrintingKubeClient
+}
+
+func (d *deleteFailingKubeClient) Delete(ns string, r io.Reader) error {
+	return kube.ErrNoObjectsVisited
+}
+
 type mockListServer struct {
 	val *services.ListReleasesResponse
 }


### PR DESCRIPTION
Enhance the error message returned by tiller when one or more objects were not found while deleting a release. Closes #4616.