### PR TITLE
Expose the resource types in addition to the api group/version in templates

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,7 +104,6 @@
 
 [prune]
   go-tests = true
-  unused-packages = true
 
 [[constraint]]
   name = "github.com/xeipuuv/gojsonschema"

--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -19,7 +19,7 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
   - `Files.GetBytes` is a function for getting the contents of a file as an array of bytes instead of as a string. This is useful for things like images.
 - `Capabilities`: This provides information about what capabilities the Kubernetes cluster supports.
   - `Capabilities.APIVersions` is a set of versions.
-  - `Capabilities.APIVersions.Has $version` indicates whether a version (`batch/v1`) is enabled on the cluster.
+  - `Capabilities.APIVersions.Has $version` indicates whether a version (e.g., `batch/v1`) or resource (e.g., `apps/v1/Deployment`) is available on the cluster.
   - `Capabilities.Kube.Version` is the Kubernetes version.
   - `Capabilities.Kube` is a short form for Kubernetes version.
   - `Capabilities.Kube.Major` is the Kubernetes major version.

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chartutil"
@@ -186,4 +187,20 @@ type hookFailingKubeClient struct {
 
 func (h *hookFailingKubeClient) WatchUntilReady(r io.Reader, timeout time.Duration) error {
 	return errors.New("Failed watch")
+}
+
+func TestGetVersionSet(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+
+	vs, err := GetVersionSet(client.Discovery())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !vs.Has("v1") {
+		t.Errorf("Expected supported versions to at least include v1.")
+	}
+	if vs.Has("nosuchversion/v1") {
+		t.Error("Non-existent version is reported found.")
+	}
 }


### PR DESCRIPTION
Ported #5842 to Helm v3

Note, dep pruning unused packages was pruning packages used in
tests. Disabled pruning unused code.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
