### PR TITLE
refactor(helm): Make all functions returning cobra.Command public

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -42,7 +42,8 @@ var (
 	}
 )
 
-func newCompletionCmd(out io.Writer) *cobra.Command {
+// NewCompletionCmd returns cobra.Command to generate autocompletion scripts for bash or zsh
+func NewCompletionCmd(out io.Writer) *cobra.Command {
 	shells := []string{}
 	for s := range completionShells {
 		shells = append(shells, s)

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -63,7 +63,8 @@ type createCmd struct {
 	starter string
 }
 
-func newCreateCmd(out io.Writer) *cobra.Command {
+// NewCreateCmd returns cobra.Command to create a new chart with the given name
+func NewCreateCmd(out io.Writer) *cobra.Command {
 	cc := &createCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -46,7 +46,7 @@ func TestCreateCmd(t *testing.T) {
 	defer os.Chdir(pwd)
 
 	// Run a create
-	cmd := newCreateCmd(ioutil.Discard)
+	cmd := NewCreateCmd(ioutil.Discard)
 	if err := cmd.RunE(cmd, []string{cname}); err != nil {
 		t.Errorf("Failed to run create: %s", err)
 		return
@@ -117,7 +117,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	defer os.Chdir(pwd)
 
 	// Run a create
-	cmd := newCreateCmd(ioutil.Discard)
+	cmd := NewCreateCmd(ioutil.Discard)
 	cmd.ParseFlags([]string{"--starter", "starterchart"})
 	if err := cmd.RunE(cmd, []string{cname}); err != nil {
 		t.Errorf("Failed to run create: %s", err)

--- a/cmd/helm/delete.go
+++ b/cmd/helm/delete.go
@@ -46,7 +46,8 @@ type deleteCmd struct {
 	client helm.Interface
 }
 
-func newDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
+// NewDeleteCmd returns cobra.Command to delete a release from Kubernetes
+func NewDeleteCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	del := &deleteCmd{
 		out:    out,
 		client: c,

--- a/cmd/helm/delete_test.go
+++ b/cmd/helm/delete_test.go
@@ -76,6 +76,6 @@ func TestDelete(t *testing.T) {
 		},
 	}
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newDeleteCmd(c, out)
+		return NewDeleteCmd(c, out)
 	})
 }

--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -87,7 +87,8 @@ This will produce an error if the chart cannot be loaded. It will emit a warning
 if it cannot find a requirements.yaml.
 `
 
-func newDependencyCmd(out io.Writer) *cobra.Command {
+// NewDependencyCmd returns cobra.Command to manage chart dependencies
+func NewDependencyCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dependency update|build|list",
 		Aliases: []string{"dep", "dependencies"},
@@ -95,9 +96,9 @@ func newDependencyCmd(out io.Writer) *cobra.Command {
 		Long:    dependencyDesc,
 	}
 
-	cmd.AddCommand(newDependencyListCmd(out))
-	cmd.AddCommand(newDependencyUpdateCmd(out))
-	cmd.AddCommand(newDependencyBuildCmd(out))
+	cmd.AddCommand(NewDependencyListCmd(out))
+	cmd.AddCommand(NewDependencyUpdateCmd(out))
+	cmd.AddCommand(NewDependencyBuildCmd(out))
 
 	return cmd
 }
@@ -107,7 +108,8 @@ type dependencyListCmd struct {
 	chartpath string
 }
 
-func newDependencyListCmd(out io.Writer) *cobra.Command {
+// NewDependencyListCmd returns cobra.Command to list the dependencies for the given chart
+func NewDependencyListCmd(out io.Writer) *cobra.Command {
 	dlc := &dependencyListCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -44,7 +44,8 @@ type dependencyBuildCmd struct {
 	helmhome  helmpath.Home
 }
 
-func newDependencyBuildCmd(out io.Writer) *cobra.Command {
+// NewDependencyBuildCmd returns cobra.Command to rebuild the charts/ directory based on requirements.lock file
+func NewDependencyBuildCmd(out io.Writer) *cobra.Command {
 	dbc := &dependencyBuildCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/dependency_test.go
+++ b/cmd/helm/dependency_test.go
@@ -53,6 +53,6 @@ func TestDependencyListCmd(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newDependencyListCmd(out)
+		return NewDependencyListCmd(out)
 	})
 }

--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -50,8 +50,8 @@ type dependencyUpdateCmd struct {
 	skipRefresh bool
 }
 
-// newDependencyUpdateCmd creates a new dependency update command.
-func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
+// NewDependencyUpdateCmd returns cobra.Command to update charts/ based on content of requirements.yaml
+func NewDependencyUpdateCmd(out io.Writer) *cobra.Command {
 	duc := &dependencyUpdateCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -44,7 +44,8 @@ type docsCmd struct {
 	topCmd        *cobra.Command
 }
 
-func newDocsCmd(out io.Writer) *cobra.Command {
+// NewDocsCmd returns cobra.Command to generate documentation as markdown or man pages
+func NewDocsCmd(out io.Writer) *cobra.Command {
 	dc := &docsCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/fetch.go
+++ b/cmd/helm/fetch.go
@@ -68,7 +68,8 @@ type fetchCmd struct {
 	out io.Writer
 }
 
-func newFetchCmd(out io.Writer) *cobra.Command {
+// NewFetchCmd returns cobra.Command to download a chart from a repository and (optionally) unpack it in local directory
+func NewFetchCmd(out io.Writer) *cobra.Command {
 	fch := &fetchCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/fetch_test.go
+++ b/cmd/helm/fetch_test.go
@@ -147,7 +147,7 @@ func TestFetchCmd(t *testing.T) {
 		os.Mkdir(outdir, 0755)
 
 		buf := bytes.NewBuffer(nil)
-		cmd := newFetchCmd(buf)
+		cmd := NewFetchCmd(buf)
 		tt.flags = append(tt.flags, "-d", outdir)
 		cmd.ParseFlags(tt.flags)
 		if err := cmd.RunE(cmd, []string{tt.chart}); err != nil {

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -47,7 +47,8 @@ type getCmd struct {
 	version int32
 }
 
-func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewGetCmd returns cobra.Command to download a names release
+func NewGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	get := &getCmd{
 		out:    out,
 		client: client,
@@ -74,10 +75,10 @@ func newGetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	settings.AddFlagsTLS(f)
 	f.Int32Var(&get.version, "revision", 0, "get the named release with revision")
 
-	cmd.AddCommand(newGetValuesCmd(nil, out))
-	cmd.AddCommand(newGetManifestCmd(nil, out))
-	cmd.AddCommand(newGetHooksCmd(nil, out))
-	cmd.AddCommand(newGetNotesCmd(nil, out))
+	cmd.AddCommand(NewGetValuesCmd(nil, out))
+	cmd.AddCommand(NewGetManifestCmd(nil, out))
+	cmd.AddCommand(NewGetHooksCmd(nil, out))
+	cmd.AddCommand(NewGetNotesCmd(nil, out))
 
 	// set defaults from environment
 	settings.InitTLS(f)

--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -38,7 +38,8 @@ type getHooksCmd struct {
 	version int32
 }
 
-func newGetHooksCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewGetHooksCmd returns cobra.Command to download all hooks for a named release
+func NewGetHooksCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	ghc := &getHooksCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -43,6 +43,6 @@ func TestGetHooks(t *testing.T) {
 		},
 	}
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newGetHooksCmd(c, out)
+		return NewGetHooksCmd(c, out)
 	})
 }

--- a/cmd/helm/get_manifest.go
+++ b/cmd/helm/get_manifest.go
@@ -40,7 +40,8 @@ type getManifestCmd struct {
 	version int32
 }
 
-func newGetManifestCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewGetManifestCmd returns cobra.Command to download the manifest for a named release
+func NewGetManifestCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	get := &getManifestCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/get_manifest_test.go
+++ b/cmd/helm/get_manifest_test.go
@@ -42,6 +42,6 @@ func TestGetManifest(t *testing.T) {
 		},
 	}
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newGetManifestCmd(c, out)
+		return NewGetManifestCmd(c, out)
 	})
 }

--- a/cmd/helm/get_notes.go
+++ b/cmd/helm/get_notes.go
@@ -36,7 +36,8 @@ type getNotesCmd struct {
 	version int32
 }
 
-func newGetNotesCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewGetNotesCmd returns cobra.Command to displays the notes of the named release
+func NewGetNotesCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	get := &getNotesCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/get_notes_test.go
+++ b/cmd/helm/get_notes_test.go
@@ -46,7 +46,7 @@ func TestGetNotesCmd(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newGetNotesCmd(c, out)
+		return NewGetNotesCmd(c, out)
 	})
 
 }

--- a/cmd/helm/get_test.go
+++ b/cmd/helm/get_test.go
@@ -42,7 +42,7 @@ func TestGetCmd(t *testing.T) {
 	}
 
 	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newGetCmd(c, out)
+		return NewGetCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)
 }

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -40,7 +40,8 @@ type getValuesCmd struct {
 	output    string
 }
 
-func newGetValuesCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewGetValuesCmd returns cobra.Command to download the values file for a named release
+func NewGetValuesCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	get := &getValuesCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -72,7 +72,7 @@ func TestGetValuesCmd(t *testing.T) {
 		},
 	}
 	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newGetValuesCmd(c, out)
+		return NewGetValuesCmd(c, out)
 	}
 	runReleaseCases(t, tests, cmd)
 }

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -77,7 +77,8 @@ Environment:
 
 `
 
-func newRootCmd(args []string) *cobra.Command {
+// NewRootCmd returns cobra.Command for the root command of helm CLI
+func NewRootCmd(args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "helm",
 		Short:        "The Helm package manager for Kubernetes.",
@@ -112,42 +113,42 @@ func newRootCmd(args []string) *cobra.Command {
 
 	cmd.AddCommand(
 		// chart commands
-		newCreateCmd(out),
-		newDependencyCmd(out),
-		newFetchCmd(out),
-		newInspectCmd(out),
-		newLintCmd(out),
-		newPackageCmd(out),
-		newRepoCmd(out),
-		newSearchCmd(out),
-		newServeCmd(out),
-		newVerifyCmd(out),
+		NewCreateCmd(out),
+		NewDependencyCmd(out),
+		NewFetchCmd(out),
+		NewInspectCmd(out),
+		NewLintCmd(out),
+		NewPackageCmd(out),
+		NewRepoCmd(out),
+		NewSearchCmd(out),
+		NewServeCmd(out),
+		NewVerifyCmd(out),
 
 		// release commands
-		newDeleteCmd(nil, out),
-		newGetCmd(nil, out),
-		newHistoryCmd(nil, out),
-		newInstallCmd(nil, out),
-		newListCmd(nil, out),
-		newRollbackCmd(nil, out),
-		newStatusCmd(nil, out),
-		newUpgradeCmd(nil, out),
+		NewDeleteCmd(nil, out),
+		NewGetCmd(nil, out),
+		NewHistoryCmd(nil, out),
+		NewInstallCmd(nil, out),
+		NewListCmd(nil, out),
+		NewRollbackCmd(nil, out),
+		NewStatusCmd(nil, out),
+		NewUpgradeCmd(nil, out),
 
-		newReleaseTestCmd(nil, out),
-		newResetCmd(nil, out),
-		newVersionCmd(nil, out),
+		NewReleaseTestCmd(nil, out),
+		NewResetCmd(nil, out),
+		NewVersionCmd(nil, out),
 
-		newCompletionCmd(out),
-		newHomeCmd(out),
-		newInitCmd(out),
-		newPluginCmd(out),
-		newTemplateCmd(out),
+		NewCompletionCmd(out),
+		NewHomeCmd(out),
+		NewInitCmd(out),
+		NewPluginCmd(out),
+		NewTemplateCmd(out),
 
 		// Hidden documentation generator command: 'helm docs'
-		newDocsCmd(out),
+		NewDocsCmd(out),
 
 		// Deprecated
-		markDeprecated(newRepoUpdateCmd(out), "use 'helm repo update'\n"),
+		markDeprecated(NewRepoUpdateCmd(out), "use 'helm repo update'\n"),
 	)
 
 	flags.Parse(args)
@@ -167,7 +168,7 @@ func init() {
 }
 
 func main() {
-	cmd := newRootCmd(os.Args[1:])
+	cmd := NewRootCmd(os.Args[1:])
 	if err := cmd.Execute(); err != nil {
 		switch e := err.(type) {
 		case pluginError:

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -211,7 +211,7 @@ func TestRootCmd(t *testing.T) {
 				os.Setenv(k, v)
 			}
 
-			cmd := newRootCmd(tt.args)
+			cmd := NewRootCmd(tt.args)
 			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tt.args)
 			cmd.Run = func(*cobra.Command, []string) {}
@@ -525,7 +525,7 @@ func TestTLSFlags(t *testing.T) {
 				defer os.Unsetenv(k)
 			}
 
-			cmd := newRootCmd(tt.args)
+			cmd := NewRootCmd(tt.args)
 			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tt.args)
 			cmd.Run = func(*cobra.Command, []string) {}

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -66,7 +66,8 @@ type historyCmd struct {
 	outputFormat string
 }
 
-func newHistoryCmd(c helm.Interface, w io.Writer) *cobra.Command {
+// NewHistoryCmd returns cobra.Command to fetch release history
+func NewHistoryCmd(c helm.Interface, w io.Writer) *cobra.Command {
 	his := &historyCmd{out: w, helmc: c}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -80,6 +80,6 @@ func TestHistoryCmd(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newHistoryCmd(c, out)
+		return NewHistoryCmd(c, out)
 	})
 }

--- a/cmd/helm/home.go
+++ b/cmd/helm/home.go
@@ -28,7 +28,8 @@ This command displays the location of HELM_HOME. This is where
 any helm configuration files live.
 `
 
-func newHomeCmd(out io.Writer) *cobra.Command {
+// NewHomeCmd returns cobra.Command to display the location of HELM_HOME
+func NewHomeCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "home",
 		Short: "displays the location of HELM_HOME",

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -99,7 +99,8 @@ type initCmd struct {
 	wait           bool
 }
 
-func newInitCmd(out io.Writer) *cobra.Command {
+// NewInitCmd returns cobra.Command to initialize Helm on both client and server
+func NewInitCmd(out io.Writer) *cobra.Command {
 	i := &initCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/inspect.go
+++ b/cmd/helm/inspect.go
@@ -75,7 +75,8 @@ const (
 
 var readmeFileNames = []string{"readme.md", "readme.txt", "readme"}
 
-func newInspectCmd(out io.Writer) *cobra.Command {
+// NewInspectCmd returns cobra.Command to inspect a chart
+func NewInspectCmd(out io.Writer) *cobra.Command {
 	insp := &inspectCmd{
 		out:    out,
 		output: all,

--- a/cmd/helm/inspect_test.go
+++ b/cmd/helm/inspect_test.go
@@ -129,7 +129,7 @@ func TestInspectPreReleaseChart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.flags = append(tt.flags, "--repo", srv.URL())
-			cmd := newInspectCmd(ioutil.Discard)
+			cmd := NewInspectCmd(ioutil.Discard)
 			cmd.SetArgs(tt.args)
 			cmd.ParseFlags(tt.flags)
 			if err := cmd.RunE(cmd, tt.args); err != nil {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -162,7 +162,8 @@ func (v *valueFiles) Set(value string) error {
 	return nil
 }
 
-func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
+// NewInstallCmd returns cobra.Command to install a chart archive
+func NewInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	inst := &installCmd{
 		out:    out,
 		client: c,

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -194,7 +194,7 @@ func TestInstall(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newInstallCmd(c, out)
+		return NewInstallCmd(c, out)
 	})
 }
 

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -54,7 +54,8 @@ type lintCmd struct {
 	out        io.Writer
 }
 
-func newLintCmd(out io.Writer) *cobra.Command {
+// NewLintCmd returns cobra.Command to examine a chart for possible issues
+func NewLintCmd(out io.Writer) *cobra.Command {
 	l := &lintCmd{
 		paths: []string{"."},
 		out:   out,

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -96,7 +96,8 @@ type listRelease struct {
 	Namespace  string
 }
 
-func newListCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewListCmd returns cobra.Command to list releases
+func NewListCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	list := &listCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -226,6 +226,6 @@ Releases: []
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newListCmd(c, out)
+		return NewListCmd(c, out)
 	})
 }

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -65,7 +65,8 @@ type packageCmd struct {
 	home helmpath.Home
 }
 
-func newPackageCmd(out io.Writer) *cobra.Command {
+// NewPackageCmd returns cobra.Command to package a chart directory into a chart archive
+func NewPackageCmd(out io.Writer) *cobra.Command {
 	pkg := &packageCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -164,7 +164,7 @@ func TestPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		buf := bytes.NewBuffer(nil)
-		c := newPackageCmd(buf)
+		c := NewPackageCmd(buf)
 
 		// This is an unfortunate byproduct of the tmpdir
 		if v, ok := tt.flags["keyring"]; ok && len(v) > 0 {
@@ -228,7 +228,7 @@ func TestSetAppVersion(t *testing.T) {
 
 	settings.Home = helmpath.Home(thome)
 
-	c := newPackageCmd(&bytes.Buffer{})
+	c := NewPackageCmd(&bytes.Buffer{})
 	flags := map[string]string{
 		"destination": tmp,
 		"app-version": expectedAppVersion,

--- a/cmd/helm/plugin.go
+++ b/cmd/helm/plugin.go
@@ -30,17 +30,18 @@ const pluginHelp = `
 Manage client-side Helm plugins.
 `
 
-func newPluginCmd(out io.Writer) *cobra.Command {
+// NewPluginCmd returns cobra.Command to add, list, or remove Helm plugins
+func NewPluginCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plugin",
 		Short: "add, list, or remove Helm plugins",
 		Long:  pluginHelp,
 	}
 	cmd.AddCommand(
-		newPluginInstallCmd(out),
-		newPluginListCmd(out),
-		newPluginRemoveCmd(out),
-		newPluginUpdateCmd(out),
+		NewPluginInstallCmd(out),
+		NewPluginListCmd(out),
+		NewPluginRemoveCmd(out),
+		NewPluginUpdateCmd(out),
 	)
 	return cmd
 }

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -40,7 +40,8 @@ Example usage:
     $ helm plugin install https://github.com/technosophos/helm-template
 `
 
-func newPluginInstallCmd(out io.Writer) *cobra.Command {
+// NewPluginInstallCmd returns cobra.Command to install one or more Helm plugins
+func NewPluginInstallCmd(out io.Writer) *cobra.Command {
 	pcmd := &pluginInstallCmd{out: out}
 	cmd := &cobra.Command{
 		Use:   "install [options] <path|url>...",

--- a/cmd/helm/plugin_list.go
+++ b/cmd/helm/plugin_list.go
@@ -30,7 +30,8 @@ type pluginListCmd struct {
 	out  io.Writer
 }
 
-func newPluginListCmd(out io.Writer) *cobra.Command {
+// NewPluginListCmd returns cobra.Command to list installed Helm plugins
+func NewPluginListCmd(out io.Writer) *cobra.Command {
 	pcmd := &pluginListCmd{out: out}
 	cmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/helm/plugin_remove.go
+++ b/cmd/helm/plugin_remove.go
@@ -34,7 +34,8 @@ type pluginRemoveCmd struct {
 	out   io.Writer
 }
 
-func newPluginRemoveCmd(out io.Writer) *cobra.Command {
+// NewPluginRemoveCmd returns cobra.Command to remove one or more Helm plugins
+func NewPluginRemoveCmd(out io.Writer) *cobra.Command {
 	pcmd := &pluginRemoveCmd{out: out}
 	cmd := &cobra.Command{
 		Use:   "remove <plugin>...",

--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -35,7 +35,8 @@ type pluginUpdateCmd struct {
 	out   io.Writer
 }
 
-func newPluginUpdateCmd(out io.Writer) *cobra.Command {
+// NewPluginUpdateCmd returns cobra.Command to update one or more Helm plugins
+func NewPluginUpdateCmd(out io.Writer) *cobra.Command {
 	pcmd := &pluginUpdateCmd{out: out}
 	cmd := &cobra.Command{
 		Use:   "update <plugin>...",

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -42,7 +42,8 @@ type releaseTestCmd struct {
 	parallel bool
 }
 
-func newReleaseTestCmd(c helm.Interface, out io.Writer) *cobra.Command {
+// NewReleaseTestCmd returns cobra.Command to test a release
+func NewReleaseTestCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	rlsTest := &releaseTestCmd{
 		out:    out,
 		client: c,

--- a/cmd/helm/release_testing_test.go
+++ b/cmd/helm/release_testing_test.go
@@ -78,6 +78,6 @@ func TestReleaseTesting(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newReleaseTestCmd(c, out)
+		return NewReleaseTestCmd(c, out)
 	})
 }

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -30,18 +30,19 @@ Example usage:
     $ helm repo add [NAME] [REPO_URL]
 `
 
-func newRepoCmd(out io.Writer) *cobra.Command {
+// NewRepoCmd returns cobra.Command to manage chart repositories
+func NewRepoCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repo [FLAGS] add|remove|list|index|update [ARGS]",
 		Short: "add, list, remove, update, and index chart repositories",
 		Long:  repoHelm,
 	}
 
-	cmd.AddCommand(newRepoAddCmd(out))
-	cmd.AddCommand(newRepoListCmd(out))
-	cmd.AddCommand(newRepoRemoveCmd(out))
-	cmd.AddCommand(newRepoIndexCmd(out))
-	cmd.AddCommand(newRepoUpdateCmd(out))
+	cmd.AddCommand(NewRepoAddCmd(out))
+	cmd.AddCommand(NewRepoListCmd(out))
+	cmd.AddCommand(NewRepoRemoveCmd(out))
+	cmd.AddCommand(NewRepoIndexCmd(out))
+	cmd.AddCommand(NewRepoUpdateCmd(out))
 
 	return cmd
 }

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -44,7 +44,8 @@ type repoAddCmd struct {
 	out io.Writer
 }
 
-func newRepoAddCmd(out io.Writer) *cobra.Command {
+// NewRepoAddCmd returns cobra.Command to add a chart repository
+func NewRepoAddCmd(out io.Writer) *cobra.Command {
 	add := &repoAddCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -57,7 +57,7 @@ func TestRepoAddCmd(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newRepoAddCmd(out)
+		return NewRepoAddCmd(out)
 	})
 }
 

--- a/cmd/helm/repo_index.go
+++ b/cmd/helm/repo_index.go
@@ -45,7 +45,8 @@ type repoIndexCmd struct {
 	merge string
 }
 
-func newRepoIndexCmd(out io.Writer) *cobra.Command {
+// NewRepoIndexCmd returns cobra.Command to generate an index file given a directory containing packaged charts
+func NewRepoIndexCmd(out io.Writer) *cobra.Command {
 	index := &repoIndexCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/repo_index_test.go
+++ b/cmd/helm/repo_index_test.go
@@ -45,7 +45,7 @@ func TestRepoIndexCmd(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	c := newRepoIndexCmd(buf)
+	c := NewRepoIndexCmd(buf)
 
 	if err := c.RunE(c, []string{dir}); err != nil {
 		t.Error(err)

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -33,7 +33,8 @@ type repoListCmd struct {
 	home helmpath.Home
 }
 
-func newRepoListCmd(out io.Writer) *cobra.Command {
+// NewRepoListCmd returns cobra.Command to list chart repositories
+func NewRepoListCmd(out io.Writer) *cobra.Command {
 	list := &repoListCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/repo_remove.go
+++ b/cmd/helm/repo_remove.go
@@ -33,7 +33,8 @@ type repoRemoveCmd struct {
 	home helmpath.Home
 }
 
-func newRepoRemoveCmd(out io.Writer) *cobra.Command {
+// NewRepoRemoveCmd returns cobra.Command to remove a chart repository
+func NewRepoRemoveCmd(out io.Writer) *cobra.Command {
 	remove := &repoRemoveCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -82,7 +82,7 @@ func TestRepoRemove(t *testing.T) {
 }
 
 func TestRepoRemove_NoArguments(t *testing.T) {
-	cmd := newRepoRemoveCmd(ioutil.Discard)
+	cmd := NewRepoRemoveCmd(ioutil.Discard)
 	if err := cmd.RunE(cmd, []string{}); err == nil {
 		t.Errorf("Expected an error since no repo names were provided")
 	}
@@ -119,7 +119,7 @@ func TestRepoRemove_MultipleRepos(t *testing.T) {
 
 	b := bytes.NewBuffer(nil)
 
-	cmd := newRepoRemoveCmd(b)
+	cmd := NewRepoRemoveCmd(b)
 	if err := cmd.RunE(cmd, []string{repoFoo, repoBar}); err != nil {
 		t.Error(err)
 	}

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -46,7 +46,8 @@ type repoUpdateCmd struct {
 	strict bool
 }
 
-func newRepoUpdateCmd(out io.Writer) *cobra.Command {
+// NewRepoUpdateCmd returns cobra.Command to update information about available charts locally from chart repositories
+func NewRepoUpdateCmd(out io.Writer) *cobra.Command {
 	u := &repoUpdateCmd{
 		out:    out,
 		update: updateCharts,

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -121,7 +121,7 @@ func TestUpdateCmdStrictFlag(t *testing.T) {
 	settings.Home = thome
 
 	out := bytes.NewBuffer(nil)
-	cmd := newRepoUpdateCmd(out)
+	cmd := NewRepoUpdateCmd(out)
 	cmd.ParseFlags([]string{"--strict"})
 
 	if err := cmd.RunE(cmd, []string{}); err == nil {

--- a/cmd/helm/reset.go
+++ b/cmd/helm/reset.go
@@ -48,7 +48,8 @@ type resetCmd struct {
 	kubeClient     kubernetes.Interface
 }
 
-func newResetCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewResetCmd returns cobra.Command to uninstalls Tiller from a cluster
+func NewResetCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	d := &resetCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -49,7 +49,8 @@ type rollbackCmd struct {
 	description  string
 }
 
-func newRollbackCmd(c helm.Interface, out io.Writer) *cobra.Command {
+// NewRollbackCmd returns cobra.Command to roll back a release to a previous revision
+func NewRollbackCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	rollback := &rollbackCmd{
 		out:    out,
 		client: c,

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -59,7 +59,7 @@ func TestRollbackCmd(t *testing.T) {
 	}
 
 	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newRollbackCmd(c, out)
+		return NewRollbackCmd(c, out)
 	}
 
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -50,7 +50,8 @@ type searchCmd struct {
 	colWidth uint
 }
 
-func newSearchCmd(out io.Writer) *cobra.Command {
+// NewSearchCmd returns cobra.Command to search for a keyword in charts
+func NewSearchCmd(out io.Writer) *cobra.Command {
 	sc := &searchCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -92,6 +92,6 @@ func TestSearchCmd(t *testing.T) {
 	settings.Home = "testdata/helmhome"
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newSearchCmd(out)
+		return NewSearchCmd(out)
 	})
 }

--- a/cmd/helm/serve.go
+++ b/cmd/helm/serve.go
@@ -49,7 +49,8 @@ type serveCmd struct {
 	repoPath string
 }
 
-func newServeCmd(out io.Writer) *cobra.Command {
+// NewServeCmd returns cobra.Command to start a local http web server
+func NewServeCmd(out io.Writer) *cobra.Command {
 	srv := &serveCmd{out: out}
 	cmd := &cobra.Command{
 		Use:   "serve",

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -53,7 +53,8 @@ type statusCmd struct {
 	outfmt  string
 }
 
-func newStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewStatusCmd returns cobra.Command to displays the status of the named release
+func NewStatusCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	status := &statusCmd{
 		out:    out,
 		client: client,

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -128,7 +128,7 @@ func TestStatusCmd(t *testing.T) {
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newStatusCmd(c, out)
+		return NewStatusCmd(c, out)
 	})
 
 }

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -78,7 +78,8 @@ type templateCmd struct {
 	outputDir        string
 }
 
-func newTemplateCmd(out io.Writer) *cobra.Command {
+// NewTemplateCmd returns cobra.Command to locally render templates
+func NewTemplateCmd(out io.Writer) *cobra.Command {
 
 	t := &templateCmd{
 		out: out,

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -188,7 +188,7 @@ func TestTemplateCmd(t *testing.T) {
 			os.Stdout = w
 			// execute template command
 			out := bytes.NewBuffer(nil)
-			cmd := newTemplateCmd(out)
+			cmd := NewTemplateCmd(out)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -118,7 +118,8 @@ type upgradeCmd struct {
 	caFile   string
 }
 
-func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
+// NewUpgradeCmd returns cobra.Command to upgrade a release
+func NewUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 
 	upgrade := &upgradeCmd{
 		out:    out,

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -186,7 +186,7 @@ func TestUpgradeCmd(t *testing.T) {
 	}
 
 	cmd := func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newUpgradeCmd(c, out)
+		return NewUpgradeCmd(c, out)
 	}
 
 	runReleaseCases(t, tests, cmd)

--- a/cmd/helm/verify.go
+++ b/cmd/helm/verify.go
@@ -42,7 +42,8 @@ type verifyCmd struct {
 	out io.Writer
 }
 
-func newVerifyCmd(out io.Writer) *cobra.Command {
+// NewVerifyCmd returns cobra.Command to verify that a chart at the given path has been signed and is valid
+func NewVerifyCmd(out io.Writer) *cobra.Command {
 	vc := &verifyCmd{out: out}
 
 	cmd := &cobra.Command{

--- a/cmd/helm/verify_test.go
+++ b/cmd/helm/verify_test.go
@@ -74,7 +74,7 @@ func TestVerifyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		b := bytes.NewBuffer(nil)
-		vc := newVerifyCmd(b)
+		vc := NewVerifyCmd(b)
 		vc.ParseFlags(tt.flags)
 		err := vc.RunE(vc, tt.args)
 		if tt.err {

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -58,7 +58,8 @@ type versionCmd struct {
 	template   string
 }
 
-func newVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
+// NewVersionCmd returns cobra.Command to print the client/server version information
+func NewVersionCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	version := &versionCmd{
 		client: c,
 		out:    out,

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -66,6 +66,6 @@ func TestVersion(t *testing.T) {
 	}
 	settings.TillerHost = "fake-localhost"
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {
-		return newVersionCmd(c, out)
+		return NewVersionCmd(c, out)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change enables developers to compose commands from helm, from kubectl and other tools into custom CLI for their projects running on kubernetes.

Closes #5311

**Special notes for your reviewer**:
None. It's a trivial change

**If applicable**:
- [-] this PR contains documentation
- [-] this PR contains unit tests
- [+] this PR has been tested for backwards compatibility
