### PR TITLE
Adding newline for references

### DIFF
--- a/docs/tiller_ssl.md
+++ b/docs/tiller_ssl.md
@@ -310,6 +310,6 @@ If your tiller certificate has expired, you'll need to sign a new certificate, b
 
 ## References
 
-https://github.com/denji/golang-tls
-https://www.openssl.org/docs/
+https://github.com/denji/golang-tls  
+https://www.openssl.org/docs/  
 https://jamielinux.com/docs/openssl-certificate-authority/sign-server-and-client-certificates.html


### PR DESCRIPTION
Just adding newlines to have references for Tiler SSL more readable.