### PR TITLE
Adding backticks for readability

### DIFF
--- a/docs/helm/helm.md
+++ b/docs/helm/helm.md
@@ -20,6 +20,7 @@ Common actions from this point include:
 - helm install:   upload the chart to Kubernetes
 - helm list:      list releases of charts
 
+```
 Environment:
   $HELM_HOME           set an alternative location for Helm files. By default, these are stored in ~/.helm
   $HELM_HOST           set an alternative Tiller host. The format is host:port
@@ -34,6 +35,7 @@ Environment:
   $HELM_TLS_HOSTNAME   the hostname or IP address used to verify the Tiller server certificate (default "127.0.0.1")
   $HELM_KEY_PASSPHRASE set HELM_KEY_PASSPHRASE to the passphrase of your PGP private key. If set, you will not be prompted for
                        the passphrase while signing helm charts
+```
 
 
 


### PR DESCRIPTION
Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

**What this PR does / why we need it**:

If you navigate to https://docs.helm.sh/helm/#helm and scroll down a little, you'll see a difficult-to-read paragraph. 

![image](https://user-images.githubusercontent.com/2104453/53122933-84cf1b80-351d-11e9-84bd-af145442ba5c.png)


Looking at the raw file(https://github.com/helm/helm/blame/master/docs/helm/helm.md#L23-L36), it seems likely it should be rendered literally. This does come with the disadvantage of side-scrolling, but I think it would be an improvement over the current situation.


**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
