### PR TITLE
ref(version): catch some edge cases

### DIFF
--- a/cmd/helm/testdata/output/version-short.txt
+++ b/cmd/helm/testdata/output/version-short.txt
@@ -1,0 +1,1 @@
+v3.0+unreleased

--- a/cmd/helm/testdata/output/version.txt
+++ b/cmd/helm/testdata/output/version.txt
@@ -1,1 +1,1 @@
-version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:"go1.12.5"}
+version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -80,7 +80,10 @@ func (o *versionOptions) run(out io.Writer) error {
 func formatVersion(short bool) string {
 	v := version.Get()
 	if short {
-		return fmt.Sprintf("%s+g%s", v.Version, v.GitCommit[:7])
+		if len(v.GitCommit) >= 7 {
+			return fmt.Sprintf("%s+g%s", v.Version, v.GitCommit[:7])
+		}
+		return version.GetVersion()
 	}
 	return fmt.Sprintf("%#v", v)
 }

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -25,6 +25,10 @@ func TestVersion(t *testing.T) {
 		cmd:    "version",
 		golden: "output/version.txt",
 	}, {
+		name:   "short",
+		cmd:    "version --short",
+		golden: "output/version-short.txt",
+	}, {
 		name:   "template",
 		cmd:    "version --template='Version: {{.Version}}'",
 		golden: "output/version-template.txt",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package version // import "helm.sh/helm/internal/version"
 
 import (
+	"flag"
 	"runtime"
 
 	hversion "helm.sh/helm/pkg/version"
@@ -50,10 +51,16 @@ func GetVersion() string {
 
 // Get returns build info
 func Get() hversion.BuildInfo {
-	return hversion.BuildInfo{
+	v := hversion.BuildInfo{
 		Version:      GetVersion(),
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		GoVersion:    runtime.Version(),
 	}
+
+	// HACK(bacongobbler): strip out GoVersion during a test run for consistent test output
+	if flag.Lookup("test.v") != nil {
+		v.GoVersion = ""
+	}
+	return v
 }


### PR DESCRIPTION
- strip GoVersion from `helm version` test output
- catch some edge cases when GitCommit is unset or less than 7 characters (e.g. during integration tests)
- add a test case for `helm version --short`

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>