### PR TITLE
Doc(Migration): Add Helm v2 to v3 migration doc

### DIFF
--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -13,14 +13,19 @@ The changes are as follows:
 1. Removal of Tiller: 
    - Replaces client/server with client/library architecture (`Helm` binary only)
    - Security is now on per user basis (delegated to Kubernetes user cluster security)
-   - State now stored as in-cluster Secrets
+   - State now stored as in-cluster Secrets and release object metadata has changed
    - State persisted on a namespace basis and no longer global (release names now unique only in a namespace) 
 2. Chart repository updated:
    - Support added for upload of a chart to a repo (`helm push`)
    - Support added for OCI registries (`helm chart <sub_command>`) :
      - Authentication supported for repo login/logout (`helm registry <sub_command>`)
      - Authorization (OAuth2) supported which enables chart upload/install access rights
-3. Additional changes:
+3. Chart apiVersion bumped to "v2" for following specification changes:
+   - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
+   - Library charts (helper charts) can now be added as dynamically linked chart dependencies
+   - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
+     default which means it is renderable and installable.
+4. Additional changes:
    - Add schema to values which enables value validation at runtime (install/upgrade etc.)
    - Helm install/set-up is simplified:
      - Helm client (helm) only (no tiller)
@@ -45,18 +50,15 @@ The changes are as follows:
        - upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
    - Improvements to error responses
    - Improvements on command argument validation and argument naming
-   - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
-   - Library charts (helper charts) can now be added as dynamically linked chart dependencies
-   - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
-     default which means it is renderable and installable.
    - Go import path is changed from `k8s.io/helm` to `helm.sh/helm` 
+   - Helm SDK updates
 
 ## Migration Use Cases
 
 The migration use cases are as follows:
 
 1. Running Helm v2 and v3 concurrently on the same cluster:
-   - v2 and v3 history/state are independent of each other. v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
+   - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the the Tiller namespace (for example, v2 default Tiller namespace kube-system).v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
    - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namepsace as the resources would clash.
    - Make sure to not override the v2 client binary (`helm`). Rename or use separate directory for one of the releases.
    - v3 has configuration and when initialized will override the v2 configuration. To avoid this use a separate `HELM_HOME`, for example, `export HELM_HOME=$HOME/.helm3`.
@@ -64,85 +66,6 @@ The migration use cases are as follows:
 2. Deploying a new chart:
    - Use v3 to deploy
  
