### PR TITLE
Add imagePullSecret to the `default` helm create template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -190,10 +190,10 @@ spec:
         app.kubernetes.io/name: {{ include "<CHARTNAME>.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+    {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -62,8 +62,8 @@ image:
   repository: nginx
   tag: stable
   pullPolicy: IfNotPresent
-  # pullSecret: my_secret
 
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -190,9 +190,9 @@ spec:
         app.kubernetes.io/name: {{ include "<CHARTNAME>.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if .Values.image.pullSecret -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -62,6 +62,7 @@ image:
   repository: nginx
   tag: stable
   pullPolicy: IfNotPresent
+  # pullSecret: my_secret
 
 nameOverride: ""
 fullnameOverride: ""
@@ -189,6 +190,10 @@ spec:
         app.kubernetes.io/name: {{ include "<CHARTNAME>.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.image.pullSecret -}}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This relates to [#3529](https://github.com/helm/helm/issues/3529).
It adds image.pullSecret to the default generate blank chart
when the user does `helm create`.

Signed-off-by: Don Bowman <don@agilicus.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
