### PR TITLE
Obtain release info from api.github.com

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -78,11 +78,16 @@ verifySupported() {
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
   # Use the GitHub releases webpage for the project to find the desired version for this project.
-  local release_url="https://github.com/helm/helm/releases/${DESIRED_VERSION:-latest}"
+  local release_url="https://api.github.com/repos/helm/helm/releases"
+  if [ -n "${DESIRED_VERSION}" ]; then
+      release_url="${release_url}/tags/${DESIRED_VERSION}"
+  else
+      release_url="${release_url}/latest"
+  fi
   if type "curl" > /dev/null; then
-    TAG=$(curl -SsL $release_url | awk '/\/tag\//' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+    TAG=$(curl -SsL $release_url | awk '/tag_name/ { print $NF }' | cut -d '"' -f 2)
   elif type "wget" > /dev/null; then
-    TAG=$(wget -q -O - $release_url | awk '/\/tag\//' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+    TAG=$(wget -q -O - $release_url | awk '/tag_name/ { print $NF }' | cut -d '"' -f 2)
   fi
   if [ "x$TAG" == "x" ]; then
     echo "Cannot determine ${DESIRED_VERSION} tag."


### PR DESCRIPTION
Using the API is more stable than parsing HTML from the github.com web site.

Closes #5477

Signed-off-by: Craig Rodrigues <craig@portworx.com>

**What this PR does / why we need it**:

The get script is currently broken because it parses the GitHub release web site's HTML, and the format of the web site has changed.