### PR TITLE
deleted lint for directory name - not realy needed in real life

### DIFF
--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -48,7 +48,6 @@ func Chartfile(linter *support.Linter) {
 
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartNamePresence(chartFile))
 	linter.RunLinterRule(support.WarningSev, chartFileName, validateChartNameFormat(chartFile))
-	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartNameDirMatch(linter.ChartDir, chartFile))
 
 	// Chart metadata
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartVersion(chartFile))
@@ -85,13 +84,6 @@ func validateChartNamePresence(cf *chart.Metadata) error {
 func validateChartNameFormat(cf *chart.Metadata) error {
 	if strings.Contains(cf.Name, ".") {
 		return errors.New("name should be lower case letters and numbers. Words may be separated with dashes")
-	}
-	return nil
-}
-
-func validateChartNameDirMatch(chartDir string, cf *chart.Metadata) error {
-	if cf.Name != filepath.Base(chartDir) {
-		return fmt.Errorf("directory name (%s) and chart name (%s) must be the same", filepath.Base(chartDir), cf.Name)
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -82,23 +82,6 @@ func TestValidateChartNameFormat(t *testing.T) {
 	}
 }
 
-func TestValidateChartNameDirMatch(t *testing.T) {
-	err := validateChartNameDirMatch(goodChartDir, goodChart)
-	if err != nil {
-		t.Errorf("validateChartNameDirMatch to return no error, gor a linter error")
-	}
-	// It has not name
-	err = validateChartNameDirMatch(badChartDir, badChart)
-	if err == nil {
-		t.Errorf("validatechartnamedirmatch to return a linter error, got no error")
-	}
-
-	// Wrong path
-	err = validateChartNameDirMatch(badChartDir, goodChart)
-	if err == nil {
-		t.Errorf("validatechartnamedirmatch to return a linter error, got no error")
-	}
-}
 
 func TestValidateChartVersion(t *testing.T) {
 	var failTest = []struct {


### PR DESCRIPTION
#### Why it realy needed

Many repositories uses `./.helm/ ` as storage for helm charts inside the repository with code. And many peoples can't use helm linter inside automatic pipelines. I think, it's usless check. For what we need Chart.yaml?
