### PR TITLE
fix(helm): Only validate new manifests

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -141,7 +141,7 @@ func (c *Client) validator() validation.Schema {
 	return schema
 }
 
-// BuildUnstructured validates for Kubernetes objects and returns unstructured infos.
+// BuildUnstructured reads Kubernetes objects and returns unstructured infos.
 func (c *Client) BuildUnstructured(namespace string, reader io.Reader) (Result, error) {
 	var result Result
 
@@ -150,11 +150,24 @@ func (c *Client) BuildUnstructured(namespace string, reader io.Reader) (Result, 
 		ContinueOnError().
 		NamespaceParam(namespace).
 		DefaultNamespace().
-		Schema(c.validator()).
 		Stream(reader, "").
 		Flatten().
 		Do().Infos()
 	return result, scrubValidationError(err)
+}
+
+// Validate reads Kubernetes manifests and validates the content.
+func (c *Client) Validate(namespace string, reader io.Reader) error {
+	_, err := c.NewBuilder().
+		Unstructured().
+		ContinueOnError().
+		NamespaceParam(namespace).
+		DefaultNamespace().
+		Schema(c.validator()).
+		Stream(reader, "").
+		Flatten().
+		Do().Infos()
+	return scrubValidationError(err)
 }
 
 // Build validates for Kubernetes objects and returns resource Infos from a io.Reader.

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -147,7 +147,19 @@ type KubeClient interface {
 	UpdateWithOptions(namespace string, originalReader, modifiedReader io.Reader, opts kube.UpdateOptions) error
 
 	Build(namespace string, reader io.Reader) (kube.Result, error)
+
+	// BuildUnstructured reads a stream of manifests from a reader and turns them into
+	// info objects. Manifests are not validated against the schema, but it will fail if
+	// any resoures types are not known by the apiserver.
+	//
+	// reader must contain a YAML stream (one or more YAML documents separated by "\n---\n").
 	BuildUnstructured(namespace string, reader io.Reader) (kube.Result, error)
+
+	// Validate reads a stream of manifests from a reader and validates them against
+	// the schema from the apiserver. It returns an error if any of the manifests does not validate.
+	//
+	// reader must contain a YAML stream (one or more YAML documents separated by "\n---\n").
+	Validate(namespace string, reader io.Reader) error
 
 	// WaitAndGetCompletedPodPhase waits up to a timeout until a pod enters a completed phase
 	// and returns said phase (PodSucceeded or PodFailed qualify).
@@ -212,6 +224,11 @@ func (p *PrintingKubeClient) Build(ns string, reader io.Reader) (kube.Result, er
 // BuildUnstructured implements KubeClient BuildUnstructured.
 func (p *PrintingKubeClient) BuildUnstructured(ns string, reader io.Reader) (kube.Result, error) {
 	return []*resource.Info{}, nil
+}
+
+// Validate implements KubeClient Validate
+func (p *PrintingKubeClient) Validate(ns string, reader io.Reader) error {
+	return nil
 }
 
 // WaitAndGetCompletedPodPhase implements KubeClient WaitAndGetCompletedPodPhase.

--- a/pkg/tiller/environment/environment_test.go
+++ b/pkg/tiller/environment/environment_test.go
@@ -64,6 +64,9 @@ func (k *mockKubeClient) Build(ns string, reader io.Reader) (kube.Result, error)
 func (k *mockKubeClient) BuildUnstructured(ns string, reader io.Reader) (kube.Result, error) {
 	return []*resource.Info{}, nil
 }
+func (k *mockKubeClient) Validate(ns string, reader io.Reader) error {
+	return nil
+}
 func (k *mockKubeClient) WaitAndGetCompletedPodPhase(namespace string, reader io.Reader, timeout time.Duration) (v1.PodPhase, error) {
 	return v1.PodUnknown, nil
 }

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -436,8 +436,7 @@ func (s *ReleaseServer) execHook(hs []*release.Hook, name, namespace, hook strin
 
 func validateManifest(c environment.KubeClient, ns string, manifest []byte) error {
 	r := bytes.NewReader(manifest)
-	_, err := c.BuildUnstructured(ns, r)
-	return err
+	return c.Validate(ns, r)
 }
 
 func validateReleaseName(releaseName string) error {

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -650,6 +650,9 @@ func (kc *mockHooksKubeClient) Build(ns string, reader io.Reader) (kube.Result, 
 func (kc *mockHooksKubeClient) BuildUnstructured(ns string, reader io.Reader) (kube.Result, error) {
 	return []*resource.Info{}, nil
 }
+func (kc *mockHooksKubeClient) Validate(ns string, reader io.Reader) error {
+	return nil
+}
 func (kc *mockHooksKubeClient) WaitAndGetCompletedPodPhase(namespace string, reader io.Reader, timeout time.Duration) (v1.PodPhase, error) {
 	return v1.PodUnknown, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Validation of manifests in charts was fixed in #5576. But unfortunately this led to a situation where existing releases that doesn't validate can't be updated, even when the issue has been fixed in the new version of the chart (#5640).
I think the root of the problem here is that Helm combines validation and turning yaml manifests into infos into one function. There are many scenarios where turning manifests into infos should succeed, even if a manifest doesn't pass validation.
This PR adds a new function `Validate` to the KubeClient. This function does validation, but does not return infos. The existing `BuildUnstructured` function returns infos, but it does not do any validation. The `Validate` function is called from the release server to do validation of new charts while the `BuildUnstructured` function is used internally in the Client to turn manifests into infos for delete, update, install...

Fixes #5640 

@distorhead @bacongobbler 

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
