### PR TITLE
ref(helm): rename fetch to pull

### DIFF
--- a/cmd/helm/pull.go
+++ b/cmd/helm/pull.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/helm/pkg/repo"
 )
 
-const fetchDesc = `
+const pullDesc = `
 Retrieve a package from a package repository, and download it locally.
 
 This is useful for fetching packages to inspect, modify, or repackage. It can
@@ -48,7 +48,7 @@ file, and MUST pass the verification process. Failure in any part of this will
 result in an error, and the chart will not be saved locally.
 `
 
-type fetchOptions struct {
+type pullOptions struct {
 	destdir     string // --destination
 	devel       bool   // --devel
 	untar       bool   // --untar
@@ -60,14 +60,15 @@ type fetchOptions struct {
 	chartPathOptions
 }
 
-func newFetchCmd(out io.Writer) *cobra.Command {
-	o := &fetchOptions{}
+func newPullCmd(out io.Writer) *cobra.Command {
+	o := &pullOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "fetch [chart URL | repo/chartname] [...]",
-		Short: "download a chart from a repository and (optionally) unpack it in local directory",
-		Long:  fetchDesc,
-		Args:  require.MinimumNArgs(1),
+		Use:     "pull [chart URL | repo/chartname] [...]",
+		Short:   "download a chart from a repository and (optionally) unpack it in local directory",
+		Aliases: []string{"fetch"},
+		Long:    pullDesc,
+		Args:    require.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if o.version == "" && o.devel {
 				debug("setting version to >0.0.0-0")
@@ -96,7 +97,7 @@ func newFetchCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *fetchOptions) run(out io.Writer) error {
+func (o *pullOptions) run(out io.Writer) error {
 	c := downloader.ChartDownloader{
 		HelmHome: settings.Home,
 		Out:      out,

--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/helm/pkg/repo/repotest"
 )
 
-func TestFetchCmd(t *testing.T) {
+func TestPullCmd(t *testing.T) {
 	defer resetEnv()()
 
 	hh := testHelmHome(t)

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -62,7 +62,7 @@ func newRootCmd(c helm.Interface, out io.Writer, args []string) *cobra.Command {
 		// chart commands
 		newCreateCmd(out),
 		newDependencyCmd(out),
-		newFetchCmd(out),
+		newPullCmd(out),
 		newInspectCmd(out),
 		newLintCmd(out),
 		newPackageCmd(out),

--- a/docs/chart_repository_faq.md
+++ b/docs/chart_repository_faq.md
@@ -6,9 +6,9 @@ This section tracks some of the more frequently encountered issues with using ch
 information, [file an issue](https://github.com/kubernetes/helm/issues) or
 send us a pull request.
 
-## Fetching
+## Pulling
 
-**Q: Why do I get a `unsupported protocol scheme ""` error when trying to fetch a chart from my custom repo?**
+**Q: Why do I get a `unsupported protocol scheme ""` error when trying to pull a chart from my custom repo?**
 
 A: (Helm < 2.5.0) This is likely caused by you creating your chart repo index without specifying the `--url` flag.
 Try recreating your `index.yaml` file with a command like `helm repo index --url http://my-repo/charts .`,

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -449,7 +449,7 @@ on Apache and MySQL by including those charts inside of its `charts/`
 directory.
 
 **TIP:** _To drop a dependency into your `charts/` directory, use the
-`helm fetch` command_
+`helm pull` command_
 
 ### Operational aspects of using dependencies
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -112,7 +112,7 @@ There are some strategies for working with plugin commands:
   but will not handle `helm myplugin --help`.
 
 ## Downloader Plugins
-By default, Helm is able to fetch Charts using HTTP/S. As of Helm 2.4.0, plugins
+By default, Helm is able to pull Charts using HTTP/S. As of Helm 2.4.0, plugins
 can have a special capability to download Charts from arbitrary sources.
 
 Plugins shall declare this special capability in the `plugin.yaml` file (top level):


### PR DESCRIPTION
Rename `helm fetch` to `helm pull`. This is one of a handful of renames to do during the v3 development cycle