### PR TITLE
chore: update Sprig to 2.16

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9d3eee153a34027ed93ccbcbfb4778baead73ed3f5bd4c665114e02aef747606
-updated: 2018-08-01T07:48:30.2009451Z
+hash: a4a7df055da2413c8e42cb127833a77d6a2910396efdabf5a7dc5af956478fef
+updated: 2018-09-13T18:30:19.732109-06:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -39,7 +39,7 @@ imports:
   subpackages:
   - md2man
 - name: github.com/cyphar/filepath-securejoin
-  version: 06bda8370f45268db985f7af15732444d94ed51c
+  version: a261ee33d7a517f054effbf451841abaafe3e0fd
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
@@ -196,7 +196,7 @@ imports:
 - name: github.com/Masterminds/semver
   version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/Masterminds/sprig
-  version: 6b2a58267f6a8b1dc8e2eb5519b984008fa85e8c
+  version: 15f9564e7e9cf0da02a48e0d25f12a7b83559aa6
 - name: github.com/Masterminds/vcs
   version: 3084677c2c188840777bff30054f2b553729d329
 - name: github.com/mattn/go-runewidth
@@ -596,7 +596,7 @@ imports:
   - pkg/util/proto/testing
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: 8b3d76091fd500b7c59c83e113c9048ee612b205
+  version: 2e809eed16445fff9dcbfc56e9936cf76ccbdadc
   subpackages:
   - pkg/api/events
   - pkg/api/legacyscheme
@@ -786,3 +786,4 @@ testImports:
   version: e3a8ff8ce36581f87a15341206f205b1da467059
   subpackages:
   - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - package: github.com/Masterminds/sprig
-  version: ^2.15.0
+  version: ^2.16.0
 - package: github.com/ghodss/yaml
 - package: github.com/Masterminds/semver
   version: ~1.3.1


### PR DESCRIPTION
This is just an update of the Sprig library to the latest version.

Closes #4644