### PR TITLE
Fix Slack channel references

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The [Helm roadmap uses Github milestones](https://github.com/helm/helm/milestone
 
 You can reach the Helm community and developers via the following channels:
 
-- [Kubernetes Slack](http://slack.k8s.io):
+- [Kubernetes Slack](https://kubernetes.slack.com):
   - [#helm-users](https://kubernetes.slack.com/messages/helm-users)
   - [#helm-dev](https://kubernetes.slack.com/messages/helm-dev)
   - [#charts](https://kubernetes.slack.com/messages/charts)

--- a/docs/chart_template_guide/wrapping_up.md
+++ b/docs/chart_template_guide/wrapping_up.md
@@ -13,8 +13,10 @@ But there are many things this guide has not covered when it comes to the practi
 - The [Go template docs](https://godoc.org/text/template) explain the template syntax in detail.
 - The [Schelm tool](https://github.com/databus23/schelm) is a nice helper utility for debugging charts.
 
-Sometimes it's easier to ask a few questions and get answers from experienced developers. The best place to do that is in the Kubernetes `#Helm` Slack channel:
+Sometimes it's easier to ask a few questions and get answers from experienced developers. The best place to do this is in the [Kubernetes Slack](https://kubernetes.slack.com) Helm channels:
 
-- [Kubernetes Slack](https://slack.k8s.io/): `#helm`
+- [#helm-users](https://kubernetes.slack.com/messages/helm-users)
+- [#helm-dev](https://kubernetes.slack.com/messages/helm-dev)
+- [#charts](https://kubernetes.slack.com/messages/charts)
 
 Finally, if you find errors or omissions in this document, want to suggest some new content, or would like to contribute, visit [The Helm Project](https://github.com/helm/helm).

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -220,7 +220,7 @@ Helm vX.Y.Z is a feature release. This release, we focused on <insert focal poin
 
 The community keeps growing, and we'd love to see you there!
 
-- Join the discussion in [Kubernetes Slack](https://slack.k8s.io/):
+- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
   - `#helm-users` for questions and just to hang out
   - `#helm-dev` for discussing PRs, code, and bugs
 - Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)


### PR DESCRIPTION
Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>