### PR TITLE
Remove executable bits from chartutil generated files

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -49,7 +49,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save values.yaml
 	if c.Values != nil && len(c.Values.Raw) > 0 {
 		vf := filepath.Join(outdir, ValuesfileName)
-		if err := ioutil.WriteFile(vf, []byte(c.Values.Raw), 0755); err != nil {
+		if err := ioutil.WriteFile(vf, []byte(c.Values.Raw), 0644); err != nil {
 			return err
 		}
 	}
@@ -63,7 +63,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(outdir, f.Name)
-		if err := ioutil.WriteFile(n, f.Data, 0755); err != nil {
+		if err := ioutil.WriteFile(n, f.Data, 0644); err != nil {
 			return err
 		}
 	}
@@ -77,7 +77,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(n, f.Value, 0755); err != nil {
+		if err := ioutil.WriteFile(n, f.Value, 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Files generated in the `SaveDir` function of `chartutil` currently have the executable bit set. This PR changes the file permissions from `0755` to `0644`.