### PR TITLE
Use apps/v1 as deployment apiVersion

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -161,7 +161,7 @@ spec:
 {{- end }}
 `
 
-const defaultDeployment = `apiVersion: apps/v1beta2
+const defaultDeployment = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "<CHARTNAME>.fullname" . }}


### PR DESCRIPTION
feat(helm): use apps/v1 as deployment apiVersion

Use 'apps/v1' as the apiVersion field for the deployment.yaml written
by the 'helm create' command, rather than the deprecated 'apps/v1beta2'. Fixes #4708 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>