### PR TITLE
Fix issue #5273 for get script on armv7l

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -29,7 +29,7 @@ initArch() {
   case $ARCH in
     armv5*) ARCH="armv5";;
     armv6*) ARCH="armv6";;
-    armv7*) ARCH="armv7";;
+    armv7*) ARCH="arm";;
     aarch64) ARCH="arm64";;
     x86) ARCH="386";;
     x86_64) ARCH="amd64";;


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This fixes issue #5273 in the get script by making the armv7l
architecture point at the correctly named "arm" binary on the
release page.

**Special notes for your reviewer**:

Change suggested by @bacongobbler 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
