### PR TITLE
Missing the batch permission in one of the example

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -142,7 +142,7 @@ metadata:
   name: tiller-manager
   namespace: myorg-users
 rules:
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "batch", "extensions", "apps"]
   resources: ["*"]
   verbs: ["*"]
 ```


### PR DESCRIPTION
Small change, but without it:
```
Error: release <some release name> failed: cronjobs.batch is forbidden: User "system:serviceaccount:default:tiller" cannot create cronjobs.batch in the namespace "default"
```