### PR TITLE
ref: require name by default on 'helm install'

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -562,14 +562,6 @@
   revision = "e3a8ff8ce36581f87a15341206f205b1da467059"
 
 [[projects]]
-  branch = "master"
-  digest = "1:9123998e9b4a6ed0fcf9cae137a6cd9e265a5d18823e34d1cd12e9d9845b2719"
-  name = "github.com/technosophos/moniker"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "ab470f5e105a44d0c87ea21bacd6a335c4816d83"
-
-[[projects]]
   digest = "1:9601e4354239b69f62c86d24c74a19d7c7e3c7f7d2d9f01d42e5830b4673e121"
   name = "golang.org/x/crypto"
   packages = [
@@ -1174,7 +1166,6 @@
     "github.com/spf13/cobra/doc",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
-    "github.com/technosophos/moniker",
     "golang.org/x/crypto/openpgp",
     "golang.org/x/crypto/openpgp/clearsign",
     "golang.org/x/crypto/openpgp/errors",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,10 +28,6 @@
   branch = "master"
 
 [[constraint]]
-  name = "github.com/technosophos/moniker"
-  branch = "master"
-
-[[constraint]]
   name = "k8s.io/api"
   branch = "release-1.12"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINDIR     := $(CURDIR)/bin
 DIST_DIRS  := find * -type d -exec
 TARGETS    := darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64
+BINNAME    ?= helm
 
 # go option
 GO         ?= go
@@ -41,12 +42,12 @@ all: build
 
 .PHONY: build
 build:
-	$(GO) build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BINDIR)/helm k8s.io/helm/cmd/helm
+	$(GO) build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(BINNAME) k8s.io/helm/cmd/helm
 
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
-	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
+	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
 
 .PHONY: dist
 dist:

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -27,37 +27,37 @@ func TestInstall(t *testing.T) {
 		// Install, base case
 		{
 			name:   "basic install",
-			cmd:    "install testdata/testcharts/alpine --name aeneas",
+			cmd:    "install aeneas testdata/testcharts/alpine ",
 			golden: "output/install.txt",
 		},
 		// Install, no hooks
 		{
 			name:   "install without hooks",
-			cmd:    "install testdata/testcharts/alpine --name aeneas --no-hooks",
+			cmd:    "install aeneas testdata/testcharts/alpine --no-hooks",
 			golden: "output/install-no-hooks.txt",
 		},
 		// Install, values from cli
 		{
 			name:   "install with values",
-			cmd:    "install testdata/testcharts/alpine --name virgil --set foo=bar",
+			cmd:    "install virgil testdata/testcharts/alpine --set foo=bar",
 			golden: "output/install-with-values.txt",
 		},
 		// Install, values from cli via multiple --set
 		{
 			name:   "install with multiple values",
-			cmd:    "install testdata/testcharts/alpine --name virgil --set foo=bar --set bar=foo",
+			cmd:    "install virgil testdata/testcharts/alpine --set foo=bar --set bar=foo",
 			golden: "output/install-with-multiple-values.txt",
 		},
 		// Install, values from yaml
 		{
 			name:   "install with values file",
-			cmd:    "install testdata/testcharts/alpine --name virgil -f testdata/testcharts/alpine/extra_values.yaml",
+			cmd:    "install virgil testdata/testcharts/alpine  -f testdata/testcharts/alpine/extra_values.yaml",
 			golden: "output/install-with-values-file.txt",
 		},
 		// Install, values from multiple yaml
 		{
 			name:   "install with values",
-			cmd:    "install testdata/testcharts/alpine --name virgil -f testdata/testcharts/alpine/extra_values.yaml -f testdata/testcharts/alpine/more_values.yaml",
+			cmd:    "install virgil testdata/testcharts/alpine -f testdata/testcharts/alpine/extra_values.yaml -f testdata/testcharts/alpine/more_values.yaml",
 			golden: "output/install-with-multiple-values-files.txt",
 		},
 		// Install, no charts
@@ -70,19 +70,19 @@ func TestInstall(t *testing.T) {
 		// Install, re-use name
 		{
 			name:   "install and replace release",
-			cmd:    "install testdata/testcharts/alpine --name aeneas --replace",
+			cmd:    "install aeneas testdata/testcharts/alpine --replace",
 			golden: "output/install-and-replace.txt",
 		},
 		// Install, with timeout
 		{
 			name:   "install with a timeout",
-			cmd:    "install testdata/testcharts/alpine --name foobar --timeout 120",
+			cmd:    "install foobar testdata/testcharts/alpine --timeout 120",
 			golden: "output/install-with-timeout.txt",
 		},
 		// Install, with wait
 		{
 			name:   "install with a wait",
-			cmd:    "install testdata/testcharts/alpine --name apollo --wait",
+			cmd:    "install apollo testdata/testcharts/alpine --wait",
 			golden: "output/install-with-wait.txt",
 		},
 		// Install, using the name-template
@@ -94,28 +94,28 @@ func TestInstall(t *testing.T) {
 		// Install, perform chart verification along the way.
 		{
 			name:      "install with verification, missing provenance",
-			cmd:       "install testdata/testcharts/compressedchart-0.1.0.tgz --verify --keyring testdata/helm-test-key.pub",
+			cmd:       "install bogus testdata/testcharts/compressedchart-0.1.0.tgz --verify --keyring testdata/helm-test-key.pub",
 			wantError: true,
 		},
 		{
 			name:      "install with verification, directory instead of file",
-			cmd:       "install testdata/testcharts/signtest --verify --keyring testdata/helm-test-key.pub",
+			cmd:       "install bogus testdata/testcharts/signtest --verify --keyring testdata/helm-test-key.pub",
 			wantError: true,
 		},
 		{
 			name: "install with verification, valid",
-			cmd:  "install testdata/testcharts/signtest-0.1.0.tgz --verify --keyring testdata/helm-test-key.pub",
+			cmd:  "install signtest testdata/testcharts/signtest-0.1.0.tgz --verify --keyring testdata/helm-test-key.pub",
 		},
 		// Install, chart with missing dependencies in /charts
 		{
 			name:      "install chart with missing dependencies",
-			cmd:       "install testdata/testcharts/chart-missing-deps",
+			cmd:       "install nodeps testdata/testcharts/chart-missing-deps",
 			wantError: true,
 		},
 		// Install, chart with bad dependencies in Chart.yaml in /charts
 		{
 			name:      "install chart with bad  dependencies in Chart.yaml",
-			cmd:       "install testdata/testcharts/chart-bad-requirements",
+			cmd:       "install badreq testdata/testcharts/chart-bad-requirements",
 			wantError: true,
 		},
 	}
@@ -165,7 +165,7 @@ func TestNameTemplate(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		n, err := generateName(tc.tpl)
+		n, err := templateName(tc.tpl)
 		if err != nil {
 			if tc.expectedErrorStr == "" {
 				t.Errorf("Was not expecting error, but got: %v", err)

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -146,7 +146,7 @@ func (o *templateOptions) run(out io.Writer) error {
 
 	// If template is specified, try to run the template.
 	if o.nameTemplate != "" {
-		o.releaseName, err = generateName(o.nameTemplate)
+		o.releaseName, err = templateName(o.nameTemplate)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/testdata/output/install-no-args.txt
+++ b/cmd/helm/testdata/output/install-no-args.txt
@@ -1,3 +1,3 @@
-Error: "helm install" requires 1 argument
+Error: "helm install" requires at least 1 argument
 
-Usage:  helm install [CHART] [flags]
+Usage:  helm install [NAME] [CHART] [flags]

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -334,8 +334,8 @@ func TestUniqName(t *testing.T) {
 		reuse  bool
 		err    bool
 	}{
+		{"", "", false, true}, // Blank name is illegal
 		{"first", "first", false, false},
-		{"", "[a-z]+-[a-z]+", false, false},
 		{"angry-panda", "", false, true},
 		{"happy-panda", "", false, true},
 		{"happy-panda", "happy-panda", true, false},

--- a/pkg/tiller/release_update_test.go
+++ b/pkg/tiller/release_update_test.go
@@ -130,6 +130,7 @@ func TestUpdateRelease_ComplexReuseValues(t *testing.T) {
 	rs := rsFixture(t)
 
 	installReq := &hapi.InstallReleaseRequest{
+		Name:      "complex-reuse-values",
 		Namespace: "spaced",
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{Name: "hello"},


### PR DESCRIPTION
This is described in the official Helm 3 proposal: https://github.com/helm/community/blob/master/helm-v3/000-helm-v3.md

The new version of `helm install` is now:

```
$ helm install NAME CHART
```

Moniker (a.k.a. "the cute namer") is gone 😢 🐼 , and the default naming scheme for `--generate-name` is now `basename(CHART)-unix_timestamp()`