### PR TITLE
feat(cmd/helm): re-add --history-max option to v3

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -65,6 +65,7 @@ type upgradeOptions struct {
 	reuseValues  bool  // --reuse-values
 	timeout      int64 // --timeout
 	wait         bool  // --wait
+	maxHistory   int   // --max-history
 
 	valuesOptions
 	chartPathOptions
@@ -109,6 +110,7 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f.BoolVar(&o.reuseValues, "reuse-values", false, "when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' is specified, this is ignored.")
 	f.BoolVar(&o.wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&o.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
+	f.IntVar(&o.maxHistory, "history-max", 0, "limit the maximum number of revisions saved per release. Use 0 for no limit.")
 	o.valuesOptions.addFlags(f)
 	o.chartPathOptions.addFlags(f)
 
@@ -168,7 +170,8 @@ func (o *upgradeOptions) run(out io.Writer) error {
 		helm.UpgradeTimeout(o.timeout),
 		helm.ResetValues(o.resetValues),
 		helm.ReuseValues(o.reuseValues),
-		helm.UpgradeWait(o.wait))
+		helm.UpgradeWait(o.wait),
+		helm.MaxHistory(o.maxHistory))
 	if err != nil {
 		return errors.Wrap(err, "UPGRADE FAILED")
 	}

--- a/pkg/hapi/tiller.go
+++ b/pkg/hapi/tiller.go
@@ -117,6 +117,8 @@ type UpdateReleaseRequest struct {
 	ReuseValues bool `json:"reuse_values,omitempty"`
 	// Force resource update through delete/recreate if needed.
 	Force bool `json:"force,omitempty"`
+	// Limit the maximum number of revisions saved per release.
+	MaxHistory int `json:"max_history,omitempty"`
 }
 
 // RollbackReleaseRequest is the request for a release to be rolledback to a

--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -346,6 +346,13 @@ func UpgradeForce(force bool) UpdateOption {
 	}
 }
 
+// Limit the maximum number of revisions saved per release
+func MaxHistory(maxHistory int) UpdateOption {
+	return func(opts *options) {
+		opts.updateReq.MaxHistory = maxHistory
+	}
+}
+
 // UninstallOption allows setting optional attributes when
 // performing a UninstallRelease tiller rpc.
 type UninstallOption func(*options)

--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -45,6 +45,8 @@ func (s *ReleaseServer) UpdateRelease(req *hapi.UpdateReleaseRequest) (*release.
 		return nil, err
 	}
 
+	s.Releases.MaxHistory = req.MaxHistory
+
 	if !req.DryRun {
 		s.Log("creating updated release for %s", req.Name)
 		if err := s.Releases.Create(updatedRelease); err != nil {


### PR DESCRIPTION
Since there is no tiller anymore this option make most sense with the
'helm upgrade' commando.

Origininally this was added in PR #2636 implementing the feature #2081.