### PR TITLE
Make sure a plugin command name does not already exist

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -44,6 +44,8 @@ var (
 	settings     helm_env.EnvSettings
 )
 
+var RootCmd *cobra.Command
+
 var globalUsage = `The Kubernetes package manager
 
 To begin working with Helm, run the 'helm init' command:
@@ -156,6 +158,8 @@ func newRootCmd(args []string) *cobra.Command {
 
 	// Find and add plugins
 	loadPlugins(cmd, out)
+
+	RootCmd = cmd
 
 	return cmd
 }

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -42,9 +42,8 @@ import (
 var (
 	tillerTunnel *kube.Tunnel
 	settings     helm_env.EnvSettings
+	rootCmd      *cobra.Command
 )
-
-var RootCmd *cobra.Command
 
 var globalUsage = `The Kubernetes package manager
 
@@ -159,7 +158,7 @@ func newRootCmd(args []string) *cobra.Command {
 	// Find and add plugins
 	loadPlugins(cmd, out)
 
-	RootCmd = cmd
+	rootCmd = cmd
 
 	return cmd
 }
@@ -294,4 +293,9 @@ func newClient() helm.Interface {
 		options = append(options, helm.WithTLS(tlscfg))
 	}
 	return helm.NewClient(options...)
+}
+
+// GetRootCmd returns the root cobra command
+func GetRootCmd() *cobra.Command {
+	return rootCmd
 }

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -62,6 +62,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 	}
 
 	// Now we create commands for all of these.
+loop:
 	for _, plug := range found {
 		plug := plug
 		md := plug.Metadata
@@ -117,7 +118,12 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 			}
 		}
 
-		// TODO: Make sure a command with this name does not already exist.
+		// Make sure a command with this name does not already exist.
+		for _, cmd := range baseCmd.Commands() {
+			if cmd.Name() == md.Name {
+				continue loop
+			}
+		}
 		baseCmd.AddCommand(c)
 	}
 }

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -23,21 +23,11 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"text/template"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/plugin"
 )
-
-var pluginLoadWarningTemp = template.Must(template.New("plugin").Parse(`
-Helm Client Plugin Load Warning(s):
-{{range $_, $warning := .Warnings}}
-- {{ $warning }}
-{{end}}
-In order to eliminate this warning(s), please try to uninstall or reinstall the plugin(s) in question.
-------------------------------------------------------------------------------------------------------
-`))
 
 type pluginError struct {
 	error
@@ -72,8 +62,6 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 	}
 
 	// Now we create commands for all of these.
-	warnings := []string{}
-loop:
 	for _, plug := range found {
 		plug := plug
 		md := plug.Metadata
@@ -129,22 +117,9 @@ loop:
 			}
 		}
 
-		// Make sure a command with this name does not already exist.
-		for _, cmd := range baseCmd.Commands() {
-			if cmd.Name() == md.Name {
-				warning := fmt.Sprintf("A command with the name of [%s] already exists, so the plugin at [%s] will not be loaded.", md.Name, plug.Dir)
-				warnings = append(warnings, warning)
-				continue loop
-			}
-		}
+		// TODO: Make sure a command with this name does not already exist.
 		baseCmd.AddCommand(c)
 	}
-
-	ctx := map[string]interface{}{
-		"Warnings": warnings,
-	}
-
-	pluginLoadWarningTemp.Execute(out, ctx)
 }
 
 // manuallyProcessArgs processes an arg array, removing special args.

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -86,7 +86,8 @@ func (pcmd *pluginInstallCmd) run() error {
 
 	// Make sure a command with this name does not already exist.
 	pluginCmdName := p.Metadata.Name
-	for _, cmd := range RootCmd.Commands() {
+	rootCmd := GetRootCmd()
+	for _, cmd := range rootCmd.Commands() {
 		if cmd.Name() == pluginCmdName {
 			os.Remove(p.Dir)
 			err = fmt.Errorf("Plugin <%s> not installed as plugin with that name is already installed.", pluginCmdName)

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/plugin"
@@ -83,10 +84,20 @@ func (pcmd *pluginInstallCmd) run() error {
 		return err
 	}
 
+	// Make sure a command with this name does not already exist.
+	pluginCmdName := p.Metadata.Name
+	for _, cmd := range RootCmd.Commands() {
+		if cmd.Name() == pluginCmdName {
+			os.Remove(p.Dir)
+			err = fmt.Errorf("Plugin <%s> not installed as plugin with that name is already installed.", pluginCmdName)
+			return err
+		}
+	}
+
 	if err := runHook(p, plugin.Install); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(pcmd.out, "Installed plugin: %s\n", p.Metadata.Name)
+	fmt.Fprintf(pcmd.out, "Installed plugin: %s\n", pluginCmdName)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Plugins load: make sure a plugin command name does not already exist.

Also, I think maybe we should do some command uniqueness checks before perform `plugin install` ?!

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
