### PR TITLE
Revert "Fix for existing CRDs are deleted when crd-install hook is in…

### DIFF
--- a/pkg/tiller/hooks.go
+++ b/pkg/tiller/hooks.go
@@ -174,13 +174,6 @@ func (file *manifestFile) sort(result *result) error {
 				isUnknownHook = true
 				break
 			}
-			if e == release.Hook_CRD_INSTALL {
-				result.generic = append(result.generic, Manifest{
-					Name:    file.path,
-					Content: m,
-					Head:    &entry,
-				})
-			}
 			h.Events = append(h.Events, e)
 		}
 


### PR DESCRIPTION
…troduced (#4709)"

This reverts commit e2a0e7fa545585a29c1e9602e6320479788eb9a6.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

closes #5054