### PR TITLE
Update deprecated URL for Helm's chart format in kubernetes.io

### DIFF
--- a/_proto/hapi/chart/metadata.proto
+++ b/_proto/hapi/chart/metadata.proto
@@ -32,7 +32,7 @@ message Maintainer {
 
 //	Metadata for a Chart file. This models the structure of a Chart.yaml file.
 //
-// 	Spec: https://k8s.io/helm/blob/master/docs/design/chart_format.md#the-chart-file
+// 	Spec: https://helm.sh/docs/developing_charts/#the-chart-yaml-file
 message Metadata {
 	enum Engine {
 		UNKNOWN = 0;


### PR DESCRIPTION
Currently, the URL to **Chart format** in **kubernetes.io** is out of date.
This commit aims to update this URL to the working one in Helm's github that
user are able to access.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Update deprecated URL
**Special notes for your reviewer**:
Just minor commit
**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
