### PR TITLE
pkg/chartutil: fix SaveDir for nested templates directories

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -63,6 +63,12 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(outdir, f.Name)
+
+		d := filepath.Dir(n)
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return err
+		}
+
 		if err := ioutil.WriteFile(n, f.Data, 0644); err != nil {
 			return err
 		}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -48,6 +48,9 @@ func TestSave(t *testing.T) {
 		Files: []*any.Any{
 			{TypeUrl: "scheherazade/shahryar.txt", Value: []byte("1,001 Nights")},
 		},
+		Templates: []*chart.Template{
+			{Name: "templates/scheherazade/shahryar.txt.tmpl", Data: []byte("{{ \"1,001 Nights\" }}")},
+		},
 	}
 
 	where, err := Save(c, tmp)
@@ -75,6 +78,9 @@ func TestSave(t *testing.T) {
 	if len(c2.Files) != 1 || c2.Files[0].TypeUrl != "scheherazade/shahryar.txt" {
 		t.Fatal("Files data did not match")
 	}
+	if len(c2.Templates) != 1 || c2.Templates[0].Name != "templates/scheherazade/shahryar.txt.tmpl" {
+		t.Fatal("Templates data did not match")
+	}
 }
 
 func TestSavePreservesTimestamps(t *testing.T) {
@@ -99,6 +105,9 @@ func TestSavePreservesTimestamps(t *testing.T) {
 		},
 		Files: []*any.Any{
 			{TypeUrl: "scheherazade/shahryar.txt", Value: []byte("1,001 Nights")},
+		},
+		Templates: []*chart.Template{
+			{Name: "templates/scheherazade/shahryar.txt.tmpl", Data: []byte("{{ \"1,001 Nights\" }}")},
 		},
 	}
 
@@ -171,6 +180,9 @@ func TestSaveDir(t *testing.T) {
 		Files: []*any.Any{
 			{TypeUrl: "scheherazade/shahryar.txt", Value: []byte("1,001 Nights")},
 		},
+		Templates: []*chart.Template{
+			{Name: "templates/scheherazade/shahryar.txt.tmpl", Data: []byte("{{ \"1,001 Nights\" }}")},
+		},
 	}
 
 	if err := SaveDir(c, tmp); err != nil {
@@ -190,5 +202,8 @@ func TestSaveDir(t *testing.T) {
 	}
 	if len(c2.Files) != 1 || c2.Files[0].TypeUrl != "scheherazade/shahryar.txt" {
 		t.Fatal("Files data did not match")
+	}
+	if len(c2.Templates) != 1 || c2.Templates[0].Name != "templates/scheherazade/shahryar.txt.tmpl" {
+		t.Fatal("Templates data did not match")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes `chartutil.SaveDir` for Helm charts that contain subdirectories in the templates directory (e.g. https://github.com/helm/charts/tree/master/stable/stolon)

**Special notes for your reviewer**:
Similar fix for files with nested directories here: https://github.com/helm/helm/commit/5b77335415dc98c087a63bcd36c1d2db5ebf7dba

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
