### PR TITLE
Skip waiting for paused deployments

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -71,6 +71,10 @@ func (c *Client) waitForResources(timeout time.Duration, created Result) error {
 				if err != nil {
 					return false, err
 				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
+				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, kcs.AppsV1())
 				if err != nil || newReplicaSet == nil {
@@ -85,6 +89,10 @@ func (c *Client) waitForResources(timeout time.Duration, created Result) error {
 				currentDeployment, err := kcs.AppsV1().Deployments(value.Namespace).Get(value.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
+				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
 				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, kcs.AppsV1())
@@ -101,6 +109,10 @@ func (c *Client) waitForResources(timeout time.Duration, created Result) error {
 				if err != nil {
 					return false, err
 				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
+				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, kcs.AppsV1())
 				if err != nil || newReplicaSet == nil {
@@ -115,6 +127,10 @@ func (c *Client) waitForResources(timeout time.Duration, created Result) error {
 				currentDeployment, err := kcs.AppsV1().Deployments(value.Namespace).Get(value.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
+				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
 				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, kcs.AppsV1())


### PR DESCRIPTION
**What this PR does / why we need it**:
In my chart I have multiple Deployments for different micro-services in my application. Some of the services have upgrade dependencies or requires special logic to perform rolling upgrade. To facilitate this I set those deployments to be in `paused` state before the chart is upgraded.

When running helm upgrade with paused deployments and when using the `--wait` flag, the upgrade processed is stalled forever (or until timeout) since Kubernetes will not perform rolling upgrade on paused deployments. I propose to have Tiller ignore paused deployments altogether when waiting for a upgrade to finish since these will otherwise block the upgrade process.
