### PR TITLE
fix incorrect yaml output format of get hooks command

### DIFF
--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -75,7 +75,7 @@ func (g *getHooksCmd) run() error {
 	}
 
 	for _, hook := range res.Release.Hooks {
-		fmt.Fprintf(g.out, "---\n# %s\n%s", hook.Name, hook.Manifest)
+		fmt.Fprintf(g.out, "---\n# %s\n%s\n", hook.Name, hook.Manifest)
 	}
 	return nil
 }

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestGetHooks(t *testing.T) {
 		{
 			name:     "get hooks with release",
 			args:     []string{"aeneas"},
-			expected: helm.MockHookTemplate,
+			expected: fmt.Sprintf("---\n# %s\n%s\n", "pre-install-hook", helm.MockHookTemplate),
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"}),
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "aeneas"})},
 		},


### PR DESCRIPTION
fix(helm): fix incorrect yaml output format of get hooks command. Fixes #4624 