### PR TITLE
Fix(helm): Use spaces in ingress template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -158,12 +158,12 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
+        {{- range $ingressPaths }}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-	{{- end }}
+        {{- end }}
   {{- end }}
 {{- end }}
 `


### PR DESCRIPTION
**What this PR does / why we need it**:
The ingress file created by `helm create` was using spaces to indent, but had two lines tabs in there. This changes it so all lines are spaces.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
