### PR TITLE
ref(ci): persist dep cache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,8 @@ install:
   - go version
   - dep ensure -vendor-only -v
 cache:
-  - c:\go\src\k8s.io\helm\vendor -> Gopkg.lock
-  - c:\go\cache -> Gopkg.lock
+  - c:\go\pkg\dep -> Gopkg.lock
+  - c:\go\cache
 build: "off"
 deploy: "off"
 test_script:


### PR DESCRIPTION
AppVeyor should persist dep's store of remote repositories.