### PR TITLE
helm3: Use environment variables in templates

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -62,13 +62,6 @@ func TestSortTemplates(t *testing.T) {
 
 func TestFuncMap(t *testing.T) {
 	fns := funcMap()
-	forbidden := []string{"env", "expandenv"}
-	for _, f := range forbidden {
-		if _, ok := fns[f]; ok {
-			t.Errorf("Forbidden function %s exists in FuncMap.", f)
-		}
-	}
-
 	// Test for Engine-specific template functions.
 	expect := []string{"include", "required", "tpl", "toYaml", "fromYaml", "toToml", "toJson", "fromJson"}
 	for _, f := range expect {

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -44,8 +44,6 @@ import (
 //
 func funcMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
-	delete(f, "env")
-	delete(f, "expandenv")
 
 	// Add some extra functionality
 	extra := template.FuncMap{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the deletion of the `env` and `expandenv` template functions of sprig. It would be nice if one could use environment variables within templates without passing all values by `--set`. 

According to https://helm.sh/docs/charts_tips_and_tricks/ they were removed to not expose the environment of tiller, so it should be ok to make them available again in helm3.

This PR should also fix the problem of the reporter of #5779 .
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
