### PR TITLE
fixes #4728 problem that arise in tiller.kind_sorter.less func wrong order for Namespace because of the zero value of unknown

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -124,12 +124,13 @@ func (k *kindSorter) Less(i, j int) bool {
 	b := k.manifests[j]
 	first, aok := k.ordering[a.Head.Kind]
 	second, bok := k.ordering[b.Head.Kind]
-	// if same kind (including unknown) sub sort alphanumeric
-	if first == second {
-		// if both are unknown and of different kind sort by kind alphabetically
-		if !aok && !bok && a.Head.Kind != b.Head.Kind {
+	// if both are unknown
+	if !aok && !bok {
+		// and of different kind sort by kind alphabetically
+		if a.Head.Kind != b.Head.Kind {
 			return a.Head.Kind < b.Head.Kind
 		}
+		// and of same kind sort by name alphabetically
 		return a.Name < b.Name
 	}
 	// unknown kind is last
@@ -138,6 +139,10 @@ func (k *kindSorter) Less(i, j int) bool {
 	}
 	if !bok {
 		return true
+	}
+	// if same kind sort alphanumeric
+	if first == second {
+		return a.Name < b.Name
 	}
 	// sort different kinds
 	return first < second


### PR DESCRIPTION
and the logic of kind_sorter. This messes helm template when having unknown (ie NOTES) or other files and the sorter catches namespace

Signed-off-by: Filinto Duran <duranto@gmail.com>