### PR TITLE
fix(storage): when pruning release versions, never delete the last deployed revision

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -181,21 +181,37 @@ func (s *Storage) removeLeastRecent(name string, max int) error {
 	if len(h) <= max {
 		return nil
 	}
-	overage := len(h) - max
 
 	// We want oldest to newest
 	relutil.SortByRevision(h)
 
+	lastDeployed, err := s.Deployed(name)
+	if err != nil {
+		return err
+	}
+
+	var toDelete []*rspb.Release
+	for _, rel := range h {
+		// once we have enough releases to delete to reach the max, stop
+		if len(h)-len(toDelete) == max {
+			break
+		}
+		if lastDeployed != nil {
+			if rel.GetVersion() != lastDeployed.GetVersion() {
+				toDelete = append(toDelete, rel)
+			}
+		} else {
+			toDelete = append(toDelete, rel)
+		}
+	}
+
 	// Delete as many as possible. In the case of API throughput limitations,
 	// multiple invocations of this function will eventually delete them all.
-	toDelete := h[0:overage]
 	errors := []error{}
 	for _, rel := range toDelete {
-		key := makeKey(name, rel.Version)
-		_, innerErr := s.Delete(name, rel.Version)
-		if innerErr != nil {
-			s.Log("error pruning %s from release history: %s", key, innerErr)
-			errors = append(errors, innerErr)
+		err = s.deleteReleaseVersion(name, rel.GetVersion())
+		if err != nil {
+			errors = append(errors, err)
 		}
 	}
 
@@ -208,6 +224,16 @@ func (s *Storage) removeLeastRecent(name string, max int) error {
 	default:
 		return fmt.Errorf("encountered %d deletion errors. First is: %s", c, errors[0])
 	}
+}
+
+func (s *Storage) deleteReleaseVersion(name string, version int32) error {
+	key := makeKey(name, version)
+	_, err := s.Delete(name, version)
+	if err != nil {
+		s.Log("error pruning %s from release history: %s", key, err)
+		return err
+	}
+	return nil
 }
 
 // Last fetches the last revision of the named release.


### PR DESCRIPTION
When tiller-max-history has been set, let's say to 3, if you attempt 3 releases that fail, you end up with a release with no deployed releases.

This doesn't make sense. By changing the prune function to never delete the most recent successfully deployed revision, we never enter a case where a release has no deployed revisions.

See the test case for a good example of this. 