### PR TITLE
Remove k8s.io/kubernetes deps for simple pod and svc util methods

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 )
 
@@ -203,7 +201,7 @@ func (c *Client) waitForResources(timeout time.Duration, created Result) error {
 
 func (c *Client) podsReady(pods []v1.Pod) bool {
 	for _, pod := range pods {
-		if !podutil.IsPodReady(&pod) {
+		if !isPodReady(&pod) {
 			c.Log("Pod is not ready: %s/%s", pod.GetNamespace(), pod.GetName())
 			return false
 		}
@@ -219,7 +217,7 @@ func (c *Client) servicesReady(svc []v1.Service) bool {
 		}
 
 		// Make sure the service is not explicitly set to "None" before checking the IP
-		if s.Spec.ClusterIP != v1.ClusterIPNone && !helper.IsServiceIPSet(&s) {
+		if s.Spec.ClusterIP != v1.ClusterIPNone && s.Spec.ClusterIP == "" {
 			c.Log("Service is not ready: %s/%s", s.GetNamespace(), s.GetName())
 			return false
 		}
@@ -258,4 +256,16 @@ func getPods(client kubernetes.Interface, namespace string, selector map[string]
 		LabelSelector: labels.Set(selector).AsSelector().String(),
 	})
 	return list.Items, err
+}
+
+func isPodReady(pod *v1.Pod) bool {
+	if &pod.Status != nil && len(pod.Status.Conditions) > 0 {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == v1.PodReady &&
+				condition.Status == v1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Avoiding the use of k8s.io/kubernetes as much as we can. These are simple methods in this PR. Functionally, this PR is expected to not change the helm code.