### PR TITLE
[WIP] (feat)helm: External plugins

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -25,7 +25,6 @@ import (
 
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
-
 	"k8s.io/helm/internal/test"
 	"k8s.io/helm/pkg/hapi/release"
 	"k8s.io/helm/pkg/helm"

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
 	"k8s.io/helm/pkg/plugin"
 )
 
@@ -41,8 +40,9 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 		return
 	}
 
+	pluginsDirs := []string{settings.PluginDirs(), settings.SystemPluginsDir}
 	// debug("HELM_PLUGIN_DIRS=%s", settings.PluginDirs())
-	found, err := findPlugins(settings.PluginDirs())
+	found, err := findPlugins(pluginsDirs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load plugins: %s", err)
 		return
@@ -137,15 +137,17 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 }
 
 // findPlugins returns a list of YAML files that describe plugins.
-func findPlugins(plugdirs string) ([]*plugin.Plugin, error) {
+func findPlugins(plugdirs []string) ([]*plugin.Plugin, error) {
 	found := []*plugin.Plugin{}
 	// Let's get all UNIXy and allow path separators
-	for _, p := range filepath.SplitList(plugdirs) {
-		matches, err := plugin.LoadAll(p)
-		if err != nil {
-			return matches, err
+	for _, pd := range plugdirs {
+		for _, p := range filepath.SplitList(pd) {
+			matches, err := plugin.LoadAll(p)
+			if err != nil {
+				return matches, err
+			}
+			found = append(found, matches...)
 		}
-		found = append(found, matches...)
 	}
 	return found, nil
 }

--- a/cmd/helm/plugin_list.go
+++ b/cmd/helm/plugin_list.go
@@ -19,10 +19,9 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/helm/pkg/helm/helmpath"
-
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
+	"k8s.io/helm/pkg/helm/helmpath"
 )
 
 type pluginListOptions struct {
@@ -44,7 +43,8 @@ func newPluginListCmd(out io.Writer) *cobra.Command {
 
 func (o *pluginListOptions) run(out io.Writer) error {
 	debug("pluginDirs: %s", settings.PluginDirs())
-	plugins, err := findPlugins(settings.PluginDirs())
+	directories := []string{settings.PluginDirs(), settings.SystemPluginsDir}
+	plugins, err := findPlugins(directories)
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/plugin_remove.go
+++ b/cmd/helm/plugin_remove.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/plugin"
 )
@@ -59,7 +58,7 @@ func (o *pluginRemoveOptions) complete(args []string) error {
 
 func (o *pluginRemoveOptions) run(out io.Writer) error {
 	debug("loading installed plugins from %s", settings.PluginDirs())
-	plugins, err := findPlugins(settings.PluginDirs())
+	plugins, err := findPlugins([]string{settings.PluginDirs()})
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -23,10 +23,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/plugin"
-
-	"github.com/spf13/cobra"
 )
 
 func TestManuallyProcessArgs(t *testing.T) {
@@ -65,6 +64,7 @@ func TestLoadPlugins(t *testing.T) {
 	defer resetEnv()()
 
 	settings.Home = "testdata/helmhome"
+	settings.SystemPluginsDir = "test"
 
 	os.Setenv("HELM_HOME", settings.Home.String())
 	hh := settings.Home

--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/plugin"
 	"k8s.io/helm/pkg/plugin/installer"
@@ -61,7 +60,7 @@ func (o *pluginUpdateOptions) complete(args []string) error {
 func (o *pluginUpdateOptions) run(out io.Writer) error {
 	installer.Debug = settings.Debug
 	debug("loading installed plugins from %s", settings.PluginDirs())
-	plugins, err := findPlugins(settings.PluginDirs())
+	plugins, err := findPlugins([]string{settings.PluginDirs()})
 	if err != nil {
 		return err
 	}

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -30,7 +30,8 @@ import (
 // collectPlugins scans for getter plugins.
 // This will load plugins according to the environment.
 func collectPlugins(settings environment.EnvSettings) (Providers, error) {
-	plugins, err := plugin.FindPlugins(settings.PluginDirs())
+	pluginsDirs := []string{settings.PluginDirs(), settings.SystemPluginsDir}
+	plugins, err := plugin.FindPlugins(pluginsDirs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/environment/environment.go
+++ b/pkg/helm/environment/environment.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
-
 	"k8s.io/helm/pkg/helm/helmpath"
 )
 
@@ -47,6 +46,8 @@ type EnvSettings struct {
 	KubeContext string
 	// Debug indicates whether or not Helm is running in Debug mode.
 	Debug bool
+	// SystemPluginsDir system dir plugin
+	SystemPluginsDir string
 }
 
 // AddFlags binds flags to the given flagset.
@@ -55,6 +56,7 @@ func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.Namespace, "namespace", "n", "", "namespace scope for this request")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", "", "path to the kubeconfig file")
 	fs.StringVar(&s.KubeContext, "kube-context", "", "name of the kubeconfig context to use")
+	fs.StringVar(&s.SystemPluginsDir, "system-plugins-dir", "/usr/share", "path system plugins configfiles")
 	fs.BoolVar(&s.Debug, "debug", false, "enable verbose output")
 }
 

--- a/pkg/helm/environment/environment_test.go
+++ b/pkg/helm/environment/environment_test.go
@@ -18,12 +18,12 @@ package environment
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
-	"k8s.io/helm/pkg/helm/helmpath"
-
 	"github.com/spf13/pflag"
+	"k8s.io/helm/pkg/helm/helmpath"
 )
 
 func TestEnvSettings(t *testing.T) {
@@ -90,7 +90,7 @@ func TestEnvSettings(t *testing.T) {
 			if settings.Home != helmpath.Home(tt.home) {
 				t.Errorf("expected home %q, got %q", tt.home, settings.Home)
 			}
-			if settings.PluginDirs() != tt.plugins {
+			if !reflect.DeepEqual(settings.PluginDirs(), tt.plugins) {
 				t.Errorf("expected plugins %q, got %q", tt.plugins, settings.PluginDirs())
 			}
 			if settings.Debug != tt.debug {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,9 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	helm_env "k8s.io/helm/pkg/helm/environment"
-
 	"github.com/ghodss/yaml"
+	helm_env "k8s.io/helm/pkg/helm/environment"
 )
 
 const pluginFileName = "plugin.yaml"
@@ -148,15 +147,17 @@ func LoadAll(basedir string) ([]*Plugin, error) {
 }
 
 // FindPlugins returns a list of YAML files that describe plugins.
-func FindPlugins(plugdirs string) ([]*Plugin, error) {
+func FindPlugins(plugdirs []string) ([]*Plugin, error) {
 	found := []*Plugin{}
 	// Let's get all UNIXy and allow path separators
-	for _, p := range filepath.SplitList(plugdirs) {
-		matches, err := LoadAll(p)
-		if err != nil {
-			return matches, err
+	for _, pd := range plugdirs {
+		for _, p := range filepath.SplitList(pd) {
+			matches, err := LoadAll(p)
+			if err != nil {
+				return matches, err
+			}
+			found = append(found, matches...)
 		}
-		found = append(found, matches...)
 	}
 	return found, nil
 }


### PR DESCRIPTION
# Helm External Plugins

## Description
Helm external plugins can live anywhere in your `PATH`.

These plugins become necessary because of systems that are closed to manual
configuration and the only way to get software installed is by an administrator
managing the plugins at system level via a linux distribution package manager.

These plugins are going to be available globally. All users may use the plugin,
not limited to a user like Native Plugins.

The only condition for these plugins is that they provide the yaml description
in the folder `/usr/share`; and the full path should look like this
`/usr/share/<helm-external-plugin>/plugin.yaml`.

## Example

```console
/usr/
  |- bin/
    |- helm-mirror
  |- share/
      |- helm-mirror
        |- plugin.yaml
```

### plugin.yaml for External Plugins

```
name: "mirror"
version: "0.1.0"
usage: "Mirrors Helm charts to a local folder"
description: "Mirrors Helm charts to a local folder"
ignoreFlags: false
useTunnel: false
command: "/usr/bin/helm-mirror"
```


## Concerns
This is a WIP, I have a concern about the location of the `yaml` configuration files, I went this way to have it working with the current process almost seamlessly, but we can think on something more organized like having all external plugins configuration `yaml` in the same folder `/usr/share/helm` and have the yaml named after the plugin. e.g. `/usr/share/helm/helm-mirror.yaml`

