### PR TITLE
add descriptive error if dependency has blank "repository" field

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -371,6 +371,9 @@ func (m *Manager) getRepoNames(deps []*chartutil.Dependency) (map[string]string,
 	// by Helm.
 	missing := []string{}
 	for _, dd := range deps {
+		if dd.Repository == "" {
+			return nil, fmt.Errorf("no 'repository' field specified for dependency: %q", dd.Name)
+		}
 		// if dep chart is from local path, verify the path is valid
 		if strings.HasPrefix(dd.Repository, "file://") {
 			if _, err := resolver.GetLocalPath(dd.Repository, m.ChartPath); err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
add a descriptive error if dependency has blank `repository` field, e.g. if the field is misspelled `repo`. Closes #5124 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
