### PR TITLE
Fix some typos in comment

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -302,7 +302,7 @@ func (h *Client) RunReleaseTest(rlsName string, opts ...ReleaseTestOption) (<-ch
 	return h.test(ctx, req)
 }
 
-// PingTiller pings the Tiller pod and ensure's that it is up and running
+// PingTiller pings the Tiller pod and ensures that it is up and running
 func (h *Client) PingTiller() error {
 	ctx := NewContext()
 	return h.ping(ctx)

--- a/pkg/helm/fake.go
+++ b/pkg/helm/fake.go
@@ -257,7 +257,7 @@ func (c *FakeClient) RunReleaseTest(rlsName string, opts ...ReleaseTestOption) (
 	return results, errc
 }
 
-// PingTiller pings the Tiller pod and ensure's that it is up and running
+// PingTiller pings the Tiller pod and ensures that it is up and running
 func (c *FakeClient) PingTiller() error {
 	return nil
 }

--- a/pkg/helm/option.go
+++ b/pkg/helm/option.go
@@ -460,7 +460,7 @@ type VersionOption func(*options)
 // the defaults used when running the `helm upgrade` command.
 type UpdateOption func(*options)
 
-// RollbackOption allows specififying various settings configurable
+// RollbackOption allows specifying various settings configurable
 // by the helm client user for overriding the defaults used when
 // running the `helm rollback` command.
 type RollbackOption func(*options)


### PR DESCRIPTION
1. "ensure's" to "ensures".
2. "specififying" to "specifying".