### PR TITLE
Remove the duplicated words that makes error in printing

### DIFF
--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -263,7 +263,7 @@ func matchValues(t *testing.T, data map[string]interface{}) {
 	if o, err := ttpl("{{.water.water.where}}", data); err != nil {
 		t.Errorf(".water.water.where: %s", err)
 	} else if o != "everywhere" {
-		t.Errorf("Expected water water everywhere")
+		t.Errorf("Expected water everywhere")
 	}
 }
 


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

**What this PR does / why we need it**:
Fix printing to make  it easy while reading

**Special notes for your reviewer**:
Minor commit

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
