### PR TITLE
restore klog flags

### DIFF
--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
+	"k8s.io/klog"
 
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -100,6 +101,7 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
 	// TODO: use spf13/cobra for tiller instead of flags
 	flag.Parse()
 


### PR DESCRIPTION
In #5033, glog was switched to klog in Kubernetes 1.13, which also made a breaking change by moving the flag initialization from `init()` to `klog.InitFlags`. This restores those flags.

Thanks to @jlegrone for identifying the fix.

Closes #5408

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>