### PR TITLE
Preserve file permissions from tarball during plugin install

### DIFF
--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -195,7 +195,7 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 				return err
 			}
 		case tar.TypeReg:
-			outFile, err := os.Create(path)
+			outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return err
 			}

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -217,15 +217,16 @@ func TestExtract(t *testing.T) {
 	tw := tar.NewWriter(&tarbuf)
 	var files = []struct {
 		Name, Body string
+		Mode       int64
 	}{
-		{"../../plugin.yaml", "sneaky plugin metadata"},
-		{"README.md", "some text"},
+		{"../../plugin.yaml", "sneaky plugin metadata", 0600},
+		{"README.md", "some text", 0777},
 	}
 	for _, file := range files {
 		hdr := &tar.Header{
 			Name:     file.Name,
 			Typeflag: tar.TypeReg,
-			Mode:     0600,
+			Mode:     file.Mode,
 			Size:     int64(len(file.Body)),
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
@@ -257,21 +258,25 @@ func TestExtract(t *testing.T) {
 	}
 
 	pluginYAMLFullPath := filepath.Join(cacheDir, "plugin.yaml")
-	if _, err := os.Stat(pluginYAMLFullPath); err != nil {
+	if info, err := os.Stat(pluginYAMLFullPath); err != nil {
 		if os.IsNotExist(err) {
 			t.Errorf("Expected %s to exist but doesn't", pluginYAMLFullPath)
 		} else {
 			t.Error(err)
 		}
+	} else if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected %s to have 0600 mode it but has %o", pluginYAMLFullPath, info.Mode().Perm())
 	}
 
 	readmeFullPath := filepath.Join(cacheDir, "README.md")
-	if _, err := os.Stat(readmeFullPath); err != nil {
+	if info, err := os.Stat(readmeFullPath); err != nil {
 		if os.IsNotExist(err) {
 			t.Errorf("Expected %s to exist but doesn't", readmeFullPath)
 		} else {
 			t.Error(err)
 		}
+	} else if info.Mode().Perm() != 0777 {
+		t.Errorf("Expected %s to have 0777 mode it but has %o", readmeFullPath, info.Mode().Perm())
 	}
 
 }

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/helm/pkg/helm/helmpath"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -212,6 +213,8 @@ func TestExtract(t *testing.T) {
 	//{"plugin.yaml", "plugin metadata up in here"},
 	//{"README.md", "so you know what's upp"},
 	//{"script.sh", "echo script"},
+
+	syscall.Umask(0000)
 
 	var tarbuf bytes.Buffer
 	tw := tar.NewWriter(&tarbuf)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where the files extracted from a tarball during plugin install do not have their permissions preserved. This is an issue because the binary for the plugin and the install hook are not set as executable, so they cannot be run which results in a permissions denied error when attempting to install a plugin via its tarball.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility


