### PR TITLE
Removed old link for Cabin mobile app

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -89,7 +89,6 @@ Tools layered on top of Helm or Tiller.
 
 Platforms, distributions, and services that include Helm support.
 
-- [Cabin](http://www.skippbox.com/cabin/) - Mobile App for Managing Kubernetes
 - [Fabric8](https://fabric8.io) - Integrated development platform for Kubernetes
 - [Jenkins X](http://jenkins-x.io/) - open source automated CI/CD for Kubernetes which uses Helm for [promoting](http://jenkins-x.io/about/features/#promotion) applications through [environments via GitOps](http://jenkins-x.io/about/features/#environments)
 - [Kubernetic](https://kubernetic.com/) - Kubernetes Desktop Client


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the documentation by removing an invalid link for the Cabin mobile app.

**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