-3. Move an existing release from v2 to v3, choices as follows:
-   - Lose the release history: Deploy as new using v3 and delete the existing release using v2.
-   - Maintain the release history:
-     - Retrieve v2 release states by getting the ConfigMaps from the `kube-system` namespace for `Tiller` owner
-
-       ```console
-       $ kubectl get configmap -n kube-system -l "OWNER=TILLER"
-       NAME          DATA   AGE
-       mychart.v1    1      27h
-       easy-chrt.v1  1      26h
-       ```
-
-     - For each release and version (e.g. `mychart.v1`) you want to move::
-       - Extract the data from the ConfigMap: `kubectl get configmap ${RELEASE_NAME} -n kube-system -o json > ${RELEASE_NAME}-cm.json`
-       - Map it to a v3 Secret as follows:
-         - Set owner to `helm`
-         - Set namespace to namespace of release in v2. Check with command: `helm ls`
-
-           ```console
-           $ helm ls
-           NAME    	REVISION	UPDATED                 	STATUS  	CHART         	APP VERSION	NAMESPACE
-           mychart 	1       	Wed Jun 12 10:58:22 2019	DEPLOYED	mychart-0.1.0 	1.0        	default  
-           easy-chrt	1       	Wed Jun 12 12:16:56 2019	DEPLOYED	new-chrt-0.1.0	1.0        	default  
-           ```
-
-         - Set 'kind' to `Secret`
-         - Add type `helm.sh/release`
-         - Update some keys from capital case to camel case and lower case
-
-           ```
-           # Make copy of the ConfigMap output
-           cp ${RELEASE_NAME}-cm.json ${RELEASE_NAME}-secret.json
-
-           # Update fields and values to correspond to v3 state secret object
-           sed -i -e 's/ConfigMap/Secret/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/MODIFIED_AT/modifiedAt/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/NAME/name/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/OWNER/owner/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/STATUS/status/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/VERSION/version/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/configmaps/secrets/g' ./${RELEASE_NAME}-secret.json
-           sed -i -e "s/kube-system/${NAMESPACE}/g" ./${RELEASE_NAME}-secret.json
-           sed -i -e 's/TILLER/helm/g' ./${RELEASE_NAME}-secret.json
-           STATUS=`jq '.metadata.labels.status' ${RELEASE_NAME}-secret.json | tr '[:upper:]' '[:lower:]'`
-           jq ".metadata.labels.status=${STATUS}" ${RELEASE_NAME}-secret.json > ${RELEASE_NAME}-secret.tmp && mv ${RELEASE_NAME}-secret.tmp ${RELEASE_NAME}-secret.json
-           ```
-
-           *** Note: The release data in the ConfigMap is a base-64 encoded, gzipped archive of the entire release record. TODO: This is currently failing to be loaded by v3. ***
-
-       - Create the Secret resource in the namespace of the release
-
-         ```
-         # Deploy the ${RELEASE_NAME} secret into the ${NAMESPACE} namespace
-         kubens ${NAMESPACE}
-         kubectl create -f ${RELEASE_NAME}-secret.json
-         ```
-
-       - Check the release now exists in v3 (`helm ls`) and has state stored as a Secret (`kubectl get secret --all-namespaces -l "owner=helm"`):
-
-         ```console
-         $ helm ls
-         NAME     	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART          
-         mychart  	default  	1       	2019-06-12 10:43:19.949644311 +0100 IST	deployed	mychart-0.1.0  
-         easy-chrt	default  	1       	2019-06-12 10:09:20.903353326 +0100 IST	deployed	easy-chrt-0.1.0
-         demo     	default  	1       	2019-06-12 14:31:52.264875915 +0100 IST	deployed	demo-0.1.0    
-
-         $ kubectl get secret --all-namespaces -l "owner=helm"
-         NAMESPACE   NAME           TYPE              DATA   AGE
-         default     demo.v1        helm.sh/release   1      23h
-         default     easy-chrt.v1   helm.sh/release   1      28h
-         default     mychart.v1     helm.sh/release   1      27h
-         ```
-
-       - Delete the release ConfigMap: `kubectl delete configmap ${RELEASE_NAME} -n kube-system`
- 
-4. Move Helm releaes and it's Kubernetes resources from it's default v2 namespace (only current release version applicable with namespaced scoped resources):
-   - Get all resources from the current release: `helm get <release>`
-   - For each resource:
-     - Create the resource in the new namespace: `kubectl get <resource_type> <resource_name> -o json --namespace <ns_old> | jq '.items[].metadata.namespace = "ns_new"' | kubectl create-f  -`
-     - Delete the resource in the old namespace: `kubectl delete <resource_type> --namespace <ns_old>`
-   - Update the release Secret resource to new namespace: `kubectl edit secret <release_name> -n <<ns_old>>`
+3. Migrating Helm v2 releases in-place to v3:
+   - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154
 

--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -24,7 +24,6 @@ The changes are as follows:
    - Add schema to values which enables value validation at runtime (install/upgrade etc.)
    - Helm install/set-up is simplified:
      - Helm client (helm) only (no tiller)
-     - No Helm initialization and no Tiller installation
      - Run-as-is paradigm
    - Commands removed/replaced/added:
        - chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
@@ -36,7 +35,6 @@ The changes are as follows:
          - save: save a chart directory  
        - delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
        - fetch --> pull
-       - init (removed?)
        - install: requires release name or `--generate-name` argument
        - inspect --> show
        - registry: login to or logout from a registry
@@ -58,46 +56,93 @@ The changes are as follows:
 The migration use cases are as follows:
 
 1. Running Helm v2 and v3 concurrently on the same cluster:
-   - v2 and v3 history/state are independent of each other. v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.
-   - The only issue could be if Kubernetes resources are not named with unique capability like with release in its name and you depoy the chart again for v3. This would happen for v2 anyway when not an upgrade. Can be avoided by naming resources uniquely.
-   - Make sure to not override the v2 client binary (`helm`). Rename or separate directory.
-   - v3 has no configuration and therefore doesn't need to be initialized. Run as is.
+   - v2 and v3 history/state are independent of each other. v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
+   - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namepsace as the resources would clash.
+   - Make sure to not override the v2 client binary (`helm`). Rename or use separate directory for one of the releases.
+   - v3 has configuration and when initialized will override the v2 configuration. To avoid this use a separate `HELM_HOME`, for example, `export HELM_HOME=$HOME/.helm3`.
  
 2. Deploying a new chart:
    - Use v3 to deploy
  
