### PR TITLE
[docs/related] add helm tiller-info plugin, related to #5111

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -53,6 +53,7 @@ or [pull request](https://github.com/helm/helm/pulls).
 - [helm-stop](https://github.com/IBM/helm-stop) - Plugin for stopping a release pods
 - [helm-template](https://github.com/technosophos/helm-template) - Debug/render templates client-side
 - [helm-tiller](https://github.com/adamreese/helm-tiller) - Additional commands to work with Tiller
+- [helm-tiller-info](https://github.com/maorfr/helm-tiller-info) - Plugin which prints information about Tiller
 - [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit testing chart locally with YAML
 - [Tillerless Helm v2](https://github.com/rimusz/helm-tiller) - Helm plugin for using Tiller locally and in CI/CD pipelines
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a plugin to complete a feature described in issue #5111 

**Special notes for your reviewer**:
Thanks!

**If applicable**:
- [x] this PR contains documentation
