### PR TITLE
Relative home path part3 dev v3

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -144,9 +144,7 @@ func initRepo(url, cacheFile string, out io.Writer, skipRefresh bool, home helmp
 		return &c, nil
 	}
 
-	// In this case, the cacheFile is always absolute. So passing empty string
-	// is safe.
-	if err := r.DownloadIndexFile(""); err != nil {
+	if err := r.DownloadIndexFile(home.Cache()); err != nil {
 		return nil, errors.Wrapf(err, "%s is not a valid chart repository or cannot be reached", url)
 	}
 

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -115,7 +115,11 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool, url
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewFile()
-		sr, err := initRepo(url, filepath.Rel(home.Cache(), home.CacheIndex(stableRepository)), out, skipRefresh, home)
+		sif, err := filepath.Rel(home.Cache(), home.CacheIndex(stableRepository))
+		if err != nil {
+			return err
+		}
+		sr, err := initRepo(url, sif, out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -114,7 +114,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool, url
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewFile()
-		sr, err := initRepo(url, home.CacheIndex(stableRepository), out, skipRefresh, home)
+		sr, err := initRepo(url, home.CacheRelativeIndex(stableRepository), out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -114,7 +115,7 @@ func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool, url
 	if fi, err := os.Stat(repoFile); err != nil {
 		fmt.Fprintf(out, "Creating %s \n", repoFile)
 		f := repo.NewFile()
-		sr, err := initRepo(url, home.CacheRelativeIndex(stableRepository), out, skipRefresh, home)
+		sr, err := initRepo(url, filepath.Rel(home.Cache(), home.CacheIndex(stableRepository)), out, skipRefresh, home)
 		if err != nil {
 			return err
 		}

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/helm/pkg/helm/helmpath"
@@ -43,7 +44,7 @@ func TestEnsureHome(t *testing.T) {
 		t.Error(err)
 	}
 
-	rr, err := repo.LoadRepositoriesFile(hh.RepositoryFile())
+	rr, err := repo.LoadFile(hh.RepositoryFile())
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/helm/pkg/helm/helmpath"
+	"k8s.io/helm/pkg/repo"
 )
 
 func TestEnsureHome(t *testing.T) {
@@ -40,6 +41,35 @@ func TestEnsureHome(t *testing.T) {
 	}
 	if err := ensureRepoFileFormat(hh.RepositoryFile(), b); err != nil {
 		t.Error(err)
+	}
+
+	rr, err := repo.LoadRepositoriesFile(hh.RepositoryFile())
+	if err != nil {
+		t.Error(err)
+	}
+
+	foundStable := false
+	for _, rr := range rr.Repositories {
+		if rr.Name == stableRepository {
+			foundStable = true
+			if err != nil {
+				t.Error(err)
+			}
+			if !filepath.IsAbs(rr.Cache) {
+				t.Errorf("%s stable repo cache path is an absolute path", rr.Cache)
+			}
+			absCache, err := filepath.Abs(filepath.Join(hh.Cache(), rr.Cache))
+			if err != nil {
+				t.Error(err)
+			}
+			if absCache != hh.CacheIndex(stableRepository) {
+				t.Errorf("%s stable repo cache path doesn't resolve to absolute cache index path", rr.Cache)
+			}
+			break
+		}
+	}
+	if !foundStable {
+		t.Errorf("stable repo not found")
 	}
 
 	expectedDirs := []string{hh.String(), hh.Repository(), hh.Cache()}

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -55,7 +55,7 @@ func TestEnsureHome(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if !filepath.IsAbs(rr.Cache) {
+			if filepath.IsAbs(rr.Cache) {
 				t.Errorf("%s stable repo cache path is an absolute path", rr.Cache)
 			}
 			absCache, err := filepath.Abs(filepath.Join(hh.Cache(), rr.Cache))


### PR DESCRIPTION
ported https://github.com/helm/helm/pull/3647 to dev-v3 branch

> makes the stable repo add a relative path from the cache directory to `repositories.yaml` and downloads to that location.