### PR TITLE
Moving nebril to emeritus status due to inactivity

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ maintainers:
   - jascott1
   - mattfarina
   - michelleN
-  - nebril
   - prydonius
   - SlickNik
   - technosophos
@@ -27,6 +26,7 @@ reviewers:
   - viglesiasce
 emeritus:
   - migmartri
+  - nebril
   - seh
   - vaikas-google
   - rimusz


### PR DESCRIPTION
Note, he has been emailed regarding the move including an offer to
re-engage. He has not taken this up. The governance has a 3 months
of inactivity clause that causes maintainers to fall off. This
period has been long exceeded per metrics measured in devstats.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
