### PR TITLE
Fix 'THE INCLUDE FUNCTION' in 'Developing Templates' output

### DIFF
--- a/docs/chart_template_guide/named_templates.md
+++ b/docs/chart_template_guide/named_templates.md
@@ -215,7 +215,7 @@ data:
   myvalue: "Hello World"
   drink: "coffee"
   food: "pizza"
-  app_name: mychart
+app_name: mychart
 app_version: "0.1.0+1478129847"
 ```
 


### PR DESCRIPTION
Signed-off-by: Kenta Iso <type.mafty@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is Document fix PR.

I tried the tutorial of The Chart Template Developer’s Guide.
It is very useful to me.
And I found that the example output in「THE INCLUDE FUNCTION」is different from actual output.

・Document link
https://helm.sh/docs/chart_template_guide/#the-include-function

・Example output
```
# Source: mychart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: measly-whippet-configmap
  labels:
    app_name: mychart
app_version: "0.1.0+1478129847"
data:
  myvalue: "Hello World"
  drink: "coffee"
  food: "pizza"
  app_name: mychart
app_version: "0.1.0+1478129847"
```

・Actual output
```
# Source: mychart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: measly-whippet-configmap
  labels:
    app_name: mychart
app_version: "0.1.0+1478129847"
data:
  myvalue: "Hello World"
  drink: "coffee"
  food: "pizza"
app_name: mychart
app_version: "0.1.0+1478129847"
```

※  Indent of「data.app_name」is different.

**Special notes for your reviewer**:
