### PR TITLE
fix snap install command in install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,7 @@ The Snap package for Helm is maintained by
 [Snapcrafters](https://github.com/snapcrafters/helm).
 
 ```
-$ sudo snap install helm
+$ sudo snap install helm --classic
 ```
 
 ### From Homebrew (macOS)


### PR DESCRIPTION
helm was published using classic confinement and so requires a `--classic` switch to enable installation.  Otherwise it will generate an error instructing the user to use classic mode.