### PR TITLE
Fixes #5046, zsh completion

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -212,6 +212,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}compopt${RWORD}/__helm_compopt/g" \
 	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
+	-e 's/aliashash\["\(\w\+\)"\]/aliashash[\1]/g' \
 	<<'BASH_COMPLETION_EOF'
 `
 	out.Write([]byte(zshInitialization))


### PR DESCRIPTION
Signed-off-by: Peter Stalman <sarkedev@gmail.com>

**What this PR does / why we need it**:
Closes #5046

**Special notes for your reviewer**:
Small fix.  Removes quotes in aliashash keys to work with ZSH.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
