### PR TITLE
ref(create): app version should be 0.1.0

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -80,7 +80,7 @@ func (o *createOptions) run(out io.Writer) error {
 		Description: "A Helm chart for Kubernetes",
 		Type:        "application",
 		Version:     "0.1.0",
-		AppVersion:  "1.0",
+		AppVersion:  "0.1.0",
 		APIVersion:  chart.APIVersionV1,
 	}
 
@@ -90,6 +90,6 @@ func (o *createOptions) run(out io.Writer) error {
 		return chartutil.CreateFrom(cfile, filepath.Dir(o.name), lstarter)
 	}
 
-	_, err := chartutil.Create(cfile, filepath.Dir(o.name))
+	_, err := chartutil.Create(chartname, filepath.Dir(o.name))
 	return err
 }

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -73,11 +73,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	// Create a starter.
 	starterchart := hh.Starters()
 	os.Mkdir(starterchart, 0755)
-	if dest, err := chartutil.Create(&chart.Metadata{
-		APIVersion: chart.APIVersionV1,
-		Name:       "starterchart",
-		Version:    "0.1.0",
-	}, starterchart); err != nil {
+	if dest, err := chartutil.Create("starterchart", starterchart); err != nil {
 		t.Fatalf("Could not create chart: %s", err)
 	} else {
 		t.Logf("Created %s", dest)

--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -46,8 +46,9 @@ func TestDependencyUpdateCmd(t *testing.T) {
 	t.Logf("Listening on directory %s", srv.Root())
 
 	chartname := "depup"
-	md := createTestingMetadata(chartname, srv.URL())
-	if _, err := chartutil.Create(md, hh.String()); err != nil {
+	ch := createTestingMetadata(chartname, srv.URL())
+	md := ch.Metadata
+	if err := chartutil.SaveDir(ch, hh.String()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -203,14 +204,16 @@ func TestDependencyUpdateCmd_DontDeleteOldChartsOnError(t *testing.T) {
 // createTestingMetadata creates a basic chart that depends on reqtest-0.1.0
 //
 // The baseURL can be used to point to a particular repository server.
-func createTestingMetadata(name, baseURL string) *chart.Metadata {
-	return &chart.Metadata{
-		APIVersion: chart.APIVersionV1,
-		Name:       name,
-		Version:    "1.2.3",
-		Dependencies: []*chart.Dependency{
-			{Name: "reqtest", Version: "0.1.0", Repository: baseURL},
-			{Name: "compressedchart", Version: "0.1.0", Repository: baseURL},
+func createTestingMetadata(name, baseURL string) *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: chart.APIVersionV1,
+			Name:       name,
+			Version:    "1.2.3",
+			Dependencies: []*chart.Dependency{
+				{Name: "reqtest", Version: "0.1.0", Repository: baseURL},
+				{Name: "compressedchart", Version: "0.1.0", Repository: baseURL},
+			},
 		},
 	}
 }
@@ -220,6 +223,5 @@ func createTestingMetadata(name, baseURL string) *chart.Metadata {
 // The baseURL can be used to point to a particular repository server.
 func createTestingChart(dest, name, baseURL string) error {
 	cfile := createTestingMetadata(name, baseURL)
-	_, err := chartutil.Create(cfile, dest)
-	return err
+	return chartutil.SaveDir(cfile, dest)
 }

--- a/cmd/helm/testdata/output/upgrade-with-install-timeout.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install-timeout.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=crazy-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade-with-install.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=zany-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade-with-reset-values.txt
+++ b/cmd/helm/testdata/output/upgrade-with-reset-values.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=funny-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade-with-reset-values2.txt
+++ b/cmd/helm/testdata/output/upgrade-with-reset-values2.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=funny-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade-with-timeout.txt
+++ b/cmd/helm/testdata/output/upgrade-with-timeout.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=funny-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade-with-wait.txt
+++ b/cmd/helm/testdata/output/upgrade-with-wait.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=crazy-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/testdata/output/upgrade.txt
+++ b/cmd/helm/testdata/output/upgrade.txt
@@ -4,8 +4,3 @@ LAST DEPLOYED: 1977-09-02 22:04:05 +0000 UTC
 NAMESPACE: default
 STATUS: deployed
 
-NOTES:
-1. Get the application URL by running these commands:
-  export POD_NAME=$(kubectl get pods -l "app=testUpgradeChart,release=funny-bunny" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"helm.sh/helm/pkg/chart"
@@ -28,14 +29,16 @@ import (
 
 func TestUpgradeCmd(t *testing.T) {
 	tmpChart := testTempDir(t)
-	cfile := &chart.Metadata{
-		APIVersion:  chart.APIVersionV1,
-		Name:        "testUpgradeChart",
-		Description: "A Helm chart for Kubernetes",
-		Version:     "0.1.0",
+	cfile := &chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion:  chart.APIVersionV1,
+			Name:        "testUpgradeChart",
+			Description: "A Helm chart for Kubernetes",
+			Version:     "0.1.0",
+		},
 	}
-	chartPath, err := chartutil.Create(cfile, tmpChart)
-	if err != nil {
+	chartPath := filepath.Join(tmpChart, cfile.Metadata.Name)
+	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart for upgrade: %v", err)
 	}
 	ch, err := loader.Load(chartPath)
@@ -48,14 +51,9 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 
 	// update chart version
-	cfile = &chart.Metadata{
-		Name:        "testUpgradeChart",
-		Description: "A Helm chart for Kubernetes",
-		Version:     "0.1.2",
-	}
+	cfile.Metadata.Version = "0.1.2"
 
-	chartPath, err = chartutil.Create(cfile, tmpChart)
-	if err != nil {
+	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart: %v", err)
 	}
 	ch, err = loader.Load(chartPath)
@@ -64,14 +62,9 @@ func TestUpgradeCmd(t *testing.T) {
 	}
 
 	// update chart version again
-	cfile = &chart.Metadata{
-		Name:        "testUpgradeChart",
-		Description: "A Helm chart for Kubernetes",
-		Version:     "0.1.3",
-	}
+	cfile.Metadata.Version = "0.1.3"
 
-	chartPath, err = chartutil.Create(cfile, tmpChart)
-	if err != nil {
+	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart: %v", err)
 	}
 	var ch2 *chart.Chart

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -34,13 +34,7 @@ func TestCreate(t *testing.T) {
 	}
 	defer os.RemoveAll(tdir)
 
-	cf := &chart.Metadata{
-		APIVersion: chart.APIVersionV1,
-		Name:       "foo",
-		Version:    "0.1.0",
-	}
-
-	c, err := Create(cf, tdir)
+	c, err := Create("foo", tdir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -36,7 +36,10 @@ var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
 func SaveDir(c *chart.Chart, dest string) error {
 	// Create the chart directory
 	outdir := filepath.Join(dest, c.Name())
-	if err := os.Mkdir(outdir, 0755); err != nil {
+	if fi, err := os.Stat(outdir); err == nil && !fi.IsDir() {
+		return errors.Errorf("file %s already exists and is not a directory", outdir)
+	}
+	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When creating a Helm chart for the first time, the assumption should be that the app version is also 0.1.0, implying this is for a new application.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
