### PR TITLE
Print manifest output for dry-run option

### DIFF
--- a/pkg/action/printer.go
+++ b/pkg/action/printer.go
@@ -56,6 +56,10 @@ func PrintRelease(out io.Writer, rel *release.Release) {
 			formatTestResults(lastRun.Results))
 	}
 
+	if strings.EqualFold(rel.Info.Description, "Dry run complete") {
+	        fmt.Fprintf(out, "MANIFEST:\n%s\n", rel.Manifest)
+	}
+
 	if len(rel.Info.Notes) > 0 {
 		fmt.Fprintf(out, "NOTES:\n%s\n", strings.TrimSpace(rel.Info.Notes))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As per v2, print manifest output for `--dry-run` option

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
