### PR TITLE
Install tiller as well if it exists

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -18,6 +18,7 @@
 # the package manager for Go: https://github.com/Masterminds/glide.sh/blob/master/get
 
 PROJECT_NAME="helm"
+TILLER_NAME="tiller"
 USE_SUDO="true"
 
 : ${HELM_INSTALL_DIR:="/usr/local/bin"}
@@ -142,8 +143,16 @@ installFile() {
   mkdir -p "$HELM_TMP"
   tar xf "$HELM_TMP_FILE" -C "$HELM_TMP"
   HELM_TMP_BIN="$HELM_TMP/$OS-$ARCH/$PROJECT_NAME"
-  echo "Preparing to install into ${HELM_INSTALL_DIR}"
+  TILLER_TMP_BIN="$HELM_TMP/$OS-$ARCH/$TILLER_NAME"
+  echo "Preparing to install $PROJECT_NAME and $TILLER_NAME into ${HELM_INSTALL_DIR}"
   runAsRoot cp "$HELM_TMP_BIN" "$HELM_INSTALL_DIR"
+  echo "$PROJECT_NAME installed into $HELM_INSTALL_DIR/$PROJECT_NAME"
+  if [ -x "$TILLER_TMP_BIN" ]; then
+    runAsRoot cp "$TILLER_TMP_BIN" "$HELM_INSTALL_DIR"
+    echo "$TILLER_NAME installed into $HELM_INSTALL_DIR/$TILLER_NAME"
+  else
+    echo "warn: $TILLER_NAME is not included in this version of binary release"
+  fi
 }
 
 # fail_trap is executed if an error occurs.
@@ -165,7 +174,6 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
   set +e
-  echo "$PROJECT_NAME installed into $HELM_INSTALL_DIR/$PROJECT_NAME"
   HELM="$(which $PROJECT_NAME)"
   if [ "$?" = "1" ]; then
     echo "$PROJECT_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'

--- a/scripts/get
+++ b/scripts/get
@@ -151,7 +151,7 @@ installFile() {
     runAsRoot cp "$TILLER_TMP_BIN" "$HELM_INSTALL_DIR"
     echo "$TILLER_NAME installed into $HELM_INSTALL_DIR/$TILLER_NAME"
   else
-    echo "warn: $TILLER_NAME is not included in this version of binary release"
+    echo "info: $TILLER_NAME binary was not found in this release; skipping $TILLER_NAME installation"
   fi
 }
 


### PR DESCRIPTION
## What I Did

I modified `scripts/get` to install `tiller` as well if it exists in a version of release binary.

### When tiller exists

```
$ HELM_INSTALL_DIR=/tmp/helm ./scripts/get --version v2.11.0-rc.1
Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.11.0-rc.1-darwin-amd64.tar.gz
Preparing to install helm and tiller into /tmp/helm
helm installed into /tmp/helm/helm
tiller installed into /tmp/helm/tiller
Run 'helm init' to configure helm.
```

### When tiller does not exist

```
$ HELM_INSTALL_DIR=/tmp/helm ./scripts/get --version v2.9.1
Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.9.1-darwin-amd64.tar.gz
Preparing to install helm and tiller into /tmp/helm
helm installed into /tmp/helm/helm
info: tiller binary was not found in this release; skipping tiller installation
Run 'helm init' to configure helm.
```

## Background

Since release candidates of v2.11.0, the binary releases got to include `tiller` in it.

* The issue proposed to include `tiller`
  * https://github.com/helm/helm/issues/1690
* The PR fixed the issue
  * https://github.com/helm/helm/pull/4443