### PR TITLE
Fix/validate tar paths

### DIFF
--- a/pkg/chartutil/expand.go
+++ b/pkg/chartutil/expand.go
@@ -53,7 +53,6 @@ func Expand(dir string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	println(chartdir)
 
 	// Copy all files verbatim. We don't parse these files because parsing can remove
 	// comments.

--- a/pkg/chartutil/expand_test.go
+++ b/pkg/chartutil/expand_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package chartutil
 
 import (

--- a/pkg/chartutil/expand_test.go
+++ b/pkg/chartutil/expand_test.go
@@ -1,0 +1,105 @@
+package chartutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	dest, err := ioutil.TempDir("", "helm-testing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	reader, err := os.Open("testdata/frobnitz-1.2.3.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Expand(dest, reader); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChartPath := filepath.Join(dest, "frobnitz")
+	fi, err := os.Stat(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("expected a chart directory at %s", expectedChartPath)
+	}
+
+	dir, err := os.Open(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fis, err := dir.Readdir(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectLen := 12
+	if len(fis) != expectLen {
+		t.Errorf("Expected %d files, but got %d", expectLen, len(fis))
+	}
+
+	for _, fi := range fis {
+		expect, err := os.Stat(filepath.Join("testdata", "frobnitz", fi.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size() != expect.Size() {
+			t.Errorf("Expected %s to have size %d, got %d", fi.Name(), expect.Size(), fi.Size())
+		}
+	}
+}
+
+func TestExpandFile(t *testing.T) {
+	dest, err := ioutil.TempDir("", "helm-testing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	if err := ExpandFile(dest, "testdata/frobnitz-1.2.3.tgz"); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChartPath := filepath.Join(dest, "frobnitz")
+	fi, err := os.Stat(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("expected a chart directory at %s", expectedChartPath)
+	}
+
+	dir, err := os.Open(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fis, err := dir.Readdir(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectLen := 12
+	if len(fis) != expectLen {
+		t.Errorf("Expected %d files, but got %d", expectLen, len(fis))
+	}
+
+	for _, fi := range fis {
+		expect, err := os.Stat(filepath.Join("testdata", "frobnitz", fi.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size() != expect.Size() {
+			t.Errorf("Expected %s to have size %d, got %d", fi.Name(), expect.Size(), fi.Size())
+		}
+	}
+}

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -100,6 +101,19 @@ func LoadArchive(in io.Reader) (*chart.Chart, error) {
 
 		// Normalize the path to the / delimiter
 		n = strings.Replace(n, delimiter, "/", -1)
+
+		if path.IsAbs(n) {
+			return nil, errors.New("chart illegally contains absolute paths")
+		}
+
+		println("path", n)
+		n = path.Clean(n)
+		if n == "." {
+			return nil, errors.New("chart illegally contains empty path")
+		}
+		if strings.HasPrefix(n, "..") {
+			return nil, errors.New("chart illegally references parent directory")
+		}
 
 		if parts[0] == "Chart.yaml" {
 			return nil, errors.New("chart yaml not in base directory")

--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -109,9 +109,7 @@ func LoadArchive(in io.Reader) (*chart.Chart, error) {
 			return nil, errors.New("chart illegally contains absolute paths")
 		}
 
-		println("path", n)
 		n = path.Clean(n)
-		println("  cleaned", n)
 		if n == "." {
 			// In this case, the original path was relative when it should have been absolute.
 			return nil, errors.New("chart illegally contains empty path")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR fixes a few cases where tar files were unpacked without sanitizing the paths inside the tarball. This PR will prevent unpacking charts that have non-resolved relative paths or which try to write to parent directories.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
