### PR TITLE
doc: tuple replaced by list

### DIFF
--- a/docs/chart_template_guide/accessing_files.md
+++ b/docs/chart_template_guide/accessing_files.md
@@ -54,13 +54,13 @@ metadata:
   name: {{ .Release.Name }}-configmap
 data:
   {{- $files := .Files }}
-  {{- range tuple "config1.toml" "config2.toml" "config3.toml" }}
+  {{- range list "config1.toml" "config2.toml" "config3.toml" }}
   {{ . }}: |-
     {{ $files.Get . }}
   {{- end }}
 ```
 
-This config map uses several of the techniques discussed in previous sections. For example, we create a `$files` variable to hold a reference to the `.Files` object. We also use the `tuple` function to create a list of files that we loop through. Then we print each file name (`{{.}}: |-`) followed by the contents of the file `{{ $files.Get . }}`.
+This config map uses several of the techniques discussed in previous sections. For example, we create a `$files` variable to hold a reference to the `.Files` object. We also use the `list` function to create a list of files that we loop through. Then we print each file name (`{{.}}: |-`) followed by the contents of the file `{{ $files.Get . }}`.
 
 Running this template will produce a single ConfigMap with the contents of all three files:
 

--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -1,6 +1,6 @@
 # Built-in Objects
 
-Objects are passed into a template from the template engine. And your code can pass objects around (we'll see examples when we look at the `with` and `range` statements). There are even a few ways to create new objects within your templates, like with the `tuple` function we'll see later.
+Objects are passed into a template from the template engine. And your code can pass objects around (we'll see examples when we look at the `with` and `range` statements). There are even a few ways to create new objects within your templates, like with the `list` function we'll see later.
 
 Objects can be simple, and have just one value. Or they can contain other objects or functions. For example. the `Release` object contains several objects (like `Release.Name`) and the `Files` object has a few functions.
 

--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -333,11 +333,11 @@ Now, in this example we've done something tricky. The `toppings: |-` line is dec
 
 > The `|-` marker in YAML takes a multi-line string. This can be a useful technique for embedding big blocks of data inside of your manifests, as exemplified here.
 
-Sometimes it's useful to be able to quickly make a list inside of your template, and then iterate over that list. Helm templates have a function to make this easy: `tuple`. In computer science, a tuple is a list-like collection of fixed size, but with arbitrary data types. This roughly conveys the way a `tuple` is used.
+Sometimes it's useful to be able to quickly make a list inside of your template, and then iterate over that list. Helm templates have a function that's called just that: `list`.
 
 ```yaml
   sizes: |-
-    {{- range tuple "small" "medium" "large" }}
+    {{- range list "small" "medium" "large" }}
     - {{ . }}
     {{- end }}
 ```
@@ -351,4 +351,4 @@ The above will produce this:
     - large
 ```
 
-In addition to lists and tuples, `range` can be used to iterate over collections that have a key and a value (like a `map` or `dict`). We'll see how to do that in the next section when we introduce template variables.
+In addition to lists, `range` can be used to iterate over collections that have a key and a value (like a `map` or `dict`). We'll see how to do that in the next section when we introduce template variables.


### PR DESCRIPTION
**What this PR does / why we need it**:
All list functions also work on tuple (implemented in Sprig as list, see https://github.com/Masterminds/sprig/blob/2625cd487a689ca112e1301a58b89b347ba2c994/functions.go#L237 ) and for all purposes a 'tuple' is a 'list'. Replace documentation ref. to 'tuple' with 'list' so there is no need to explain what a tuple is.

**Special notes for your reviewer**:
Behaviour-wise 'list' and associated functions return tuples because values are immutable:
```
  {{ $t := tuple 1 2 -}}
  {{- $t_plus := append $t 3 -}}
  {{ $l := list 4 5 -}}
  {{- $l_plus := append $l 6 -}}
  t: {{ $t }}
  t_plus: {{ $t_plus }}
  l: {{ $l }}
  l_plus: {{ $l_plus }}
```
renders to (note append on a list should update and return source list):
```
  t: [1 2]
  t_plus: [1 2 3]
  l: [4 5]
  l_plus: [4 5 6]
```
where _$l_ is not updated after append as expected. However I think just using 'list' is clearer.

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
