### PR TITLE
fix issue that values are not applied while running upgrade cmd

### DIFF
--- a/cmd/helm/testdata/output/upgrade-with-missing-dependencies.txt
+++ b/cmd/helm/testdata/output/upgrade-with-missing-dependencies.txt
@@ -1,3 +1,1 @@
-Error: "helm upgrade" requires 2 arguments
-
-Usage:  helm upgrade [RELEASE] [CHART] [flags]
+Error: found in Chart.yaml, but missing in charts/ directory: reqsubchart2

--- a/cmd/helm/testdata/testcharts/upgradetest/templates/configmap.yaml
+++ b/cmd/helm/testdata/testcharts/upgradetest/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Release.Name }}-configmap"
+data:
+  myvalue: "Hello World"
+  drink: {{ .Values.favoriteDrink }}

--- a/cmd/helm/testdata/testcharts/upgradetest/values.yaml
+++ b/cmd/helm/testdata/testcharts/upgradetest/values.yaml
@@ -1,0 +1,1 @@
+favoriteDrink: beer

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -267,7 +267,7 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release) erro
 		return nil
 	}
 
-	if len(u.Values) == 0 && len(current.Config) > 0 {
+	if len(u.rawValues) == 0 && len(current.Config) > 0 {
 		u.cfg.Log("copying values from %s (v%d) to new release.", current.Name, current.Version)
 		u.rawValues = current.Config
 	}


### PR DESCRIPTION
closes #5792
It should not define additional values as ValueOptions will consolidate from various value sources to rawValues. 
This PR also fixes an UT assert bug.
- [x] this PR contains unit tests

