### PR TITLE
fix(helm): Disable schema validation for manifests

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -157,13 +157,16 @@ func (c *Client) BuildUnstructured(namespace string, reader io.Reader) (Result, 
 }
 
 // Validate reads Kubernetes manifests and validates the content.
+//
+// This function does not actually do schema validation of manifests. Adding
+// validation now breaks existing clients of helm: https://github.com/helm/helm/issues/5750
 func (c *Client) Validate(namespace string, reader io.Reader) error {
 	_, err := c.NewBuilder().
 		Unstructured().
 		ContinueOnError().
 		NamespaceParam(namespace).
 		DefaultNamespace().
-		Schema(c.validator()).
+		// Schema(c.validator()). // No schema validation
 		Stream(reader, "").
 		Flatten().
 		Do().Infos()


### PR DESCRIPTION
Signed-off-by: Morten Torkildsen <mortent@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The change in #5576 and #5643 added schema validation for new manifests. This seems to cause problems for existing Helm setups, so this change removes schema validation of charts in all situations.

Ref discussion in #5750 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
