### PR TITLE
Fix syntax in example if statement

### DIFF
--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -53,7 +53,7 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{ if and (.Values.favorite.drink) (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
+  {{ if (.Values.favorite.drink) and (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
 ```
 
 Note that `.Values.favorite.drink` must be defined or else it will throw an error when comparing it to "coffee". Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:


### PR DESCRIPTION
The `and` in the example if statement appears to be out of order. With the position shown, I see an error when trying to do a dry-run of the install `error calling eq: invalid type for comparison`:

```
$ grep and templates/configmap.yaml 
  {{ if and (.Values.favorite.drink) (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
$ helm install --dry-run --debug .
[debug] Created tunnel using local port: '33955'

[debug] SERVER: "127.0.0.1:33955"

[debug] Original chart version: ""
[debug] CHART PATH: /home/mark/Downloads/mychart

Error: render error in "mychart/templates/configmap.yaml": template: mychart/templates/configmap.yaml:9:38: executing "mychart/templates/configmap.yaml" at <eq .Values.favorite....>: error calling eq: invalid type for comparison
```
When I move the `and` the example appears to work fine:

```
$ grep and templates/configmap.yaml 
  {{ if (.Values.favorite.drink) and (eq .Values.favorite.drink "coffee") }}mug: true{{ end }}
$ helm install --dry-run --debug .
[debug] Created tunnel using local port: '35277'

[debug] SERVER: "127.0.0.1:35277"

[debug] Original chart version: ""
[debug] CHART PATH: /home/mark/Downloads/mychart

NAME:   happy-unicorn
REVISION: 1
RELEASED: Thu Dec  6 15:01:07 2018
CHART: mychart-0.1.0
USER-SUPPLIED VALUES:
{}

COMPUTED VALUES:
favorite:
  food: pizza

HOOKS:
MANIFEST:

---
# Source: mychart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: happy-unicorn-configmap
data:
  myvalue: "Hello World"
  drink: "tea"
  food: "PIZZA"
```