### PR TITLE
fix(chartutil): Scaffold chart deployment fails with template error

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -301,9 +301,9 @@ Common labels
 app.kubernetes.io/name: {{ include "<CHARTNAME>.name" . }}
 helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion -}}
+{{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end -}}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 `


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes an issue which is caused by the following label in scaffold chart helper function:
```
{{- if .Chart.AppVersion -}}
app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
{{- end -}}
```

The minus sign in the `if` and `end` delimiters (`}}`) was resulting in the label appending onto the label before it and the next label appended onto this label, all on the one line.

A template including the label helper definitions would thus render as follows:
```
labels:
    app.kubernetes.io/name: mychart
    helm.sh/chart: mychart-0.1.0
    app.kubernetes.io/instance: wobbling-camelapp.kubernetes.io/version: "1.0"app.kubernetes.io/managed-by: Tiller
```
As a consequence when you tried to install the scaffold chart from OOTB, you got an error similar to the following:
`Error: YAML parse error on mychart/templates/deployment.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key`

Closes #5659 

**Special notes for your reviewer**:
This seems to be a regression bug from #5373. 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
