### PR TITLE
Fix some spelling errors in comment

### DIFF
--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -148,7 +148,7 @@ func (s *Server) URL() string {
 	return s.srv.URL
 }
 
-// LinkIndices links the index created with CreateIndex and makes a symboic link to the repositories/cache directory.
+// LinkIndices links the index created with CreateIndex and makes a symbolic link to the repositories/cache directory.
 //
 // This makes it possible to simulate a local cache of a repository.
 func (s *Server) LinkIndices() error {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -45,7 +45,7 @@ type Secrets struct {
 	Log  func(string, ...interface{})
 }
 
-// NewSecrets initializes a new Secrets wrapping an implmenetation of
+// NewSecrets initializes a new Secrets wrapping an implementation of
 // the kubernetes SecretsInterface.
 func NewSecrets(impl corev1.SecretInterface) *Secrets {
 	return &Secrets{

--- a/pkg/tiller/release_list.go
+++ b/pkg/tiller/release_list.go
@@ -140,7 +140,7 @@ func (s *ReleaseServer) partition(rels []*release.Release, cap int) <-chan []*re
 				// Over-cap, push chunk onto channel to send over gRPC stream
 				s.Log("partitioned at %d with %d releases (cap=%d)", fill, len(chunk), cap)
 				chunks <- chunk
-				// reset paritioning state
+				// reset partitioning state
 				chunk = nil
 				fill = 0
 			}


### PR DESCRIPTION
1. "symboic" to "symbolic" in line 151.
2. "implmenetation" to "implementation" in line 48.
3. "paritioning" to "partitioning" in line 143.