### PR TITLE
Fix: kind sorter incorrectly compares unknown and namespace

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -122,20 +122,27 @@ func (k *kindSorter) Less(i, j int) bool {
 	b := k.manifests[j]
 	first, aok := k.ordering[a.Head.Kind]
 	second, bok := k.ordering[b.Head.Kind]
-	// if same kind (including unknown) sub sort alphanumeric
-	if first == second {
-		// if both are unknown and of different kind sort by kind alphabetically
-		if !aok && !bok && a.Head.Kind != b.Head.Kind {
+
+	if !aok && !bok {
+		// if both are unknown then sort alphabetically by kind and name
+		if a.Head.Kind != b.Head.Kind {
 			return a.Head.Kind < b.Head.Kind
+		} else {
+			return a.Name < b.Name
 		}
-		return a.Name < b.Name
 	}
+
 	// unknown kind is last
 	if !aok {
 		return false
 	}
 	if !bok {
 		return true
+	}
+
+	// if same kind sub sort alphanumeric
+	if first == second {
+		return a.Name < b.Name
 	}
 	// sort different kinds
 	return first < second

--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -219,3 +219,24 @@ func TestKindSorterSubSort(t *testing.T) {
 		})
 	}
 }
+
+func TestKindSorterNamespaceAgainstUnknown(t *testing.T) {
+	unknown := Manifest{
+		Name: "a",
+		Head: &util.SimpleHead{Kind: "Unknown"},
+	}
+	namespace := Manifest{
+		Name: "b",
+		Head: &util.SimpleHead{Kind: "Namespace"},
+	}
+
+	manifests := []Manifest{unknown, namespace}
+	sortByKind(manifests, InstallOrder)
+
+	expectedOrder := []Manifest{namespace, unknown}
+	for i, manifest := range manifests {
+		if expectedOrder[i].Name != manifest.Name {
+			t.Errorf("Expected %s, got %s", expectedOrder[i].Name, manifest.Name)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The kind_sorter incorrectly compares Namespace and unknown type. This PR fixes comparison logic in Less method.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
