### PR TITLE
Display the checksums in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ dist:
 checksum:
 	for f in _dist/*.{gz,zip} ; do \
 		shasum -a 256 "$${f}"  | awk '{print $$1}' > "$${f}.sha256" ; \
+		echo -n "Checksum: " && cat $${f}.sha256 ; \
 	done
 
 .PHONY: check-docker


### PR DESCRIPTION
When Helm is packaging up the bundles it generates the checksums
but does not display them. Having them here will aide in the
generation of release notes and provide another source
listing them.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
