### PR TITLE
docs(faq): list changes since Helm 2

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,6 +6,15 @@ This page provides help with the most common questions about Helm.
 information, [file an issue](https://github.com/helm/helm/issues) or
 send us a pull request.
 
+## Changes since Helm 2
+
+Here's an exhaustive list of all the major changes introduced in Helm 3.
+
+### Go import path changes
+
+In Helm 3, Helm switched the Go import path over from `k8s.io/helm` to `helm.sh/helm`. If you intend
+to upgrade to the Helm 3 Go client libraries, make sure to change your import paths.
+
 
 ## Installing
 


### PR DESCRIPTION
This adds a small section in the docs for listing any major changes that occurred between Helm 2 and Helm 3.

I added the Go import path changes proposed in #5440 as a placeholder. Will add more to the FAQ in a follow-up