### PR TITLE
Update README with scoop install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you want to use a package manager:
 
 - [Homebrew](https://brew.sh/) users can use `brew install kubernetes-helm`.
 - [Chocolatey](https://chocolatey.org/) users can use `choco install kubernetes-helm`.
+- [Scoop](https://scoop.sh/) users can use `scoop install helm`.
 - [GoFish](https://gofi.sh/) users can use `gofish install helm`.
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).


### PR DESCRIPTION
Signed-off-by: Marcin Kłopotek <marcin.klopotek@gmail.com>

**What this PR does / why we need it**:

Updated documentation - added option to install `helm` binary via [`scoop`](https://scoop.sh) command-line installer.

This is a supplement for #5207 (I forgot to update README file as well).

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility