### PR TITLE
[Docs] Change kubernetes to helm in docs and yaml files when refer the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The Kubernetes Helm project accepts contributions via GitHub pull requests. This
 ## Reporting a Security Issue
 
 Most of the time, when you find a bug in Helm, it should be reported
-using [GitHub issues](https://github.com/kubernetes/helm/issues). However, if
+using [GitHub issues](https://github.com/helm/helm/issues). However, if
 you are reporting a _security vulnerability_, please email a report to
 [cncf-kubernetes-helm-security@lists.cncf.io](mailto:cncf-kubernetes-helm-security@lists.cncf.io). This will give
 us a chance to try to fix the issue before it is exploited in the wild.
@@ -84,7 +84,7 @@ your PR will be rejected by the automated DCO check.
 
 Whether you are a user or contributor, official support channels include:
 
-- GitHub [issues](https://github.com/kubernetes/helm/issues/new)
+- GitHub [issues](https://github.com/helm/helm/issues/new)
 - Slack [Kubernetes Slack](http://slack.kubernetes.io/):
   - User: #helm-users
   - Contributor: #helm-dev
@@ -177,7 +177,7 @@ contributing to Helm. All issue types follow the same general lifecycle. Differe
 3. Submit a pull request.
 
 Coding conventions and standards are explained in the official developer docs:
-https://github.com/kubernetes/helm/blob/master/docs/developers.md
+https://github.com/helm/helm/blob/master/docs/developers.md
 
 The next section contains more information on the workflow followed for PRs
 

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -8,7 +8,7 @@
 # and will be removed and replaced if they violate that agreement.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
-# INSTRUCTIONS AT https://github.com/kubernetes/helm/blob/master/CONTRIBUTING.md#reporting-a-security-issue
+# INSTRUCTIONS AT https://github.com/helm/helm/blob/master/CONTRIBUTING.md#reporting-a-security-issue
 
 adamreese
 bacongobbler

--- a/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/repository/cache/testing-index.yaml
@@ -6,7 +6,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.1.0
       appVersion: 1.2.3
       description: Deploy a basic Alpine Linux pod
@@ -19,7 +19,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.2.0
       appVersion: 2.3.4
       description: Deploy a basic Alpine Linux pod

--- a/cmd/helm/testdata/testcharts/alpine/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/alpine/Chart.yaml
@@ -2,5 +2,5 @@ description: Deploy a basic Alpine Linux pod
 home: https://k8s.io/helm
 name: alpine
 sources:
-- https://github.com/kubernetes/helm
+- https://github.com/helm/helm
 version: 0.1.0

--- a/cmd/helm/testdata/testcharts/novals/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/novals/Chart.yaml
@@ -2,5 +2,5 @@ description: Deploy a basic Alpine Linux pod
 home: https://k8s.io/helm
 name: novals
 sources:
-- https://github.com/kubernetes/helm
+- https://github.com/helm/helm
 version: 0.2.0

--- a/cmd/helm/testdata/testcharts/signtest/alpine/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/signtest/alpine/Chart.yaml
@@ -2,5 +2,5 @@ description: Deploy a basic Alpine Linux pod
 home: https://k8s.io/helm
 name: alpine
 sources:
-- https://github.com/kubernetes/helm
+- https://github.com/helm/helm
 version: 0.1.0

--- a/docs/chart_repository.md
+++ b/docs/chart_repository.md
@@ -21,7 +21,7 @@ optionally some packaged charts.  When you're ready to share your charts, the
 preferred way to do so is by uploading them to a chart repository.
 
 **Note:** For Helm 2.0.0, chart repositories do not have any intrinsic
-authentication. There is an [issue tracking progress](https://github.com/kubernetes/helm/issues/1038)
+authentication. There is an [issue tracking progress](https://github.com/helm/helm/issues/1038)
 in GitHub.
 
 Because a chart repository can be any HTTP server that can serve YAML and tar
@@ -78,7 +78,7 @@ entries:
       home: https://k8s.io/helm
       name: alpine
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       urls:
       - https://technosophos.github.io/tscharts/alpine-0.2.0.tgz
       version: 0.2.0
@@ -88,7 +88,7 @@ entries:
       home: https://k8s.io/helm
       name: alpine
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       urls:
       - https://technosophos.github.io/tscharts/alpine-0.1.0.tgz
       version: 0.1.0

--- a/docs/chart_repository_faq.md
+++ b/docs/chart_repository_faq.md
@@ -3,7 +3,7 @@
 This section tracks some of the more frequently encountered issues with using chart repositories.
 
 **We'd love your help** making this document better. To add, correct, or remove
-information, [file an issue](https://github.com/kubernetes/helm/issues) or
+information, [file an issue](https://github.com/helm/helm/issues) or
 send us a pull request.
 
 ## Fetching

--- a/docs/chart_repository_sync_example.md
+++ b/docs/chart_repository_sync_example.md
@@ -29,7 +29,7 @@ Upload the contents of the directory to your GCS bucket by running `scripts/sync
 For example:
 ```console
 $ pwd
-/Users/funuser/go/src/github.com/kubernetes/helm
+/Users/funuser/go/src/github.com/helm/helm
 $ scripts/sync-repo.sh fantastic-charts/ fantastic-charts
 Getting ready to sync your local directory (fantastic-charts/) to a remote repository at gs://fantastic-charts
 Verifying Prerequisites....

--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -16,7 +16,7 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
   - `Release.IsInstall`: This is set to `true` if the current operation is an install.
 - `Values`: Values passed into the template from the `values.yaml` file and from user-supplied files. By default, `Values` is empty.
 - `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will be accessible here. For example `{{.Chart.Name}}-{{.Chart.Version}}` will print out the `mychart-0.1.0`.
-  - The available fields are listed in the [Charts Guide](https://github.com/kubernetes/helm/blob/master/docs/charts.md#the-chartyaml-file)
+  - The available fields are listed in the [Charts Guide](https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file)
 - `Files`: This provides access to all non-special files in a chart. While you cannot use it to access templates, you can use it to access other files in the chart. See the section _Accessing Files_ for more.
   - `Files.Get` is a function for getting a file by name (`.Files.Get config.ini`)
   - `Files.GetBytes` is a function for getting the contents of a file as an array of bytes instead of as a string. This is useful for things like images.

--- a/docs/chart_template_guide/wrapping_up.md
+++ b/docs/chart_template_guide/wrapping_up.md
@@ -17,4 +17,4 @@ Sometimes it's easier to ask a few questions and get answers from experienced de
 
 - [Kubernetes Slack](https://slack.k8s.io/): `#helm`
 
-Finally, if you find errors or omissions in this document, want to suggest some new content, or would like to contribute, visit [The Helm Project](https://github.com/kubernetes/helm).
+Finally, if you find errors or omissions in this document, want to suggest some new content, or would like to contribute, visit [The Helm Project](https://github.com/helm/helm).

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -488,7 +488,7 @@ the Kubernetes objects from the charts and all its dependencies are
 Hence a single release is created with all the objects for the chart and its dependencies.
 
 The install order of Kubernetes types is given by the enumeration InstallOrder in kind_sorter.go 
-(see [the Helm source file](https://github.com/kubernetes/helm/blob/master/pkg/tiller/kind_sorter.go#L26)).
+(see [the Helm source file](https://github.com/helm/helm/blob/master/pkg/tiller/kind_sorter.go#L26)).
 
 ## Templates and Values
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -132,7 +132,7 @@ elegant and high-quality open source code so that our users will benefit.
 
 Make sure you have read and understood the main CONTRIBUTING guide:
 
-https://github.com/kubernetes/helm/blob/master/CONTRIBUTING.md
+https://github.com/helm/helm/blob/master/CONTRIBUTING.md
 
 ### Structure of the Code
 
@@ -162,7 +162,7 @@ We accept changes to the code via GitHub Pull Requests (PRs). One
 workflow for doing this is as follows:
 
 1. Go to your `$GOPATH/src/k8s.io` directory and `git clone` the
-   `github.com/kubernetes/helm` repository.
+   `github.com/helm/helm` repository.
 2. Fork that repository into your GitHub account
 3. Add your repository as a remote for `$GOPATH/src/k8s.io/helm`
 4. Create a new working branch (`git checkout -b feat/my-feature`) and

--- a/docs/examples/alpine/Chart.yaml
+++ b/docs/examples/alpine/Chart.yaml
@@ -1,7 +1,7 @@
 name: alpine
 description: Deploy a basic Alpine Linux pod
 version: 0.1.0
-home: https://github.com/kubernetes/helm
+home: https://github.com/helm/helm
 sources:
-  - https://github.com/kubernetes/helm
+  - https://github.com/helm/helm
 appVersion: 3.3

--- a/docs/examples/nginx/Chart.yaml
+++ b/docs/examples/nginx/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - nginx
   - www
   - web
-home: https://github.com/kubernetes/helm
+home: https://github.com/helm/helm
 sources:
   - https://hub.docker.com/_/nginx/
 maintainers:

--- a/docs/helm/helm_serve.md
+++ b/docs/helm/helm_serve.md
@@ -15,7 +15,7 @@ This command is intended to be used for educational and testing purposes only.
 It is best to rely on a dedicated web server or a cloud-hosted solution like
 Google Cloud Storage for production use.
 
-See https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md#hosting-chart-repositories
+See https://github.com/helm/helm/blob/master/docs/chart_repository.md#hosting-chart-repositories
 for more information on hosting chart repositories in a production setting.
 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,11 +13,11 @@ releases.
 
 ### From the Binary Releases
 
-Every [release](https://github.com/kubernetes/helm/releases) of Helm
+Every [release](https://github.com/helm/helm/releases) of Helm
 provides binary releases for a variety of OSes. These binary versions
 can be manually downloaded and installed.
 
-1. Download your [desired version](https://github.com/kubernetes/helm/releases)
+1. Download your [desired version](https://github.com/helm/helm/releases)
 2. Unpack it (`tar -zxvf helm-v2.0.0-linux-amd64.tgz`)
 3. Find the `helm` binary in the unpacked directory, and move it to its
    desired destination (`mv linux-amd64/helm /usr/local/bin/helm`)
@@ -57,18 +57,18 @@ choco install kubernetes-helm
 ## From Script
 
 Helm now has an installer script that will automatically grab the latest version
-of the Helm client and [install it locally](https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get).
+of the Helm client and [install it locally](https://raw.githubusercontent.com/helm/helm/master/scripts/get).
 
 You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
 ```
-$ curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+$ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
 $ chmod 700 get_helm.sh
 $ ./get_helm.sh
 ```
 
-Yes, you can `curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash` that if you want to live on the edge.
+Yes, you can `curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash` that if you want to live on the edge.
 
 ### From Canary Builds
 
@@ -96,7 +96,7 @@ You must have a working Go environment with
 $ cd $GOPATH
 $ mkdir -p src/k8s.io
 $ cd src/k8s.io
-$ git clone https://github.com/kubernetes/helm.git
+$ git clone https://github.com/helm/helm.git
 $ cd helm
 $ make bootstrap build
 ```

--- a/docs/install_faq.md
+++ b/docs/install_faq.md
@@ -4,7 +4,7 @@ This section tracks some of the more frequently encountered issues with installi
 or getting started with Helm.
 
 **We'd love your help** making this document better. To add, correct, or remove
-information, [file an issue](https://github.com/kubernetes/helm/issues) or
+information, [file an issue](https://github.com/helm/helm/issues) or
 send us a pull request.
 
 ## Downloading
@@ -94,8 +94,8 @@ recommends reading this:
 
 Here are a few resolved issues that may help you get started:
 
-- https://github.com/kubernetes/helm/issues/1371
-- https://github.com/kubernetes/helm/issues/966
+- https://github.com/helm/helm/issues/1371
+- https://github.com/helm/helm/issues/966
 
 **Q: Trying to use Helm, I get the error "lookup XXXXX on 8.8.8.8:53: no such host"**
 
@@ -113,7 +113,7 @@ follows. On each of the control plane nodes:
 3) Remove the k8s api server container (kubelet will recreate it)
 4) Then `systemctl restart docker` (or reboot the node) for it to pick up the /etc/resolv.conf changes
 
-See this issue for more information: https://github.com/kubernetes/helm/issues/1455
+See this issue for more information: https://github.com/helm/helm/issues/1455
 
 **Q: On GKE (Google Container Engine) I get "No SSH tunnels currently open"**
 

--- a/docs/man/man1/helm_serve.1
+++ b/docs/man/man1/helm_serve.1
@@ -29,7 +29,7 @@ Google Cloud Storage for production use.
 
 .PP
 See 
-\[la]https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md#hosting-chart-repositories\[ra]
+\[la]https://github.com/helm/helm/blob/master/docs/chart_repository.md#hosting-chart-repositories\[ra]
 for more information on hosting chart repositories in a production setting.
 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,7 +43,7 @@ to [configure a service account and rules](rbac.md) before proceeding.
 ## Install Helm
 
 Download a binary release of the Helm client. You can use tools like
-`homebrew`, or look at [the official releases page](https://github.com/kubernetes/helm/releases).
+`homebrew`, or look at [the official releases page](https://github.com/helm/helm/releases).
 
 For more details, or for other options, see [the installation
 guide](install.md).

--- a/docs/related.md
+++ b/docs/related.md
@@ -2,8 +2,8 @@
 
 The Helm community has produced many extra tools, plugins, and documentation about
 Helm. We love to hear about these projects. If you have anything you'd like to
-add to this list, please open an [issue](https://github.com/kubernetes/helm/issues)
-or [pull request](https://github.com/kubernetes/helm/pulls).
+add to this list, please open an [issue](https://github.com/helm/helm/issues)
+or [pull request](https://github.com/helm/helm/pulls).
 
 ## Article, Blogs, How-Tos, and Extra Documentation
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -39,12 +39,12 @@ Just kidding! :trollface:
 
 All releases will be of the form vX.Y.Z where X is the major version number, Y is the minor version number and Z is the patch release number. This project strictly follows [semantic versioning](http://semver.org/) so following this step is critical.
 
-It is important to note that this document assumes that the git remote in your repository that corresponds to "https://github.com/kubernetes/helm" is named "upstream". If yours is not (for example, if you've chosen to name it "origin" or something similar instead), be sure to adjust the listed snippets for your local environment accordingly. If you are not sure what your upstream remote is named, use a command like `git remote -v` to find out.
+It is important to note that this document assumes that the git remote in your repository that corresponds to "https://github.com/helm/helm" is named "upstream". If yours is not (for example, if you've chosen to name it "origin" or something similar instead), be sure to adjust the listed snippets for your local environment accordingly. If you are not sure what your upstream remote is named, use a command like `git remote -v` to find out.
 
 If you don't have an upstream remote, you can add one easily using something like:
 
 ```shell
-git remote add upstream git@github.com:kubernetes/helm.git
+git remote add upstream git@github.com:helm/helm.git
 ```
 
 In this doc, we are going to reference a few environment variables as well, which you may want to set for convenience. For major/minor releases, use the following:
@@ -134,7 +134,7 @@ In order for others to start testing, we can now push the release branch upstrea
 git push upstream $RELEASE_BRANCH_NAME
 ```
 
-Make sure to check [helm on CircleCI](https://circleci.com/gh/kubernetes/helm) and make sure the release passed CI before proceeding.
+Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) and make sure the release passed CI before proceeding.
 
 If anyone is available, let others peer-review the branch before continuing to ensure that all the proper changes have been made and all of the commits for the release are there.
 
@@ -240,7 +240,7 @@ Download Helm X.Y. The common platform binaries are here:
 
 Once you have the client installed, upgrade Tiller with `helm init --upgrade`.
 
-The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get) on any system with `bash`.
+The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get) on any system with `bash`.
 
 ## What's Next
 

--- a/pkg/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
@@ -7,7 +7,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.1.0
       description: Deploy a basic Alpine Linux pod
       keywords: []
@@ -20,7 +20,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.2.0
       description: Deploy a basic Alpine Linux pod
       keywords: []

--- a/pkg/downloader/testdata/helmhome/repository/cache/malformed-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/malformed-index.yaml
@@ -7,7 +7,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 1.2.3
       description: Deploy a basic Alpine Linux pod
       keywords: []

--- a/pkg/downloader/testdata/helmhome/repository/cache/testing-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/testing-index.yaml
@@ -7,7 +7,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 1.2.3
       description: Deploy a basic Alpine Linux pod
       keywords: []
@@ -21,7 +21,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.2.0
       description: Deploy a basic Alpine Linux pod
       keywords: []

--- a/pkg/downloader/testdata/helmhome/repository/cache/testing-querystring-index.yaml
+++ b/pkg/downloader/testdata/helmhome/repository/cache/testing-querystring-index.yaml
@@ -7,7 +7,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 1.2.3
       description: Deploy a basic Alpine Linux pod
       keywords: []

--- a/pkg/downloader/testdata/signtest/alpine/Chart.yaml
+++ b/pkg/downloader/testdata/signtest/alpine/Chart.yaml
@@ -2,5 +2,5 @@ description: Deploy a basic Alpine Linux pod
 home: https://k8s.io/helm
 name: alpine
 sources:
-- https://github.com/kubernetes/helm
+- https://github.com/helm/helm
 version: 0.1.0

--- a/pkg/resolver/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
+++ b/pkg/resolver/testdata/helmhome/repository/cache/kubernetes-charts-index.yaml
@@ -7,7 +7,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.2.0
       description: Deploy a basic Alpine Linux pod
       keywords: []
@@ -20,7 +20,7 @@ entries:
       checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
       home: https://k8s.io/helm
       sources:
-      - https://github.com/kubernetes/helm
+      - https://github.com/helm/helm
       version: 0.1.0
       description: Deploy a basic Alpine Linux pod
       keywords: []


### PR DESCRIPTION
Replace `https://github.com/kubernetes/helm/` with `https://github.com/helm/helm`in the docs and yaml files.

Did not replace when this URL is mentioned in the go files. if needed I can change that as well.