### PR TITLE
fix(helm): Use line breaks consistently in status output

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -213,8 +213,13 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 	// track of tab widths.
 	buf := new(bytes.Buffer)
 	p, _ := get.NewHumanPrintFlags().ToPrinter("")
+	index := 0
 	for t, ot := range objs {
-		if _, err = buf.WriteString("==> " + t + "\n"); err != nil {
+		kindHeader := fmt.Sprintf("==> %s", t)
+		if index == 0 {
+			kindHeader = kindHeader + "\n"
+		}
+		if _, err = buf.WriteString(kindHeader); err != nil {
 			return "", err
 		}
 		for _, o := range ot {
@@ -226,6 +231,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 		if _, err := buf.WriteString("\n"); err != nil {
 			return "", err
 		}
+		index += 1
 	}
 	if len(missing) > 0 {
 		buf.WriteString(MissingGetHeader)


### PR DESCRIPTION
The output from helm status does not have consistent use of line breaks.
For some resources there is a line break after the kind header, for
others there is not. This is caused by how the printer handles column
headers. This removes a line break for all but the first resource listed.

Signed-off-by: Morten Torkildsen <mortent@google.com>