### PR TITLE
Fix debug printouts for zsh completion

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -213,6 +213,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
 	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
+	-e 's/FUNCNAME\[0\]/funcstack[1]/g' \
 	<<'BASH_COMPLETION_EOF'
 `
 	out.Write([]byte(zshInitialization))

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -213,7 +213,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
 	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
-	-e 's/FUNCNAME\[0\]/funcstack[1]/g' \
+	-e 's/FUNCNAME/funcstack/g' \
 	<<'BASH_COMPLETION_EOF'
 `
 	out.Write([]byte(zshInitialization))


### PR DESCRIPTION
**What this PR does / why we need it**:

Cobra provides some out-of-the-box debugging for bash completion.
To use it, one must set the variable BASH_COMP_DEBUG_FILE to
some file where the debug output will be written.  Many of the
debug printouts indicate the current method name; they do so
by using bash's ${FUNCNAME[0]} variable. This variable is
different in zsh. To obtain the current method name in zsh
we must use ${funcstack[1]}.

This commit adds the proper sed modification to convert from
bash to zsh.

Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>

**Special notes for your reviewer**:

Here is an example of the logs before and after the change:
```
> source <(helm completion zsh)
> export BASH_COMP_DEBUG_FILE=/tmp/hello
> helm list<TAB>
> cat /tmp/hello
: c is 0 words[c] is helm
: c is 0 words[c] is helm
: looking for _helm_root_command

# Notice there is nothing before the :

> source <(bin/helm completion zsh)   # Newly built helm with this PR included
> helm list<TAB>
> cat /tmp/hello
: c is 0 words[c] is helm
: c is 0 words[c] is helm
: looking for _helm_root_command

__start_helm: c is 0 words[c] is helm
__helm_handle_word: c is 0 words[c] is helm
__helm_handle_word: looking for _helm_root_command
__helm_handle_word

# Notice that the function name is now printed before the :
```