### PR TITLE
chore(dep): bump kubernetes to 1.14.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -619,6 +619,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:10b85f58562d487a3bd7da6ba5b895bc221d5ecbd89df9c7c5a36004e827ade1"
+  name = "github.com/liggitt/tabwriter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "89fcab3d43de07060e4fd4c1547430ed57e87f24"
+
+[[projects]]
+  branch = "master"
   digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
   packages = [
@@ -1122,12 +1130,11 @@
   version = "v2.2.2"
 
 [[projects]]
-  branch = "release-1.13"
-  digest = "1:59f8bed7a7fbb14fb4d57cd578e2f65b1779b11573e7aa7fdba942198bbf8c07"
+  branch = "release-1.14"
+  digest = "1:7b8963a5f5bb45d0b3c18806459c02b2284a4267c8c7e9444606e95b95b51fe3"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
@@ -1144,16 +1151,21 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "imagepolicy/v1alpha1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -1162,19 +1174,19 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  revision = "40a48860b5abbba9aa891b02b32da429b08d96a0"
 
 [[projects]]
-  branch = "release-1.13"
-  digest = "1:5c8e30a40644c03c864f2a9e3d32b6346ab05c8cafafd1833954c3957abcb160"
+  branch = "release-1.14"
+  digest = "1:fa65856d5086d5338e962b3bd409e09cd70cb0ceb110167cdf565edd6920ed2e"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
   pruneopts = "UT"
-  revision = "bfb440be4b874c001bc64ea4b3324d37ab3c98dd"
+  revision = "53c4693659ed354d76121458fb819202dd1635fa"
 
 [[projects]]
-  branch = "release-1.13"
-  digest = "1:bdcf6344cebab8b19627c9beb2ea676f584eca1d255b060f01bb30236bcb5be5"
+  branch = "release-1.14"
+  digest = "1:c10a6fffe98df81cdaaeef73a38e4d669d59d2b46a3fe18565d5eb7264d19255"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1232,11 +1244,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  revision = "d7deff9243b165ee192f5551710ea4285dcfd615"
 
 [[projects]]
-  branch = "release-1.13"
-  digest = "1:138928c37ee6ec1be14aec46c97dab5f110ffa7e81828b9d27919df371fd8f62"
+  branch = "release-1.14"
+  digest = "1:71c95d81a294dcee66147ff711896968d512b05df9bf6183cb289c6570c60b4f"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/authentication/authenticator",
@@ -1246,40 +1258,41 @@
     "pkg/util/feature",
   ]
   pruneopts = "UT"
-  revision = "5838f549963bed8c4af81f430f23a29eccad093e"
+  revision = "8b27c41bdbb11ff103caa673315e097bf0289171"
 
 [[projects]]
   branch = "master"
-  digest = "1:79d60410b8f3339b77a36d6096cea81ebe4974b7cb8108446a121266b58bff01"
+  digest = "1:1617a9d82f05ddcd88c9f3638359de6c12012f61f0fea110a37f5fc1861dc48b"
   name = "k8s.io/cli-runtime"
   packages = [
     "pkg/genericclioptions",
-    "pkg/genericclioptions/printers",
-    "pkg/genericclioptions/resource",
+    "pkg/kustomize",
     "pkg/kustomize/k8sdeps",
     "pkg/kustomize/k8sdeps/configmapandsecret",
     "pkg/kustomize/k8sdeps/kunstruct",
+    "pkg/kustomize/k8sdeps/kv",
     "pkg/kustomize/k8sdeps/transformer",
     "pkg/kustomize/k8sdeps/transformer/hash",
     "pkg/kustomize/k8sdeps/transformer/patch",
     "pkg/kustomize/k8sdeps/validator",
+    "pkg/printers",
+    "pkg/resource",
   ]
   pruneopts = "UT"
-  revision = "8abb1aeb8307ee1f2335c4331d850a232efb1cbd"
+  revision = "44a48934c135b31e4f1c0d12e91d384e1cb2304c"
 
 [[projects]]
-  digest = "1:bbd76e2885a4c5d22210e1196c24e1dac3d695717892beb1231f7226e6aea7de"
+  digest = "1:8774c035808c344c148ba5135b282d487561233ee3be10f6115ea9a9da5e1c56"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/cached/disk",
     "discovery/fake",
     "dynamic",
     "dynamic/fake",
     "kubernetes",
     "kubernetes/fake",
     "kubernetes/scheme",
-    "kubernetes/typed/admissionregistration/v1alpha1",
-    "kubernetes/typed/admissionregistration/v1alpha1/fake",
     "kubernetes/typed/admissionregistration/v1beta1",
     "kubernetes/typed/admissionregistration/v1beta1/fake",
     "kubernetes/typed/apps/v1",
@@ -1312,6 +1325,8 @@
     "kubernetes/typed/batch/v2alpha1/fake",
     "kubernetes/typed/certificates/v1beta1",
     "kubernetes/typed/certificates/v1beta1/fake",
