### PR TITLE
Fix issues with concurrent `helm repo add` commands

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -135,7 +135,7 @@ func addRepository(name, url, username, password string, home helmpath.Home, cer
 		return fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", url, err.Error())
 	}
 
-	// Lock the repository file for concurrent processes synchronization and re-read its content before updating it
+	// Lock the repository file for concurrent goroutines or processes synchronization
 	fileLock := flock.New(home.RepositoryFile())
 	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -147,6 +147,8 @@ func addRepository(name, url, username, password string, home helmpath.Home, cer
 		return err
 	}
 
+	// Re-read the repositories file before updating it as its content may have been changed
+	// by a concurrent execution after the first read and before being locked
 	f, err = repo.LoadRepositoriesFile(home.RepositoryFile())
 	if err != nil {
 		return err

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -137,7 +137,7 @@ func addRepository(name, url, username, password string, home helmpath.Home, cer
 
 	// Lock the repository file for concurrent processes synchronization and re-read its content before updating it
 	fileLock := flock.New(home.RepositoryFile())
-	lockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	locked, err := fileLock.TryLockContext(lockCtx, time.Second)
 	if err == nil && locked {

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -128,6 +128,7 @@ func TestRepoAddConcurrentGoRoutines(t *testing.T) {
 	wg.Add(3)
 	for i := 0; i < 3; i++ {
 		go func(name string) {
+			// TODO: launch repository additions in sub-processes as file locks are bound to processes, not file descriptors
 			defer wg.Done()
 			if err := addRepository(name, ts.URL(), "", "", settings.Home, "", "", "", true); err != nil {
 				t.Error(err)

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -17,13 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/repo"
 	"k8s.io/helm/pkg/repo/repotest"
 )
@@ -99,5 +104,113 @@ func TestRepoAdd(t *testing.T) {
 
 	if err := addRepository(testName, ts.URL(), "", "", hh, "", "", "", false); err != nil {
 		t.Errorf("Duplicate repository name was added")
+	}
+}
+func TestRepoAddConcurrentGoRoutines(t *testing.T) {
+	ts, thome, err := repotest.NewTempServer("testdata/testserver/*.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := resetEnv()
+	defer func() {
+		ts.Stop()
+		os.RemoveAll(thome.String())
+		cleanup()
+	}()
+
+	settings.Home = thome
+	if err := ensureTestHome(settings.Home, t); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func(name string) {
+			defer wg.Done()
+			if err := addRepository(name, ts.URL(), "", "", settings.Home, "", "", "", true); err != nil {
+				t.Error(err)
+			}
+		}(fmt.Sprintf("%s-%d", testName, i))
+	}
+	wg.Wait()
+
+	f, err := repo.LoadRepositoriesFile(settings.Home.RepositoryFile())
+	if err != nil {
+		t.Error(err)
+	}
+
+	var name string
+	for i := 0; i < 3; i++ {
+		name = fmt.Sprintf("%s-%d", testName, i)
+		if !f.Has(name) {
+			t.Errorf("%s was not successfully inserted into %s", name, settings.Home.RepositoryFile())
+		}
+	}
+}
+
+// Same as TestRepoAddConcurrentGoRoutines but with repository additions in sub-processes
+func TestRepoAddConcurrentSubProcesses(t *testing.T) {
+	goWantHelperProcess := os.Getenv("GO_WANT_HELPER_PROCESS")
+	if goWantHelperProcess == "" {
+		// parent
+
+		ts, thome, err := repotest.NewTempServer("testdata/testserver/*.*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		settings.Home = thome
+
+		cleanup := resetEnv()
+		defer func() {
+			ts.Stop()
+			os.RemoveAll(thome.String())
+			cleanup()
+		}()
+		if err := ensureTestHome(settings.Home, t); err != nil {
+			t.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		for i := 0; i < 3; i++ {
+			go func(name string) {
+				defer wg.Done()
+
+				cmd := exec.Command(os.Args[0], "-test.run=^TestRepoAddConcurrentSubProcesses$")
+				cmd.Env = append(os.Environ(), fmt.Sprintf("GO_WANT_HELPER_PROCESS=%s,%s", name, ts.URL()), fmt.Sprintf("HELM_HOME=%s", settings.Home))
+				out, err := cmd.CombinedOutput()
+				if len(out) > 0 || err != nil {
+					t.Fatalf("child process: %q, %v", out, err)
+				}
+			}(fmt.Sprintf("%s-%d", testName, i))
+		}
+		wg.Wait()
+
+		f, err := repo.LoadRepositoriesFile(settings.Home.RepositoryFile())
+		if err != nil {
+			t.Error(err)
+		}
+
+		var name string
+		for i := 0; i < 3; i++ {
+			name = fmt.Sprintf("%s-%d", testName, i)
+			if !f.Has(name) {
+				t.Errorf("%s was not successfully inserted into %s", name, settings.Home.RepositoryFile())
+			}
+		}
+	} else {
+		// child
+		s := strings.Split(goWantHelperProcess, ",")
+		settings.Home = helmpath.Home(os.Getenv("HELM_HOME"))
+		repoName := s[0]
+		tsURL := s[1]
+		if err := addRepository(repoName, tsURL, "", "", settings.Home, "", "", "", true); err != nil {
+			t.Fatal(err)
+		}
+
+		os.Exit(0)
 	}
 }

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -174,8 +174,8 @@ func TestRepoAddConcurrentSubProcesses(t *testing.T) {
 		}
 
 		var wg sync.WaitGroup
-		wg.Add(3)
-		for i := 0; i < 3; i++ {
+		wg.Add(2)
+		for i := 0; i < 2; i++ {
 			go func(name string) {
 				defer wg.Done()
 
@@ -195,7 +195,7 @@ func TestRepoAddConcurrentSubProcesses(t *testing.T) {
 		}
 
 		var name string
-		for i := 0; i < 3; i++ {
+		for i := 0; i < 2; i++ {
 			name = fmt.Sprintf("%s-%d", testName, i)
 			if !f.Has(name) {
 				t.Errorf("%s was not successfully inserted into %s", name, settings.Home.RepositoryFile())

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -128,7 +128,6 @@ func TestRepoAddConcurrentGoRoutines(t *testing.T) {
 	wg.Add(3)
 	for i := 0; i < 3; i++ {
 		go func(name string) {
-			// TODO: launch repository additions in sub-processes as file locks are bound to processes, not file descriptors
 			defer wg.Done()
 			if err := addRepository(name, ts.URL(), "", "", settings.Home, "", "", "", true); err != nil {
 				t.Error(err)

--- a/glide.lock
+++ b/glide.lock
@@ -114,6 +114,8 @@ imports:
   - syntax/lexer
   - util/runes
   - util/strings
+- name: github.com/gofrs/flock
+  version: 392e7fae8f1b0bdbd67dad7237d23f618feb6dbb
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -67,6 +67,8 @@ import:
   - package: github.com/jmoiron/sqlx
     version: ^1.2.0
   - package: github.com/rubenv/sql-migrate
+  - package: github.com/gofrs/flock
+    version: v0.7.1
 
 testImports:
   - package: github.com/stretchr/testify


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR aims to fix the issue with concurrent `helm repo add` commands reported in #5677.
It adds a test case to reproduce the issue:

```
# go test -v ./cmd/helm/ -run=TestRepoAdd
=== RUN   TestRepoAddCmd
=== RUN   TestRepoAddCmd/add_a_repository
--- PASS: TestRepoAddCmd (0.01s)
    helm_test.go:154: $HELM_HOME has been configured at .
    --- PASS: TestRepoAddCmd/add_a_repository (0.01s)
=== RUN   TestRepoAdd
--- FAIL: TestRepoAdd (0.01s)
    helm_test.go:154: $HELM_HOME has been configured at .
    repo_add_test.go:106: test-name-1 was not successfully inserted into /tmp/helm-repotest-391309255/repository/repositories.yaml
    repo_add_test.go:106: test-name-2 was not successfully inserted into /tmp/helm-repotest-391309255/repository/repositories.yaml
FAIL
FAIL    k8s.io/helm/cmd/helm    0.069s
```
```
# go test -v ./cmd/helm/ -run=TestRepoAdd
=== RUN   TestRepoAddCmd
=== RUN   TestRepoAddCmd/add_a_repository
--- PASS: TestRepoAddCmd (0.01s)
    helm_test.go:154: $HELM_HOME has been configured at .
    --- PASS: TestRepoAddCmd/add_a_repository (0.00s)
=== RUN   TestRepoAdd
--- FAIL: TestRepoAdd (0.01s)
    helm_test.go:154: $HELM_HOME has been configured at .
    repo_add_test.go:106: test-name-0 was not successfully inserted into /tmp/helm-repotest-560212793/repository/repositories.yaml
    repo_add_test.go:106: test-name-2 was not successfully inserted into /tmp/helm-repotest-560212793/repository/repositories.yaml
FAIL
FAIL    k8s.io/helm/cmd/helm    0.067s
```

**Special notes for your reviewer**:

The fix is implemented with github.com/gofrs/flock for cross platform file locking.
Timeout is hard-coded to 5 minutes for now.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