-3. Upgrading an existing release from v2 to v3:
-   - The choices are as follows:
-     - Lose the release history: Deploy as new using v3 and delete the existing release using v2
-     - Maintain the release history: TBD: Detail the steps involved in migration of v2 history to v3. This should describe the steps manually and then any tools provided for those manual steps. Are the steps involved:
-       - Retrieve ConfigMaps for Tiller owner
-       - Find ConfigMaps for a release
-       - For each release:
-         - Extract the data from the ConfigMap and map it to a Secret:
-           - Ownere is `helm` and namespace is set 
-           - Releases are incremental in both v2 and v3:
+3. Move an existing release from v2 to v3, choices as follows:
+   - Lose the release history: Deploy as new using v3 and delete the existing release using v2.
+   - Maintain the release history:
+     - Retrieve v2 release states by getting the ConfigMaps from the `kube-system` namespace for `Tiller` owner
 
-             ```console
-             $ kubectl get configmap -n kube-system -l "OWNER=TILLER"
-             NAME                      DATA   AGE
-             cautious-hummingbird.v1   1      5d2h
-             chrt-5586.v1              1      6d21h
-             chrt-5586.v2              1      6d21h
+       ```console
+       $ kubectl get configmap -n kube-system -l "OWNER=TILLER"
+       NAME          DATA   AGE
+       mychart.v1    1      27h
+       easy-chrt.v1  1      26h
+       ```
 
-             $ kubectl get secret -n default -l "owner=helm"
-             NAME                 TYPE              DATA   AGE
-             foo-chrt.v1          helm.sh/release   1      7d20h
-             fuzzy-bear.v1        helm.sh/release   1      7d
-             moo-chrt.v1          helm.sh/release   1      6d4h
-             moo-chrt.v2          helm.sh/release   1      5s
-             tst-lib-chart-1.v1   helm.sh/release   1      7d
-             tst-lib-chart.v1     helm.sh/release   1      7d4h
-             ```
+     - For each release and version (e.g. `mychart.v1`) you want to move::
+       - Extract the data from the ConfigMap: `kubectl get configmap ${RELEASE_NAME} -n kube-system -o json > ${RELEASE_NAME}-cm.json`
+       - Map it to a v3 Secret as follows:
+         - Set owner to `helm`
+         - Set namespace to namespace of release in v2. Check with command: `helm ls`
 
-           - The release data in the config map is a base-64 encoded, gzipped archive of the entire release record.
-         - Create secret under a user provided or a default user if not provided. 
-       - Delete the release ConfigMaps
+           ```console
+           $ helm ls
+           NAME    	REVISION	UPDATED                 	STATUS  	CHART         	APP VERSION	NAMESPACE
+           mychart 	1       	Wed Jun 12 10:58:22 2019	DEPLOYED	mychart-0.1.0 	1.0        	default  
+           easy-chrt	1       	Wed Jun 12 12:16:56 2019	DEPLOYED	new-chrt-0.1.0	1.0        	default  
+           ```
+
+         - Set 'kind' to `Secret`
+         - Add type `helm.sh/release`
+         - Update some keys from capital case to camel case and lower case
+
+           ```
+           # Make copy of the ConfigMap output
+           cp ${RELEASE_NAME}-cm.json ${RELEASE_NAME}-secret.json
+
+           # Update fields and values to correspond to v3 state secret object
+           sed -i -e 's/ConfigMap/Secret/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/MODIFIED_AT/modifiedAt/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/NAME/name/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/OWNER/owner/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/STATUS/status/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/VERSION/version/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/configmaps/secrets/g' ./${RELEASE_NAME}-secret.json
+           sed -i -e "s/kube-system/${NAMESPACE}/g" ./${RELEASE_NAME}-secret.json
+           sed -i -e 's/TILLER/helm/g' ./${RELEASE_NAME}-secret.json
+           STATUS=`jq '.metadata.labels.status' ${RELEASE_NAME}-secret.json | tr '[:upper:]' '[:lower:]'`
+           jq ".metadata.labels.status=${STATUS}" ${RELEASE_NAME}-secret.json > ${RELEASE_NAME}-secret.tmp && mv ${RELEASE_NAME}-secret.tmp ${RELEASE_NAME}-secret.json
+           ```
+
+           *** Note: The release data in the ConfigMap is a base-64 encoded, gzipped archive of the entire release record. TODO: This is currently failing to be loaded by v3. ***
+
+       - Create the Secret resource in the namespace of the release
+
+         ```
+         # Deploy the ${RELEASE_NAME} secret into the ${NAMESPACE} namespace
+         kubens ${NAMESPACE}
+         kubectl create -f ${RELEASE_NAME}-secret.json
+         ```
+
+       - Check the release now exists in v3 (`helm ls`) and has state stored as a Secret (`kubectl get secret --all-namespaces -l "owner=helm"`):
+
+         ```console
+         $ helm ls
+         NAME     	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART          
+         mychart  	default  	1       	2019-06-12 10:43:19.949644311 +0100 IST	deployed	mychart-0.1.0  
+         easy-chrt	default  	1       	2019-06-12 10:09:20.903353326 +0100 IST	deployed	easy-chrt-0.1.0
+         demo     	default  	1       	2019-06-12 14:31:52.264875915 +0100 IST	deployed	demo-0.1.0    
+
+         $ kubectl get secret --all-namespaces -l "owner=helm"
+         NAMESPACE   NAME           TYPE              DATA   AGE
+         default     demo.v1        helm.sh/release   1      23h
+         default     easy-chrt.v1   helm.sh/release   1      28h
+         default     mychart.v1     helm.sh/release   1      27h
+         ```
+
+       - Delete the release ConfigMap: `kubectl delete configmap ${RELEASE_NAME} -n kube-system`
  
