### PR TITLE
docs(install): use classic argument for snap installation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,7 @@ The Snap package for Helm is maintained by
 [Snapcrafters](https://github.com/snapcrafters/helm).
 
 ```
-$ sudo snap install helm
+$ sudo snap install helm --classic
 ```
 
 ### From Homebrew (macOS)


### PR DESCRIPTION
Otherwise this error message will pop up on ubuntu 18.04 LTS

```txt
error: This revision of snap "helm" was published using classic confinement and thus may perform
       arbitrary system changes outside of the security sandbox that snaps are usually confined to,
       which may put your system at risk.

       If you understand and want to proceed repeat the command including --classic.
```