### PR TITLE
Fix incorrect flow example and improve operator documentation

### DIFF
--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -53,7 +53,7 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{ if and (.Values.favorite.drink) (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
+  {{ if and .Values.favorite.drink (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
 ```
 
 Note that `.Values.favorite.drink` must be defined or else it will throw an error when comparing it to "coffee". Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:

--- a/docs/chart_template_guide/functions_and_pipelines.md
+++ b/docs/chart_template_guide/functions_and_pipelines.md
@@ -150,6 +150,16 @@ Template functions and pipelines are a powerful way to transform information and
 
 ## Operators are functions
 
-For templates, the operators (`eq`, `ne`, `lt`, `gt`, `and`, `or` and so on) are all implemented as functions. In pipelines, operations can be grouped with parentheses (`(`, and `)`).
+Operators are implemented as functions that return a boolean value. To use `eq`, `ne`, `lt`, `gt`, `and`, `or`, `not` etcetera place the operator at the front of the statement followed by its parameters just as you would a function. To chain multiple operations together, separate individual functions by surrounding them with paranthesis.
+
+```yaml
+{{ if and .Values.fooString (eq .Values.fooString "foo") }}
+    #Include this when the variable .Values.fooString exists and is set to "foo"
+{{ end }}
+
+{{ if or .Values.unsetVariable (not .Values.setVariable) }}
+    #do not include this because unset variables evaluate to false and .Values.setVariable was negated with the not function.
+{{ end }}
+```
 
 Now we can turn from functions and pipelines to flow control with conditions, loops, and scope modifiers.

--- a/docs/chart_template_guide/functions_and_pipelines.md
+++ b/docs/chart_template_guide/functions_and_pipelines.md
@@ -153,12 +153,15 @@ Template functions and pipelines are a powerful way to transform information and
 Operators are implemented as functions that return a boolean value. To use `eq`, `ne`, `lt`, `gt`, `and`, `or`, `not` etcetera place the operator at the front of the statement followed by its parameters just as you would a function. To chain multiple operations together, separate individual functions by surrounding them with paranthesis.
 
 ```yaml
+{{/* include the body of this if statement when the variable .Values.fooString exists and is set to "foo" */}}
 {{ if and .Values.fooString (eq .Values.fooString "foo") }}
-    #Include this when the variable .Values.fooString exists and is set to "foo"
+    {{ ... }}
 {{ end }}
 
-{{ if or .Values.unsetVariable (not .Values.setVariable) }}
-    #do not include this because unset variables evaluate to false and .Values.setVariable was negated with the not function.
+
+{{/* do not include the body of this if statement because unset variables evaluate to false and .Values.setVariable was negated with the not function. */}}
+{{ if or .Values.anUnsetVariable (not .Values.aSetVariable) }}
+   {{ ... }}
 {{ end }}
 ```
 


### PR DESCRIPTION
The syntax demonstrated in the present documentation is incorrect

values.yaml
```
stringVar: "foo"
boolVar: true
#unsetVar: "unset"
setVar: "set"
```
templates/test.yaml
```
{{ if (.Values.setVar) and eq .Values.setVar "set" }}
#infixing 'and', this should be included 
{{- end}}
 
{{- if (.Values.setVar) and false }}
#infixing 'and', this should NOT be included
{{- end}}
 
{{- if and .Values.setVar (eq .Values.setVar "set") }}
#prefixing 'and', this should be included
{{- end}}
 
{{- if and .Values.setVar (eq .Values.setVar "garbage") }}
#prefixing 'and', this should NOT be included
{{- end}}
```

results:
``` 
$ helm template ./test                                                                                                                                                                     
---
#infixing 'and', this should be included
#infixing 'and', this should NOT be included
#prefixing 'and', this should be included
```

Signed-off-by: Alex <login@sneaksneak.org>