-4. Move release Kubernetes resources to user namespace
-   - Get all resources from the release state, update the namespace and then update the resource. Suggestion here: https://gist.github.com/simonswine/6bf3b665e4117f42b550c3ea12dd171a
+4. Move Helm releaes and it's Kubernetes resources from it's default v2 namespace (only current release version applicable with namespaced scoped resources):
+   - Get all resources from the current release: `helm get <release>`
+   - For each resource:
+     - Create the resource in the new namespace: `kubectl get <resource_type> <resource_name> -o json --namespace <ns_old> | jq '.items[].metadata.namespace = "ns_new"' | kubectl create-f  -`
+     - Delete the resource in the old namespace: `kubectl delete <resource_type> --namespace <ns_old>`
+   - Update the release Secret resource to new namespace: `kubectl edit secret <release_name> -n <<ns_old>>`
 

--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -11,58 +11,93 @@ Migration from v2 to v3 Helm
 The changes are as follows:
 
 1. Removal of Tiller: 
-   - Replaces client/server with client/library architecture
-   - Security is now on per user basis (delegated to Kubernetes RBAC)
-   - State stored as in-cluster Secrets
-   - State persisted on a namespace basis and no longer global (release names now unique in namespace??) 
+   - Replaces client/server with client/library architecture (`Helm` binary only)
+   - Security is now on per user basis (delegated to Kubernetes user cluster security)
+   - State now stored as in-cluster Secrets
+   - State persisted on a namespace basis and no longer global (release names now unique only in a namespace) 
 2. Chart repository updated:
    - Support added for upload of a chart to a repo (`helm push`)
-   - Authentication supported for repo login
-   - Authorization (OAuth2) supported which enables chart upload/install access rights
-   - Support added for OCI registries (`helm chart <sub_command>`) 
+   - Support added for OCI registries (`helm chart <sub_command>`) :
+     - Authentication supported for repo login/logout (`helm registry <sub_command>`)
+     - Authorization (OAuth2) supported which enables chart upload/install access rights
 3. Additional changes:
    - Add schema to values which enables value validation at runtime (install/upgrade etc.)
    - Helm install/set-up is simplified:
-     - Helm client (helm binary) only (no Tiller)
+     - Helm client (helm) only (no tiller)
      - No Helm initialization and no Tiller installation
      - Run-as-is paradigm
    - Commands removed/replaced/added:
-       -  chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
-           - export: export a chart to directory
-           - list: list all saved charts
-           - pull: pull a chart from remote
-           - push: push a chart to remote
-           - remove: remove a chart
-           - save: save a chart directory  
-       -  delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
-       -  fetch --> pull
-       -  init (removed?)
-       -  install: requires release name or `--generate-name` argument
-       -  inspect --> show
-       -  reset (removed)
-       -  serve (removed)
-       -  upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
+       - chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
+         - export: export a chart to directory
+         - list: list all saved charts
+         - pull: pull a chart from remote
+         - push: push a chart to remote
+         - remove: remove a chart
+         - save: save a chart directory  
+       - delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
+       - fetch --> pull
+       - init (removed?)
+       - install: requires release name or `--generate-name` argument
+       - inspect --> show
+       - registry: login to or logout from a registry
+         - login: login to a registry
+         - logout: logout from a registry
+       - reset (removed)
+       - serve (removed)
+       - upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
    - Improvements to error responses
    - Improvements on command argument validation and argument naming
    - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
    - Library charts (helper charts) can now be added as dynamically linked chart dependencies
