### PR TITLE
Return empty string instead of nil when linting on required

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -159,7 +159,7 @@ func (e *Engine) alterFuncMap(t *template.Template, referenceTpls map[string]ren
 			if e.LintMode {
 				// Don't fail on missing required values when linting
 				log.Printf("[INFO] Missing required value: %s", warn)
-				return val, nil
+				return "", nil
 			}
 			// Convert nil to "" in case required is piped into other functions
 			return "", fmt.Errorf(warn)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -161,7 +161,8 @@ func (e *Engine) alterFuncMap(t *template.Template, referenceTpls map[string]ren
 				log.Printf("[INFO] Missing required value: %s", warn)
 				return val, nil
 			}
-			return val, fmt.Errorf(warn)
+			// Convert nil to "" in case required is piped into other functions
+			return "", fmt.Errorf(warn)
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -466,12 +466,37 @@ func TestAlterFuncMap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	expectStr := "All your base are belong to us"
 	if gotStr := outReq["conan/templates/quote"]; gotStr != expectStr {
 		t.Errorf("Expected %q, got %q (%v)", expectStr, gotStr, outReq)
 	}
 	expectNum := "All 2 of them!"
+	if gotNum := outReq["conan/templates/bases"]; gotNum != expectNum {
+		t.Errorf("Expected %q, got %q (%v)", expectNum, gotNum, outReq)
+	}
+
+	// test required without passing in needed values with lint mode on
+	// verifies lint replaces required with an empty string (should not fail)
+	lintValues := chartutil.Values{
+		"Values": chartutil.Values{
+			"who": "us",
+		},
+		"Chart": reqChart.Metadata,
+		"Release": chartutil.Values{
+			"Name": "That 90s meme",
+		},
+	}
+	e := New()
+	e.LintMode = true
+	outReq, err = e.Render(reqChart, lintValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectStr = "All your base are belong to us"
+	if gotStr := outReq["conan/templates/quote"]; gotStr != expectStr {
+		t.Errorf("Expected %q, got %q (%v)", expectStr, gotStr, outReq)
+	}
+	expectNum = "All  of them!"
 	if gotNum := outReq["conan/templates/bases"]; gotNum != expectNum {
 		t.Errorf("Expected %q, got %q (%v)", expectNum, gotNum, outReq)
 	}


### PR DESCRIPTION
This allows lint to work in scenarios when required is used in secrets or it's output is passed to another function.

Due to lint mode no longer failing on missing value in required it is passing nil through which not all functions can accept.

Fixes #4747