### PR TITLE
feat(resource-policy): delete manifests when policy value is delete

### DIFF
--- a/docs/charts_tips_and_tricks.md
+++ b/docs/charts_tips_and_tricks.md
@@ -235,6 +235,9 @@ orphaned. Helm will no longer manage it in any way. This can lead to problems
 if using `helm install --replace` on a release that has already been deleted, but
 has kept resources.
 
+To explicitly opt in to resource deletion, for example when overriding a chart's
+default annotations, set the resource policy annotation value to `delete`.
+
 ## Using "Partials" and Template Includes
 
 Sometimes you want to create some reusable parts in your chart, whether

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -23,11 +23,12 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"log"
 	"sort"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/evanphx/json-patch"
 	appsv1 "k8s.io/api/apps/v1"
@@ -362,8 +363,9 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 		if err != nil {
 			c.Log("Unable to get annotations on %q, err: %s", info.Name, err)
 		}
-		if annotations != nil && annotations[ResourcePolicyAnno] == KeepPolicy {
-			c.Log("Skipping delete of %q due to annotation [%s=%s]", info.Name, ResourcePolicyAnno, KeepPolicy)
+		if ResourcePolicyIsKeep(annotations) {
+			policy := annotations[ResourcePolicyAnno]
+			c.Log("Skipping delete of %q due to annotation [%s=%s]", info.Name, ResourcePolicyAnno, policy)
 			continue
 		}
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -213,7 +213,7 @@ func TestUpdate(t *testing.T) {
 
 	// Test resource policy is respected
 	actions = nil
-	listA.Items[2].ObjectMeta.Annotations = map[string]string{ResourcePolicyAnno: KeepPolicy}
+	listA.Items[2].ObjectMeta.Annotations = map[string]string{ResourcePolicyAnno: "keep"}
 	if err := c.Update(v1.NamespaceDefault, objBody(&listA), objBody(&listB), false, false, 0, false); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kube/resource_policy.go
+++ b/pkg/kube/resource_policy.go
@@ -19,8 +19,23 @@ package kube
 // ResourcePolicyAnno is the annotation name for a resource policy
 const ResourcePolicyAnno = "helm.sh/resource-policy"
 
-// KeepPolicy is the resource policy type for keep
+// deletePolicy is the resource policy type for delete
 //
-// This resource policy type allows resources to skip being deleted
-//   during an uninstallRelease action.
-const KeepPolicy = "keep"
+// This resource policy type allows explicitly opting in to the default
+//   resource deletion behavior, for example when overriding a chart's
+//   default annotations. Any other value allows resources to skip being
+//   deleted during an uninstallRelease action.
+const deletePolicy = "delete"
+
+// ResourcePolicyIsKeep accepts a map of Kubernetes resource annotations and
+//   returns true if the resource should be kept, otherwise false if it is safe
+//   for Helm to delete.
+func ResourcePolicyIsKeep(annotations map[string]string) bool {
+	if annotations != nil {
+		resourcePolicyType, ok := annotations[ResourcePolicyAnno]
+		if ok && resourcePolicyType != deletePolicy {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kube/resource_policy_test.go
+++ b/pkg/kube/resource_policy_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import "testing"
+
+func TestResourcePolicyIsKeep(t *testing.T) {
+	type annotations map[string]string
+	type testcase struct {
+		annotations
+		keep bool
+	}
+	cases := []testcase{
+		{nil, false},
+		{
+			annotations{
+				"foo": "bar",
+			},
+			false,
+		},
+		{
+			annotations{
+				ResourcePolicyAnno: "keep",
+			},
+			true,
+		},
+		{
+			annotations{
+				ResourcePolicyAnno: "KEEP   ",
+			},
+			true,
+		},
+		{
+			annotations{
+				ResourcePolicyAnno: "",
+			},
+			true,
+		},
+		{
+			annotations{
+				ResourcePolicyAnno: "delete",
+			},
+			false,
+		},
+		{
+			annotations{
+				ResourcePolicyAnno: "DELETE",
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		if tc.keep != ResourcePolicyIsKeep(tc.annotations) {
+			t.Errorf("Expected function to return %t for annotations %v", tc.keep, tc.annotations)
+		}
+	}
+}

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -89,9 +89,18 @@ spec:
 
 var manifestWithKeep = `kind: ConfigMap
 metadata:
-  name: test-cm-keep
+  name: test-cm-keep-a
   annotations:
     "helm.sh/resource-policy": keep
+data:
+  name: value
+`
+
+var manifestWithKeepEmpty = `kind: ConfigMap
+metadata:
+  name: test-cm-keep-b
+  annotations:
+    "helm.sh/resource-policy": ""
 data:
   name: value
 `
@@ -449,23 +458,27 @@ func releaseWithKeepStub(rlsName string) *release.Release {
 			Name: "bunnychart",
 		},
 		Templates: []*chart.Template{
-			{Name: "templates/configmap", Data: []byte(manifestWithKeep)},
+			{Name: "templates/configmap-keep-a", Data: []byte(manifestWithKeep)},
+			{Name: "templates/configmap-keep-b", Data: []byte(manifestWithKeepEmpty)},
 		},
 	}
 
 	date := timestamp.Timestamp{Seconds: 242085845, Nanos: 0}
-	return &release.Release{
+	rl := &release.Release{
 		Name: rlsName,
 		Info: &release.Info{
 			FirstDeployed: &date,
 			LastDeployed:  &date,
 			Status:        &release.Status{Code: release.Status_DEPLOYED},
 		},
-		Chart:    ch,
-		Config:   &chart.Config{Raw: `name: value`},
-		Version:  1,
-		Manifest: manifestWithKeep,
+		Chart:   ch,
+		Config:  &chart.Config{Raw: `name: value`},
+		Version: 1,
 	}
+
+	helm.RenderReleaseMock(rl, false)
+
+	return rl
 }
 
 func MockEnvironment() *environment.Environment {

--- a/pkg/tiller/release_uninstall_test.go
+++ b/pkg/tiller/release_uninstall_test.go
@@ -150,7 +150,10 @@ func TestUninstallReleaseWithKeepPolicy(t *testing.T) {
 	if res.Info == "" {
 		t.Errorf("Expected response info to not be empty")
 	} else {
-		if !strings.Contains(res.Info, "[ConfigMap] test-cm-keep") {
+		if !strings.Contains(res.Info, "[ConfigMap] test-cm-keep-a") {
+			t.Errorf("unexpected output: %s", res.Info)
+		}
+		if !strings.Contains(res.Info, "[ConfigMap] test-cm-keep-b") {
 			t.Errorf("unexpected output: %s", res.Info)
 		}
 	}

--- a/pkg/tiller/resource_policy.go
+++ b/pkg/tiller/resource_policy.go
@@ -34,17 +34,11 @@ func filterManifestsToKeep(manifests []Manifest) ([]Manifest, []Manifest) {
 			continue
 		}
 
-		resourcePolicyType, ok := m.Head.Metadata.Annotations[kube.ResourcePolicyAnno]
-		if !ok {
-			remaining = append(remaining, m)
-			continue
-		}
-
-		resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
-		if resourcePolicyType == kube.KeepPolicy {
+		if kube.ResourcePolicyIsKeep(m.Head.Metadata.Annotations) {
 			keep = append(keep, m)
+		} else {
+			remaining = append(remaining, m)
 		}
-
 	}
 	return keep, remaining
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #3150, closes #4713, closes #5394

**What this PR does / why we need it**:

This PR allows opting in to resource deletion if the `helm.sh/resource-policy` annotation has a value of `delete`. This PR also makes a small change related to https://github.com/helm/helm/pull/5225 in order to respond to resource policy annotation values consistently between upgrades and deletes (always keep resources if they have the annotation unless the value is `delete`).

From https://github.com/helm/helm/issues/3150#issuecomment-448436708:

> For more background, the particular issue I'm running into is I have charts with this annotation set, but there's no way to override the annotation when it comes time to install via --set parameters -- the resources are always retained. I've tried null, ~, delete, empty strings and so forth. The key always continues to be present.

A time when this might be convenient is if a chart is meant to ship with production-ready values by default, and therefore may opt to protect against data loss by using this annotation on resources such as a PerisistentVolumeClaim. The most common current approach is to support this configuration via a separate value, for example:

https://github.com/helm/charts/blob/cbd5e811a44c7bac6226b019f1d1810ef5ee45fa/stable/lamp/templates/pvc.yaml#L11-L13

However it is more flexible to be able to specify a default set of annotations in values.yaml, and allow end users (or parent charts) to override the value of those annotations if desired. This works well in any case where a chart allows specifying arbitrary annotations (eg. [kibana](https://github.com/helm/charts/blob/b3226cf40a681859092312306e5c48ea7cd9d05e/stable/kibana/values.yaml#L158)), but does not already specifically support the resource policy annotation.

**Special notes for your reviewer**:

Relates to https://github.com/helm/helm/pull/4715

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
