### PR TITLE
Restoring the Release.Namespace docs

### DIFF
--- a/docs/chart_template_guide/builtin_objects.md
+++ b/docs/chart_template_guide/builtin_objects.md
@@ -8,6 +8,7 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
 
 - `Release`: This object describes the release itself. It has several objects inside of it:
   - `Release.Name`: The release name
+  - `Release.Namespace`: The namespace to be released into (if the manifest doesn’t override)
   - `Release.IsUpgrade`: This is set to `true` if the current operation is an upgrade or rollback.
   - `Release.IsInstall`: This is set to `true` if the current operation is an install.
 - `Values`: Values passed into the template from the `values.yaml` file and from user-supplied files. By default, `Values` is empty.

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -575,6 +575,7 @@ cannot be overridden. As with all values, the names are _case
 sensitive_.
 
 - `Release.Name`: The name of the release (not the chart)
+- `Release.Namespace`: The namespace the chart was released to.
 - `Release.Service`: The service that conducted the release.
 - `Release.IsUpgrade`: This is set to true if the current operation is an upgrade or rollback.
 - `Release.IsInstall`: This is set to true if the current operation is an


### PR DESCRIPTION
`Release.Namespace` was removed and then later restored (see https://github.com/helm/helm/pull/5737). When it was restored the docs were missed. This adds the docs back.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
