### PR TITLE
Allow missing trailing '/' in --repo url

### DIFF
--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -270,10 +270,12 @@ func ResolveReferenceURL(baseURL, refURL string) (string, error) {
 		return "", fmt.Errorf("failed to parse %s as URL: %v", refURL, err)
 	}
 
+	// We need a trailing slash for ResolveReference to work, but make sure there isn't already one
+	parsedBaseURL.Path = strings.TrimSuffix(parsedBaseURL.Path, "/") + "/"
+	resolvedURL := parsedBaseURL.ResolveReference(parsedRefURL)
 	// if the base URL contains query string parameters,
 	// propagate them to the child URL but only if the
 	// refURL is relative to baseURL
-	resolvedURL := parsedBaseURL.ResolveReference(parsedRefURL)
 	if (resolvedURL.Hostname() == parsedBaseURL.Hostname()) && (resolvedURL.Port() == parsedBaseURL.Port()) {
 		resolvedURL.RawQuery = parsedBaseURL.RawQuery
 	}

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -287,6 +287,14 @@ func TestResolveReferenceURL(t *testing.T) {
 		t.Errorf("%s", chartURL)
 	}
 
+	chartURL, err = ResolveReferenceURL("http://localhost:8123/charts", "nginx-0.2.0.tgz")
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if chartURL != "http://localhost:8123/charts/nginx-0.2.0.tgz" {
+		t.Errorf("%s", chartURL)
+	}
+
 	chartURL, err = ResolveReferenceURL("http://localhost:8123/charts/?st=2018-08-06T22%3A59%3A04Z&se=2018-08-07T22%3A59%3A04Z&sp=rl&sv=2018-03-28&sr=c&sig=cyqM4%2F5G7HNk%2F3faaHSDMaWxFxefCglvZlYSnmQBwiY%3D", "nginx-0.2.0.tgz")
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
Apply the same procedure to allow missing trailing slash in repo base URLs used in `repo/chart` inputs to `--repo` inputs.

Fixes #4954.

Signed-off-by: Luke Hoban <luke@pulumi.com>