### PR TITLE
Updating OWERS to remove outdated reviewers and to reflect current case

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,11 @@
 maintainers:
   - adamreese
   - bacongobbler
+  - fibonacci1729
   - hickeyma
   - jascott1
   - mattfarina
   - michelleN
-  - prydonius
-  - SlickNik
-  - technosophos
-  - thomastaylor312
-  - viglesiasce
-reviewers:
-  - adamreese
-  - bacongobbler
-  - fibonacci1729
-  - jascott1
-  - mattfarina
-  - michelleN
-  - migmartri
-  - nebril
   - prydonius
   - SlickNik
   - technosophos


### PR DESCRIPTION
Two changes in this:
1. Remove the reviewers. These are from when Helm was under
   Kubernetes and used its tools. That is no longer the case
   so this section has no use.
2. List fibonacci1729 with the maintainers. He has been a
   maintainer a long time. The original listing had to do with
   department locations within Deis rather than his work. He
   has been a maintainer since before Helm was a CNCF project.

Fixes #5685