### PR TITLE
The 'Linuxes' is obscure

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -32,7 +32,7 @@ docker-test`.
 
 To run Helm and Tiller locally, you can run `bin/helm` or `bin/tiller`.
 
-- Helm and Tiller are known to run on macOS and most Linuxes, including
+- Helm and Tiller are known to run on macOS and most Linux distributions, including
   Alpine.
 - Tiller must have access to a Kubernetes cluster. It learns about the
   cluster by examining the Kube config files that `kubectl` uses.


### PR DESCRIPTION
Using `Linux distributions` instead of `Linuxes`

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>
