### PR TITLE
Update dependency build doc to improve understanding

### DIFF
--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -29,11 +29,11 @@ const dependencyBuildDesc = `
 Build out the charts/ directory from the requirements.lock file.
 
 Build is used to reconstruct a chart's dependencies to the state specified in
-the lock file. This will not re-negotiate dependencies, as 'helm dependency update'
-does.
+the lock file.
 
-If no lock file is found, 'helm dependency build' will mirror the behavior
-of 'helm dependency update'.
+If no lock file is found, 'helm dependency build' will mirror the behavior of
+the 'helm dependency update' command. This means it will update the on-disk
+dependencies to mirror the requirements.yaml file and generate a lock file.
 `
 
 type dependencyBuildCmd struct {

--- a/docs/helm/helm_dependency_build.md
+++ b/docs/helm/helm_dependency_build.md
@@ -8,12 +8,11 @@ rebuild the charts/ directory based on the requirements.lock file
 Build out the charts/ directory from the requirements.lock file.
 
 Build is used to reconstruct a chart's dependencies to the state specified in
-the lock file. This will not re-negotiate dependencies, as 'helm dependency update'
-does.
+the lock file.
 
-If no lock file is found, 'helm dependency build' will mirror the behavior
-of 'helm dependency update'.
-
+If no lock file is found, 'helm dependency build' will mirror the behavior of
+the 'helm dependency update' command. This means it will update the on-disk
+dependencies to mirror the requirements.yaml file and generate a lock file.
 
 ```
 helm dependency build [flags] CHART

--- a/docs/man/man1/helm_dependency_build.1
+++ b/docs/man/man1/helm_dependency_build.1
@@ -19,13 +19,12 @@ Build out the charts/ directory from the requirements.lock file.
 
 .PP
 Build is used to reconstruct a chart's dependencies to the state specified in
-the lock file. This will not re\-negotiate dependencies, as 'helm dependency update'
-does.
+the lock file.
 
 .PP
-If no lock file is found, 'helm dependency build' will mirror the behavior
-of 'helm dependency update'.
-
+If no lock file is found, 'helm dependency build' will mirror the behavior of
+the 'helm dependency update' command. This means it will update the on-disk
+dependencies to mirror the requirements.yaml file and generate a lock file.
 
 .SH OPTIONS
 .PP


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the `helm dependency build` documentation to improve clarity around the difference with `helm dependency update`.

Closes #5155 

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
