### PR TITLE
fix(helm): sort release list with flags --reverse and --date

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -86,7 +86,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVarP(&client.Short, "short", "q", false, "output short (quiet) listing format")
 	f.BoolVarP(&client.ByDate, "date", "d", false, "sort by release date")
-	f.BoolVarP(&client.SortDesc, "reverse", "r", false, "reverse the sort order")
+	f.BoolVarP(&client.SortReverse, "reverse", "r", false, "reverse the sort order")
 	f.BoolVarP(&client.All, "all", "a", false, "show all releases, not just the ones marked deployed")
 	f.BoolVar(&client.Uninstalled, "uninstalled", false, "show uninstalled releases")
 	f.BoolVar(&client.Superseded, "superseded", false, "show superseded releases")

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -87,7 +87,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVarP(&client.Short, "short", "q", false, "output short (quiet) listing format")
 	f.BoolVarP(&client.ByDate, "date", "d", false, "sort by release date")
 	f.BoolVarP(&client.SortReverse, "reverse", "r", false, "reverse the sort order")
-	f.BoolVarP(&client.All, "all", "a", false, "show all releases, not just the ones marked deployed")
+	f.BoolVarP(&client.All, "all", "a", false, "show all releases, not just the ones marked deployed or failed")
 	f.BoolVar(&client.Uninstalled, "uninstalled", false, "show uninstalled releases")
 	f.BoolVar(&client.Superseded, "superseded", false, "show superseded releases")
 	f.BoolVar(&client.Uninstalling, "uninstalling", false, "show releases that are currently being uninstalled")

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -66,7 +66,6 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if client.AllNamespaces {
 				client.SetConfiguration(newActionConfig(true))
 			}
