### PR TITLE
Remove missing value validation

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -228,13 +228,9 @@ func (e *Engine) renderWithReferences(tpls map[string]renderable, referenceTpls 
 		}
 	}()
 	t := template.New("gotpl")
-	if e.Strict {
-		t.Option("missingkey=error")
-	} else {
-		// Not that zero will attempt to add default values for types it knows,
-		// but will still emit <no value> for others. We mitigate that later.
-		t.Option("missingkey=zero")
-	}
+	// Not that zero will attempt to add default values for types it knows,
+	// but will still emit <no value> for others. We mitigate that later.
+	t.Option("missingkey=zero")
 
 	funcMap := e.alterFuncMap(t, referenceTpls)
 


### PR DESCRIPTION
Signed-off-by: walkafwalka <2865898-walkafwalka@users.noreply.gitlab.com>

**What this PR does / why we need it**:

This PR prevents `helm lint --strict` from failing values without a default value defined.

There are possible alternatives available which are described in https://github.com/helm/helm/issues/5417#issuecomment-473381728. I chose to disable the missing value validation because 1) it was meant to be disabled based on https://github.com/helm/helm/issues/1463, 2) this is not being tested, and 3) requires minimal change.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #5417, #4573