### PR TITLE
change deployment version

### DIFF
--- a/cmd/helm/installer/install.go
+++ b/cmd/helm/installer/install.go
@@ -125,7 +125,7 @@ func Deployment(opts *Options) (*v1beta1.Deployment, error) {
 	}
 	dep.TypeMeta = metav1.TypeMeta{
 		Kind:       "Deployment",
-		APIVersion: "extensions/v1beta1",
+		APIVersion: "apps/v1",
 	}
 	return dep, nil
 }

--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This uses a "fullname" template (see _helpers)

--- a/docs/install.md
+++ b/docs/install.md
@@ -280,7 +280,7 @@ helm init --override metadata.annotations."deployment\.kubernetes\.io/revision"=
 Output:
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -337,7 +337,7 @@ The Tiller installation is skipped and the manifest is output to stdout
 in JSON format.
 
 ```
-"apiVersion": "extensions/v1beta1",
+"apiVersion": "apps/v1",
 "kind": "Deployment",
 "metadata": {
     "creationTimestamp": null,

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiapps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -700,7 +700,7 @@ spec:
     tier: backend
     role: master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-master
@@ -740,7 +740,7 @@ spec:
     tier: backend
     role: slave
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave
@@ -780,7 +780,7 @@ spec:
     app: guestbook
     tier: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiapps/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
Signed-off-by: dj kim <dj.kim@kakaobank.com>

**What this PR does / why we need it**:  
change deployment api version extensions/v1beta1 -> apps/v1

**Special notes for your reviewer**:
Deployment resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility