### PR TITLE
Fetching latest valid Superseded release when using 0

### DIFF
--- a/pkg/tiller/release_rollback.go
+++ b/pkg/tiller/release_rollback.go
@@ -78,7 +78,11 @@ func (s *ReleaseServer) prepareRollback(req *services.RollbackReleaseRequest) (*
 
 	previousVersion := req.Version
 	if req.Version == 0 {
-		previousVersion = currentRelease.Version - 1
+		p := s.lastSupersededRelease(req.Name)
+		if p < 0 || err != nil {
+			return nil, nil, errInvalidRevision
+		}
+		previousVersion = p
 	}
 
 	s.Log("rolling back %s (current: v%d, target: v%d)", req.Name, currentRelease.Version, previousVersion)

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -230,6 +230,15 @@ func (s *ReleaseServer) createUniqName(m moniker.Namer) (string, error) {
 	return "ERROR", errors.New("no available release name found")
 }
 
+func (s *ReleaseServer) lastSupersededRelease(name string) int32 {
+	releases, err := s.env.Releases.SupersededAll(name)
+	if len(releases) == 0 || err != nil {
+		return -1
+	}
+	relutil.Reverse(releases, relutil.SortByRevision)
+	return releases[0].Version
+}
+
 func (s *ReleaseServer) engine(ch *chart.Chart) environment.Engine {
 	renderer := s.env.EngineYard.Default()
 	if ch.Metadata.Engine != "" {

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -381,6 +381,40 @@ func TestUniqName(t *testing.T) {
 	}
 }
 
+func TestLastSupersededRelease(t *testing.T) {
+	rs := rsFixture()
+
+	sr := rs.lastSupersededRelease("non-existent-name")
+	if sr != -1 {
+		t.Errorf("Expected -1 return for a not existent release.")
+	}
+
+	rel1 := releaseStub()
+	rel1.Version = 1
+	rel1.Info.Status.Code = release.Status_FAILED
+	rs.env.Releases.Create(rel1)
+
+	rel2 := releaseStub()
+	rel2.Version = 2
+	rel2.Info.Status.Code = release.Status_SUPERSEDED
+	rs.env.Releases.Create(rel2)
+
+	rel3 := releaseStub()
+	rel3.Version = 3
+	rel3.Info.Status.Code = release.Status_SUPERSEDED
+	rs.env.Releases.Create(rel3)
+
+	rel4 := releaseStub()
+	rel4.Version = 4
+	rel4.Info.Status.Code = release.Status_DEPLOYED
+	rs.env.Releases.Create(rel4)
+
+	sr = rs.lastSupersededRelease("angry-panda")
+	if sr != 3 {
+		t.Errorf("Wrong release version return, got: %d", sr)
+	}
+}
+
 type fakeNamer struct {
 	name string
 }


### PR DESCRIPTION
Signed-off-by: Amim Knabben <amim.knabben@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Uses the latest release in SUPERSEDED state when rolling back with (0) revision.

**Special notes for your reviewer**:
refs #1796

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
