### PR TITLE
Fix #5046 compatible with MacOS

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -212,7 +212,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}compopt${RWORD}/__helm_compopt/g" \
 	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
-	-e 's/aliashash\["\(\w\+\)"\]/aliashash[\1]/g' \
+	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
 	<<'BASH_COMPLETION_EOF'
 `
 	out.Write([]byte(zshInitialization))


### PR DESCRIPTION
Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>

**What this PR does / why we need it**:

Fix issue #5046 for MacOS.

The sed tool on MacOS does not support the use of `\w`.  This PR uses a more portable syntax to convert bash completion to zsh completions.

Different regex could have been used, but I tried to mimic what the original `\w\+` aimed to do, which was to match one or more characters.  Granted, `.` matches more things than `\w`, but I don't believe it is necessary to be that strict in the matching rule.

I've tested the syntax on my mac and on alpine linux in docker.
I've also built helm with the change on my mac and confirmed that it fixes the zsh completion.
