### PR TITLE
Improve check for template count in create unit test

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -143,8 +143,9 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.ApiVersion)
 	}
 
-	if l := len(c.Templates); l != 7 {
-		t.Errorf("Expected 6 templates, got %d", l)
+	expectedTemplateCount := 7
+	if l := len(c.Templates); l != expectedTemplateCount {
+		t.Errorf("Expected %d templates, got %d", expectedTemplateCount, l)
 	}
 
 	found := false


### PR DESCRIPTION
Minor improvement to resiliency of the test against future changes to the number of templates. In addition, the error message (should the check fail) is corrected.

Closes #5009 