### PR TITLE
ref(urlutil): remove stripPort

### DIFF
--- a/pkg/urlutil/urlutil.go
+++ b/pkg/urlutil/urlutil.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"strings"
 )
 
 // URLJoin joins a base URL to one or more path components.
@@ -70,18 +69,5 @@ func ExtractHostname(addr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return stripPort(u.Host), nil
-}
-
-// Backported from Go 1.8 because Circle is still on 1.7
-func stripPort(hostport string) string {
-	colon := strings.IndexByte(hostport, ':')
-	if colon == -1 {
-		return hostport
-	}
-	if i := strings.IndexByte(hostport, ']'); i != -1 {
-		return strings.TrimPrefix(hostport[:i], "[")
-	}
-	return hostport[:colon]
-
+	return u.Hostname(), nil
 }


### PR DESCRIPTION
This function was introduced because an older version of Go did not correctly strip the port number from the hostname with .Hostname(). This has since been fixed so it's safe to remove this.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
