### PR TITLE
fix(helm): cmd/helm/helm.go portForward Connection does not use tillerTunnel value

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -186,13 +186,13 @@ func setupConnection() error {
 			return err
 		}
 
-		tunnel, err := portforwarder.New(settings.TillerNamespace, client, config)
+		tillerTunnel, err = portforwarder.New(settings.TillerNamespace, client, config)
 		if err != nil {
 			return err
 		}
 
-		settings.TillerHost = fmt.Sprintf("127.0.0.1:%d", tunnel.Local)
-		debug("Created tunnel using local port: '%d'\n", tunnel.Local)
+		settings.TillerHost = fmt.Sprintf("127.0.0.1:%d", tillerTunnel.Local)
+		debug("Created tunnel using local port: '%d'\n", tillerTunnel.Local)
 	}
 
 	// Set up the gRPC config.


### PR DESCRIPTION
portforwarder tunnel does not use global values "tillerTunnel" 
https://github.com/helm/helm/blob/9579f3b87d25c916ce597cdebbd912ee3df9e553/cmd/helm/helm.go#L43