### PR TITLE
Add a call to InitTLS after parsing the cmd line

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -155,6 +155,9 @@ func newRootCmd(args []string) *cobra.Command {
 	// set defaults from environment
 	settings.Init(flags)
 
+	// set defaults for TLS from environment
+	settings.InitTLS(flags)
+
 	// Find and add plugins
 	loadPlugins(cmd, out)
 

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -65,8 +65,8 @@ func TestEqual(t *testing.T) {
 
 func TestExtractHostname(t *testing.T) {
 	tests := map[string]string{
-		"http://example.com":      "example.com",
-		"https://example.com/foo": "example.com",
+		"http://example.com":                                      "example.com",
+		"https://example.com/foo":                                 "example.com",
 		"https://example.com:31337/not/with/a/bang/but/a/whimper": "example.com",
 	}
 	for start, expect := range tests {


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dominique.vernier@us.ibm.com>

Close: #4755

**What this PR does / why we need it**:
This PR allows to use environment variables like "HELM_TLS_ENABLE", "HELM_TLS_VERIFY"....

**Special notes for your reviewer**:
I just added a call to the settings.InitTLS(flags) in the helm.go and this will allow to read the environment variables:

```
var tlsEnvMap = map[string]string{
	"tls-hostname": "HELM_TLS_HOSTNAME",
	"tls-ca-cert":  "HELM_TLS_CA_CERT",
	"tls-cert":     "HELM_TLS_CERT",
	"tls-key":      "HELM_TLS_KEY",
	"tls-verify":   "HELM_TLS_VERIFY",
	"tls":          "HELM_TLS_ENABLE",
}
```
https://github.com/helm/helm/blob/master/pkg/helm/environment/environment.go#L124
to be taken into account.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
