### PR TITLE
fix(chartutil): remove duplicated assignment

### DIFF
--- a/pkg/chartutil/requirements_test.go
+++ b/pkg/chartutil/requirements_test.go
@@ -228,7 +228,6 @@ func TestProcessRequirementsImportValues(t *testing.T) {
 	e["imported-chart1.SC1string"] = "dollywood"
 	e["imported-chart1.SC1extra1"] = "11"
 	e["imported-chart1.SPextra1"] = "helm rocks"
-	e["imported-chart1.SC1extra1"] = "11"
 
 	e["imported-chartA.SCAbool"] = "false"
 	e["imported-chartA.SCAfloat"] = "3.1"


### PR DESCRIPTION
Key `imported-chart1.SC1extra1` assigned to the same value of `11` twice.
Removed the second assignment.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>