### PR TITLE
docs: add Shipper to the list of additional tools

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -81,6 +81,7 @@ Tools layered on top of Helm or Tiller.
 - [Quay App Registry](https://coreos.com/blog/quay-application-registry-for-kubernetes.html) - Open Kubernetes application registry, including a Helm access client
 - [Rudder](https://github.com/AcalephStorage/rudder) - RESTful (JSON) proxy for Tiller's API
 - [Schelm](https://github.com/databus23/schelm) - Render a Helm manifest to a directory
+- [Shipper](https://github.com/bookingcom/shipper) - Multi-cluster canary or blue-green rollouts using Helm
 - [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin for Kubernetes and Helm
 
 ## Helm Included


### PR DESCRIPTION
Hey folks,

I'm not sure what the threshold is for inclusion on the "related projects" doc, but @mattfarina suggested this as a good way to reach the Helm community.

[Shipper](https://github.com/bookingcom/shipper) is a controller that replaces Tiller. It uses a set of CRDs to consume charts directly from a Chart repo like ChartMuseum, and install them into one or many clusters using a customizable rollout strategy. Kind of like a tiny, Kubernetes-native Spinnaker.

I've spoken with a few of the Helm gang at KubeCon, and am happy to elaborate more on the project and its goals here or in person in Seattle. Totally understand if it doesn't yet look like it has enough footprint to include on the list.

Thank you!