### PR TITLE
ref(kube): Gets rid of superfluous Sprintf call

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -220,8 +220,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 	buf := new(bytes.Buffer)
 	printFlags := get.NewHumanPrintFlags()
 	for t, ot := range objs {
-		kindHeader := fmt.Sprintf("==> %s\n", t)
-		if _, err = buf.WriteString(kindHeader); err != nil {
+		if _, err = fmt.Fprintf(buf, "==> %s\n", t); err != nil {
 			return "", err
 		}
 		typePrinter, _ := printFlags.ToPrinter("")


### PR DESCRIPTION
During some PR reviews, we found a superfluous call to print a string. This now just prints straight to the buffer