+   - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
+     default which means it is renderable and installable.
+   - Go import path is changed from `k8s.io/helm` to `helm.sh/helm` 
 
 ## Migration Use Cases
 
 The migration use cases are as follows:
 
 1. Running Helm v2 and v3 concurrently on the same cluster:
-   - v2 and v3 history/state are independent of each other. v2 uses "Configmaps" under Tiller namespace and ownership. v3 uses "Secrets" in user namespace and Helm ownership. There should be no conflicts.
-   - The only issue could be if Kubernetes resources are not named with unique capability like with rease in its name and you depoy the chart again for v3. This would happen for v2 anyway when not an upgrade. Can be avoided by naming resources uniqyely.
-   - Make sure to not override the v2 binary (`helm`)
-   - TBC: Will v3 have configuration and if so will it be the same directory as v2?
+   - v2 and v3 history/state are independent of each other. v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.
+   - The only issue could be if Kubernetes resources are not named with unique capability like with release in its name and you depoy the chart again for v3. This would happen for v2 anyway when not an upgrade. Can be avoided by naming resources uniquely.
+   - Make sure to not override the v2 client binary (`helm`). Rename or separate directory.
+   - v3 has no configuration and therefore doesn't need to be initialized. Run as is.
  
 2. Deploying a new chart:
    - Use v3 to deploy
  
-3. Upgrading an existing release:
-   - Deploy as new on v3 and delete the existing release on v2
+3. Upgrading an existing release from v2 to v3:
+   - The choices are as follows:
+     - Lose the release history: Deploy as new using v3 and delete the existing release using v2
+     - Maintain the release history: TBD: Detail the steps involved in migration of v2 history to v3. This should describe the steps manually and then any tools provided for those manual steps. Are the steps involved:
+       - Retrieve ConfigMaps for Tiller owner
+       - Find ConfigMaps for a release
+       - For each release:
+         - Extract the data from the ConfigMap and map it to a Secret:
+           - Ownere is `helm` and namespace is set 
+           - Releases are incremental in both v2 and v3:
+
+             ```console
+             $ kubectl get configmap -n kube-system -l "OWNER=TILLER"
+             NAME                      DATA   AGE
+             cautious-hummingbird.v1   1      5d2h
+             chrt-5586.v1              1      6d21h
+             chrt-5586.v2              1      6d21h
+
+             $ kubectl get secret -n default -l "owner=helm"
+             NAME                 TYPE              DATA   AGE
+             foo-chrt.v1          helm.sh/release   1      7d20h
+             fuzzy-bear.v1        helm.sh/release   1      7d
+             moo-chrt.v1          helm.sh/release   1      6d4h
+             moo-chrt.v2          helm.sh/release   1      5s
+             tst-lib-chart-1.v1   helm.sh/release   1      7d
+             tst-lib-chart.v1     helm.sh/release   1      7d4h
+             ```
+
+           - The release data in the config map is a base-64 encoded, gzipped archive of the entire release record.
+         - Create secret under a user provided or a default user if not provided. 
+       - Delete the release ConfigMaps
  
-4. Migrate state of existing v2 releases:
-   - TBD: Detail the steps involved in migration v2 envoironment to v3. This should describe the steps manually and then any tools provided for those manual steps.
+4. Move release Kubernetes resources to user namespace
+   - Get all resources from the release state, update the namespace and then update the resource. Suggestion here: https://gist.github.com/simonswine/6bf3b665e4117f42b550c3ea12dd171a
 

--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -17,19 +17,27 @@ The changes are as follows:
    - State persisted on a namespace basis and no longer global (release names now unique only in a namespace) 
 2. Chart repository updated:
    - Support added for upload of a chart to a repo (`helm push`)
-   - Support added for OCI registries (`helm chart <sub_command>`) :
+   - helm search now supports both local repository searches and making search queries against Helm Hub
+   - Experimental support added for OCI registries (`helm chart <sub_command>`) :
      - Authentication supported for repo login/logout (`helm registry <sub_command>`)
      - Authorization (OAuth2) supported which enables chart upload/install access rights
 3. Chart apiVersion bumped to "v2" for following specification changes:
    - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
