### PR TITLE
helm v3: dynamic completion of releases

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -879,15 +879,15 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"
+  digest = "1:2e72f9cdc8b6f94a145fa1c97e305e1654d40507d04d2fbb0c37bf461a4b85f7"
   name = "github.com/spf13/cobra"
   packages = [
     ".",
     "doc",
   ]
   pruneopts = "UT"
-  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
-  version = "v0.0.3"
+  revision = "67fc4837d267bc9bfd6e47f77783fcc3dffc68de"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -109,3 +109,7 @@
 [[constraint]]
   name = "github.com/xeipuuv/gojsonschema"
   version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "0.0.4"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Add dynamic completion after
```
helm status <TAB>
helm uninstall <TAB>
helm history <TAB>
helm test run <TAB>
helm upgrade <TAB>
helm get <subcommand> <TAB>
helm rollback <TAB>
```
by fetching the list of releases from the cluster.

**Special notes for your reviewer**:

This PR is the adapted v3 version of #5562 as requested by @technosophos.
It puts in the foundation for dynamic completion support in Helm v3.
It is inspired by the dynamic completion provided by kubectl.
Both bash and zsh are handled.

As dynamic completion actually sends queries to the cluster, this PR handles the use of Helm flags that affect which cluster should be contacted:
```
--kubeconfig 
--kube-context 
--home 
--namespace
-n
```

This PR requires the use of Cobra v0.0.4 which allows dynamic completion to co-exist between helm and kubectl (while Cobra v0.0.3 had a bug that would cause the two to clash).
