### PR TITLE
Clarify section title

### DIFF
--- a/docs/chart_template_guide/subcharts_and_globals.md
+++ b/docs/chart_template_guide/subcharts_and_globals.md
@@ -63,7 +63,7 @@ data:
   dessert: cake
 ```
 
-## Overriding Values from a Parent Chart
+## Overriding Values of a Child Chart
 
 Our original chart, `mychart` is now the _parent_ chart of `mysubchart`. This relationship is based entirely on the fact that `mysubchart` is within `mychart/charts`.
 


### PR DESCRIPTION
As stated by @schollii [here](https://github.com/helm/helm/issues/4505#issuecomment-415886732) "Overriding Values from a Parent Chart" is unclear. This changes that text to "Overriding Values of a Child Chart". See @scholli's comment for justification.

Fixes  #4505