### PR TITLE
fixes #4728 problem that arise because of the zero value of unknown

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -81,6 +81,7 @@ Tools layered on top of Helm or Tiller.
 - [Quay App Registry](https://coreos.com/blog/quay-application-registry-for-kubernetes.html) - Open Kubernetes application registry, including a Helm access client
 - [Rudder](https://github.com/AcalephStorage/rudder) - RESTful (JSON) proxy for Tiller's API
 - [Schelm](https://github.com/databus23/schelm) - Render a Helm manifest to a directory
+- [Shipper](https://github.com/bookingcom/shipper) - Multi-cluster canary or blue-green rollouts using Helm
 - [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin for Kubernetes and Helm
 
 ## Helm Included

--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -124,12 +124,13 @@ func (k *kindSorter) Less(i, j int) bool {
 	b := k.manifests[j]
 	first, aok := k.ordering[a.Head.Kind]
 	second, bok := k.ordering[b.Head.Kind]
-	// if same kind (including unknown) sub sort alphanumeric
-	if first == second {
-		// if both are unknown and of different kind sort by kind alphabetically
-		if !aok && !bok && a.Head.Kind != b.Head.Kind {
+	// if both are unknown
+	if !aok && !bok {
+		// and of different kind sort by kind alphabetically
+		if a.Head.Kind != b.Head.Kind {
 			return a.Head.Kind < b.Head.Kind
 		}
+		// and of same kind sort by name alphabetically
 		return a.Name < b.Name
 	}
 	// unknown kind is last
@@ -138,6 +139,10 @@ func (k *kindSorter) Less(i, j int) bool {
 	}
 	if !bok {
 		return true
+	}
+	// if same kind sort alphanumeric
+	if first == second {
+		return a.Name < b.Name
 	}
 	// sort different kinds
 	return first < second


### PR DESCRIPTION
The logic for comparison breaks when a template with kind=="Unknown" is compared with a Namespace template, if the name of the manifest is lexicographically smaller, making it win over Namespace when it should not had.