### PR TITLE
fix(helm): --set for out of order list values

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -61,7 +61,13 @@ func TestInstall(t *testing.T) {
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "virgil",
 		},
-		// Install, values from yaml
+		{
+			name:     "install with multiple unordered list values",
+			args:     []string{"testdata/testcharts/alpine"},
+			flags:    strings.Split("--name virgil --set foo[1].bar=baz,foo[0].baz=bar", " "),
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
+			expected: "virgil",
+		},
 		{
 			name:     "install with values",
 			args:     []string{"testdata/testcharts/alpine"},

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -288,7 +288,13 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		// We have a nested object. Send to t.key
 		inner := map[string]interface{}{}
 		if len(list) > i {
-			inner = list[i].(map[string]interface{})
+			var ok bool
+			inner, ok = list[i].(map[string]interface{})
+			if !ok {
+				// We have indices out of order. Initialize empty value.
+				list[i] = map[string]interface{}{}
+				inner = list[i].(map[string]interface{})
+			}
 		}
 
 		// Recurse

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -294,6 +294,30 @@ func TestParseSet(t *testing.T) {
 			str:    "nested[1][1]=1",
 			expect: map[string]interface{}{"nested": []interface{}{nil, []interface{}{nil, 1}}},
 		},
+		{
+			str: "name1.name2[0].foo=bar,name1.name2[1].foo=bar",
+			expect: map[string]interface{}{
+				"name1": map[string]interface{}{
+					"name2": []map[string]interface{}{{"foo": "bar"}, {"foo": "bar"}},
+				},
+			},
+		},
+		{
+			str: "name1.name2[1].foo=bar,name1.name2[0].foo=bar",
+			expect: map[string]interface{}{
+				"name1": map[string]interface{}{
+					"name2": []map[string]interface{}{{"foo": "bar"}, {"foo": "bar"}},
+				},
+			},
+		},
+		{
+			str: "name1.name2[1].foo=bar",
+			expect: map[string]interface{}{
+				"name1": map[string]interface{}{
+					"name2": []map[string]interface{}{nil, {"foo": "bar"}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When a user specifies value overrides for list values out of order,
strvals.listItem panics. Change strvals.listItem to handle this case by
re-initializing nil values to a new map.

Closes #4503

Co-authored-by: Cameron Childress <cameron@cchildress.org>
Co-authored-by: Kevin Collette <hal.collette@gmail.com>
Co-authored-by: Connor McKelvey <connor.mckelvey@gmail.com>
Co-authored-by: Dan Winter <dan.j.winter@gmail.com>
Signed-off-by: Dan Winter <dan.j.winter@gmail.com>