### PR TITLE
change deployment version

### DIFF
--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This uses a "fullname" template (see _helpers)

--- a/docs/install.md
+++ b/docs/install.md
@@ -280,7 +280,7 @@ helm init --override metadata.annotations."deployment\.kubernetes\.io/revision"=
 Output:
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -130,7 +130,7 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -700,7 +700,7 @@ spec:
     tier: backend
     role: master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-master
@@ -740,7 +740,7 @@ spec:
     tier: backend
     role: slave
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave
@@ -780,7 +780,7 @@ spec:
     app: guestbook
     tier: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend


### PR DESCRIPTION
**What this PR does / why we need it**:  
change deployment api version extensions/v1beta1 -> apps/v1

**Special notes for your reviewer**:
DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
