### PR TITLE
Remove redundant nil checks

### DIFF
--- a/pkg/chartutil/files.go
+++ b/pkg/chartutil/files.go
@@ -36,10 +36,8 @@ type Files map[string][]byte
 // Given an []*any.Any (the format for files in a chart.Chart), extract a map of files.
 func NewFiles(from []*any.Any) Files {
 	files := map[string][]byte{}
-	if from != nil {
-		for _, f := range from {
-			files[f.TypeUrl] = f.Value
-		}
+	for _, f := range from {
+		files[f.TypeUrl] = f.Value
 	}
 	return files
 }


### PR DESCRIPTION
The nil check before the range loop is redundant

Signed-off-by: Rijnard van Tonder <hi.teresy@gmail.com>