### PR TITLE
fix(helm): Fix line breaks when printing custom resources

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -211,18 +211,15 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 	// an object type changes, so we can just rely on that. Problem is it doesn't seem to keep
 	// track of tab widths.
 	buf := new(bytes.Buffer)
-	p, _ := get.NewHumanPrintFlags().ToPrinter("")
-	index := 0
+	printFlags := get.NewHumanPrintFlags()
 	for t, ot := range objs {
-		kindHeader := fmt.Sprintf("==> %s", t)
-		if index == 0 {
-			kindHeader = kindHeader + "\n"
-		}
+		kindHeader := fmt.Sprintf("==> %s\n", t)
 		if _, err = buf.WriteString(kindHeader); err != nil {
 			return "", err
 		}
+		typePrinter, _ := printFlags.ToPrinter("")
 		for _, o := range ot {
-			if err := p.PrintObj(o, buf); err != nil {
+			if err := typePrinter.PrintObj(o, buf); err != nil {
 				c.Log("failed to print object type %s, object: %q :\n %v", t, o, err)
 				return "", err
 			}
@@ -230,7 +227,6 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 		if _, err := buf.WriteString("\n"); err != nil {
 			return "", err
 		}
-		index += 1
 	}
 	if len(missing) > 0 {
 		buf.WriteString(MissingGetHeader)


### PR DESCRIPTION
The output from helm status is not correct for custom resources. The
HumanReadablePrinter from Kubernetes only outputs the column names when
the type differs from the previous one. This makes the output from Helm
inconsistent and also makes it difficult to put in the correct line
breaks. This PR sets up a new printer for each type, thereby making sure
that all types are printed with the correct use of line breaks and with
column names.

Signed-off-by: Morten Torkildsen <mortent@google.com>