### PR TITLE
Add missing test hooks in the list of annotations

### DIFF
--- a/docs/charts_hooks.md
+++ b/docs/charts_hooks.md
@@ -49,6 +49,10 @@ The following hooks are defined:
   have been modified.
 - crd-install: Adds CRD resources before any other checks are run. This is used
   only on CRD definitions that are used by other manifests in the chart.
+- test-success: Executes when running `helm test` and expects the pod to
+  return successfully (return code == 0).
+- test-failure: Executes when running `helm test` and expects the pod to
+  fail (return code != 0).
 
 ## Hooks and the Release Lifecycle
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `test-success` and `test-failure` hooks to the list of annotations.

**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
