### PR TITLE
fix: use RFC 1123 subdomain validation for name verification

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -249,8 +249,8 @@ func (i *installCmd) run() error {
 		fmt.Printf("FINAL NAME: %s\n", i.name)
 	}
 
-	if msgs := validation.IsDNS1123Label(i.name); i.name != "" && len(msgs) > 0 {
-		return fmt.Errorf("release name %s is not a valid DNS label: %s", i.name, strings.Join(msgs, ";"))
+	if msgs := validation.IsDNS1123Subdomain(i.name); i.name != "" && len(msgs) > 0 {
+		return fmt.Errorf("release name %s is invalid: %s", i.name, strings.Join(msgs, ";"))
 	}
 
 	// Check chart requirements to make sure all dependencies are present in /charts

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -169,7 +169,6 @@ func TestInstall(t *testing.T) {
 			name:  "install chart with release name using periods",
 			args:  []string{"testdata/testcharts/alpine"},
 			flags: []string{"--name", "foo.bar"},
-			err:   true,
 		},
 		{
 			name:  "install chart with release name using underscores",

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -147,8 +147,8 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if msgs := validation.IsDNS1123Label(t.releaseName); t.releaseName != "" && len(msgs) > 0 {
-		return fmt.Errorf("release name %s is not a valid DNS label: %s", t.releaseName, strings.Join(msgs, ";"))
+	if msgs := validation.IsDNS1123Subdomain(t.releaseName); t.releaseName != "" && len(msgs) > 0 {
+		return fmt.Errorf("release name %s is invalid: %s", t.releaseName, strings.Join(msgs, ";"))
 	}
 
 	// Check chart requirements to make sure all dependencies are present in /charts

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -112,21 +112,21 @@ func TestTemplateCmd(t *testing.T) {
 			desc:        "verify the release name using capitals is invalid",
 			args:        []string{subchart1ChartPath, "--name", "FOO"},
 			expectKey:   "subchart1/templates/service.yaml",
-			expectError: "is not a valid DNS label",
+			expectError: "is invalid",
 		},
 		{
 			name:        "check_invalid_name_uppercase",
 			desc:        "verify the release name using periods is invalid",
 			args:        []string{subchart1ChartPath, "--name", "foo.bar"},
 			expectKey:   "subchart1/templates/service.yaml",
-			expectError: "is not a valid DNS label",
+			expectValue: "release-name: \"foo.bar\"",
 		},
 		{
 			name:        "check_invalid_name_uppercase",
 			desc:        "verify the release name using underscores is invalid",
 			args:        []string{subchart1ChartPath, "--name", "foo_bar"},
 			expectKey:   "subchart1/templates/service.yaml",
-			expectError: "is not a valid DNS label",
+			expectError: "is invalid",
 		},
 		{
 			name:        "check_release_is_install",
@@ -160,7 +160,7 @@ func TestTemplateCmd(t *testing.T) {
 			name:        "check_invalid_name_template",
 			desc:        "verify the relase name generate by template is invalid",
 			args:        []string{subchart1ChartPath, "--name-template", "foobar-{{ b64enc \"abc\" }}-baz"},
-			expectError: "is not a valid DNS label",
+			expectError: "is invalid",
 		},
 		{
 			name:        "check_name_template",


### PR DESCRIPTION
As noted in Slack by a community member, release names with periods are
considered usable. Switching to RFC 1123 subdomain verification
continues to block bad release names like BAD_NAME, but allows names
like good.name to continue working.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

refs #4883 