### PR TITLE
Fix credentials not set for ResolveChartVersion default HTTP client

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -170,8 +170,11 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 				if err != nil {
 					return u, nil, err
 				}
-				getter, err := getterConstructor(ref, "", "", "")
-				return u, getter, err
+				g, err := getterConstructor(ref, "", "", "")
+				if t, ok := g.(*getter.HttpGetter); ok {
+					t.SetCredentials(c.Username, c.Password)
+				}
+				return u, g, err
 			}
 			return u, nil, err
 		}


### PR DESCRIPTION
Fixes Issue #4299 and Issue #4445 by setting credentials on the default HTTP client when the code takes that path.