### PR TITLE
Fixed typos in docs/chart_best_practices

### DIFF
--- a/docs/chart_best_practices/values.md
+++ b/docs/chart_best_practices/values.md
@@ -88,7 +88,7 @@ data is lost after one parse.
 
 ## Consider How Users Will Use Your Values
 
-There are three potential sources of values:
+There are four potential sources of values:
 
 - A chart's `values.yaml` file
 - A values file supplied by `helm install -f` or `helm upgrade -f`


### PR DESCRIPTION
Not 3, but 4 potential sources of values.