### PR TITLE
fix: ignore pax_global_header "file" in chart validation

### DIFF
--- a/pkg/chartutil/load.go
+++ b/pkg/chartutil/load.go
@@ -93,6 +93,12 @@ func loadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 			continue
 		}
 
+		switch hd.Typeflag {
+		// We don't want to process these extension header files.
+		case tar.TypeXGlobalHeader, tar.TypeXHeader:
+			continue
+		}
+
 		// Archive could contain \ if generated on Windows
 		delimiter := "/"
 		if strings.ContainsRune(hd.Name, '\\') {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

PR #5165 introduced tar file validation but that validation fails when attempting to install charts that are GitHub archives (eg. `https://github.com/org/repo/master.tar.gz`) due to the presence of a meta-file called `pax_global_header`.

Files of type `x` or `g` can be ignored.

**Special notes for your reviewer**:

I wasn't sure how to write a unit test for this. Thoughts?

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

/cc @technosophos 