### PR TITLE
Adding '/usr/bin/env bash'

### DIFF
--- a/scripts/completions.bash
+++ b/scripts/completions.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # bash completion for helm                                 -*- shell-script -*-
 
 __debug()


### PR DESCRIPTION
This commit aims to add '/usr/bin/env bash' as a shebang line
to indicates scripts use bash shell for interpreting.
