### PR TITLE
Don't print ROLLING BACK if atomic is not set

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -275,8 +275,9 @@ func (u *upgradeCmd) run() error {
 		helm.UpgradeWait(u.wait),
 		helm.UpgradeDescription(u.description))
 	if err != nil {
-		fmt.Fprintf(u.out, "UPGRADE FAILED\nROLLING BACK\nError: %v\n", prettyError(err))
+		fmt.Fprintf(u.out, "UPGRADE FAILED\nError: %v\n", prettyError(err))
 		if u.atomic {
+			fmt.Fprint(u.out, "ROLLING BACK")
 			rollback := &rollbackCmd{
 				out:          u.out,
 				client:       u.client,


### PR DESCRIPTION
Signed-off-by: Mike Eves <meves23@gmail.com>

**What this PR does / why we need it**:
Helm will only automatically rollback if `--atomic` has been passed as an argument to the upgrade command. Currently though Helm will print `ROLLING BACK` on _all_ failed upgrades which causes some confusion when atomic has not been set.

This PR changes the logging slightly to be less misleading.

