### PR TITLE
fix(helm): fix selector typo in service template for 'helm create'

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -232,7 +232,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: {{ include "<CHARTNAME>.name" . }}
-    app.kubernetes.io/instancelease: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 `
 
 const defaultNotes = `1. Get the application URL by running these commands:


### PR DESCRIPTION
changed instancelease to instance in service template

closes #4661

Signed-off-by: Qiang Li <liqiang@gmail.com>