### PR TITLE
Fix nested null value overrides

### DIFF
--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -29,8 +29,11 @@ import (
 
 func TestGetValuesCmd(t *testing.T) {
 	releaseWithValues := helm.ReleaseMock(&helm.MockReleaseOptions{
-		Name:   "thomas-guide",
-		Chart:  &chart.Chart{Values: &chart.Config{Raw: `foo2: "bar2"`}},
+		Name: "thomas-guide",
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{Name: "thomas-guide-chart-name"},
+			Values:   &chart.Config{Raw: `foo2: "bar2"`},
+		},
 		Config: &chart.Config{Raw: `foo: "bar"`},
 	})
 

--- a/pkg/chartutil/testdata/moby/values.yaml
+++ b/pkg/chartutil/testdata/moby/values.yaml
@@ -7,3 +7,18 @@ right: exists
 left: exists
 front: exists
 back: exists
+
+# nested tables for null coalesce testing
+web:
+  livenessProbe:
+    failureThreshold: 5
+    httpGet:
+      path: /api/v1/info
+      port: atc
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+  readinessProbe:
+    httpGet:
+      path: /api/v1/info
+      port: atc

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -327,21 +327,32 @@ func coalesceTables(dst, src map[string]interface{}, chartName string) map[strin
 	// Because dest has higher precedence than src, dest values override src
 	// values.
 	for key, val := range src {
+		dv, ok := dst[key]
+		if ok && dv == nil {
+			// skip here, we delete at end
+			continue
+		}
 		if istable(val) {
-			if innerdst, ok := dst[key]; !ok {
+			if !ok {
 				dst[key] = val
-			} else if istable(innerdst) {
-				coalesceTables(innerdst.(map[string]interface{}), val.(map[string]interface{}), chartName)
+			} else if istable(dv) {
+				coalesceTables(dv.(map[string]interface{}), val.(map[string]interface{}), chartName)
 			} else {
 				log.Printf("Warning: Merging destination map for chart '%s'. Cannot overwrite table item '%s', with non table value: %v", chartName, key, val)
 			}
 			continue
-		} else if dv, ok := dst[key]; ok && istable(dv) {
+		} else if ok && istable(dv) {
 			log.Printf("Warning: Merging destination map for chart '%s'. The destination item '%s' is a table and ignoring the source '%s' as it has a non-table value of: %v", chartName, key, key, val)
 			continue
 		} else if !ok { // <- ok is still in scope from preceding conditional.
 			dst[key] = val
 			continue
+		}
+	}
+	// never return a nil value, rather delete the key
+	for k, v := range dst {
+		if v == nil {
+			delete(dst, k)
 		}
 	}
 	return dst


### PR DESCRIPTION
Closes #5184 

**What this PR does / why we need it**:

This PR adds tests for setting nested values to `null` and ensure such values are actually deleted.

**Special notes for your reviewer**:

I've split this into 4 commits. They do the following:

1. Adds some code to the tests to make it easier to add nested null values tests.
2. Adds tests that fails.
3. Does a fairly minimal fix - this is enough to make the tests pass.
4. The last commit touches a bit more code, and attempts to simplify the coalescence more broadly by consolidating on to a single codepath, and being a bit more careful about which maps are mutated. Tests continue to pass - but I'm a little less confident about the full impact of this commit.

**If applicable**:

- [x] this PR contains unit tests