-			client.All = client.Limit == -1
 			client.SetStateMask()
 
 			results, err := client.Run()

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -65,7 +65,7 @@ func TestListCmd(t *testing.T) {
 			Version:   1,
 			Namespace: defaultNamespace,
 			Info: &release.Info{
-				LastDeployed: timestamp2,
+				LastDeployed: timestamp1,
 				Status:       release.StatusUninstalled,
 			},
 			Chart: chartInfo,

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -26,14 +26,19 @@ import (
 
 func TestListCmd(t *testing.T) {
 	defaultNamespace := "default"
-	timestamp1 := time.Unix(1452902400, 0).UTC()
-	timestamp2 := time.Unix(1452902401, 0).UTC()
+
+	sampleTimeSeconds := int64(1452902400)
+	timestamp1 := time.Unix(sampleTimeSeconds+1, 0).UTC()
+	timestamp2 := time.Unix(sampleTimeSeconds+2, 0).UTC()
+	timestamp3 := time.Unix(sampleTimeSeconds+3, 0).UTC()
+	timestamp4 := time.Unix(sampleTimeSeconds+4, 0).UTC()
 	chartInfo := &chart.Chart{
 		Metadata: &chart.Metadata{
 			Name:    "chickadee",
 			Version: "1.0.0",
 		},
 	}
+
 	releaseFixture := []*release.Release{
 		{
 			Name:      "starlord",
@@ -105,6 +110,26 @@ func TestListCmd(t *testing.T) {
 			},
 			Chart: chartInfo,
 		},
+		{
+			Name:      "hummingbird",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp3,
+				Status:       release.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "iguana",
+			Version:   2,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp4,
+				Status:       release.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
 	}
 
 	tests := []cmdTestCase{{
@@ -151,6 +176,11 @@ func TestListCmd(t *testing.T) {
 		name:   "list releases in reverse order",
 		cmd:    "list --reverse",
 		golden: "output/list-reverse.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases sorted by reversed release date",
+		cmd:    "list --date --reverse",
+		golden: "output/list-date-reversed.txt",
 		rels:   releaseFixture,
 	}, {
 		name:   "list releases in short output format",

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -1,3 +1,3 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
 rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -1,3 +1,10 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          
+drax       	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling   	chickadee-1.0.0
+gamora     	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0
+groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chickadee-1.0.0
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0
+starlord   	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0
+thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date-reversed.txt
+++ b/cmd/helm/testdata/output/list-date-reversed.txt
@@ -1,0 +1,3 @@
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date-reversed.txt
+++ b/cmd/helm/testdata/output/list-date-reversed.txt
@@ -1,3 +1,5 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date.txt
+++ b/cmd/helm/testdata/output/list-date.txt
@@ -1,3 +1,5 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-failed.txt
+++ b/cmd/helm/testdata/output/list-failed.txt
@@ -1,2 +1,2 @@
 NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
-rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0
+rocket	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-filter.txt
+++ b/cmd/helm/testdata/output/list-filter.txt
@@ -1,3 +1,3 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
 rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-filter.txt
+++ b/cmd/helm/testdata/output/list-filter.txt
@@ -1,3 +1,5 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-max.txt
+++ b/cmd/helm/testdata/output/list-max.txt
@@ -1,2 +1,2 @@
-NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
-rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-max.txt
+++ b/cmd/helm/testdata/output/list-max.txt
@@ -1,2 +1,2 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
+rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-offset.txt
+++ b/cmd/helm/testdata/output/list-offset.txt
@@ -1,2 +1,2 @@
-NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          
-rocket	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed	chickadee-1.0.0
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-offset.txt
+++ b/cmd/helm/testdata/output/list-offset.txt
@@ -1,2 +1,4 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+iguana  	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
+rocket  	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-pending.txt
+++ b/cmd/helm/testdata/output/list-pending.txt
@@ -1,2 +1,2 @@
 NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          
-thanos	default  	1       	2016-01-16 00:00:00 +0000 UTC	pending-install	chickadee-1.0.0
+thanos	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-reverse.txt
+++ b/cmd/helm/testdata/output/list-reverse.txt
@@ -1,3 +1,5 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-short.txt
+++ b/cmd/helm/testdata/output/list-short.txt
@@ -1,2 +1,4 @@
+hummingbird
+iguana
 rocket
 starlord

--- a/cmd/helm/testdata/output/list-short.txt
+++ b/cmd/helm/testdata/output/list-short.txt
@@ -1,2 +1,2 @@
-starlord
 rocket
+starlord

--- a/cmd/helm/testdata/output/list-superseded.txt
+++ b/cmd/helm/testdata/output/list-superseded.txt
@@ -1,3 +1,3 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
 rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-superseded.txt
+++ b/cmd/helm/testdata/output/list-superseded.txt
@@ -1,3 +1,3 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS    	CHART          
+gamora  	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0
+starlord	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-uninstalling.txt
+++ b/cmd/helm/testdata/output/list-uninstalling.txt
@@ -1,2 +1,2 @@
 NAME	NAMESPACE	REVISION	UPDATED                      	STATUS      	CHART          
-drax	default  	1       	2016-01-16 00:00:00 +0000 UTC	uninstalling	chickadee-1.0.0
+drax	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list.txt
+++ b/cmd/helm/testdata/output/list.txt
@@ -1,3 +1,3 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
 rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
+starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list.txt
+++ b/cmd/helm/testdata/output/list.txt
@@ -1,3 +1,5 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-rocket  	default  	1       	2016-01-16 00:00:01 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:00 +0000 UTC	deployed	chickadee-1.0.0
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -241,6 +241,9 @@ func (l *List) SetStateMask() {
 	if l.Failed {
 		state |= ListFailed
 	}
+	if l.Superseded {
+		state |= ListSuperseded
+	}
 
 	// Apply a default
 	if state == 0 {

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -87,10 +87,8 @@ const ListAll = ListDeployed | ListUninstalled | ListUninstalling | ListPendingI
 type Sorter uint
 
 const (
-	// ByNameAsc sorts by ascending lexicographic order
-	ByNameAsc Sorter = iota
 	// ByNameDesc sorts by descending lexicographic order
-	ByNameDesc
+	ByNameDesc Sorter = iota + 1
 	// ByDateAsc sorts by ascending dates (oldest updated release first)
 	ByDateAsc
 	// ByDateDesc sorts by descending dates (latest updated release first)

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -87,14 +87,14 @@ const ListAll = ListDeployed | ListUninstalled | ListUninstalling | ListPendingI
 type Sorter uint
 
 const (
-	// ByDateAsc sorts by ascending dates (oldest updated release first)
-	ByDateAsc Sorter = iota
-	// ByDateDesc sorts by descending dates (latest updated release first)
-	ByDateDesc
 	// ByNameAsc sorts by ascending lexicographic order
-	ByNameAsc
+	ByNameAsc Sorter = iota
 	// ByNameDesc sorts by descending lexicographic order
 	ByNameDesc
+	// ByDateAsc sorts by ascending dates (oldest updated release first)
+	ByDateAsc
+	// ByDateDesc sorts by descending dates (latest updated release first)
+	ByDateDesc
 )
 
 // List is the action for listing releases.
@@ -197,7 +197,6 @@ func (l *List) Run() ([]*release.Release, error) {
 
 // sort is an in-place sort where order is based on the value of a.Sort
 func (l *List) sort(rels []*release.Release) {
-	l.Sort = ByNameAsc
 	if l.SortReverse {
 		l.Sort = ByNameDesc
 	}

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -81,6 +81,7 @@ func TestList_AllNamespaces(t *testing.T) {
 	lister := newListFixture(t)
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	lister.AllNamespaces = true
+	lister.SetStateMask()
 	list, err := lister.Run()
 	is.NoError(err)
 	is.Len(list, 3)
@@ -221,6 +222,11 @@ func makeMeSomeReleases(store *storage.Storage, t *testing.T) {
 	three.Name = "three"
 	three.Namespace = "default"
 	three.Version = 3
+	four := releaseStub()
+	four.Name = "four"
+	four.Namespace = "default"
+	four.Version = 4
+	four.Info.Status = release.StatusSuperseded
 
 	for _, rel := range []*release.Release{one, two, three} {
 		if err := store.Create(rel); err != nil {

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -103,13 +103,10 @@ func TestList_Limit(t *testing.T) {
 	is := assert.New(t)
 	lister := newListFixture(t)
 	lister.Limit = 2
-	// Sort because otherwise there is no guaranteed order
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	list, err := lister.Run()
 	is.NoError(err)
 	is.Len(list, 2)
-
 	// Lex order means one, three, two
 	is.Equal("one", list[0].Name)
 	is.Equal("three", list[1].Name)
@@ -119,8 +116,6 @@ func TestList_BigLimit(t *testing.T) {
 	is := assert.New(t)
 	lister := newListFixture(t)
 	lister.Limit = 20
-	// Sort because otherwise there is no guaranteed order
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	list, err := lister.Run()
 	is.NoError(err)
@@ -137,8 +132,6 @@ func TestList_LimitOffset(t *testing.T) {
 	lister := newListFixture(t)
 	lister.Limit = 2
 	lister.Offset = 1
-	// Sort because otherwise there is no guaranteed order
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	list, err := lister.Run()
 	is.NoError(err)
@@ -154,8 +147,6 @@ func TestList_LimitOffsetOutOfBounds(t *testing.T) {
 	lister := newListFixture(t)
 	lister.Limit = 2
 	lister.Offset = 3 // Last item is index 2
-	// Sort because otherwise there is no guaranteed order
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	list, err := lister.Run()
 	is.NoError(err)
@@ -170,8 +161,6 @@ func TestList_LimitOffsetOutOfBounds(t *testing.T) {
 func TestList_StateMask(t *testing.T) {
 	is := assert.New(t)
 	lister := newListFixture(t)
-	// Sort because otherwise there is no guaranteed order
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 	one, err := lister.cfg.Releases.Get("one", 1)
 	is.NoError(err)
@@ -200,7 +189,6 @@ func TestList_Filter(t *testing.T) {
 	is := assert.New(t)
 	lister := newListFixture(t)
 	lister.Filter = "th."
-	lister.Sort = ByNameAsc
 	makeMeSomeReleases(lister.cfg.Releases, t)
 
 	res, err := lister.Run()

--- a/pkg/releaseutil/sorter.go
+++ b/pkg/releaseutil/sorter.go
@@ -38,8 +38,8 @@ type ByDate struct{ list }
 
 // Less compares to releases
 func (s ByDate) Less(i, j int) bool {
-	ti := s.list[i].Info.LastDeployed.Second()
-	tj := s.list[j].Info.LastDeployed.Second()
+	ti := s.list[i].Info.LastDeployed.Unix()
+	tj := s.list[j].Info.LastDeployed.Unix()
 	return ti < tj
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Bug fix and closes #5499

**Special notes for your reviewer**:
Apart from fixing the bug for `--date` and `--reverse` flags in `helm list` command, this PR also makes sure the behavior is as expected if both `--date` and `--reverse` flags are enabled
Precisely:
`helm list` (Default case - sort by name Asc)
`helm list -r` sorts by name Desc
`helm list -d` sorts by date Asc (recent updated release last)
`helm list -d -r` sorts by date Desc (recently updated release first)

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
