### PR TITLE
Fail linting when `required` function fails.

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,7 +19,6 @@ package engine
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"path"
 	"sort"
 	"strings"
@@ -156,20 +155,10 @@ func (e *Engine) alterFuncMap(t *template.Template, referenceTpls map[string]ren
 	// Add the 'required' function here
 	funcMap["required"] = func(warn string, val interface{}) (interface{}, error) {
 		if val == nil {
-			if e.LintMode {
-				// Don't fail on missing required values when linting
-				log.Printf("[INFO] Missing required value: %s", warn)
-				return "", nil
-			}
 			// Convert nil to "" in case required is piped into other functions
 			return "", fmt.Errorf(warn)
 		} else if _, ok := val.(string); ok {
 			if val == "" {
-				if e.LintMode {
-					// Don't fail on missing required values when linting
-					log.Printf("[INFO] Missing required value: %s", warn)
-					return val, nil
-				}
 				return val, fmt.Errorf(warn)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug caused by https://github.com/helm/helm/pull/4221
**Special notes for your reviewer**:

This is a revert of the original change that was made as a result of: https://github.com/helm/helm/issues/2347
And was made in: https://github.com/helm/helm/pull/4221

The original change broke backwards compatibility with the behavior of the linter.

I believe this original change to be incorrect, hence the revert. My reasoning follows:

1. The purpose of the required function, per the documentation is to cause a chart failure when the value tested by the required function is not present.
1. The purpose of linting is to ensure the proper "compilation" of a chart (or code, or whatever is being linted) can take place. 

If values are missing that should be supplied, in order to validate proper compilation (that the template can run) then the linter should error in the exact same way that an executing template should error. The original change here circumvents that behavior. In fact, this change caused us to miss an issue with our chart during one of our build processes that subsequently caused a chart installation/upgrade to fail in a later process. 

We were using the linter to ensure that all of the secrets (which are obviously not part of the default `values.yaml` file in the chart) needed for installation/upgrade of the chart are actually present in our secret store. We run the linter against the chart with a values file supplied on the command line containing these secrets. This prevents someone from adding template code to the chart which depends on a value supplied as a secret which is not present in the secret store we use. This original change broke that behavior.

My suggestion is that if there is a desire for linting to behave as suggested in: https://github.com/helm/helm/issues/2347 then a flag needs to be added to the linter specifically for not failing on calls to the `required` function.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
