### PR TITLE
feat(*): Add app version to history table

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -35,11 +35,11 @@ configures the maximum length of the revision list returned.
 The historical release set is printed as a formatted table, e.g:
 
     $ helm history angry-bird --max=4
-    REVISION   UPDATED                      STATUS           CHART        DESCRIPTION
-    1           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0  Initial install
-    2           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0  Upgraded successfully
-    3           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0  Rolled back to 2
-    4           Mon Oct 3 10:15:13 2016     deployed        alpine-0.1.0  Upgraded successfully
+    REVISION    UPDATED                     STATUS          CHART             APP_VERSION     DESCRIPTION
+    1           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Initial install
+    2           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Upgraded successfully
+    3           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Rolled back to 2
+    4           Mon Oct 3 10:15:13 2016     deployed        alpine-0.1.0      1.0             Upgraded successfully
 `
 
 func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -35,7 +35,7 @@ configures the maximum length of the revision list returned.
 The historical release set is printed as a formatted table, e.g:
 
     $ helm history angry-bird --max=4
-    REVISION    UPDATED                     STATUS          CHART             APP_VERSION     DESCRIPTION
+    REVISION    UPDATED                     STATUS          CHART             APP VERSION     DESCRIPTION
     1           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Initial install
     2           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Upgraded successfully
     3           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Rolled back to 2

--- a/cmd/helm/testdata/output/history-limit.txt
+++ b/cmd/helm/testdata/output/history-limit.txt
@@ -1,3 +1,3 @@
-REVISION	UPDATED                      	STATUS    	CHART           	APP_VERSION	DESCRIPTION 
+REVISION	UPDATED                      	STATUS    	CHART           	APP VERSION	DESCRIPTION 
 3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
 4       	1977-09-02 22:04:05 +0000 UTC	deployed  	foo-0.1.0-beta.1	1.0        	Release mock

--- a/cmd/helm/testdata/output/history-limit.txt
+++ b/cmd/helm/testdata/output/history-limit.txt
@@ -1,3 +1,3 @@
-REVISION	UPDATED                      	STATUS    	CHART           	DESCRIPTION 
-3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	Release mock
-4       	1977-09-02 22:04:05 +0000 UTC	deployed  	foo-0.1.0-beta.1	Release mock
+REVISION	UPDATED                      	STATUS    	CHART           	APP_VERSION	DESCRIPTION 
+3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+4       	1977-09-02 22:04:05 +0000 UTC	deployed  	foo-0.1.0-beta.1	1.0        	Release mock

--- a/cmd/helm/testdata/output/history.json
+++ b/cmd/helm/testdata/output/history.json
@@ -1,1 +1,1 @@
-[{"revision":3,"updated":"1977-09-02 22:04:05 +0000 UTC","status":"superseded","chart":"foo-0.1.0-beta.1","description":"Release mock"},{"revision":4,"updated":"1977-09-02 22:04:05 +0000 UTC","status":"deployed","chart":"foo-0.1.0-beta.1","description":"Release mock"}]
+[{"revision":3,"updated":"1977-09-02 22:04:05 +0000 UTC","status":"superseded","chart":"foo-0.1.0-beta.1","app_version":"1.0","description":"Release mock"},{"revision":4,"updated":"1977-09-02 22:04:05 +0000 UTC","status":"deployed","chart":"foo-0.1.0-beta.1","app_version":"1.0","description":"Release mock"}]

--- a/cmd/helm/testdata/output/history.txt
+++ b/cmd/helm/testdata/output/history.txt
@@ -1,4 +1,4 @@
-REVISION	UPDATED                      	STATUS    	CHART           	APP_VERSION	DESCRIPTION 
+REVISION	UPDATED                      	STATUS    	CHART           	APP VERSION	DESCRIPTION 
 1       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
 2       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
 3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock

--- a/cmd/helm/testdata/output/history.txt
+++ b/cmd/helm/testdata/output/history.txt
@@ -1,5 +1,5 @@
-REVISION	UPDATED                      	STATUS    	CHART           	DESCRIPTION 
-1       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	Release mock
-2       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	Release mock
-3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	Release mock
-4       	1977-09-02 22:04:05 +0000 UTC	deployed  	foo-0.1.0-beta.1	Release mock
+REVISION	UPDATED                      	STATUS    	CHART           	APP_VERSION	DESCRIPTION 
+1       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+2       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+3       	1977-09-02 22:04:05 +0000 UTC	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+4       	1977-09-02 22:04:05 +0000 UTC	deployed  	foo-0.1.0-beta.1	1.0        	Release mock

--- a/cmd/helm/testdata/output/history.yaml
+++ b/cmd/helm/testdata/output/history.yaml
@@ -1,9 +1,11 @@
-- chart: foo-0.1.0-beta.1
+- app_version: "1.0"
+  chart: foo-0.1.0-beta.1
   description: Release mock
   revision: 3
   status: superseded
   updated: 1977-09-02 22:04:05 +0000 UTC
-- chart: foo-0.1.0-beta.1
+- app_version: "1.0"
+  chart: foo-0.1.0-beta.1
   description: Release mock
   revision: 4
   status: deployed

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -165,7 +165,7 @@ func getReleaseHistory(rls []*release.Release) (history releaseHistory) {
 func formatAsTable(releases releaseHistory) []byte {
 	tbl := uitable.New()
 
-	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP_VERSION", "DESCRIPTION")
+	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for i := 0; i <= len(releases)-1; i++ {
 		r := releases[i]
 		tbl.AddRow(r.Revision, r.Updated, r.Status, r.Chart, r.AppVersion, r.Description)

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -34,6 +34,7 @@ type releaseInfo struct {
 	Updated     string `json:"updated"`
 	Status      string `json:"status"`
 	Chart       string `json:"chart"`
+	AppVersion  string `json:"app_version"`
 	Description string `json:"description"`
 }
 
@@ -142,11 +143,13 @@ func getReleaseHistory(rls []*release.Release) (history releaseHistory) {
 		s := r.Info.Status.String()
 		v := r.Version
 		d := r.Info.Description
+		a := formatAppVersion(r.Chart)
 
 		rInfo := releaseInfo{
 			Revision:    v,
 			Status:      s,
 			Chart:       c,
+			AppVersion:  a,
 			Description: d,
 		}
 		if !r.Info.LastDeployed.IsZero() {
@@ -162,10 +165,10 @@ func getReleaseHistory(rls []*release.Release) (history releaseHistory) {
 func formatAsTable(releases releaseHistory) []byte {
 	tbl := uitable.New()
 
-	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "DESCRIPTION")
+	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP_VERSION", "DESCRIPTION")
 	for i := 0; i <= len(releases)-1; i++ {
 		r := releases[i]
-		tbl.AddRow(r.Revision, r.Updated, r.Status, r.Chart, r.Description)
+		tbl.AddRow(r.Revision, r.Updated, r.Status, r.Chart, r.AppVersion, r.Description)
 	}
 	return tbl.Bytes()
 }
@@ -177,4 +180,13 @@ func formatChartname(c *chart.Chart) string {
 		return "MISSING"
 	}
 	return fmt.Sprintf("%s-%s", c.Name(), c.Metadata.Version)
+}
+
+func formatAppVersion(c *chart.Chart) string {
+	if c == nil || c.Metadata == nil {
+		// This is an edge case that has happened in prod, though we don't
+		// know how: https://github.com/helm/helm/issues/1347
+		return "MISSING"
+	}
+	return c.AppVersion()
 }

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -100,3 +100,11 @@ func (ch *Chart) ChartFullPath() string {
 func (ch *Chart) Validate() error {
 	return ch.Metadata.Validate()
 }
+
+// AppVersion returns the appversion of the chart.
+func (ch *Chart) AppVersion() string {
+	if ch.Metadata == nil {
+		return ""
+	}
+	return ch.Metadata.AppVersion
+}

--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -71,8 +71,9 @@ func Mock(opts *MockReleaseOptions) *Release {
 	if opts.Chart == nil {
 		ch = &chart.Chart{
 			Metadata: &chart.Metadata{
-				Name:    "foo",
-				Version: "0.1.0-beta.1",
+				Name:       "foo",
+				Version:    "0.1.0-beta.1",
+				AppVersion: "1.0",
 			},
 			Templates: []*chart.File{
 				{Name: "templates/foo.tpl", Data: []byte(MockManifest)},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds "App Version" column to the `helm history` table output.

Closes #5205 

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
