### PR TITLE
fix missing package name

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -108,7 +108,7 @@ func (p *Package) Run(path string) (string, error) {
 		err = p.Clearsign(name)
 	}
 
-	return "", err
+	return name, err
 }
 
 func setVersion(ch *chart.Chart, ver string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix missing package name when running `helm package ...`

fixes: https://github.com/helm/helm/issues/5741
