### PR TITLE
fix(circle): only upload packages and checksums, not cross-builds

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -48,4 +48,4 @@ make build-cross
 make dist checksum VERSION="${VERSION}"
 
 echo "Pushing binaries to Azure"
-az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'helm-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"


### PR DESCRIPTION
I noticed that the assets from `make build-cross` was being uploaded along with the release assets. Restricting `az storage blob upload-batch` to just the release assets prevents that from happening going forward.