### PR TITLE
fix(loader): assume apiVersion is v1 when loading charts

### DIFF
--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -79,6 +79,12 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if err := yaml.Unmarshal(f.Data, c.Metadata); err != nil {
 				return c, errors.Wrap(err, "cannot load Chart.yaml")
 			}
+			// NOTE(bacongobbler): while the chart specification says that APIVersion must be set,
+			// Helm 2 accepted charts that did not provide an APIVersion in their chart metadata.
+			// Because of that, if APIVersion is unset, we should assume we're loading a v1 chart.
+			if c.Metadata.APIVersion == "" {
+				c.Metadata.APIVersion = chart.APIVersionV1
+			}
 		case f.Name == "Chart.lock":
 			c.Lock = new(chart.Lock)
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {

--- a/pkg/chart/loader/testdata/albatross/Chart.yaml
+++ b/pkg/chart/loader/testdata/albatross/Chart.yaml
@@ -1,4 +1,3 @@
-apiVersion: v1
 name: albatross
 description: A Helm chart for Kubernetes
 version: 0.1.0


### PR DESCRIPTION
In Helm 2, no chart validation was performed on v1 charts, so there are
a few charts out there that never added an apiVersion to the Chart.yaml.
To ensure those charts continue to work for Helm 3, we should assume
that charts loaded without an apiVersion set should be assumed as v1.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
