### PR TITLE
fix(tiller): respect resource policy on upgrade

### DIFF
--- a/pkg/kube/resource_policy.go
+++ b/pkg/kube/resource_policy.go
@@ -1,0 +1,26 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+// ResourcePolicyAnno is the annotation name for a resource policy
+const ResourcePolicyAnno = "helm.sh/resource-policy"
+
+// KeepPolicy is the resource policy type for keep
+//
+// This resource policy type allows resources to skip being deleted
+//   during an uninstallRelease action.
+const KeepPolicy = "keep"

--- a/pkg/tiller/resource_policy.go
+++ b/pkg/tiller/resource_policy.go
@@ -24,15 +24,6 @@ import (
 	"k8s.io/helm/pkg/tiller/environment"
 )
 
-// resourcePolicyAnno is the annotation name for a resource policy
-const resourcePolicyAnno = "helm.sh/resource-policy"
-
-// keepPolicy is the resource policy type for keep
-//
-// This resource policy type allows resources to skip being deleted
-//   during an uninstallRelease action.
-const keepPolicy = "keep"
-
 func filterManifestsToKeep(manifests []Manifest) ([]Manifest, []Manifest) {
 	remaining := []Manifest{}
 	keep := []Manifest{}
@@ -43,14 +34,14 @@ func filterManifestsToKeep(manifests []Manifest) ([]Manifest, []Manifest) {
 			continue
 		}
 
-		resourcePolicyType, ok := m.Head.Metadata.Annotations[resourcePolicyAnno]
+		resourcePolicyType, ok := m.Head.Metadata.Annotations[kube.ResourcePolicyAnno]
 		if !ok {
 			remaining = append(remaining, m)
 			continue
 		}
 
 		resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
-		if resourcePolicyType == keepPolicy {
+		if resourcePolicyType == kube.KeepPolicy {
 			keep = append(keep, m)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't delete a resource on upgrade if it is annotated with
helm.io/resource-policy=keep. This can cause data loss for users if the
annotation is ignored (e.g. for a PVC).

Use case:
1. As a helm chart maintainer, I want to prevent accidental deletion of users resources, such as persistent volumes - which could be catastrophic.
2. I annotate the PVCs with `helm.io/resource-policy=keep` to ensure helm never removes them.

Unfortunately, in the current implementation, this annotation only works when `helm delete` is run. If the resource is removed from the chart or renamed, helm will ignore the annotation and delete it on a chart upgrade. This is easy to do accidentally. I believe this annotation should apply in any situation where helm might delete the resource, including on upgrades.

Closes #3673

**Special notes for your reviewer**:

I don't think this will cause backwards compatibility problems. It might be surprising new behavior though if someone is relying on upgrades/resource renames to delete things with `helm.io/resource-policy=keep` on them (but that seems pretty strange!). An alternative approach would be to add a new resource policy, like `always-keep`.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
