### PR TITLE
Update docs/examples to use multi-arch tagged images

### DIFF
--- a/docs/examples/alpine/values.yaml
+++ b/docs/examples/alpine/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: alpine
-  tag: 3.3
+  tag: latest
   pullPolicy: IfNotPresent
 
 restartPolicy: Never

--- a/docs/examples/nginx/templates/post-install-job.yaml
+++ b/docs/examples/nginx/templates/post-install-job.yaml
@@ -32,6 +32,6 @@ spec:
       restartPolicy: {{ .Values.restartPolicy }}
       containers:
         - name: post-install-job
-          image: "alpine:3.3"
+          image: "alpine:latest"
           # All we're going to do is sleep for a while, then exit.
           command: ["/bin/sleep", "{{ .Values.sleepyTime }}"]

--- a/docs/examples/nginx/values.yaml
+++ b/docs/examples/nginx/values.yaml
@@ -14,7 +14,7 @@ index: >-
 
 image:
   repository: nginx
-  tag: 1.11.0
+  tag: alpine
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
**What this PR does / why we need it**:
I wanted to test deploying to `armv7hf` devices, but the examples in the docs used images that were not multi-architecture tagged. The pods failed to start because amd64 Linux containers were pulled and could not run on my Odroid HC1/XU4 device.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
