### PR TITLE
ref(getter): introduce Options for passing in getter parameters

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -751,7 +751,7 @@ func readFile(filePath string, settings cli.EnvSettings) ([]byte, error) {
 		return ioutil.ReadFile(filePath)
 	}
 
-	getter, err := getterConstructor(filePath, "", "", "")
+	getter, err := getterConstructor(getter.WithURL(filePath))
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -156,7 +156,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 	}
 
 	// TODO add user-agent
-	g, err := getter.NewHTTPGetter(ref, "", "", "")
+	g, err := getter.NewHTTPGetter(getter.WithURL(ref))
 	if err != nil {
 		return u, nil, err
 	}
@@ -240,7 +240,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 		u = repoURL.ResolveReference(u)
 		u.RawQuery = q.Encode()
 		// TODO add user-agent
-		g, err := getter.NewHTTPGetter(rc.URL, "", "", "")
+		g, err := getter.NewHTTPGetter(getter.WithURL(rc.URL))
 		if err != nil {
 			return repoURL, nil, err
 		}

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -99,7 +99,7 @@ func TestDownload(t *testing.T) {
 		t.Fatal("No http provider found")
 	}
 
-	g, err := provider.New(srv.URL, "", "", "")
+	g, err := provider.New(getter.WithURL(srv.URL))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,11 +124,13 @@ func TestDownload(t *testing.T) {
 	defer basicAuthSrv.Close()
 
 	u, _ := url.ParseRequestURI(basicAuthSrv.URL)
-	httpgetter, err := getter.NewHTTPGetter(u.String(), "", "", "")
+	httpgetter, err := getter.NewHTTPGetter(
+		getter.WithURL(u.String()),
+		getter.WithBasicAuth("username", "password"),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	httpgetter.SetBasicAuth("username", "password")
 	got, err = httpgetter.Get(u.String())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -24,6 +24,55 @@ import (
 	"helm.sh/helm/pkg/cli"
 )
 
+// options are generic parameters to be provided to the getter during instantiation.
+//
+// Getters may or may not ignore these parameters as they are passed in.
+type options struct {
+	url       string
+	certFile  string
+	keyFile   string
+	caFile    string
+	username  string
+	password  string
+	userAgent string
+}
+
+// Option allows specifying various settings configurable by the user for overriding the defaults
+// used when performing Get operations with the Getter.
+type Option func(*options)
+
+// WithURL informs the getter the server name that will be used when fetching objects. Used in conjunction with
+// WithTLSClientConfig to set the TLSClientConfig's server name.
+func WithURL(url string) Option {
+	return func(opts *options) {
+		opts.url = url
+	}
+}
+
+// WithBasicAuth sets the request's Authorization header to use the provided credentials
+func WithBasicAuth(username, password string) Option {
+	return func(opts *options) {
+		opts.username = username
+		opts.password = password
+	}
+}
+
+// WithUserAgent sets the request's User-Agent header to use the provided agent name.
+func WithUserAgent(userAgent string) Option {
+	return func(opts *options) {
+		opts.userAgent = userAgent
+	}
+}
+
+// WithTLSClientConfig sets the client client auth with the provided credentials.
+func WithTLSClientConfig(certFile, keyFile, caFile string) Option {
+	return func(opts *options) {
+		opts.certFile = certFile
+		opts.keyFile = keyFile
+		opts.caFile = caFile
+	}
+}
+
 // Getter is an interface to support GET to the specified URL.
 type Getter interface {
 	//Get file content by url string
@@ -32,7 +81,7 @@ type Getter interface {
 
 // Constructor is the function for every getter which creates a specific instance
 // according to the configuration
-type Constructor func(URL, CertFile, KeyFile, CAFile string) (Getter, error)
+type Constructor func(options ...Option) (Getter, error)
 
 // Provider represents any getter and the schemes that it supports.
 //
@@ -69,8 +118,8 @@ func (p Providers) ByScheme(scheme string) (Constructor, error) {
 }
 
 // All finds all of the registered getters as a list of Provider instances.
-// Currently the build-in http/https getter and the discovered
-// plugins with downloader notations are collected.
+// Currently, the built-in getters and the discovered plugins with downloader
+// notations are collected.
 func All(settings cli.EnvSettings) Providers {
 	result := Providers{
 		{

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -23,7 +23,7 @@ import (
 func TestProvider(t *testing.T) {
 	p := Provider{
 		[]string{"one", "three"},
-		func(h, e, l, m string) (Getter, error) { return nil, nil },
+		func(_ ...Option) (Getter, error) { return nil, nil },
 	}
 
 	if !p.Provides("three") {
@@ -33,8 +33,8 @@ func TestProvider(t *testing.T) {
 
 func TestProviders(t *testing.T) {
 	ps := Providers{
-		{[]string{"one", "three"}, func(h, e, l, m string) (Getter, error) { return nil, nil }},
-		{[]string{"two", "four"}, func(h, e, l, m string) (Getter, error) { return nil, nil }},
+		{[]string{"one", "three"}, func(_ ...Option) (Getter, error) { return nil, nil }},
+		{[]string{"two", "four"}, func(_ ...Option) (Getter, error) { return nil, nil }},
 	}
 
 	if _, err := ps.ByScheme("one"); err != nil {

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -78,7 +78,7 @@ func TestPluginGetter(t *testing.T) {
 
 	env := hh(false)
 	pg := newPluginGetter("echo", env, "test", ".")
-	g, err := pg("test://foo/bar", "", "", "")
+	g, err := pg()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/getter/testdata/output/httpgetter-servername.txt
+++ b/pkg/getter/testdata/output/httpgetter-servername.txt
@@ -1,0 +1,1 @@
+example.com

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -84,7 +84,7 @@ func NewHTTPInstaller(source string, home helmpath.Home) (*HTTPInstaller, error)
 		return nil, err
 	}
 
-	get, err := getConstructor.New(source, "", "", "")
+	get, err := getConstructor.New(getter.WithURL(source))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -63,7 +63,10 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 	if err != nil {
 		return nil, errors.Errorf("could not find protocol handler for: %s", u.Scheme)
 	}
-	client, err := getterConstructor(cfg.URL, cfg.CertFile, cfg.KeyFile, cfg.CAFile)
+	client, err := getterConstructor(
+		getter.WithURL(cfg.URL),
+		getter.WithTLSClientConfig(cfg.CertFile, cfg.KeyFile, cfg.CAFile),
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not construct protocol handler for: %s", u.Scheme)
 	}
@@ -121,11 +124,14 @@ func (r *ChartRepository) DownloadIndexFile(cachePath string) error {
 
 	indexURL = parsedURL.String()
 	// TODO add user-agent
-	g, err := getter.NewHTTPGetter(indexURL, r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile)
+	g, err := getter.NewHTTPGetter(
+		getter.WithURL(indexURL),
+		getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile),
+		getter.WithBasicAuth(r.Config.Username, r.Config.Password),
+	)
 	if err != nil {
 		return err
 	}
-	g.SetBasicAuth(r.Config.Username, r.Config.Password)
 	resp, err := g.Get(indexURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
instead of hard-coding the parameters being passed in the constructor, we should pass in an Options struct that can be used to pass in those parameters.

Additionally, this PR allows one to set the username, password and user agent used for the HTTPGetter when being initialized. Previously, a call had to be made to SetBasicAuth and SetUserAgent.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
