### PR TITLE
fix error strings be capitalized

### DIFF
--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -138,7 +138,7 @@ func (f *fetchCmd) run() error {
 		var err error
 		dest, err = ioutil.TempDir("", "helm-")
 		if err != nil {
-			return fmt.Errorf("Failed to untar: %s", err)
+			return fmt.Errorf("failed to untar: %s", err)
 		}
 		defer os.RemoveAll(dest)
 	}
@@ -168,11 +168,11 @@ func (f *fetchCmd) run() error {
 		}
 		if fi, err := os.Stat(ud); err != nil {
 			if err := os.MkdirAll(ud, 0755); err != nil {
-				return fmt.Errorf("Failed to untar (mkdir): %s", err)
+				return fmt.Errorf("failed to untar (mkdir): %s", err)
 			}
 
 		} else if !fi.IsDir() {
-			return fmt.Errorf("Failed to untar: %s is not a directory", ud)
+			return fmt.Errorf("failed to untar: %s is not a directory", ud)
 		}
 
 		return chartutil.ExpandFile(ud, saved)

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -111,10 +111,10 @@ func formatValues(format string, values chartutil.Values) (string, error) {
 	case "json":
 		out, err := json.Marshal(values)
 		if err != nil {
-			return "", fmt.Errorf("Failed to Marshal JSON output: %s", err)
+			return "", fmt.Errorf("failed to Marshal JSON output: %s", err)
 		}
 		return string(out), nil
 	default:
-		return "", fmt.Errorf("Unknown output format %q", format)
+		return "", fmt.Errorf("unknown output format %q", format)
 	}
 }

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -219,7 +219,7 @@ func checkArgsLength(argsReceived int, requiredArgs ...string) error {
 		if expectedNum == 1 {
 			arg = "argument"
 		}
-		return fmt.Errorf("This command needs %v %s: %s", expectedNum, arg, strings.Join(requiredArgs, ", "))
+		return fmt.Errorf("this command needs %v %s: %s", expectedNum, arg, strings.Join(requiredArgs, ", "))
 	}
 	return nil
 }

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -105,7 +105,7 @@ func ensureTestHome(home helmpath.Home, t *testing.T) error {
 	for _, p := range configDirectories {
 		if fi, err := os.Stat(p); err != nil {
 			if err := os.MkdirAll(p, 0755); err != nil {
-				return fmt.Errorf("Could not create %s: %s", p, err)
+				return fmt.Errorf("could not create %s: %s", p, err)
 			}
 		} else if !fi.IsDir() {
 			return fmt.Errorf("%s must be a directory", p)

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -368,7 +368,7 @@ func ensureDirectories(home helmpath.Home, out io.Writer) error {
 		if fi, err := os.Stat(p); err != nil {
 			fmt.Fprintf(out, "Creating %s \n", p)
 			if err := os.MkdirAll(p, 0755); err != nil {
-				return fmt.Errorf("Could not create %s: %s", p, err)
+				return fmt.Errorf("could not create %s: %s", p, err)
 			}
 		} else if !fi.IsDir() {
 			return fmt.Errorf("%s must be a directory", p)
@@ -421,7 +421,7 @@ func initStableRepo(cacheFile string, out io.Writer, skipRefresh bool, home helm
 	// In this case, the cacheFile is always absolute. So passing empty string
 	// is safe.
 	if err := r.DownloadIndexFile(""); err != nil {
-		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
+		return nil, fmt.Errorf("looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
 	}
 
 	return &c, nil

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -177,7 +177,7 @@ func (p *packageCmd) run() error {
 	if err == nil {
 		fmt.Fprintf(p.out, "Successfully packaged chart and saved it to: %s\n", name)
 	} else {
-		return fmt.Errorf("Failed to save: %s", err)
+		return fmt.Errorf("failed to save: %s", err)
 	}
 
 	// Save to $HELM_HOME/local directory. This is second, because we don't want

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -128,7 +128,7 @@ func addRepository(name, url, username, password string, home helmpath.Home, cer
 	}
 
 	if err := r.DownloadIndexFile(home.Cache()); err != nil {
-		return fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", url, err.Error())
+		return fmt.Errorf("looks like %q is not a valid chart repository or cannot be reached: %s", url, err.Error())
 	}
 
 	f.Update(&c)

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -65,7 +65,7 @@ func (g *HttpGetter) get(href string) (*bytes.Buffer, error) {
 		return buf, err
 	}
 	if resp.StatusCode != 200 {
-		return buf, fmt.Errorf("Failed to fetch %s : %s", href, resp.Status)
+		return buf, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}
 
 	_, err = io.Copy(buf, resp.Body)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -318,7 +318,7 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		if _, err := helper.Get(info.Namespace, info.Name, info.Export); err != nil {
 			if !errors.IsNotFound(err) {
-				return fmt.Errorf("Could not get information about the resource: %s", err)
+				return fmt.Errorf("could not get information about the resource: %s", err)
 			}
 
 			// Since the resource does not exist, create it.
@@ -526,7 +526,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 
 				// ... and recreate
 				if err := createResource(target); err != nil {
-					return fmt.Errorf("Failed to recreate resource: %s", err)
+					return fmt.Errorf("failed to recreate resource: %s", err)
 				}
 				log.Printf("Created a new %s called %q\n", kind, target.Name)
 
@@ -676,7 +676,7 @@ func (c *Client) waitForJob(e watch.Event, name string) (bool, error) {
 		if c.Type == batch.JobComplete && c.Status == v1.ConditionTrue {
 			return true, nil
 		} else if c.Type == batch.JobFailed && c.Status == v1.ConditionTrue {
-			return true, fmt.Errorf("Job failed: %s", c.Reason)
+			return true, fmt.Errorf("job failed: %s", c.Reason)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
According to [Golang coding convention](https://github.com/golang/go/wiki/CodeReviewComments#error-strings), `error strings` should not be capitalized.