### PR TITLE
Remove newline at the start of zsh completion file

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -81,8 +81,7 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 }
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
-	zshInitialization := `
-#compdef helm
+	zshInitialization := `#compdef helm
 
 __helm_bash_source() {
 	alias shopt=':'


### PR DESCRIPTION
Because of this initial newline, zsh isn't parsing the file as a completion file.