### PR TITLE
ref(downloader): remove username/password fields from ChartDownloader

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -621,8 +621,6 @@ func (c *ChartPathOptions) LocateChart(name string, settings cli.EnvSettings) (s
 		Out:      os.Stdout,
 		Keyring:  c.Keyring,
 		Getters:  getter.All(settings),
-		Username: c.Username,
-		Password: c.Password,
 	}
 	if c.Verify {
 		dl.Verify = downloader.VerifyAlways

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -62,8 +62,6 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		Keyring:  p.Keyring,
 		Verify:   downloader.VerifyNever,
 		Getters:  getter.All(p.Settings),
-		Username: p.Username,
-		Password: p.Password,
 	}
 
 	if p.Verify {

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -68,10 +68,6 @@ type ChartDownloader struct {
 	HelmHome helmpath.Home
 	// Getter collection for the operation
 	Getters getter.Providers
-	// Chart repository username
-	Username string
-	// Chart repository password
-	Password string
 }
 
 // DownloadTo retrieves a chart. Depending on the settings, it may also download a provenance file.
@@ -255,15 +251,9 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, ge
 // then the repository's configured credentials are returned.
 // Else, this ChartDownloader's credentials are returned.
 func (c *ChartDownloader) getRepoCredentials(r *repo.ChartRepository) (username, password string) {
-	username = c.Username
-	password = c.Password
 	if r != nil && r.Config != nil {
-		if username == "" {
-			username = r.Config.Username
-		}
-		if password == "" {
-			password = r.Config.Password
-		}
+		username = r.Config.Username
+		password = r.Config.Password
 	}
 	return
 }

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -231,7 +231,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 
 		// Any failure to resolve/download a chart should fail:
 		// https://github.com/helm/helm/issues/1439
-		churl, username, password, err := findChartURL(dep.Name, dep.Version, dep.Repository, repos)
+		churl, err := findChartURL(dep.Name, dep.Version, dep.Repository, repos)
 		if err != nil {
 			saveError = errors.Wrapf(err, "could not find %s", churl)
 			break
@@ -243,8 +243,6 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			Keyring:  m.Keyring,
 			HelmHome: m.HelmHome,
 			Getters:  m.Getters,
-			Username: username,
-			Password: password,
 		}
 
 		if _, _, err := dl.DownloadTo(churl, "", destPath); err != nil {
@@ -467,7 +465,7 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 // repoURL is the repository to search
 //
 // If it finds a URL that is "relative", it will prepend the repoURL.
-func findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRepository) (url, username, password string, err error) {
+func findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRepository) (url string, err error) {
 	for _, cr := range repos {
 		if urlutil.Equal(repoURL, cr.Config.URL) {
 			var entry repo.ChartVersions
@@ -484,8 +482,6 @@ func findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRep
 			if err != nil {
 				return
 			}
-			username = cr.Config.Username
-			password = cr.Config.Password
 			return
 		}
 	}

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -77,18 +77,12 @@ func TestFindChartURL(t *testing.T) {
 	version := "0.1.0"
 	repoURL := "http://example.com/charts"
 
-	churl, username, password, err := findChartURL(name, version, repoURL, repos)
+	churl, err := findChartURL(name, version, repoURL, repos)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if churl != "https://kubernetes-charts.storage.googleapis.com/alpine-0.1.0.tgz" {
 		t.Errorf("Unexpected URL %q", churl)
-	}
-	if username != "" {
-		t.Errorf("Unexpected username %q", username)
-	}
-	if password != "" {
-		t.Errorf("Unexpected password %q", password)
 	}
 }
 


### PR DESCRIPTION
Looks like this was dead code from the beginning, as the username and password is read during `getRepoCredentials`. HTTPGetter code was being leaked into other structs that should not have been passed along. Instead, the caller should've been calling the HTTPGetter's `SetBasicAuth` function to pass these parameters in. #5917 provides a way to pass these parameters from the CLI when the getters are being initialized.

The tests passed, so... :man_shrugging: 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>