### PR TITLE
Switch to numeric user id

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -22,6 +22,6 @@ COPY helm /helm
 COPY tiller /tiller
 
 EXPOSE 44134
-USER nobody
+USER 65534
 ENTRYPOINT ["/tiller"]
 

--- a/rootfs/Dockerfile.experimental
+++ b/rootfs/Dockerfile.experimental
@@ -21,6 +21,6 @@ ENV HOME /tmp
 COPY tiller /tiller
 
 EXPOSE 44134
-USER nobody
+USER 65534
 ENTRYPOINT ["/tiller", "--experimental-release"]
 


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #4818 

Using the actual username as USER value makes a PodSecurityPolicy-enabled kubernetes cluster refuse to start the pod:

```
  Type     Reason          Age                 From                                           Message
  ----     ------          ----                ----                                           -------
  Normal   Scheduled       10m                 default-scheduler                              Successfully assigned test/tiller-deploy-cb64d6bf5-gnp6f to k8spoc-worker001
  Warning  Failed          10m (x8 over 10m)   kubelet, k8spoc-worker001  Error: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root
  Normal   SandboxChanged  10m (x8 over 10m)   kubelet, k8spoc-worker001  Pod sandbox changed, it will be killed and re-created.
  Normal   Pulled          41s (x72 over 10m)  kubelet, k8spoc-worker001  Container image "gcr.io/kubernetes-helm/tiller:v2.12.3" already present on machine
```
Changing USER to its numeric counterpart fixes this behaviour.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
