### PR TITLE
fix(tiller): fixed a typo in tiller and unit test

### DIFF
--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -195,7 +195,7 @@ func (s *ReleaseServer) uniqName(start string, reuse bool) (string, error) {
 			s.Log("name %s exists but is not in use, reusing name", start)
 			return start, nil
 		} else if reuse {
-			return "", fmt.Errorf("a released named %s is in use, cannot re-use a name that is still in use", start)
+			return "", fmt.Errorf("a release named %s is in use, cannot re-use a name that is still in use", start)
 		}
 
 		return "", fmt.Errorf("a release named %s already exists.\nRun: helm ls --all %s; to check the status of the release\nOr run: helm del --purge %s; to delete it", start, start, start)

--- a/pkg/tiller/release_update_test.go
+++ b/pkg/tiller/release_update_test.go
@@ -604,7 +604,7 @@ func TestUpdateReleasePendingInstall_Force(t *testing.T) {
 		t.Error("Expected failed update")
 	}
 
-	expectedError := "a released named forceful-luke is in use, cannot re-use a name that is still in use"
+	expectedError := "a release named forceful-luke is in use, cannot re-use a name that is still in use"
 	got := err.Error()
 	if err.Error() != expectedError {
 		t.Errorf("Expected error %q, got %q", expectedError, got)


### PR DESCRIPTION
There was a typo in a tiller error with "released named" message, I've changed it to "a release named". Also fix a unit-test for it.

closes#5370

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
