### PR TITLE
fix(helm): Display debug release info when upgrade failed because of timeout. Closes #3020

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -326,13 +326,14 @@ func (i *installCmd) run() error {
 	// If this is a dry run, we can't display status.
 	if i.dryRun {
 		// This is special casing to avoid breaking backward compatibility:
-		if res.Release.Info.Description != "Dry run complete" {
-			fmt.Fprintf(os.Stdout, "WARNING: %s\n", res.Release.Info.Description)
+		if resp.Release.Info.Description != "Dry run complete" {
+			fmt.Fprintf(os.Stdout, "WARNING: %s\n", resp.Release.Info.Description)
 		}
 		return nil
 	}
 
 	// Print the status like status command does
+	rel := resp.GetRelease()
 	status, err := i.client.ReleaseStatus(rel.Name)
 	if err != nil {
 		return prettyError(err)

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -94,7 +94,7 @@ func newRollbackCmd(c helm.Interface, out io.Writer) *cobra.Command {
 }
 
 func (r *rollbackCmd) run() error {
-	_, err := r.client.RollbackRelease(
+	resp, err := r.client.RollbackRelease(
 		r.name,
 		helm.RollbackDryRun(r.dryRun),
 		helm.RollbackRecreate(r.recreate),
@@ -121,7 +121,7 @@ func (r *rollbackCmd) run() error {
 			printRelease(r.out, rel)
 		}
 	}
-	
+
 	if err != nil {
 		return prettyError(err)
 	}

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -104,6 +104,24 @@ func (r *rollbackCmd) run() error {
 		helm.RollbackTimeout(r.timeout),
 		helm.RollbackWait(r.wait),
 		helm.RollbackDescription(r.description))
+
+	if settings.Debug {
+		// If there is an error while waiting, make a call without waiting to get the release content
+		if (resp == nil || resp.Release == nil) && r.wait {
+			if res, e := r.client.ReleaseContent(r.name); e != nil {
+				fmt.Fprintf(r.out, "Error reading release content: %v", prettyError(e))
+			} else {
+				printRelease(r.out, res.Release)
+			}
+		} else {
+			rel := resp.GetRelease()
+			if rel == nil {
+				return nil
+			}
+			printRelease(r.out, rel)
+		}
+	}
+	
 	if err != nil {
 		return prettyError(err)
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -266,12 +266,22 @@ func (u *upgradeCmd) run() error {
 		helm.ReuseValues(u.reuseValues),
 		helm.UpgradeWait(u.wait),
 		helm.UpgradeDescription(u.description))
-	if err != nil {
-		return fmt.Errorf("UPGRADE FAILED: %v", prettyError(err))
-	}
 
 	if settings.Debug {
-		printRelease(u.out, resp.Release)
+		// If there is an error while waiting, make a call without waiting to get the updated release content
+		if (resp == nil || resp.Release == nil) && u.wait {
+			if res, e := u.client.ReleaseContent(u.release); e != nil {
+				fmt.Fprintf(u.out, "Error reading release content: %v", prettyError(e))
+			} else {
+				printRelease(u.out, res.Release)
+			}
+		} else {
+			printRelease(u.out, resp.Release)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("UPGRADE FAILED: %v", prettyError(err))
 	}
 
 	fmt.Fprintf(u.out, "Release %q has been upgraded. Happy Helming!\n", u.release)


### PR DESCRIPTION
Display debug release info when upgrade failed because of timeout. 
Signed-off-by: Sebastien Plisson <sebastien.plisson@gmail.com>