### PR TITLE
Fix for existing CRDs are deleted when crd-install hook is introduced

### DIFF
--- a/pkg/tiller/hooks.go
+++ b/pkg/tiller/hooks.go
@@ -174,6 +174,13 @@ func (file *manifestFile) sort(result *result) error {
 				isUnknownHook = true
 				break
 			}
+			if e == release.Hook_CRD_INSTALL {
+				result.generic = append(result.generic, Manifest{
+					Name:    file.path,
+					Content: m,
+					Head:    &entry,
+				})
+			}
 			h.Events = append(h.Events, e)
 		}
 

--- a/pkg/tiller/hooks_test.go
+++ b/pkg/tiller/hooks_test.go
@@ -133,6 +133,21 @@ metadata:
     "helm.sh/hook": test-success
 `,
 		},
+		{
+			name:  []string{"ninth"},
+			path:  "nine",
+			kind:  []string{"CustomResourceDefinition"},
+			hooks: map[string][]release.Hook_Event{"ninth": {release.Hook_CRD_INSTALL}},
+			manifest: `apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ninth
+  labels:
+    doesnot: matter
+  annotations:
+    "helm.sh/hook": crd-install
+`,
+		},
 	}
 
 	manifests := make(map[string]string, len(data))
@@ -146,22 +161,22 @@ metadata:
 	}
 
 	// This test will fail if 'six' or 'seven' was added.
-	if len(generic) != 2 {
-		t.Errorf("Expected 2 generic manifests, got %d", len(generic))
+	// changed to account for CustomResourceDefinition with crd-install hook being added to generic list of manifests
+	if len(generic) != 3 {
+		t.Errorf("Expected 3 generic manifests, got %d", len(generic))
 	}
 
-	if len(hs) != 4 {
-		t.Errorf("Expected 4 hooks, got %d", len(hs))
+	// changed to account for 5 hooks now that there is a crd-install hook added as member 9 of the data list.  It was 4 before.
+	if len(hs) != 5 {
+		t.Errorf("Expected 5 hooks, got %d", len(hs))
 	}
 
 	for _, out := range hs {
+		t.Logf("Checking name %s path %s and kind %s", out.Name, out.Path, out.Kind)
 		found := false
 		for _, expect := range data {
 			if out.Path == expect.path {
 				found = true
-				if out.Path != expect.path {
-					t.Errorf("Expected path %s, got %s", expect.path, out.Path)
-				}
 				nameFound := false
 				for _, expectedName := range expect.name {
 					if out.Name == expectedName {
@@ -209,8 +224,8 @@ metadata:
 
 			name := sh.Metadata.Name
 
-			//only keep track of non-hook manifests
-			if err == nil && s.hooks[name] == nil {
+			//only keep track of non-hook manifests, that are not CustomResourceDefinitions with crd-install
+			if err == nil && (s.hooks[name] == nil || s.hooks[name][0] == release.Hook_CRD_INSTALL) {
 				another := Manifest{
 					Content: m,
 					Name:    name,


### PR DESCRIPTION
The PR addresses https://github.com/helm/helm/issues/4704, where the crd-install helm hook in introduced into an existing helm chart on CustomResourceDefinitions manifests.  