+    "kubernetes/typed/coordination/v1",
+    "kubernetes/typed/coordination/v1/fake",
     "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/coordination/v1beta1/fake",
     "kubernetes/typed/core/v1",
@@ -1322,6 +1337,12 @@
     "kubernetes/typed/extensions/v1beta1/fake",
     "kubernetes/typed/networking/v1",
     "kubernetes/typed/networking/v1/fake",
+    "kubernetes/typed/networking/v1beta1",
+    "kubernetes/typed/networking/v1beta1/fake",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1alpha1/fake",
+    "kubernetes/typed/node/v1beta1",
+    "kubernetes/typed/node/v1beta1/fake",
     "kubernetes/typed/policy/v1beta1",
     "kubernetes/typed/policy/v1beta1/fake",
     "kubernetes/typed/rbac/v1",
@@ -1330,6 +1351,8 @@
     "kubernetes/typed/rbac/v1alpha1/fake",
     "kubernetes/typed/rbac/v1beta1",
     "kubernetes/typed/rbac/v1beta1/fake",
+    "kubernetes/typed/scheduling/v1",
+    "kubernetes/typed/scheduling/v1/fake",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1alpha1/fake",
     "kubernetes/typed/scheduling/v1beta1",
@@ -1375,24 +1398,32 @@
     "tools/metrics",
     "tools/pager",
     "tools/record",
+    "tools/record/util",
     "tools/reference",
     "tools/remotecommand",
     "tools/watch",
     "transport",
     "transport/spdy",
-    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/exec",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
     "util/jsonpath",
+    "util/keyutil",
     "util/retry",
   ]
   pruneopts = "UT"
-  revision = "b40b2a5939e43f7ffe0028ad67586b7ce50bb675"
-  version = "kubernetes-1.13.4"
+  revision = "6ee68ca5fd8355d024d02f9db0b3b667e8357a0f"
+  version = "kubernetes-1.14.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:0b0a9bd556672d681837dab08c6b33d37c7f45f1916d9bbe8feca78e08383db3"
+  name = "k8s.io/cloud-provider"
+  packages = ["features"]
+  pruneopts = "UT"
+  revision = "9c9d72d1bf90eb62005f5112f3eea019b272c44b"
 
 [[projects]]
   digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
@@ -1416,8 +1447,8 @@
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
-  branch = "release-1.13"
-  digest = "1:c9564449a22bd640a6ab2b73decf4e8e42e9d896ea5d342a69319c32ca6f870b"
+  branch = "release-1.14"
+  digest = "1:3e8a09f07ca1d0163720064d0bcb567fdc85338e02bd63c6d84786be8b24ebdb"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/legacyscheme",
@@ -1451,6 +1482,7 @@
     "pkg/apis/certificates/v1beta1",
     "pkg/apis/coordination",
     "pkg/apis/coordination/install",
+    "pkg/apis/coordination/v1",
     "pkg/apis/coordination/v1beta1",
     "pkg/apis/core",
     "pkg/apis/core/helper",
@@ -1466,6 +1498,7 @@
     "pkg/apis/extensions/install",
     "pkg/apis/extensions/v1beta1",
     "pkg/apis/networking",
+    "pkg/apis/node",
     "pkg/apis/policy",
     "pkg/apis/policy/install",
     "pkg/apis/policy/v1beta1",
@@ -1476,6 +1509,7 @@
     "pkg/apis/rbac/v1beta1",
     "pkg/apis/scheduling",
     "pkg/apis/scheduling/install",
+    "pkg/apis/scheduling/v1",
     "pkg/apis/scheduling/v1alpha1",
     "pkg/apis/scheduling/v1beta1",
     "pkg/apis/settings",
@@ -1520,37 +1554,38 @@
     "pkg/kubectl/util/templates",
     "pkg/kubectl/util/term",
     "pkg/kubectl/validation",
-    "pkg/kubelet/apis",
     "pkg/kubelet/types",
     "pkg/master/ports",
     "pkg/printers",
     "pkg/printers/internalversion",
-    "pkg/scheduler/api",
     "pkg/security/apparmor",
     "pkg/serviceaccount",
-    "pkg/util/file",
     "pkg/util/hash",
     "pkg/util/interrupt",
     "pkg/util/labels",
-    "pkg/util/net/sets",
     "pkg/util/node",
     "pkg/util/parsers",
     "pkg/util/taints",
     "pkg/version",
   ]
   pruneopts = "UT"
-  revision = "4ad5ca43b3069ecf7a845f06ecf1c960749baa09"
+  revision = "a2e9891cd681b2682895dfd04f4cd31186cc2ac4"
 
 [[projects]]
   branch = "master"
-  digest = "1:9c6cb46fa10409b199f93e6ceda462ddfa62d74e97174591a147b38982585d24"
+  digest = "1:97af0e3995afafd52fc0135efaa3290f1f3326fd184e0ef48060f76fab51c6ef"
   name = "k8s.io/utils"
   packages = [
+    "buffer",
     "exec",
+    "integer",
+    "net",
+    "path",
     "pointer",
+    "trace",
   ]
   pruneopts = "UT"