-   - Library charts (helper charts) can now be added as dynamically linked chart dependencies
+   - Library charts (helper/common charts) can now be added as dynamically linked chart dependencies
    - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
-     default which means it is renderable and installable.
-4. Additional changes:
+     default which means it is renderable and installable
+4. XDG directory specification added:
+   - Helm home removed and replaced with XDG directory specification for storing configuration files which
+   - No longer need to initialize Helm
+   - `helm init` and `helm home` removed
+5. Additional changes:
    - Add schema to values which enables value validation at runtime (install/upgrade etc.)
    - Helm install/set-up is simplified:
      - Helm client (helm) only (no tiller)
      - Run-as-is paradigm
+   - `stable` repository not set-up by default
+   - `crd-install` hook removed and replaced with `crd` directory in chart where all CRDs defined in it will be installed before any rendering of the chart
+   - `test-failure` target removed. Use `test-success` instead
    - Commands removed/replaced/added:
        - chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
          - export: export a chart to directory
@@ -40,6 +48,8 @@ The changes are as follows:
          - save: save a chart directory  
        - delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
        - fetch --> pull
+       - home (removed)
+       - init (removed)
        - install: requires release name or `--generate-name` argument
        - inspect --> show
        - registry: login to or logout from a registry
@@ -51,21 +61,21 @@ The changes are as follows:
    - Improvements to error responses
    - Improvements on command argument validation and argument naming
    - Go import path is changed from `k8s.io/helm` to `helm.sh/helm` 
-   - Helm SDK updates
+   - Helm SDK updated. It is no longer compatible with Helm 2 library
 
 ## Migration Use Cases
 
 The migration use cases are as follows:
 
 1. Running Helm v2 and v3 concurrently on the same cluster:
-   - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the the Tiller namespace (for example, v2 default Tiller namespace kube-system).v2 uses "ConfigMaps" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
+   - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the the Tiller namespace (for example, v2 default Tiller namespace kube-system).v2 uses "ConfigMaps" or "Secrets" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
    - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namepsace as the resources would clash.
    - Make sure to not override the v2 client binary (`helm`). Rename or use separate directory for one of the releases.
-   - v3 has configuration and when initialized will override the v2 configuration. To avoid this use a separate `HELM_HOME`, for example, `export HELM_HOME=$HOME/.helm3`.
+   - v3 configuration no longer uses `HELM_HOME` and uses XDG directory specification instead. It is also created on the fly as need be. It is therefore independent of v2 configuration.
+   - Note: This use case is only recommended if you intend to phase out Helm v2 gradually and do not require v3 to manage any releases deployed by v2. All new releases being deployed are performed by v3 and existing v2 deployed releases are updated/removed by v2 only.
  
-2. Deploying a new chart:
-   - Use v3 to deploy
- 
-3. Migrating Helm v2 releases in-place to v3:
-   - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154
-
+2. Migrating Helm v2 to Helm v3:
+   - Migrating Helm v2 configuration (`helm home`) to Helm v3:
+     - - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154
+   - Migrating Helm v2 releases in-place to v3:
+     - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154

--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -1,81 +1,75 @@
-Migration from v2 to v3 Helm 
+Helm v2 to v3 Migration 
 ===
 
 ## Table of Contents
 
