### PR TITLE
Fix: type conversion for zero values

### DIFF
--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -393,6 +393,10 @@ func typedVal(v []rune, st bool) interface{} {
 		return nil
 	}
 
+	if strings.EqualFold(val, "0") {
+		return int64(0)
+	}
+
 	// If this value does not start with zero, try parsing it to an int
 	if len(val) != 0 && val[0] != '0' {
 		if iv, err := strconv.ParseInt(val, 10, 64); err == nil {

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -85,6 +85,11 @@ func TestParseSet(t *testing.T) {
 			expect: map[string]interface{}{"is_null": "null"},
 			err:    false,
 		},
+		{
+			str:    "zero=0",
+			expect: map[string]interface{}{"zero": "0"},
+			err:    false,
+		},
 	}
 	tests := []struct {
 		str    string
@@ -122,6 +127,10 @@ func TestParseSet(t *testing.T) {
 		{
 			str:    "leading_zeros=00009",
 			expect: map[string]interface{}{"leading_zeros": "00009"},
+		},
+		{
+			str:    "zero_int=0",
+			expect: map[string]interface{}{"zero_int": 0},
 		},
 		{
 			str:    "long_int=1234567890",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The current implementation does not allow allow to set a value to `0`. E.g. 
```
helm tiller install -n test stable/some-chart --set securityContext.runAsUser=0
```
fails with the following message:
```
Error: release test failed: Deployment in version "v1beta1" cannot be handled as a Deployment: v1beta1.Deployment.Spec: v1beta1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.SecurityContext: v1.SecurityContext.RunAsUser: readUint64: unexpected character: �, error found in #10 byte of ...|nAsUser":"0"},"volum|..., bigger context ...|text":{"runAsUser":"0"},"volumeMounts":[{"mountPath":"/etc/kubernetes/|...
```
since helm tries to convert 0 to a string. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
