### PR TITLE
Added extra padding to resources template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -89,11 +89,11 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
This is probably a silly PR.  However, each time I create a new chart
via `helm create`, the instructions to uncomment the resource limits
require adding a couple extra spaces back to the YAML.

This PR simply brings the spacing in-line with the rest of the generated
template.