-- [Helm 3 Changes](#helm-3-changes)
+- [Overview of Helm 3 Changes](#helm-3-changes)
 - [Migration Use Cases](#migration-use-cases)
 
-## Helm 3 Changes
+## Overview of Helm 3 Changes
 
-The changes are as follows:
+The full list of changes from Helm 2 to 3 are documented in the [FAQ section](https://v3.helm.sh/docs/faq/#changes-since-helm-2).
+The following is a summary of some of those changes that a user should be aware of before and during migration:
 
 1. Removal of Tiller: 
-   - Replaces client/server with client/library architecture (`Helm` binary only)
+   - Replaces client/server with client/library architecture (`helm` binary only)
    - Security is now on per user basis (delegated to Kubernetes user cluster security)
-   - State now stored as in-cluster Secrets and release object metadata has changed
-   - State persisted on a namespace basis and no longer global (release names now unique only in a namespace) 
+   - Releases are now stored as in-cluster secrets and the release object metadata has changed
+   - Releases are persisted on a release namespace basis and not in the Tiller namepsace anymore
 2. Chart repository updated:
-   - Support added for upload of a chart to a repo (`helm push`)
-   - helm search now supports both local repository searches and making search queries against Helm Hub
-   - Experimental support added for OCI registries (`helm chart <sub_command>`) :
-     - Authentication supported for repo login/logout (`helm registry <sub_command>`)
-     - Authorization (OAuth2) supported which enables chart upload/install access rights
+   - `helm search` now supports both local repository searches and making search queries against Helm Hub
 3. Chart apiVersion bumped to "v2" for following specification changes:
-   - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
+   - Dynamically linked chart dependencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
    - Library charts (helper/common charts) can now be added as dynamically linked chart dependencies
    - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
      default which means it is renderable and installable
+   - Helm 2 charts (apiVersion=v1) are still installable
 4. XDG directory specification added:
-   - Helm home removed and replaced with XDG directory specification for storing configuration files which
+   - Helm home removed and replaced with XDG directory specification for storing configuration files
    - No longer need to initialize Helm
    - `helm init` and `helm home` removed
 5. Additional changes:
-   - Add schema to values which enables value validation at runtime (install/upgrade etc.)
    - Helm install/set-up is simplified:
      - Helm client (helm) only (no tiller)
      - Run-as-is paradigm
-   - `stable` repository not set-up by default
+   - `local` or `stable` repositories are not set-up by default
    - `crd-install` hook removed and replaced with `crd` directory in chart where all CRDs defined in it will be installed before any rendering of the chart
    - `test-failure` target removed. Use `test-success` instead
    - Commands removed/replaced/added:
-       - chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
-         - export: export a chart to directory
-         - list: list all saved charts
-         - pull: pull a chart from remote
-         - push: push a chart to remote
-         - remove: remove a chart
-         - save: save a chart directory  
-       - delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
+       - delete --> uninstall : removes all release history by default (previously needed `--purge`)
        - fetch --> pull
        - home (removed)
        - init (removed)
        - install: requires release name or `--generate-name` argument
        - inspect --> show
-       - registry: login to or logout from a registry
-         - login: login to a registry
-         - logout: logout from a registry
        - reset (removed)
        - serve (removed)
        - upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
-   - Improvements to error responses
-   - Improvements on command argument validation and argument naming
-   - Go import path is changed from `k8s.io/helm` to `helm.sh/helm` 
-   - Helm SDK updated. It is no longer compatible with Helm 2 library
+   - Helm 3 Go library has undergone a lot of changes and it incompatible with the Helm 2 library
+   - Release binaries are now hosted on `get.helm.sh`
 
 ## Migration Use Cases
 
 The migration use cases are as follows:
 
-1. Running Helm v2 and v3 concurrently on the same cluster:
-   - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the the Tiller namespace (for example, v2 default Tiller namespace kube-system).v2 uses "ConfigMaps" or "Secrets" under Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in user namespace and `helm` ownership. There should be no conflicts.  Releases are incremental in both v2 and v3.
-   - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namepsace as the resources would clash.
-   - Make sure to not override the v2 client binary (`helm`). Rename or use separate directory for one of the releases.
-   - v3 configuration no longer uses `HELM_HOME` and uses XDG directory specification instead. It is also created on the fly as need be. It is therefore independent of v2 configuration.
-   - Note: This use case is only recommended if you intend to phase out Helm v2 gradually and do not require v3 to manage any releases deployed by v2. All new releases being deployed are performed by v3 and existing v2 deployed releases are updated/removed by v2 only.
+1. Helm v2 and v3 managing the same cluster:
+   - This use case is only recommended if you intend to phase out Helm v2 gradually and do not require v3 to manage any releases deployed by v2. All new releases being deployed should be performed by v3 and existing v2 deployed releases are updated/removed by v2 only
+   - Helm v2 and v3 can quite happily manage the same cluster. The Helm versions can be installed on the same or separate systems
+   - If installing Helm v3 on the same system, you need to to perform an additional step to ensure that both client versions can co-exist until ready to remove Helm v2 client. Rename or put the Helm v3 binary in a different folder to avoid conflict
+   - Otherwise there are no conflicts between both versions because of the following distinctions: 
+     - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the the Tiller namespace (for example, v2 default Tiller namespace kube-system). v2 uses "ConfigMaps" or "Secrets" under the Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in the user namespace and `helm` ownership. Releases are incremental in both v2 and v3
+     - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namespace as the resources would clash
+     - v3 configuration no longer uses `HELM_HOME` and uses XDG directory specification instead. It is also created on the fly as need be. It is therefore independent of v2 configuration. This is applicable only when both versions are installed on the same system
  
 2. Migrating Helm v2 to Helm v3:
-   - Migrating Helm v2 configuration (`helm home`) to Helm v3:
-     - - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154
-   - Migrating Helm v2 releases in-place to v3:
-     - Proposal is a standalone migration tool that migrates from Helm v2 to Helm v3: https://github.com/helm/helm/issues/6154
+   - This use case applies when you want Helm v3 to manage existing Helm v2 releases
+   - It should be noted that a Helm client: 
+     - can manage 1 to many Kubernetes clusters
+     - can connect to 1 to many Tiller instances for  a cluster 
+   - This means that you have to cognisant of this when migrating as releases are deployed into clusters by Tiller and its namespace. You have to therefore be aware of migrating for each cluster and each Tiller instance that is managed by the Helm v2 client instance
+   - The recommended data migration path is as follows:
+     1. Backup v2 data
+     2. Migrate Helm v2 configuration
+     3. Migrate Helm v2 releases
+     4. When happy that Helm v3 is managing all Helm v2 data (for all clusters and Tiller instances of the Helm v2 client instance) as expected, then clean up Helm v2 data
+   - The migration process is automated by the Helm [2to3](https://github.com/helm/helm-2to3) plugin

--- a/docs/v2_v3_migration.md
+++ b/docs/v2_v3_migration.md
@@ -1,0 +1,68 @@
+Migration from v2 to v3 Helm 
+===
+
+## Table of Contents
+
+- [Helm 3 Changes](#helm-3-changes)
+- [Migration Use Cases](#migration-use-cases)
+
+## Helm 3 Changes
+
+The changes are as follows:
+
+1. Removal of Tiller: 
+   - Replaces client/server with client/library architecture
+   - Security is now on per user basis (delegated to Kubernetes RBAC)
+   - State stored as in-cluster Secrets
+   - State persisted on a namespace basis and no longer global (release names now unique in namespace??) 
+2. Chart repository updated:
+   - Support added for upload of a chart to a repo (`helm push`)
+   - Authentication supported for repo login
+   - Authorization (OAuth2) supported which enables chart upload/install access rights
+   - Support added for OCI registries (`helm chart <sub_command>`) 
+3. Additional changes:
+   - Add schema to values which enables value validation at runtime (install/upgrade etc.)
+   - Helm install/set-up is simplified:
+     - Helm client (helm binary) only (no Tiller)
+     - No Helm initialization and no Tiller installation
+     - Run-as-is paradigm
+   - Commands removed/replaced/added:
+       -  chart: command consists of multiple subcommands to interact with charts and registries. Subcommands as follows:
+           - export: export a chart to directory
+           - list: list all saved charts
+           - pull: pull a chart from remote
+           - push: push a chart to remote
+           - remove: remove a chart
+           - save: save a chart directory  
+       -  delete --> uninstall : removes all release history by default (previous;y needed `--purge`)
+       -  fetch --> pull
+       -  init (removed?)
+       -  install: requires release name or `--generate-name` argument
+       -  inspect --> show
+       -  reset (removed)
+       -  serve (removed)
+       -  upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
+   - Improvements to error responses
+   - Improvements on command argument validation and argument naming
+   - Dynamically linked chart deopendencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
+   - Library charts (helper charts) can now be added as dynamically linked chart dependencies
+
+## Migration Use Cases
+
+The migration use cases are as follows:
+
+1. Running Helm v2 and v3 concurrently on the same cluster:
+   - v2 and v3 history/state are independent of each other. v2 uses "Configmaps" under Tiller namespace and ownership. v3 uses "Secrets" in user namespace and Helm ownership. There should be no conflicts.
+   - The only issue could be if Kubernetes resources are not named with unique capability like with rease in its name and you depoy the chart again for v3. This would happen for v2 anyway when not an upgrade. Can be avoided by naming resources uniqyely.
+   - Make sure to not override the v2 binary (`helm`)
+   - TBC: Will v3 have configuration and if so will it be the same directory as v2?
+ 
+2. Deploying a new chart:
+   - Use v3 to deploy
+ 
+3. Upgrading an existing release:
+   - Deploy as new on v3 and delete the existing release on v2
+ 
+4. Migrate state of existing v2 releases:
+   - TBD: Detail the steps involved in migration v2 envoironment to v3. This should describe the steps manually and then any tools provided for those manual steps.
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds user documentation for migration from Helm v2 to v3.

Partial-Closes: #5892

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility