### PR TITLE
ref(chartutil): introduce chartutil.Save

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -94,7 +94,7 @@ func (p *Package) Run(path string) (string, error) {
 		dest = p.Destination
 	}
 
-	name, err := chartutil.Save(ch, dest)
+	name, err := chartutil.SaveArchive(ch, dest)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to save")
 	}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chartutil
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -27,6 +28,36 @@ import (
 )
 
 func TestSave(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: chart.APIVersionV1,
+			Name:       "ahab",
+			Version:    "1.2.3",
+		},
+		Files: []*chart.File{
+			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	if err := Save(c, buf); err != nil {
+		t.Fatalf("Failed to save: %s", err)
+	}
+
+	c2, err := loader.LoadArchive(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c2.Name() != c.Name() {
+		t.Fatalf("Expected chart archive to have %q, got %q", c.Name(), c2.Name())
+	}
+	if len(c2.Files) != 1 || c2.Files[0].Name != "scheherazade/shahryar.txt" {
+		t.Fatal("Files data did not match")
+	}
+}
+
+func TestSaveArchive(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "helm-")
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +75,7 @@ func TestSave(t *testing.T) {
 		},
 	}
 
-	where, err := Save(c, tmp)
+	where, err := SaveArchive(c, tmp)
 	if err != nil {
 		t.Fatalf("Failed to save: %s", err)
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -623,7 +623,7 @@ func tarFromLocalDir(chartpath, name, repo, version string) (string, error) {
 	}
 
 	if constraint.Check(v) {
-		_, err = chartutil.Save(ch, destPath)
+		_, err = chartutil.SaveArchive(ch, destPath)
 		return ch.Metadata.Version, err
 	}
 

--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -113,7 +113,7 @@ func (cache *filesystemCache) ChartToLayers(ch *chart.Chart) ([]ocispec.Descript
 	metaLayer := cache.store.Add(HelmChartMetaFileName, HelmChartMetaMediaType, metaJSONRaw)
 
 	// Create content layer
-	// TODO: something better than this hack. Currently needed for chartutil.Save()
+	// TODO: something better than this hack. Currently needed for chartutil.SaveArchive()
 	// If metadata does not contain Name or Version, an error is returned
 	// such as "no chart name specified (Chart.yaml)"
 	ch.Metadata = &chart.Metadata{
@@ -122,7 +122,7 @@ func (cache *filesystemCache) ChartToLayers(ch *chart.Chart) ([]ocispec.Descript
 		Version:    "0.1.0",
 	}
 	destDir := mkdir(filepath.Join(cache.rootDir, "blobs", ".build"))
-	tmpFile, err := chartutil.Save(ch, destDir)
+	tmpFile, err := chartutil.SaveArchive(ch, destDir)
 	defer os.Remove(tmpFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to save")


### PR DESCRIPTION
chartutil.Save has been renamed to chartutil.SaveArchive.

chartutil.Save accepts a chart and an io.Writer, wrapping the logic around serializing a chart to an io.Writer.

This allows other packages to write higher-level abstractions above chart.Save. For example, streaming a chart to a *bytes.Buffer.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
