### PR TITLE
test(tiller): cover crash fixed by #4630

### DIFF
--- a/pkg/tiller/release_update_test.go
+++ b/pkg/tiller/release_update_test.go
@@ -520,6 +520,30 @@ func TestUpdateReleaseCustomDescription_Force(t *testing.T) {
 	compareStoredAndReturnedRelease(t, *rs, *res)
 }
 
+func TestUpdateReleasePendingInstall_Force(t *testing.T) {
+	c := helm.NewContext()
+	rs := rsFixture()
+	rel := namedReleaseStub("forceful-luke", release.Status_PENDING_INSTALL)
+	rs.env.Releases.Create(rel)
+
+	req := &services.UpdateReleaseRequest{
+		Name:  rel.Name,
+		Chart: rel.GetChart(),
+		Force: true,
+	}
+
+	_, err := rs.UpdateRelease(c, req)
+	if err == nil {
+		t.Error("Expected failed update")
+	}
+
+	expectedError := "a released named forceful-luke is in use, cannot re-use a name that is still in use"
+	got := err.Error()
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got %q", expectedError, got)
+	}
+}
+
 func compareStoredAndReturnedRelease(t *testing.T, rs ReleaseServer, res services.UpdateReleaseResponse) *release.Release {
 	storedRelease, err := rs.env.Releases.Get(res.Release.Name, res.Release.Version)
 	if err != nil {


### PR DESCRIPTION
While investigating a tiller crash on v2.10.0 (see recent comments in #3125), I pulled down the code
and wrote a test replicating the crash I was experiencing. I then realized that the crash had been fixed, and was able to locate the fix in #4630 after running a quck bisect.

Since there don't appear to be any tests that cover this crash, and I had written one myself, I figured I might as well put up a PR for it.

Here's what the test failure on v2.10.0 looks like:
```
-- FAIL: TestUpdateReleasePendingInstall_Force (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1d128d8]

goroutine 235 [running]:
testing.tRunner.func1(0xc420493c20)
        /usr/local/Cellar/go/1.10/libexec/src/testing/testing.go:742 +0x29d
panic(0x1eb8d80, 0x2a12db0)
        /usr/local/Cellar/go/1.10/libexec/src/runtime/panic.go:505 +0x229
k8s.io/helm/pkg/tiller.(*ReleaseServer).performUpdateForce(0xc4208210b0, 0xc4202c6dc0, 0x0, 0x0, 0x2174220)
        /Users/mattrasmus/go/src/k8s.io/helm/pkg/tiller/release_update.go:166 +0x188
k8s.io/helm/pkg/tiller.(*ReleaseServer).UpdateRelease(0xc4208210b0, 0x2191780, 0xc420820f30, 0xc4202c6dc0, 0x29aeb90, 0x38, 0x2d2)
        /Users/mattrasmus/go/src/k8s.io/helm/pkg/tiller/release_update.go:43 +0x245
k8s.io/helm/pkg/tiller.TestUpdateReleasePendingInstall_Force(0xc420493c20)
        /Users/mattrasmus/go/src/k8s.io/helm/pkg/tiller/release_update_test.go:549 +0x120
testing.tRunner(0xc420493c20, 0x20e5c70)
        /usr/local/Cellar/go/1.10/libexec/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
        /usr/local/Cellar/go/1.10/libexec/src/testing/testing.go:824 +0x2e0
FAIL    k8s.io/helm/pkg/tiller  0.118s
```

Signed-off-by: Matt Rasmus <mrasmus@betterworks.com>