### PR TITLE
Document the _proto directory

### DIFF
--- a/_proto/README.md
+++ b/_proto/README.md
@@ -1,0 +1,10 @@
+Protobuf3 type declarations for the Helm API
+--------------------------------------------
+
+Packages
+
+ - `hapi.chart` Complete serialization of Heml charts
+ - `hapi.release` Information about installed charts (Releases) such as metadata about when they were installed, their status, and how they were configured.
+ - `hapi.services.rudder` Definition for the ReleaseModuleService used by Tiller to manipulate releases on a given node
+ - `hapi.services.tiller` Definition of the ReleaseService provoded by Tiller and used by Helm clients to manipulate releases cluster wide.
+ - `hapi.version` Version meta-data used by tiller to express it's version


### PR DESCRIPTION
I'm only guessing on the use of the rudder service definition. I tried googling to no avail and neither https://github.com/timthelion/helm/blob/master/_proto/hapi/rudder/rudder.proto nor https://github.com/helm/helm/blob/master/cmd/rudder/rudder.go explain it.