### PR TITLE
fix(install): fix issue where chart metadata is not being saved on `helm install`

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -53,6 +53,9 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
+			// strip chart metadata from the output
+			rel.Chart = nil
+
 			outfmt, err := action.ParseOutputFormat(client.OutputFormat)
 			// We treat an invalid format type as the default
 			if err != nil && err != action.ErrInvalidFormatType {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -25,7 +25,7 @@ type Release struct {
 	// Info provides information about a release
 	Info *Info `json:"info,omitempty"`
 	// Chart is the chart that was released.
-	Chart *chart.Chart `json:"-"`
+	Chart *chart.Chart `json:"chart,omitempty"`
 	// Config is the set of extra Values added to the chart.
 	// These values override the default values inside of the chart.
 	Config map[string]interface{} `json:"config,omitempty"`


### PR DESCRIPTION
In #5365, I changed the Chart field in the Release object to be omitted from the output so that `helm status` would not display that information when `helm status -o json` was requested. However, that resulted in `helm install` omitting that information when serializing the data to be stored in the release secret.

By adding the field back and stripping out the chart metadata before printing, we're able to achieve the original goal of stripping out that metadata from `helm status` without causing any serialization issues.

This is a quick n' dirty hack to get `helm install` working again as it should. @adamreese pointed me [to a solution in the Go standard library](https://github.com/golang/tools/blob/8b67d361bba210f5fbb3c1a0fc121e0847b10b57/go/packages/packages.go#L286-L301) where we can translate the binary data in the release object into a struct for general consumption. I'll file a new ticket to track that refactoring work.