### PR TITLE
fix(helm): Fix manifest validation

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -142,8 +142,8 @@ func (c *Client) BuildUnstructured(namespace string, reader io.Reader) (Result, 
 		ContinueOnError().
 		NamespaceParam(namespace).
 		DefaultNamespace().
-		Stream(reader, "").
 		Schema(c.validator()).
+		Stream(reader, "").
 		Flatten().
 		Do().Infos()
 	return result, scrubValidationError(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Manifest validation is done by the builder, but it requires that the schema is set before the `Stream` function is called. Otherwise the StreamVisitor is created without a schema and no validation is done.
This PR moves the call to `Schema` before the call to `Stream`, so the `StreamVisitor` is created with the correct schema.

**Special notes for your reviewer**:
This is hard to unit test since the `TestFactory` used by the client unit tests has the schema hardcoded to use the `NullSchema`.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
