### PR TITLE
Helm 3: fix "latest" tag bug

### DIFF
--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -137,7 +137,7 @@ func (cache *filesystemCache) ChartToLayers(ch *chart.Chart) ([]ocispec.Descript
 }
 
 func (cache *filesystemCache) LoadReference(ref *Reference) ([]ocispec.Descriptor, error) {
-	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Locator), "tags", tagOrDefault(ref.Object))
+	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tagOrDefault(ref.Tag))
 
 	// add meta layer
 	metaJSONRaw, err := getSymlinkDestContent(filepath.Join(tagDir, "meta"))
@@ -165,8 +165,8 @@ func (cache *filesystemCache) LoadReference(ref *Reference) ([]ocispec.Descripto
 }
 
 func (cache *filesystemCache) StoreReference(ref *Reference, layers []ocispec.Descriptor) (bool, error) {
-	tag := tagOrDefault(ref.Object)
-	tagDir := mkdir(filepath.Join(cache.rootDir, "refs", escape(ref.Locator), "tags", tag))
+	tag := tagOrDefault(ref.Tag)
+	tagDir := mkdir(filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tag))
 
 	// Retrieve just the meta and content layers
 	metaLayer, contentLayer, err := extractLayers(layers)
@@ -239,7 +239,7 @@ func (cache *filesystemCache) StoreReference(ref *Reference, layers []ocispec.De
 }
 
 func (cache *filesystemCache) DeleteReference(ref *Reference) error {
-	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Locator), "tags", tagOrDefault(ref.Object))
+	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tagOrDefault(ref.Tag))
 	if _, err := os.Stat(tagDir); os.IsNotExist(err) {
 		return errors.New("ref not found")
 	}
@@ -427,10 +427,10 @@ func getRefsSorted(refsRootDir string) ([][]interface{}, error) {
 				tagDir := filepath.Dir(path)
 
 				// Determine the ref
-				locator := unescape(strings.TrimLeft(
+				repo := unescape(strings.TrimLeft(
 					strings.TrimPrefix(filepath.Dir(filepath.Dir(tagDir)), refsRootDir), "/\\"))
-				object := filepath.Base(tagDir)
-				ref := fmt.Sprintf("%s:%s", locator, object)
+				tag := filepath.Base(tagDir)
+				ref := fmt.Sprintf("%s:%s", repo, tag)
 
 				// Init hashmap entry if does not exist
 				if _, ok := refsMap[ref]; !ok {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -60,7 +60,7 @@ func NewClient(options *ClientOptions) *Client {
 // PushChart uploads a chart to a registry
 func (c *Client) PushChart(ref *Reference) error {
 	c.setDefaultTag(ref)
-	fmt.Fprintf(c.out, "The push refers to repository [%s]\n", ref.Locator)
+	fmt.Fprintf(c.out, "The push refers to repository [%s]\n", ref.Repo)
 	layers, err := c.cache.LoadReference(ref)
 	if err != nil {
 		return err
@@ -74,14 +74,14 @@ func (c *Client) PushChart(ref *Reference) error {
 		totalSize += layer.Size
 	}
 	fmt.Fprintf(c.out,
-		"%s: pushed to remote (%d layers, %s total)\n", ref.Object, len(layers), byteCountBinary(totalSize))
+		"%s: pushed to remote (%d layers, %s total)\n", ref.Tag, len(layers), byteCountBinary(totalSize))
 	return nil
 }
 
 // PullChart downloads a chart from a registry
 func (c *Client) PullChart(ref *Reference) error {
 	c.setDefaultTag(ref)
-	fmt.Fprintf(c.out, "%s: Pulling from %s\n", ref.Object, ref.Locator)
+	fmt.Fprintf(c.out, "%s: Pulling from %s\n", ref.Tag, ref.Repo)
 	layers, err := oras.Pull(context.Background(), c.resolver, ref.String(), c.cache.store, KnownMediaTypes()...)
 	if err != nil {
 		return err
@@ -91,9 +91,9 @@ func (c *Client) PullChart(ref *Reference) error {
 		return err
 	}
 	if !exists {
-		fmt.Fprintf(c.out, "Status: Downloaded newer chart for %s:%s\n", ref.Locator, ref.Object)
+		fmt.Fprintf(c.out, "Status: Downloaded newer chart for %s:%s\n", ref.Repo, ref.Tag)
 	} else {
-		fmt.Fprintf(c.out, "Status: Chart is up to date for %s:%s\n", ref.Locator, ref.Object)
+		fmt.Fprintf(c.out, "Status: Chart is up to date for %s:%s\n", ref.Repo, ref.Tag)
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func (c *Client) SaveChart(ch *chart.Chart, ref *Reference) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.out, "%s: saved\n", ref.Object)
+	fmt.Fprintf(c.out, "%s: saved\n", ref.Tag)
 	return nil
 }
 
@@ -131,7 +131,7 @@ func (c *Client) RemoveChart(ref *Reference) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.out, "%s: removed\n", ref.Object)
+	fmt.Fprintf(c.out, "%s: removed\n", ref.Tag)
 	return err
 }
 
@@ -152,8 +152,8 @@ func (c *Client) PrintChartTable() error {
 }
 
 func (c *Client) setDefaultTag(ref *Reference) {
-	if ref.Object == "" {
-		ref.Object = HelmChartDefaultTag
+	if ref.Tag == "" {
+		ref.Tag = HelmChartDefaultTag
 		fmt.Fprintf(c.out, "Using default tag: %s\n", HelmChartDefaultTag)
 	}
 }

--- a/pkg/registry/reference_test.go
+++ b/pkg/registry/reference_test.go
@@ -39,11 +39,23 @@ func TestReference(t *testing.T) {
 	is.Error(err, "ref contains too many colons (3)")
 
 	// good refs
-	s = "mychart:1.5.0"
+	s = "mychart"
 	ref, err := ParseReference(s)
 	is.NoError(err)
 	is.Equal("mychart", ref.Locator)
+	is.Equal("", ref.Object)
+
+	s = "mychart:1.5.0"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("mychart", ref.Locator)
 	is.Equal("1.5.0", ref.Object)
+
+	s = "myrepo/mychart"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("myrepo/mychart", ref.Locator)
+	is.Equal("", ref.Object)
 
 	s = "myrepo/mychart:1.5.0"
 	ref, err = ParseReference(s)

--- a/pkg/registry/reference_test.go
+++ b/pkg/registry/reference_test.go
@@ -25,25 +25,53 @@ import (
 func TestReference(t *testing.T) {
 	is := assert.New(t)
 
-	// bad ref
+	// bad refs
 	s := ""
 	_, err := ParseReference(s)
-	is.Error(err)
+	is.Error(err, "empty ref")
+
+	s = "my:bad:ref"
+	_, err = ParseReference(s)
+	is.Error(err, "ref contains too many colons (2)")
+
+	s = "my:really:bad:ref"
+	_, err = ParseReference(s)
+	is.Error(err, "ref contains too many colons (3)")
 
 	// good refs
-	s = "localhost:5000/mychart:latest"
+	s = "mychart:1.5.0"
 	ref, err := ParseReference(s)
 	is.NoError(err)
-	is.Equal("localhost:5000", ref.Hostname())
-	is.Equal("mychart", ref.Repo())
+	is.Equal("mychart", ref.Locator)
+	is.Equal("1.5.0", ref.Object)
+
+	s = "myrepo/mychart:1.5.0"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("myrepo/mychart", ref.Locator)
+	is.Equal("1.5.0", ref.Object)
+
+	s = "mychart:5001:1.5.0"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("mychart:5001", ref.Locator)
+	is.Equal("1.5.0", ref.Object)
+
+	s = "myrepo:5001/mychart:1.5.0"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("myrepo:5001/mychart", ref.Locator)
+	is.Equal("1.5.0", ref.Object)
+
+	s = "localhost:5000/mychart:latest"
+	ref, err = ParseReference(s)
+	is.NoError(err)
 	is.Equal("localhost:5000/mychart", ref.Locator)
 	is.Equal("latest", ref.Object)
 
 	s = "my.host.com/my/nested/repo:1.2.3"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("my.host.com", ref.Hostname())
-	is.Equal("my/nested/repo", ref.Repo())
 	is.Equal("my.host.com/my/nested/repo", ref.Locator)
 	is.Equal("1.2.3", ref.Object)
 }

--- a/pkg/registry/reference_test.go
+++ b/pkg/registry/reference_test.go
@@ -42,48 +42,48 @@ func TestReference(t *testing.T) {
 	s = "mychart"
 	ref, err := ParseReference(s)
 	is.NoError(err)
-	is.Equal("mychart", ref.Locator)
-	is.Equal("", ref.Object)
+	is.Equal("mychart", ref.Repo)
+	is.Equal("", ref.Tag)
 
 	s = "mychart:1.5.0"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("mychart", ref.Locator)
-	is.Equal("1.5.0", ref.Object)
+	is.Equal("mychart", ref.Repo)
+	is.Equal("1.5.0", ref.Tag)
 
 	s = "myrepo/mychart"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("myrepo/mychart", ref.Locator)
-	is.Equal("", ref.Object)
+	is.Equal("myrepo/mychart", ref.Repo)
+	is.Equal("", ref.Tag)
 
 	s = "myrepo/mychart:1.5.0"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("myrepo/mychart", ref.Locator)
-	is.Equal("1.5.0", ref.Object)
+	is.Equal("myrepo/mychart", ref.Repo)
+	is.Equal("1.5.0", ref.Tag)
 
 	s = "mychart:5001:1.5.0"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("mychart:5001", ref.Locator)
-	is.Equal("1.5.0", ref.Object)
+	is.Equal("mychart:5001", ref.Repo)
+	is.Equal("1.5.0", ref.Tag)
 
 	s = "myrepo:5001/mychart:1.5.0"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("myrepo:5001/mychart", ref.Locator)
-	is.Equal("1.5.0", ref.Object)
+	is.Equal("myrepo:5001/mychart", ref.Repo)
+	is.Equal("1.5.0", ref.Tag)
 
 	s = "localhost:5000/mychart:latest"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("localhost:5000/mychart", ref.Locator)
-	is.Equal("latest", ref.Object)
+	is.Equal("localhost:5000/mychart", ref.Repo)
+	is.Equal("latest", ref.Tag)
 
 	s = "my.host.com/my/nested/repo:1.2.3"
 	ref, err = ParseReference(s)
 	is.NoError(err)
-	is.Equal("my.host.com/my/nested/repo", ref.Locator)
-	is.Equal("1.2.3", ref.Object)
+	is.Equal("my.host.com/my/nested/repo", ref.Repo)
+	is.Equal("1.2.3", ref.Tag)
 }


### PR DESCRIPTION
This PR fixes the issue described here https://github.com/helm/helm/pull/5243#issuecomment-461145117

Added more tests to make sure `ParseReference` works as we would expect.

Also added new fields to Reference type (Repo and Tag) that we can use instead of fields inherited from containerd to avoid unexpected formatting issues like this in the future.

Here are some acceptable values for refs and how they are handled:

`mychart` -> {Repo: "mychart", Tag: ""}
`mychart:1.5.0` -> {Repo: "mychart", Tag: "1.5.0"}
`myrepo/mychart` -> {Repo: "myrepo/mychart", Tag: ""}
`myrepo/mychart:1.5.0` -> {Repo: "myrepo/mychart", Tag: "1.5.0"}
`mychart:5001:1.5.0` -> {Repo: "mychart:5001", Tag: "1.5.0"}
`myrepo:5001/mychart:1.5.0` -> {Repo: "myrepo:5001/mychart", Tag: "1.5.0"}
`localhost:5000/mychart:latest` -> {Repo: "localhost:5000/mychart", Tag: "latest"}
`my.host.com/my/nested/repo:1.2.3` -> {Repo: "my.host.com/my/nested/repo", Tag: "1.2.3"}