-  revision = "8a16e7dd8fb6d97d1331b0c79a16722f934b00b1"
+  revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
   branch = "master"
@@ -1562,7 +1597,7 @@
   source = "https://github.com/dmcgowan/letsencrypt.git"
 
 [[projects]]
-  digest = "1:443f6048f55fc9e389e8f7fa20b25bc30ef565953dd5c6425c9032432a677301"
+  digest = "1:cb422c75bab66a8339a38b64e837f3b28f3d5a8c06abd7b9048f420363baa18a"
   name = "sigs.k8s.io/kustomize"
   packages = [
     "pkg/commands/build",
@@ -1570,9 +1605,11 @@
     "pkg/expansion",
     "pkg/factory",
     "pkg/fs",
+    "pkg/git",
     "pkg/gvk",
     "pkg/ifc",
     "pkg/ifc/transformer",
+    "pkg/image",
     "pkg/internal/error",
     "pkg/loader",
     "pkg/patch",
@@ -1587,8 +1624,8 @@
     "pkg/types",
   ]
   pruneopts = "UT"
-  revision = "8f701a00417a812558a7b785e8354957afa469ae"
-  version = "v1.0.11"
+  revision = "a6f65144121d1955266b0cd836ce954c04122dc8"
+  version = "v2.0.3"
 
 [[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
@@ -1666,7 +1703,7 @@
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/cli-runtime/pkg/genericclioptions",
-    "k8s.io/cli-runtime/pkg/genericclioptions/resource",
+    "k8s.io/cli-runtime/pkg/resource",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,19 +28,19 @@
 
 [[constraint]]
   name = "k8s.io/api"
-  branch = "release-1.13"
+  branch = "release-1.14"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.13"
+  branch = "release-1.14"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.13.4"
+  version = "kubernetes-1.14.0"
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  branch = "release-1.13"
+  branch = "release-1.14"
 
 [[constraint]]
   name = "github.com/deislabs/oras"
@@ -55,12 +55,16 @@
   version = "^1.3.0"
 
 [[override]]
+  name = "sigs.k8s.io/kustomize"
+  version = "2.0.3"
+
+[[override]]
   name = "k8s.io/apiserver"
-  branch = "release-1.13"
+  branch = "release-1.14"
 
 [[override]]
   name = "k8s.io/apiextensions-apiserver"
-  branch = "release-1.13"
+  branch = "release-1.14"
 
 [[override]]
   name = "github.com/imdario/mergo"

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -69,7 +69,7 @@ type Client struct {
 // New creates a new Client.
 func New(getter genericclioptions.RESTClientGetter) *Client {
 	if getter == nil {
-		getter = genericclioptions.NewConfigFlags()
+		getter = genericclioptions.NewConfigFlags(true)
 	}
 	return &Client{
 		Factory: cmdutil.NewFactory(getter),

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -20,7 +20,7 @@ import "k8s.io/cli-runtime/pkg/genericclioptions"
 
 // GetConfig returns a Kubernetes client config.
 func GetConfig(kubeconfig, context, namespace string) *genericclioptions.ConfigFlags {
-	cf := genericclioptions.NewConfigFlags()
+	cf := genericclioptions.NewConfigFlags(true)
 	cf.Namespace = &namespace
 	cf.Context = &context
 	cf.KubeConfig = &kubeconfig

--- a/pkg/kube/converter.go
+++ b/pkg/kube/converter.go
@@ -19,7 +19,7 @@ package kube // import "helm.sh/helm/pkg/kube"
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
 

--- a/pkg/kube/environment.go
+++ b/pkg/kube/environment.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 )
 
 // KubernetesClient represents a client capable of communicating with the Kubernetes API.

--- a/pkg/kube/environment_test.go
+++ b/pkg/kube/environment_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 )
 
 type mockKubeClient struct{}

--- a/pkg/kube/factory.go
+++ b/pkg/kube/factory.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kube // import "helm.sh/helm/pkg/kube"
 
 import (
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl/validation"

--- a/pkg/kube/result.go
+++ b/pkg/kube/result.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package kube // import "helm.sh/helm/pkg/kube"
 
-import "k8s.io/cli-runtime/pkg/genericclioptions/resource"
+import "k8s.io/cli-runtime/pkg/resource"
 
 // Result provides convenience methods for comparing collections of Infos.
 type Result []*resource.Info

--- a/pkg/kube/result_test.go
+++ b/pkg/kube/result_test.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/cli-runtime/pkg/resource"
 )
 
 func TestResult(t *testing.T) {


### PR DESCRIPTION
Note for the reviewer: I have not manually tested if something changed upstream. I just bumped Gopkg.toml and played around with experimental apiserver features. Let me know if there's something I missed in 1.14 that might break backwards compatibility and I'll be happy to fix it.

ref to one of the changes that occurred upstream: kubernetes/kubernetes@4b524ef995eefdbf74630beaeb0742a88715c82c