### PR TITLE
ref: Update Sprig to 2.18.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,13 +1,11 @@
-hash: 5dc21cc57b38ab1076f9e12d1e4248047ccc4470af8f81c8560560cb492bee9e
-updated: 2019-02-08T15:20:12.179155-07:00
+hash: 70f4fe304d0034fd077f122570adc6bb5f40ceee5f4f53d8930ba5ad700a911d
+updated: 2019-02-12T13:10:08.039408-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
   subpackages:
   - compute/metadata
   - internal
-- name: github.com/aokoli/goutils
-  version: 9c37978a95bd5c709a15883b6242714ea6709e64
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: github.com/Azure/go-ansiterm
@@ -181,10 +179,12 @@ imports:
   - jwriter
 - name: github.com/MakeNowJust/heredoc
   version: bb23615498cded5e105af4ce27de75b089cbe851
+- name: github.com/Masterminds/goutils
+  version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/Masterminds/semver
   version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/Masterminds/sprig
-  version: 544a9b1d90f323f6509491b389714fbbd126bee3
+  version: b1fe2752acccf8c3d7f8a1e7c75c7ae7d83a1975
 - name: github.com/Masterminds/vcs
   version: 3084677c2c188840777bff30054f2b553729d329
 - name: github.com/mattn/go-runewidth

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,7 @@ import:
   - package: github.com/imdario/mergo
     version: v0.3.5
   - package: github.com/Masterminds/sprig
-    version: ^2.16.0
+    version: ^2.18.0
   - package: github.com/ghodss/yaml
   - package: github.com/Masterminds/semver
     version: ~1.3.1


### PR DESCRIPTION
This fixes a problem with Go 1.11 and also adds some new functions.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Updates Sprig to the latest release, which accommodates the breaking change on how Go 1.11 handles nils in templates.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
