### PR TITLE
Revert "Change port forward command order in default note"

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -276,8 +276,8 @@ const defaultNotes = `1. Get the application URL by running these commands:
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "<CHARTNAME>.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
 {{- end }}
 `
 


### PR DESCRIPTION
`kubectl port-forward` is a perpetually running command. Once invoked, it waits for user input to exit (CTRL + C), which is why the `echo` was on the earlier line. Now when a user copies those commands and attempts to execute them, the `echo` will not be shown.

Reverts helm/helm#5898