### PR TITLE
Update using_helm.md

### DIFF
--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -211,12 +211,12 @@ imageTag: 10.1.14-r3
 # mariadbDatabase:
 ```
 
-You can then override any of these settings in a YAML formatted file,
+You can then override any of these settings in a JSON or YAML formatted file,
 and then pass that file during installation.
 
 ```console
-$ echo '{mariadbUser: user0, mariadbDatabase: user0db}' > config.yaml
-$ helm install -f config.yaml stable/mariadb
+$ echo '{mariadbUser: user0, mariadbDatabase: user0db}' > config.json
+$ helm install -f config.json stable/mariadb
 ```
 
 The above will create a default MariaDB user with the name `user0`, and

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -215,8 +215,11 @@ You can then override any of these settings in a JSON or YAML formatted file,
 and then pass that file during installation.
 
 ```console
-$ echo '{mariadbUser: user0, mariadbDatabase: user0db}' > config.json
-$ helm install -f config.json stable/mariadb
+$ cat << EOF > config.yaml
+mariadbUser: user0
+mariadbDatabase: user0db
+EOF
+$ helm install -f config.yaml stable/mariadb
 ```
 
 The above will create a default MariaDB user with the name `user0`, and

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -1,4 +1,4 @@
-# Using Helm
+﻿# Using Helm
 
 This guide explains the basics of using Helm (and Tiller) to manage
 packages on your Kubernetes cluster. It assumes that you have already
@@ -211,7 +211,7 @@ imageTag: 10.1.14-r3
 # mariadbDatabase:
 ```
 
-You can then override any of these settings in a JSON or YAML formatted file,
+You can then override any of these settings in a YAML formatted file,
 and then pass that file during installation.
 
 ```console


### PR DESCRIPTION
In docs/using_helm.md, it says on line 214 that you can pass in a YAML formatted file, but the example commands following that sentence create JSON code but names the file with a .yml extension. For clarity, I propose saying that it will accept JSON or YAML but clarify in the code that for the example we're making a JSON file.