### PR TITLE
test and build with golang 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: /go/src/k8s.io/helm
     parallelism: 3
     docker:
-      - image: golang:1.10
+      - image: golang:1.11
     environment:
       PROJECT_NAME: "kubernetes-helm"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_REGISTRY   ?= gcr.io
 IMAGE_PREFIX      ?= kubernetes-helm
-DEV_IMAGE         ?= golang:1.10
+DEV_IMAGE         ?= golang:1.11
 SHORT_NAME        ?= tiller
 SHORT_NAME_RUDDER ?= rudder
 TARGETS           ?= darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x windows/amd64

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -65,8 +65,8 @@ func TestEqual(t *testing.T) {
 
 func TestExtractHostname(t *testing.T) {
 	tests := map[string]string{
-		"http://example.com":                                      "example.com",
-		"https://example.com/foo":                                 "example.com",
+		"http://example.com":      "example.com",
+		"https://example.com/foo": "example.com",
 		"https://example.com:31337/not/with/a/bang/but/a/whimper": "example.com",
 	}
 	for start, expect := range tests {


### PR DESCRIPTION
linters were failing with: `pkg/urlutil/urlutil_test.go:1::warning: file is not gofmted with -s (gofmt)`

https://golang.org/doc/go1.11 - For me, the primary motivation is the `text/template` update to make templating a bit easier to manage