### PR TITLE
add go version to version cmd output of helm

### DIFF
--- a/cmd/helm/testdata/output/version.txt
+++ b/cmd/helm/testdata/output/version.txt
@@ -1,1 +1,1 @@
-version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:""}
+version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:"go1.12.5"}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,6 +17,8 @@ limitations under the License.
 package version // import "helm.sh/helm/internal/version"
 
 import (
+	"runtime"
+
 	hversion "helm.sh/helm/pkg/version"
 )
 
@@ -52,5 +54,6 @@ func Get() hversion.BuildInfo {
 		Version:      GetVersion(),
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
+		GoVersion:    runtime.Version(),
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,8 +20,10 @@ package version // import "helm.sh/helm/pkg/version"
 type BuildInfo struct {
 	// Version is the current semver.
 	Version string `json:"version,omitempty"`
-	// GitCommit is the git sha1
+	// GitCommit is the git sha1.
 	GitCommit string `json:"git_commit,omitempty"`
-	// GitTreeState is the state of the git tree
+	// GitTreeState is the state of the git tree.
 	GitTreeState string `json:"git_tree_state,omitempty"`
+	// GoVersion is the version of the Go compiler used.
+	GoVersion string `json:"go_version,omitempty"`
 }


### PR DESCRIPTION
This is the helm v3 equivalent of #5693. Life sure is simple without tiller :).