### PR TITLE
fix(circle): lsb_release does not exist in linuxkit images

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -36,11 +36,11 @@ else
 fi
 
 echo "Installing Azure CLI"
-AZURE_REPO=$(lsb_release -cs)
-echo “deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZURE_REPO main” | tee /etc/apt/sources.list.d/azure-cli.list
-curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add –
-apt install apt-transport-https
-apt update && apt install azure-cli
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
+sudo apt install apt-transport-https
+sudo apt update
+sudo apt install azure-cli
 
 
 echo "Building helm binaries"


### PR DESCRIPTION
follow-up from #5694. This commit fixes a few things:

- `lsb_release` does not exist in linuxkit images such as `circleci/golang:1.12`. To fix this, I checked what's in /etc/os-release and found it's Debian Stretch, so I hardcoded that for fetching the Azure CLI.
- I accidentally used curly double quotes instead of straight. That's what I get for copying and pasting code around 🐑 
- `sudo` is required to install packages in circleci/golang as it does not run as root.

Tested and verified via

```
docker run -itv $PWD:/app circleci/golang:1.12 bash
cd /app
export AZURE_STORAGE_CONNECTION_STRING=blah
export AZURE_STORAGE_CONTAINER_NAME=blah
export CIRCLE_BRANCH=dev-v3
./.circleci/deploy.sh
```

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>