### PR TITLE
ref: remove enabling --wait when --atomic is specified; fix rollback issues

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -191,7 +191,6 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 			}
 			inst.chartPath = cp
 			inst.client = ensureHelmClient(inst.client)
-			inst.wait = inst.wait || inst.atomic
 
 			return inst.run()
 		},

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -143,7 +143,6 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 			upgrade.release = args[0]
 			upgrade.chart = args[1]
 			upgrade.client = ensureHelmClient(upgrade.client)
-			upgrade.wait = upgrade.wait || upgrade.atomic
 
 			return upgrade.run()
 		},

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -286,7 +286,6 @@ func (u *upgradeCmd) run() error {
 				timeout:      u.timeout,
 				wait:         u.wait,
 				description:  "",
-				revision:     releaseHistory.Releases[0].Version,
 				disableHooks: u.disableHooks,
 			}
 			if err := rollback.run(); err != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -285,7 +285,6 @@ func (u *upgradeCmd) run() error {
 				force:        u.force,
 				timeout:      u.timeout,
 				wait:         u.wait,
-				description:  "",
 				disableHooks: u.disableHooks,
 			}
 			if err := rollback.run(); err != nil {


### PR DESCRIPTION
Addresses some design issues with the current `--atomic` flag:

- disables the `--wait` flag by default. With the current design, there's no way to disable the `--wait` flag, and there's no technical reason why it was required in the first place. Users can opt in with `helm install/upgrade --atomic --wait` if they so choose.
- fixes an issue where `helm upgrade --atomic` will always choose the latest revision regardless of the state it was in, and regardless if it was the release we were upgrading from. By removing the `revision` field to the `rollbackCmd`, tiller will roll back to the latest deployed release.

closes #5377 
