### PR TITLE
add test for repo update command strict flag

### DIFF
--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -105,3 +105,30 @@ func TestUpdateCharts(t *testing.T) {
 		t.Error("Update was not successful")
 	}
 }
+
+func TestUpdateCmdStrictFlag(t *testing.T) {
+	thome, err := tempHelmHome(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := resetEnv()
+	defer func() {
+		os.RemoveAll(thome.String())
+		cleanup()
+	}()
+
+	settings.Home = thome
+
+	out := bytes.NewBuffer(nil)
+	cmd := newRepoUpdateCmd(out)
+	cmd.ParseFlags([]string{"--strict"})
+
+	if err := cmd.RunE(cmd, []string{}); err == nil {
+		t.Fatal("expected error due to strict flag")
+	}
+
+	if got := out.String(); !strings.Contains(got, "Unable to get an update") {
+		t.Errorf("Expected 'Unable to get an update', got %q", got)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a test to cover the `strict` flag of the `repo update` command
- Adds the required code to prevent a race condition in the `repo update` command
- Closes #4896 

**Special notes for your reviewer**:

While adding the test, noticed a race in the repo update code, due to the potential for multiple go routines to increment the error counter/write to the shared output stream.
Included the required mutex in the repo update code in the same commit, since the new test uncovered the race condition.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
