### PR TITLE
Fix for missing $root

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -129,6 +129,7 @@ You have multiple options with Globs:
 Or
 
 ```yaml
+{{ $root := . }}
 {{ range $path, $bytes := .Files.Glob "foo/*" }}
 {{ base $path }}: '{{ $root.Files.Get $path | b64enc }}'
 {{ end }}


### PR DESCRIPTION
$root is used in $root.Files.Get and needs to be defined

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
