### PR TITLE
helm test to support new test annotation

### DIFF
--- a/cmd/helm/release_testing_run.go
+++ b/cmd/helm/release_testing_run.go
@@ -44,8 +44,8 @@ func newReleaseTestRunCmd(cfg *action.Configuration, out io.Writer) *cobra.Comma
 		Long:  releaseTestRunHelp,
 		Args:  require.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, errc := client.Run(args[0])
 			testErr := &testErr{}
+			c, errc := client.Run(args[0])
 
 			for {
 				select {

--- a/docs/examples/nginx/templates/tests/service-test.yaml
+++ b/docs/examples/nginx/templates/tests/service-test.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ template "nginx.name" . }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/test-expect-success": "true"
 spec:
   containers:
     - name: curl

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -83,7 +83,7 @@ func (r *ReleaseTesting) Run(name string) (<-chan *release.TestReleaseResponse, 
 		}
 
 		if r.Cleanup {
-			testEnv.DeleteTestPods(tSuite.TestManifests)
+			testEnv.DeleteTestPods(tSuite.Tests)
 		}
 
 		if err := r.cfg.Releases.Update(rel); err != nil {

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -208,7 +208,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (kept string, errs []err
 	}
 
 	manifests := releaseutil.SplitManifests(rel.Manifest)
-	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
+	_, files, _, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
 	if err != nil {
 		// We could instead just delete everything in no particular order.
 		// FIXME: One way to delete at this point would be to try a label-based

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -159,7 +159,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart) (*release.Rele
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "")
+	hooks, manifestDoc, notesTxt, tests, err := u.cfg.renderResources(chart, valuesToRender, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -179,6 +179,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart) (*release.Rele
 		Version:  revision,
 		Manifest: manifestDoc.String(),
 		Hooks:    hooks,
+		Tests:    tests,
 	}
 
 	if len(notesTxt) > 0 {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -31,14 +31,15 @@ const HookDeleteAnno = "helm.sh/hook-delete-policy"
 
 // Types of hooks
 const (
-	PreInstall         = "pre-install"
-	PostInstall        = "post-install"
-	PreDelete          = "pre-delete"
-	PostDelete         = "post-delete"
-	PreUpgrade         = "pre-upgrade"
-	PostUpgrade        = "post-upgrade"
-	PreRollback        = "pre-rollback"
-	PostRollback       = "post-rollback"
+	PreInstall   = "pre-install"
+	PostInstall  = "post-install"
+	PreDelete    = "pre-delete"
+	PostDelete   = "post-delete"
+	PreUpgrade   = "pre-upgrade"
+	PostUpgrade  = "post-upgrade"
+	PreRollback  = "pre-rollback"
+	PostRollback = "post-rollback"
+	//TODO: remove test hooks entirely when release helm v3.0.0-beta
 	ReleaseTestSuccess = "test-success"
 	ReleaseTestFailure = "test-failure"
 )

--- a/pkg/release/hook.go
+++ b/pkg/release/hook.go
@@ -22,14 +22,15 @@ type HookEvent string
 
 // Hook event types
 const (
-	HookPreInstall         HookEvent = "pre-install"
-	HookPostInstall        HookEvent = "post-install"
-	HookPreDelete          HookEvent = "pre-delete"
-	HookPostDelete         HookEvent = "post-delete"
-	HookPreUpgrade         HookEvent = "pre-upgrade"
-	HookPostUpgrade        HookEvent = "post-upgrade"
-	HookPreRollback        HookEvent = "pre-rollback"
-	HookPostRollback       HookEvent = "post-rollback"
+	HookPreInstall   HookEvent = "pre-install"
+	HookPostInstall  HookEvent = "post-install"
+	HookPreDelete    HookEvent = "pre-delete"
+	HookPostDelete   HookEvent = "post-delete"
+	HookPreUpgrade   HookEvent = "pre-upgrade"
+	HookPostUpgrade  HookEvent = "post-upgrade"
+	HookPreRollback  HookEvent = "pre-rollback"
+	HookPostRollback HookEvent = "post-rollback"
+	//TODO: remove depricated test hooks entirely with helm v3.0.0-beta
 	HookReleaseTestSuccess HookEvent = "release-test-success"
 	HookReleaseTestFailure HookEvent = "release-test-failure"
 )

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,6 +37,8 @@ type Release struct {
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
+	// Tests are all of the release tests declared for this release.
+	Tests []*Test `json:"tests,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/release/test.go
+++ b/pkg/release/test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+// Test defines a test object.
+type Test struct {
+	Name string `json:"name,omitempty"`
+	// Kind is the Kubernetes kind.
+	Kind string `json:"kind,omitempty"`
+	// Path is the chart-relative path to the template.
+	Path string `json:"path,omitempty"`
+	// ExpectSuccess indicates whether test should be successful or fail
+	ExpectSuccess bool `json:"expect_success,omitempty"`
+	// Manifest is the manifest contents.
+	Manifest string `json:"manifest,omitempty"`
+}

--- a/pkg/releasetesting/environment.go
+++ b/pkg/releasetesting/environment.go
@@ -110,9 +110,9 @@ func (env *Environment) streamMessage(msg string, status release.TestRunStatus) 
 }
 
 // DeleteTestPods deletes resources given in testManifests
-func (env *Environment) DeleteTestPods(testManifests []string) {
-	for _, testManifest := range testManifests {
-		err := env.KubeClient.Delete(bytes.NewBufferString(testManifest))
+func (env *Environment) DeleteTestPods(ts []*release.Test) {
+	for _, t := range ts {
+		err := env.KubeClient.Delete(bytes.NewBufferString(t.Manifest))
 		if err != nil {
 			env.streamError(err.Error())
 		}

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -54,14 +54,17 @@ type result struct {
 // TODO: Refactor this out. It's here because naming conventions were not followed through.
 // So fix the Test hook names and then remove this.
 var events = map[string]release.HookEvent{
-	hooks.PreInstall:         release.HookPreInstall,
-	hooks.PostInstall:        release.HookPostInstall,
-	hooks.PreDelete:          release.HookPreDelete,
-	hooks.PostDelete:         release.HookPostDelete,
-	hooks.PreUpgrade:         release.HookPreUpgrade,
-	hooks.PostUpgrade:        release.HookPostUpgrade,
-	hooks.PreRollback:        release.HookPreRollback,
-	hooks.PostRollback:       release.HookPostRollback,
+	hooks.PreInstall:   release.HookPreInstall,
+	hooks.PostInstall:  release.HookPostInstall,
+	hooks.PreDelete:    release.HookPreDelete,
+	hooks.PostDelete:   release.HookPostDelete,
+	hooks.PreUpgrade:   release.HookPreUpgrade,
+	hooks.PostUpgrade:  release.HookPostUpgrade,
+	hooks.PreRollback:  release.HookPreRollback,
+	hooks.PostRollback: release.HookPostRollback,
+}
+
+var DepricatedHookEvents = map[string]release.HookEvent{
 	hooks.ReleaseTestSuccess: release.HookReleaseTestSuccess,
 	hooks.ReleaseTestFailure: release.HookReleaseTestFailure,
 }
@@ -194,11 +197,17 @@ func (file *manifestFile) sort(result *result) error {
 		}
 
 		isUnknownHook := false
+		isDepricatedHook := false
 		for _, hookType := range strings.Split(hookTypes, ",") {
 			hookType = strings.ToLower(strings.TrimSpace(hookType))
 			e, ok := events[hookType]
 			if !ok {
-				isUnknownHook = true
+				_, depricated := DepricatedHookEvents[hookType]
+				if depricated {
+					isDepricatedHook = true
+				} else {
+					isUnknownHook = true
+				}
 				break
 			}
 			h.Events = append(h.Events, e)
@@ -206,6 +215,11 @@ func (file *manifestFile) sort(result *result) error {
 
 		if isUnknownHook {
 			log.Printf("info: skipping unknown hook: %q", hookTypes)
+			continue
+		}
+
+		if isDepricatedHook {
+			log.Printf("info: skipping depricated hook: %q", hookTypes)
 			continue
 		}
 

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -187,12 +187,13 @@ metadata:
 		t.Errorf("Expected 3 test manifests, got %d", len(ts))
 	}
 
-	if len(hs) != 4 {
-		t.Errorf("Expected 4 hooks, got %d", len(hs))
+	if len(hs) != 3 {
+		t.Errorf("Expected 3 hook manifests, got %d", len(hs))
 	}
 
 	for _, out := range hs {
 		found := false
+
 		for _, expect := range data {
 			if out.Path == expect.path {
 				found = true


### PR DESCRIPTION
**What this PR does / why we need it**: 
This is the first PR to implement the helm test [proposal](https://github.com/helm/community/pull/88/files) for v3.
This PR makes the following changes:
- ~tests are now fetched from `templates/tests` directory in a chart~
- tests are now identified with the following annotation: "helm.sh/test-expect-success"
- tests are no longer implemented as hooks
- removes current test hooks and add a deprecation notice. Manifests with test hooks will simply not be parsed and saved on for a release. 

**Special notes for your reviewer**:
- Test hooks should be removed entirely by the first beta release.
- A follow up PR/commit will implement `helm test cleanup` which will add the labels and annotations necessary to figure out which pods to clean up as indicated in the [proposal](https://github.com/helm/community/pull/88/files).
- The final PR for helm test will include updates to documentation and cleanup/refactor. Trying not to conflate refactor with change in functionality which is why this is the last bit.
- @bacongobbler suggested that we should update the proposal with why we're going from helm 2 test system to helm 3 test system so I will do that as well (possible blog post)
