### PR TITLE
disable AppVeyor for branches other than master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,7 @@
 version: "{build}"
+branches:
+  only:
+  - master
 clone_folder: c:\go\src\k8s.io\helm
 environment:
   GOPATH: c:\go


### PR DESCRIPTION
This should disable AppVeyor from running against dev-v3 PRs.

See #5413 for a previous attempt.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
