### PR TITLE
Documentation: Fix "helm init" parameters

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,10 +54,10 @@ Once you have Helm ready, you can initialize the local CLI and also
 install Tiller into your Kubernetes cluster in one step:
 
 ```console
-$ helm init --max-history 200
+$ helm init --history-max 200
 ```
 
-**TIP:** Setting `--max-history` on helm init is recommended as configmaps and other objects in helm history can grow large in number if not purged by max limit. Without a max history set the history is kept indefinitely, leaving a large number of records for helm and tiller to maintain.
+**TIP:** Setting `--history-max` on helm init is recommended as configmaps and other objects in helm history can grow large in number if not purged by max limit. Without a max history set the history is kept indefinitely, leaving a large number of records for helm and tiller to maintain.
 
 This will install Tiller into the Kubernetes cluster you saw with
 `kubectl config current-context`.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -43,7 +43,7 @@ _Note: The cluster-admin role is created by default in a Kubernetes cluster, so 
 $ kubectl create -f rbac-config.yaml
 serviceaccount "tiller" created
 clusterrolebinding "tiller" created
-$ helm init --service-account tiller --max-history 200
+$ helm init --service-account tiller --history-max 200
 ```
 
 ### Example: Deploy Tiller in a namespace, restricted to deploying resources only in that namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
In the quickstart guide, --max-history is recommended as parameter for helm init. The actual name of the parameter is --history-max.

**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
