### PR TITLE
remove snowflake-emoji 'Happy Helming!'

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -310,7 +310,6 @@ func (i *initCmd) run() error {
 			"$ helm init --tiller-image gcr.io/kubernetes-helm/tiller:v2.8.2\n\n")
 	}
 
-	fmt.Fprintln(i.out, "Happy Helming!")
 	return nil
 }
 

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -125,6 +125,6 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer, home helmpath.Ho
 		return errors.New("Update Failed. Check log for details")
 	}
 
-	fmt.Fprintln(out, "Update Complete. ⎈ Happy Helming! ⎈")
+	fmt.Fprintln(out, "Update Complete.")
 	return nil
 }

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -112,7 +112,7 @@ func (r *rollbackCmd) run() error {
 		return prettyError(err)
 	}
 
-	fmt.Fprintf(r.out, "Rollback was a success! Happy Helming!\n")
+	fmt.Fprintf(r.out, "Rollback was a success.\n")
 
 	return nil
 }

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -31,25 +31,25 @@ func TestRollbackCmd(t *testing.T) {
 		{
 			name:     "rollback a release",
 			args:     []string{"funny-honey", "1"},
-			expected: "Rollback was a success! Happy Helming!",
+			expected: "Rollback was a success.",
 		},
 		{
 			name:     "rollback a release with timeout",
 			args:     []string{"funny-honey", "1"},
 			flags:    []string{"--timeout", "120"},
-			expected: "Rollback was a success! Happy Helming!",
+			expected: "Rollback was a success.",
 		},
 		{
 			name:     "rollback a release with wait",
 			args:     []string{"funny-honey", "1"},
 			flags:    []string{"--wait"},
-			expected: "Rollback was a success! Happy Helming!",
+			expected: "Rollback was a success.",
 		},
 		{
 			name:     "rollback a release with description",
 			args:     []string{"funny-honey", "1"},
 			flags:    []string{"--description", "foo"},
-			expected: "Rollback was a success! Happy Helming!",
+			expected: "Rollback was a success.",
 		},
 		{
 			name: "rollback a release without revision",

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -307,7 +307,7 @@ func (u *upgradeCmd) run() error {
 		printRelease(u.out, resp.Release)
 	}
 
-	fmt.Fprintf(u.out, "Release %q has been upgraded. Happy Helming!\n", u.release)
+	fmt.Fprintf(u.out, "Release %q has been upgraded.\n", u.release)
 
 	// Print the status like status command does
 	status, err := u.client.ReleaseStatus(u.release)

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -96,7 +96,7 @@ func TestUpgradeCmd(t *testing.T) {
 			name:     "upgrade a release",
 			args:     []string{"funny-bunny", chartPath},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 2, Chart: ch}),
-			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"funny-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 2, Chart: ch})},
 		},
 		{
@@ -104,7 +104,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--timeout", "120"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 3, Chart: ch2}),
-			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"funny-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 3, Chart: ch2})},
 		},
 		{
@@ -112,7 +112,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--reset-values", "true"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 4, Chart: ch2}),
-			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"funny-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 4, Chart: ch2})},
 		},
 		{
@@ -120,7 +120,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--reuse-values", "true"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 5, Chart: ch2}),
-			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"funny-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 5, Chart: ch2})},
 		},
 		{
@@ -128,7 +128,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"funny-bunny", chartPath},
 			flags:    []string{"--atomic"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 6, Chart: ch}),
-			expected: "Release \"funny-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"funny-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "funny-bunny", Version: 6, Chart: ch})},
 		},
 		{
@@ -136,7 +136,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"zany-bunny", chartPath},
 			flags:    []string{"-i"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "zany-bunny", Version: 1, Chart: ch}),
-			expected: "Release \"zany-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"zany-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "zany-bunny", Version: 1, Chart: ch})},
 		},
 		{
@@ -144,7 +144,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"-i", "--timeout", "120"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch}),
-			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"crazy-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch})},
 		},
 		{
@@ -152,7 +152,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"-i", "--description", "foo"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch, Description: "foo"}),
-			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"crazy-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 1, Chart: ch, Description: "foo"})},
 		},
 		{
@@ -160,7 +160,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"--wait"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2}),
-			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"crazy-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2})},
 		},
 		{
@@ -168,7 +168,7 @@ func TestUpgradeCmd(t *testing.T) {
 			args:     []string{"crazy-bunny", chartPath},
 			flags:    []string{"--description", "foo"},
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2}),
-			expected: "Release \"crazy-bunny\" has been upgraded. Happy Helming!\n",
+			expected: "Release \"crazy-bunny\" has been upgraded.\n",
 			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch2, Description: "foo"})},
 		},
 		{

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -191,7 +191,7 @@ Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "stable" chart repository
 ...Successfully got an update from the "example" chart repository
 ...Successfully got an update from the "another" chart repository
-Update Complete. Happy Helming!
+Update Complete.
 Saving 2 charts
 Downloading apache from repo http://example.com/charts
 Downloading mysql from repo http://another.example.com/charts

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -106,7 +106,6 @@ $ helm init --service-account tiller --tiller-namespace tiller-world
 $HELM_HOME has been configured at /Users/awesome-user/.helm.
 
 Tiller (the Helm server side component) has been installed into your Kubernetes Cluster.
-Happy Helming!
 
 $ helm install nginx --tiller-namespace tiller-world --namespace tiller-world
 NAME:   wayfaring-yak

--- a/docs/using_helm.md
+++ b/docs/using_helm.md
@@ -359,7 +359,7 @@ update things that have changed since the last release.
 ```console
 $ helm upgrade -f panda.yaml happy-panda stable/mariadb
 Fetched stable/mariadb-0.3.0.tgz to /Users/mattbutcher/Code/Go/src/k8s.io/helm/mariadb-0.3.0.tgz
-happy-panda has been upgraded. Happy Helming!
+happy-panda has been upgraded.
 Last Deployed: Wed Sep 28 12:47:54 2016
 Namespace: default
 Status: DEPLOYED

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -465,7 +465,7 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 		}(r)
 	}
 	wg.Wait()
-	fmt.Fprintln(out, "Update Complete. ⎈Happy Helming!⎈")
+	fmt.Fprintln(out, "Update Complete.")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Evan Vetere <ecv@sine.com>

**What this PR does / why we need it**:

This PR removes the pushy, chirpy good-mood-enforcement from Helm's standard output. 

Helm has greatly matured as a project and having snowflake emojis in deployment pipelines that fire hundreds of times a week (and are thus the opposite of snowflakes) feels incorrect, as well as potentially unprofessional. Also, I suspect I'm not the only one who doesn't enjoy being told how to feel. 

Just throwing this out here on a Friday at 6pm, after having spent an hour fixing my institution's deployments ahead of the weekend, while the software continually told me to cheer up about it. 

**Special notes for your reviewer**:

I'll understand if you guys are super attached to the chirpy messages, but please note that this is a culturally variable thing that just doesn't fly everywhere. I will of course keep enjoying Helm and the work y'all do, if you deny this PR. 🤒 