### PR TITLE
ref(list): move namespaces field closer to the name

### DIFF
--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"helm.sh/helm/pkg/chart"
+	"helm.sh/helm/pkg/release"
+)
+
+func TestListCmd(t *testing.T) {
+	defaultNamespace := "default"
+	timestamp1 := time.Unix(1452902400, 0).UTC()
+	timestamp2 := time.Unix(1452902401, 0).UTC()
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:    "chickadee",
+			Version: "1.0.0",
+		},
+	}
+	releaseFixture := []*release.Release{
+		{
+			Name:      "starlord",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
+				Status:       release.StatusSuperseded,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "starlord",
+			Version:   2,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
+				Status:       release.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "groot",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp2,
+				Status:       release.StatusUninstalled,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "gamora",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
+				Status:       release.StatusSuperseded,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "rocket",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp2,
+				Status:       release.StatusFailed,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "drax",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
+				Status:       release.StatusUninstalling,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "thanos",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
+				Status:       release.StatusPendingInstall,
+			},
+			Chart: chartInfo,
+		},
+	}
+
+	tests := []cmdTestCase{{
+		name:   "list releases",
+		cmd:    "list",
+		golden: "output/list.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list all releases",
+		cmd:    "list --all",
+		golden: "output/list-all.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases sorted by release date",
+		cmd:    "list --date",
+		golden: "output/list-date.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list failed releases",
+		cmd:    "list --failed",
+		golden: "output/list-failed.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list filtered releases",
+		cmd:    "list --filter='.*'",
+		golden: "output/list-filter.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases, limited to one release",
+		cmd:    "list --max 1",
+		golden: "output/list-max.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases, offset by one",
+		cmd:    "list --offset 1",
+		golden: "output/list-offset.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list pending releases",
+		cmd:    "list --pending",
+		golden: "output/list-pending.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases in reverse order",
+		cmd:    "list --reverse",
+		golden: "output/list-reverse.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases in short output format",
+		cmd:    "list --short",
+		golden: "output/list-short.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list superseded releases",
+		cmd:    "list --superseded",
+		golden: "output/list-superseded.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list uninstalled releases",
+		cmd:    "list --uninstalled",
+		golden: "output/list-uninstalled.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases currently uninstalling",
+		cmd:    "list --uninstalling",
+		golden: "output/list-uninstalling.txt",
+		rels:   releaseFixture,
+	}}
+	runTestCmd(t, tests)
+}

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date.txt
+++ b/cmd/helm/testdata/output/list-date.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-failed.txt
+++ b/cmd/helm/testdata/output/list-failed.txt
@@ -1,0 +1,2 @@
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
+rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-filter.txt
+++ b/cmd/helm/testdata/output/list-filter.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-max.txt
+++ b/cmd/helm/testdata/output/list-max.txt
@@ -1,0 +1,2 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-offset.txt
+++ b/cmd/helm/testdata/output/list-offset.txt
@@ -1,0 +1,2 @@
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
+rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-pending.txt
+++ b/cmd/helm/testdata/output/list-pending.txt
@@ -1,0 +1,2 @@
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          
+thanos	default  	1       	2016-01-16 00:00:00 +0000 UTC	pending-install	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-reverse.txt
+++ b/cmd/helm/testdata/output/list-reverse.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-short.txt
+++ b/cmd/helm/testdata/output/list-short.txt
@@ -1,0 +1,2 @@
+starlord
+rocket

--- a/cmd/helm/testdata/output/list-superseded.txt
+++ b/cmd/helm/testdata/output/list-superseded.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-uninstalled.txt
+++ b/cmd/helm/testdata/output/list-uninstalled.txt
@@ -1,0 +1,2 @@
+NAME 	NAMESPACE	REVISION	UPDATED                      	STATUS     	CHART          
+groot	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-uninstalling.txt
+++ b/cmd/helm/testdata/output/list-uninstalling.txt
@@ -1,0 +1,2 @@
+NAME	NAMESPACE	REVISION	UPDATED                      	STATUS      	CHART          
+drax	default  	1       	2016-01-16 00:00:00 +0000 UTC	uninstalling	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list.txt
+++ b/cmd/helm/testdata/output/list.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -238,7 +238,7 @@ func (l *List) SetStateMask() {
 
 func FormatList(rels []*release.Release) string {
 	table := uitable.New()
-	table.AddRow("NAME", "REVISION", "UPDATED", "STATUS", "CHART", "NAMESPACE")
+	table.AddRow("NAME", "NAMESPACE", "REVISION", "UPDATED", "STATUS", "CHART")
 	for _, r := range rels {
 		md := r.Chart.Metadata
 		c := fmt.Sprintf("%s-%s", md.Name, md.Version)
@@ -249,7 +249,7 @@ func FormatList(rels []*release.Release) string {
 		s := r.Info.Status.String()
 		v := r.Version
 		n := r.Namespace
-		table.AddRow(r.Name, v, t, s, c, n)
+		table.AddRow(r.Name, n, v, t, s, c)
 	}
 	return table.String()
 }


### PR DESCRIPTION
Most users want to see the release name and the namespace it was deployed to,
as those are the unique identifiers where the release is stored. I also added
integration tests for `helm list` to better test the command output.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
