### PR TITLE
Update release checklist with bumping release version

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -147,6 +147,24 @@ git add .
 git commit -m "bump version to $RELEASE_CANDIDATE_NAME"
 ```
 
+This will update it for the $RELEASE_BRANCH_NAME only. You will also need to pull
+this change into the master branch for when the next release is being created.
+
+```shell
+# get the last commit id i.e. commit to bump the version
+git log --format="%H" -n 1
+
+# create new branch off master
+git checkout master
+git checkout -b bump-version-<release_version>
+
+# cherry pick the commit using id from first command
+git cherry-pick -x <commit-id>
+
+# commit the change
+git push upstream bump-version-<release-version>
+```
+
 ## 3. Commit and Push the Release Branch
 
 In order for others to start testing, we can now push the release branch

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -162,7 +162,7 @@ git checkout -b bump-version-<release_version>
 git cherry-pick -x <commit-id>
 
 # commit the change
-git push upstream bump-version-<release-version>
+git push origin bump-version-<release-version>
 ```
 
 ## 3. Commit and Push the Release Branch


### PR DESCRIPTION
**What this PR does / why we need it**:
Add to the release checklist about updating the release version in the master branch when creating a release.  This is so that the correct release version is shown when build from master.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
