### PR TITLE
return error when io.Copy fails in Digest

### DIFF
--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -405,7 +405,7 @@ func DigestFile(filename string) (string, error) {
 func Digest(in io.Reader) (string, error) {
 	hash := crypto.SHA256.New()
 	if _, err := io.Copy(hash, in); err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }


### PR DESCRIPTION
This PR corrects an oversight in #5672. My apologies.

Requesting your review @bacongobbler @technosophos @hickeyma 