### PR TITLE
Refactor helm init command for local helm home directory initialization reuse

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/client-go/util/homedir"
+	"k8s.io/helm/cmd/helm/installer"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/helm/environment"
 	"k8s.io/helm/pkg/helm/helmpath"
@@ -137,7 +138,7 @@ func ensureTestHome(home helmpath.Home, t *testing.T) error {
 		}
 	}
 
-	localRepoIndexFile := home.LocalRepository(localRepositoryIndexFile)
+	localRepoIndexFile := home.LocalRepository(installer.LocalRepositoryIndexFile)
 	if fi, err := os.Stat(localRepoIndexFile); err != nil {
 		i := repo.NewIndexFile()
 		if err := i.WriteFile(localRepoIndexFile, 0644); err != nil {

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -31,11 +31,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/helm/cmd/helm/installer"
-	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/helm/portforwarder"
-	"k8s.io/helm/pkg/repo"
 	"k8s.io/helm/pkg/version"
 )
 
@@ -59,12 +57,6 @@ repository on the master branch).
 To dump a manifest containing the Tiller deployment YAML, combine the
 '--dry-run' and '--debug' flags.
 `
-
-const (
-	stableRepository         = "stable"
-	localRepository          = "local"
-	localRepositoryIndexFile = "index.yaml"
-)
 
 var (
 	stableRepositoryURL = "https://kubernetes-charts.storage.googleapis.com"
@@ -266,14 +258,8 @@ func (i *initCmd) run() error {
 		return nil
 	}
 
-	if err := ensureDirectories(i.home, i.out); err != nil {
-		return err
-	}
-	if err := ensureDefaultRepos(i.home, i.out, i.skipRefresh); err != nil {
-		return err
-	}
-	if err := ensureRepoFileFormat(i.home.RepositoryFile(), i.out); err != nil {
-		return err
+	if err := installer.Initialize(i.home, i.out, i.skipRefresh, settings, stableRepositoryURL, localRepositoryURL); err != nil {
+		return fmt.Errorf("error initializing: %s", err)
 	}
 	fmt.Fprintf(i.out, "$HELM_HOME has been configured at %s.\n", settings.Home)
 
@@ -345,117 +331,6 @@ func (i *initCmd) ping(image string) error {
 		i.client = newClient()
 		if err := i.client.PingTiller(); err != nil {
 			return fmt.Errorf("could not ping Tiller: %s", err)
-		}
-	}
-
-	return nil
-}
-
-// ensureDirectories checks to see if $HELM_HOME exists.
-//
-// If $HELM_HOME does not exist, this function will create it.
-func ensureDirectories(home helmpath.Home, out io.Writer) error {
-	configDirectories := []string{
-		home.String(),
-		home.Repository(),
-		home.Cache(),
-		home.LocalRepository(),
-		home.Plugins(),
-		home.Starters(),
-		home.Archive(),
-	}
-	for _, p := range configDirectories {
-		if fi, err := os.Stat(p); err != nil {
-			fmt.Fprintf(out, "Creating %s \n", p)
-			if err := os.MkdirAll(p, 0755); err != nil {
-				return fmt.Errorf("Could not create %s: %s", p, err)
-			}
-		} else if !fi.IsDir() {
-			return fmt.Errorf("%s must be a directory", p)
-		}
-	}
-
-	return nil
-}
-
-func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool) error {
-	repoFile := home.RepositoryFile()
-	if fi, err := os.Stat(repoFile); err != nil {
-		fmt.Fprintf(out, "Creating %s \n", repoFile)
-		f := repo.NewRepoFile()
-		sr, err := initStableRepo(home.CacheIndex(stableRepository), out, skipRefresh, home)
-		if err != nil {
-			return err
-		}
-		lr, err := initLocalRepo(home.LocalRepository(localRepositoryIndexFile), home.CacheIndex("local"), out, home)
-		if err != nil {
-			return err
-		}
-		f.Add(sr)
-		f.Add(lr)
-		if err := f.WriteFile(repoFile, 0644); err != nil {
-			return err
-		}
-	} else if fi.IsDir() {
-		return fmt.Errorf("%s must be a file, not a directory", repoFile)
-	}
-	return nil
-}
-
-func initStableRepo(cacheFile string, out io.Writer, skipRefresh bool, home helmpath.Home) (*repo.Entry, error) {
-	fmt.Fprintf(out, "Adding %s repo with URL: %s \n", stableRepository, stableRepositoryURL)
-	c := repo.Entry{
-		Name:  stableRepository,
-		URL:   stableRepositoryURL,
-		Cache: cacheFile,
-	}
-	r, err := repo.NewChartRepository(&c, getter.All(settings))
-	if err != nil {
-		return nil, err
-	}
-
-	if skipRefresh {
-		return &c, nil
-	}
-
-	// In this case, the cacheFile is always absolute. So passing empty string
-	// is safe.
-	if err := r.DownloadIndexFile(""); err != nil {
-		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
-	}
-
-	return &c, nil
-}
-
-func initLocalRepo(indexFile, cacheFile string, out io.Writer, home helmpath.Home) (*repo.Entry, error) {
-	if fi, err := os.Stat(indexFile); err != nil {
-		fmt.Fprintf(out, "Adding %s repo with URL: %s \n", localRepository, localRepositoryURL)
-		i := repo.NewIndexFile()
-		if err := i.WriteFile(indexFile, 0644); err != nil {
-			return nil, err
-		}
-
-		//TODO: take this out and replace with helm update functionality
-		if err := createLink(indexFile, cacheFile, home); err != nil {
-			return nil, err
-		}
-	} else if fi.IsDir() {
-		return nil, fmt.Errorf("%s must be a file, not a directory", indexFile)
-	}
-
-	return &repo.Entry{
-		Name:  localRepository,
-		URL:   localRepositoryURL,
-		Cache: cacheFile,
-	}, nil
-}
-
-func ensureRepoFileFormat(file string, out io.Writer) error {
-	r, err := repo.LoadRepositoriesFile(file)
-	if err == repo.ErrRepoOutOfDate {
-		fmt.Fprintln(out, "Updating repository file format...")
-		if err := r.WriteFile(file, 0644); err != nil {
-			return err
 		}
 	}
 

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -176,51 +176,6 @@ func TestInitCmd_dryRun(t *testing.T) {
 		if err := yaml.Unmarshal(doc, &y); err != nil {
 			t.Errorf("Expected parseable YAML, got %q\n\t%s", doc, err)
 		}
-	}
-}
-
-func TestEnsureHome(t *testing.T) {
-	home, err := ioutil.TempDir("", "helm_home")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(home)
-
-	b := bytes.NewBuffer(nil)
-	hh := helmpath.Home(home)
-	settings.Home = hh
-	if err := ensureDirectories(hh, b); err != nil {
-		t.Error(err)
-	}
-	if err := ensureDefaultRepos(hh, b, false); err != nil {
-		t.Error(err)
-	}
-	if err := ensureDefaultRepos(hh, b, true); err != nil {
-		t.Error(err)
-	}
-	if err := ensureRepoFileFormat(hh.RepositoryFile(), b); err != nil {
-		t.Error(err)
-	}
-
-	expectedDirs := []string{hh.String(), hh.Repository(), hh.Cache(), hh.LocalRepository()}
-	for _, dir := range expectedDirs {
-		if fi, err := os.Stat(dir); err != nil {
-			t.Errorf("%s", err)
-		} else if !fi.IsDir() {
-			t.Errorf("%s is not a directory", fi)
-		}
-	}
-
-	if fi, err := os.Stat(hh.RepositoryFile()); err != nil {
-		t.Error(err)
-	} else if fi.IsDir() {
-		t.Errorf("%s should not be a directory", fi)
-	}
-
-	if fi, err := os.Stat(hh.LocalRepository(localRepositoryIndexFile)); err != nil {
-		t.Errorf("%s", err)
-	} else if fi.IsDir() {
-		t.Errorf("%s should not be a directory", fi)
 	}
 }
 

--- a/cmd/helm/installer/init.go
+++ b/cmd/helm/installer/init.go
@@ -1,0 +1,166 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"k8s.io/helm/pkg/getter"
+	helm_env "k8s.io/helm/pkg/helm/environment"
+	"k8s.io/helm/pkg/helm/helmpath"
+	"k8s.io/helm/pkg/repo"
+)
+
+const (
+	stableRepository = "stable"
+
+	// LocalRepository is the standard name of the local repository
+	LocalRepository = "local"
+
+	// LocalRepositoryIndexFile is the standard name of the local repository index file
+	LocalRepositoryIndexFile = "index.yaml"
+)
+
+// Initialize initializes local config
+//
+// Returns an error if the command failed.
+func Initialize(home helmpath.Home, out io.Writer, skipRefresh bool, settings helm_env.EnvSettings, stableRepositoryURL, localRepositoryURL string) error {
+	if err := ensureDirectories(home, out); err != nil {
+		return err
+	}
+	if err := ensureDefaultRepos(home, out, skipRefresh, settings, stableRepositoryURL, localRepositoryURL); err != nil {
+		return err
+	}
+	if err := ensureRepoFileFormat(home.RepositoryFile(), out); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureDirectories checks to see if $HELM_HOME exists.
+//
+// If $HELM_HOME does not exist, this function will create it.
+func ensureDirectories(home helmpath.Home, out io.Writer) error {
+	configDirectories := []string{
+		home.String(),
+		home.Repository(),
+		home.Cache(),
+		home.LocalRepository(),
+		home.Plugins(),
+		home.Starters(),
+		home.Archive(),
+	}
+	for _, p := range configDirectories {
+		if fi, err := os.Stat(p); err != nil {
+			fmt.Fprintf(out, "Creating %s \n", p)
+			if err := os.MkdirAll(p, 0755); err != nil {
+				return fmt.Errorf("Could not create %s: %s", p, err)
+			}
+		} else if !fi.IsDir() {
+			return fmt.Errorf("%s must be a directory", p)
+		}
+	}
+
+	return nil
+}
+
+func ensureDefaultRepos(home helmpath.Home, out io.Writer, skipRefresh bool, settings helm_env.EnvSettings, stableRepositoryURL, localRepositoryURL string) error {
+	repoFile := home.RepositoryFile()
+	if fi, err := os.Stat(repoFile); err != nil {
+		fmt.Fprintf(out, "Creating %s \n", repoFile)
+		f := repo.NewRepoFile()
+		sr, err := initStableRepo(home.CacheIndex(stableRepository), home, out, skipRefresh, settings, stableRepositoryURL)
+		if err != nil {
+			return err
+		}
+		lr, err := initLocalRepo(home.LocalRepository(LocalRepositoryIndexFile), home.CacheIndex("local"), home, out, settings, localRepositoryURL)
+		if err != nil {
+			return err
+		}
+		f.Add(sr)
+		f.Add(lr)
+		if err := f.WriteFile(repoFile, 0644); err != nil {
+			return err
+		}
+	} else if fi.IsDir() {
+		return fmt.Errorf("%s must be a file, not a directory", repoFile)
+	}
+	return nil
+}
+
+func initStableRepo(cacheFile string, home helmpath.Home, out io.Writer, skipRefresh bool, settings helm_env.EnvSettings, stableRepositoryURL string) (*repo.Entry, error) {
+	fmt.Fprintf(out, "Adding %s repo with URL: %s \n", stableRepository, stableRepositoryURL)
+	c := repo.Entry{
+		Name:  stableRepository,
+		URL:   stableRepositoryURL,
+		Cache: cacheFile,
+	}
+	r, err := repo.NewChartRepository(&c, getter.All(settings))
+	if err != nil {
+		return nil, err
+	}
+
+	if skipRefresh {
+		return &c, nil
+	}
+
+	// In this case, the cacheFile is always absolute. So passing empty string
+	// is safe.
+	if err := r.DownloadIndexFile(""); err != nil {
+		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
+	}
+
+	return &c, nil
+}
+
+func initLocalRepo(indexFile, cacheFile string, home helmpath.Home, out io.Writer, settings helm_env.EnvSettings, localRepositoryURL string) (*repo.Entry, error) {
+	if fi, err := os.Stat(indexFile); err != nil {
+		fmt.Fprintf(out, "Adding %s repo with URL: %s \n", LocalRepository, localRepositoryURL)
+		i := repo.NewIndexFile()
+		if err := i.WriteFile(indexFile, 0644); err != nil {
+			return nil, err
+		}
+
+		//TODO: take this out and replace with helm update functionality
+		if err := createLink(indexFile, cacheFile, home); err != nil {
+			return nil, err
+		}
+	} else if fi.IsDir() {
+		return nil, fmt.Errorf("%s must be a file, not a directory", indexFile)
+	}
+
+	return &repo.Entry{
+		Name:  LocalRepository,
+		URL:   localRepositoryURL,
+		Cache: cacheFile,
+	}, nil
+}
+
+func ensureRepoFileFormat(file string, out io.Writer) error {
+	r, err := repo.LoadRepositoriesFile(file)
+	if err == repo.ErrRepoOutOfDate {
+		fmt.Fprintln(out, "Updating repository file format...")
+		if err := r.WriteFile(file, 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/helm/installer/init_test.go
+++ b/cmd/helm/installer/init_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer // import "k8s.io/helm/cmd/helm/installer"
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	helm_env "k8s.io/helm/pkg/helm/environment"
+	"k8s.io/helm/pkg/helm/helmpath"
+)
+
+func TestInitialize(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(home)
+
+	b := bytes.NewBuffer(nil)
+	hh := helmpath.Home(home)
+
+	settings := helm_env.EnvSettings{
+		Home: hh,
+	}
+	stableRepositoryURL := "https://kubernetes-charts.storage.googleapis.com"
+	localRepositoryURL := "http://127.0.0.1:8879/charts"
+
+	if err := Initialize(hh, b, false, settings, stableRepositoryURL, localRepositoryURL); err != nil {
+		t.Error(err)
+	}
+
+	expectedDirs := []string{hh.String(), hh.Repository(), hh.Cache(), hh.LocalRepository()}
+	for _, dir := range expectedDirs {
+		if fi, err := os.Stat(dir); err != nil {
+			t.Errorf("%s", err)
+		} else if !fi.IsDir() {
+			t.Errorf("%s is not a directory", fi)
+		}
+	}
+
+	if fi, err := os.Stat(hh.RepositoryFile()); err != nil {
+		t.Error(err)
+	} else if fi.IsDir() {
+		t.Errorf("%s should not be a directory", fi)
+	}
+
+	if fi, err := os.Stat(hh.LocalRepository(LocalRepositoryIndexFile)); err != nil {
+		t.Errorf("%s", err)
+	} else if fi.IsDir() {
+		t.Errorf("%s should not be a directory", fi)
+	}
+}
+
+func TestEnsureHome(t *testing.T) {
+	home, err := ioutil.TempDir("", "helm_home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(home)
+
+	b := bytes.NewBuffer(nil)
+	hh := helmpath.Home(home)
+
+	settings := helm_env.EnvSettings{
+		Home: hh,
+	}
+	stableRepositoryURL := "https://kubernetes-charts.storage.googleapis.com"
+	localRepositoryURL := "http://127.0.0.1:8879/charts"
+
+	if err := ensureDirectories(hh, b); err != nil {
+		t.Error(err)
+	}
+	if err := ensureDefaultRepos(hh, b, false, settings, stableRepositoryURL, localRepositoryURL); err != nil {
+		t.Error(err)
+	}
+	if err := ensureDefaultRepos(hh, b, true, settings, stableRepositoryURL, localRepositoryURL); err != nil {
+		t.Error(err)
+	}
+	if err := ensureRepoFileFormat(hh.RepositoryFile(), b); err != nil {
+		t.Error(err)
+	}
+
+	expectedDirs := []string{hh.String(), hh.Repository(), hh.Cache(), hh.LocalRepository()}
+	for _, dir := range expectedDirs {
+		if fi, err := os.Stat(dir); err != nil {
+			t.Errorf("%s", err)
+		} else if !fi.IsDir() {
+			t.Errorf("%s is not a directory", fi)
+		}
+	}
+
+	if fi, err := os.Stat(hh.RepositoryFile()); err != nil {
+		t.Error(err)
+	} else if fi.IsDir() {
+		t.Errorf("%s should not be a directory", fi)
+	}
+
+	if fi, err := os.Stat(hh.LocalRepository(LocalRepositoryIndexFile)); err != nil {
+		t.Errorf("%s", err)
+	} else if fi.IsDir() {
+		t.Errorf("%s should not be a directory", fi)
+	}
+}

--- a/cmd/helm/installer/init_unix.go
+++ b/cmd/helm/installer/init_unix.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
 	"os"

--- a/cmd/helm/installer/init_windows.go
+++ b/cmd/helm/installer/init_windows.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
 	"os"

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/helm/cmd/helm/installer"
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/repo"
@@ -99,7 +100,7 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer, home helmpath.Ho
 		wg.Add(1)
 		go func(re *repo.ChartRepository) {
 			defer wg.Done()
-			if re.Config.Name == localRepository {
+			if re.Config.Name == installer.LocalRepository {
 				mu.Lock()
 				fmt.Fprintf(out, "...Skip %s chart repository\n", re.Config.Name)
 				mu.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR refactors the helm init command to allow other programs to initialize the local helm home directory without shelling out to the `helm init` command.

The only moved parts are:
- `ensureDirectories()`
- `ensureDefaultRepos()`
- `ensureRepoFileFormat()`

My current use case is with the terraform-provider-helm to resolve https://github.com/terraform-providers/terraform-provider-helm/issues/139

**Special notes for your reviewer**:

~I've prefixed the PR title as WIP because the terraform provider part is not yet implemented (in progress) but I wanted to check early if this sort of change would be acceptable on the helm end.~

**If applicable**:
- [x] this PR contains documentation (N/A: no CLI user visible change)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility (N/A: no structure change)

**Unit test results**:

```
# go test -v ./cmd/helm ./cmd/helm/installer -run '^Test(InitCmd|EnsureHome|Initialize)' -count=1
=== RUN   TestInitCmd
--- PASS: TestInitCmd (50.96s)
=== RUN   TestInitCmd_exists
--- PASS: TestInitCmd_exists (87.33s)
=== RUN   TestInitCmd_clientOnly
--- PASS: TestInitCmd_clientOnly (4.09s)
=== RUN   TestInitCmd_dryRun
--- PASS: TestInitCmd_dryRun (0.00s)
=== RUN   TestInitCmd_tlsOptions
--- PASS: TestInitCmd_tlsOptions (0.00s)
=== RUN   TestInitCmd_output
--- PASS: TestInitCmd_output (0.00s)
PASS
ok      k8s.io/helm/cmd/helm    142.437s
=== RUN   TestInitialize
--- PASS: TestInitialize (52.90s)
=== RUN   TestEnsureHome
--- PASS: TestEnsureHome (36.85s)
PASS
ok      k8s.io/helm/cmd/helm/installer  89.772s
```