### PR TITLE
fix(helm): Merge nested values correctly on upgrade

### DIFF
--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -94,6 +94,22 @@ func (v Values) Encode(w io.Writer) error {
 	return err
 }
 
+// MergeInto takes the properties in src and merges them into Values. Maps
+// are merged while values and arrays are replaced.
+func (v Values) MergeInto(src Values) {
+	for key, srcVal := range src {
+		destVal, found := v[key]
+
+		if found && istable(srcVal) && istable(destVal) {
+			destMap := destVal.(map[string]interface{})
+			srcMap := srcVal.(map[string]interface{})
+			Values(destMap).MergeInto(Values(srcMap))
+		} else {
+			v[key] = srcVal
+		}
+	}
+}
+
 func tableLookup(v Values, simple string) (Values, error) {
 	v2, ok := v[simple]
 	if !ok {


### PR DESCRIPTION
Upgrading a release and override existing values doesn't work as expected for nested values. Maps should be merged recursively, but currently maps are treated just like values and replaced at the top level. 

If the existing values are:
```yaml
resources:
  requests:
    cpu: 400m
  something: else
```
and an update is done with ```--set=resources.requests.cpu=500m```, it currently ends up as
```yaml
resources:
  requests:
    cpu: 500m
```
but it should have been
```yaml
resources:
  requests:
    cpu: 500m
  something: else
```

This PR updates the way override values are merged into the existing set of values to merge rather than replace maps.

Closes: #4792

Signed-off-by: Morten Torkildsen <mortent@google.com>