### PR TITLE
Update documentation with option to install helm on Windows via scoop

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -45,13 +45,19 @@ brew install kubernetes-helm
 (Note: There is also a formula for emacs-helm, which is a different
 project.)
 
-### From Chocolatey (Windows)
+### From Chocolatey or scoop (Windows)
 
 Members of the Kubernetes community have contributed a [Helm package](https://chocolatey.org/packages/kubernetes-helm) build to
 [Chocolatey](https://chocolatey.org/). This package is generally up to date.
 
 ```
 choco install kubernetes-helm
+```
+
+The binary can also be installed via [`scoop`](https://scoop.sh) command-line installer.
+
+```
+scoop install helm
 ```
 
 ## From Script


### PR DESCRIPTION
Signed-off-by: Marcin Kłopotek <marcin.klopotek@gmail.com>

**What this PR does / why we need it**:

Updated documentation - added option to install `helm` binary via [`scoop`](https://scoop.sh) command-line installer.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility