### PR TITLE
helm 3: support writing multiple resources to the same file

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -58,6 +58,17 @@ func AssertGoldenString(t TestingT, actual, filename string) {
 	}
 }
 
+// AssertGoldenFile assers that the content of the actual file matches the contents of the expected file
+func AssertGoldenFile(t TestingT, actualFileName string, expectedFilename string) {
+	t.Helper()
+
+	actual, err := ioutil.ReadFile(actualFileName)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	AssertGoldenBytes(t, actual, expectedFilename)
+}
+
 func path(filename string) string {
 	if filepath.IsAbs(filename) {
 		return filename

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -70,6 +70,32 @@ var manifestWithTestHook = `kind: Pod
 	  cmd: fake-command
   `
 
+var rbacManifests = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: schedule-agents
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/exec", "pods/log"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: schedule-agents
+  namespace: {{ default .Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: schedule-agents
+subjects:
+- kind: ServiceAccount
+  name: schedule-agents
+  namespace: {{ .Release.Namespace }}
+`
+
 type chartOptions struct {
 	*chart.Chart
 }
@@ -121,6 +147,15 @@ func withSampleTemplates() chartOption {
 			{Name: "templates/empty", Data: []byte("")},
 			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
 			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+		}
+		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
+func withMultipleManifestTemplate() chartOption {
+	return func(opts *chartOptions) {
+		sampleTemplates := []*chart.File{
+			{Name: "templates/rbac", Data: []byte(rbacManifests)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"helm.sh/helm/internal/test"
 	"helm.sh/helm/pkg/release"
 )
 
@@ -372,7 +373,7 @@ func TestInstallReleaseOutputDir(t *testing.T) {
 
 	instAction.OutputDir = dir
 
-	_, err = instAction.Run(buildChart(withSampleTemplates()))
+	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()))
 	if err != nil {
 		t.Fatalf("Failed install: %s", err)
 	}
@@ -385,6 +386,11 @@ func TestInstallReleaseOutputDir(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dir, "hello/templates/with-partials"))
 	is.NoError(err)
+
+	_, err = os.Stat(filepath.Join(dir, "hello/templates/rbac"))
+	is.NoError(err)
+
+	test.AssertGoldenFile(t, filepath.Join(dir, "hello/templates/rbac"), "rbac.txt")
 
 	_, err = os.Stat(filepath.Join(dir, "hello/templates/empty"))
 	is.True(os.IsNotExist(err))

--- a/pkg/action/testdata/rbac.txt
+++ b/pkg/action/testdata/rbac.txt
@@ -1,0 +1,25 @@
+---
+# Source: hello/templates/rbac
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: schedule-agents
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/exec", "pods/log"]
+  verbs: ["*"]
+---
+# Source: hello/templates/rbac
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: schedule-agents
+  namespace: spaced
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: schedule-agents
+subjects:
+- kind: ServiceAccount
+  name: schedule-agents
+  namespace: spaced


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Templates can contain multiple manifests. As I made a mistake while implementing `--output-dir` option in #5762  for `helm template` only the last resource is written to that file.

This PR fixes that.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
