### PR TITLE
[documentation] make `install` command doc more explicit

### DIFF
--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -57,6 +57,8 @@ There are five different ways you can express the chart you want to install:
 4. By absolute URL: helm install https://example.com/charts/nginx-1.2.3.tgz
 5. By chart reference and repo url: helm install --repo https://example.com/charts/ nginx
 
+> Note: When installing a chart from the local filesystem it is advised that you use an absolute path like `./stable/mariadb/` to avoid the ambiguity of `stable/mariadb` being both a valid chart directory and a valid chart reference. Likewise when installing a chart from a chart reference, ensure you don't have a path in your working directory that matches the chart repo to avoid inadvertently installing from a local chart directory instead.
+
 CHART REFERENCES
 
 A chart reference is a convenient way of reference a chart in a chart repository.


### PR DESCRIPTION
The `helm install` command can have unexpected behavior when running `helm install stable/foo` which could
be both a local chart directory or a chart reference.  Providing some notes to this effect seems prudent.


Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
