### PR TITLE
docs(helm): Mention commit signing in the Developer Guide

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -167,7 +167,7 @@ workflow for doing this is as follows:
 3. Add your repository as a remote for `$GOPATH/src/k8s.io/helm`
 4. Create a new working branch (`git checkout -b feat/my-feature`) and
    do your work on that branch.
-5. When you are ready for us to review, push your branch to GitHub, and
+5. When you are ready for us to review, sign your commit, push your branch to GitHub, and
    then open a new pull request with us.
 
 For Git commit messages, we follow the [Semantic Commit Messages](http://karma-runner.github.io/0.13/dev/git-commit-msg.html):


### PR DESCRIPTION
This change adds a mention to the requirement for commit signing
to the Git Convention outline in the Developer Guide, while
leaving the existing detail on signing in the Contributing doc.

Closes #5016

Signed-off-by: Henry Nash <henry.nash@uk.ibm.com>