### PR TITLE
fix(chartutil): Scaffold chart fails to deploy pod

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -72,8 +72,9 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 0.1.0
+# incremented each time you make changes to the application. Depending on the application,
+# 'stable' can signify the latest stable version of the application.
+appVersion: stable
 `
 
 const defaultValues = `# Default values for %s.
@@ -211,7 +212,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Release.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -72,9 +72,8 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Depending on the application,
-# 'stable' can signify the latest stable version of the application.
-appVersion: stable
+# incremented each time you make changes to the application.
+appVersion: 1.16.0
 `
 
 const defaultValues = `# Default values for %s.


### PR DESCRIPTION
**What this PR does / why we need it**:
When you try to install a scaffold chart OOTB after a `helm create`, a subsequent install fails on the pod deployment with `InvalidImageName` as follows:

```console
default       pod/mychart-1556529386-576b45f6fb-w8vm4     0/1     InvalidImageName   0          31h
``` 

This is because the image name is missing the version.  The following line is used to set the image in `deployment.yaml`: `image: "{{ .Values.image.repository }}:{{ .Release.AppVersion }}"`. It seems that the `Release` object `AppVersion` property does not exist. Therefore, it gets rendered as follows:
```console
[....]
spec:
      containers:
        - name: mychart
          image: "nginx:"
[...]
```
This PR is to fix this issue.

**Special notes for your reviewer**:
Using `AppVersion` from the chart object and also setting the version to `stable` as the stable version of nginx is used. Not sure if this different to the approach that was envisaged for #5553. 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
