### PR TITLE
 ref(downloader): pass in options to ChartDownloader

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -630,8 +630,9 @@ func (c *ChartPathOptions) LocateChart(name string, settings cli.EnvSettings) (s
 		Out:      os.Stdout,
 		Keyring:  c.Keyring,
 		Getters:  getter.All(settings),
-		Username: c.Username,
-		Password: c.Password,
+		Options: []getter.Option{
+			getter.WithBasicAuth(c.Username, c.Password),
+		},
 	}
 	if c.Verify {
 		dl.Verify = downloader.VerifyAlways

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -62,8 +62,9 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		Keyring:  p.Keyring,
 		Verify:   downloader.VerifyNever,
 		Getters:  getter.All(p.Settings),
-		Username: p.Username,
-		Password: p.Password,
+		Options: []getter.Option{
+			getter.WithBasicAuth(p.Username, p.Password),
+		},
 	}
 
 	if p.Verify {

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -236,8 +236,9 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			Keyring:  m.Keyring,
 			HelmHome: m.HelmHome,
 			Getters:  m.Getters,
-			Username: username,
-			Password: password,
+			Options: []getter.Option{
+				getter.WithBasicAuth(username, password),
+			},
 		}
 
 		if _, _, err := dl.DownloadTo(churl, "", destPath); err != nil {

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -124,7 +124,7 @@ func All(settings cli.EnvSettings) Providers {
 	result := Providers{
 		{
 			Schemes: []string{"http", "https"},
-			New:     newHTTPGetter,
+			New:     NewHTTPGetter,
 		},
 	}
 	pluginDownloaders, _ := collectPlugins(settings)

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -32,17 +32,6 @@ type HTTPGetter struct {
 	opts   options
 }
 
-// SetBasicAuth sets the request's Authorization header to use the provided credentials.
-func (g *HTTPGetter) SetBasicAuth(username, password string) {
-	g.opts.username = username
-	g.opts.password = password
-}
-
-// SetUserAgent sets the request's User-Agent header to use the provided agent name.
-func (g *HTTPGetter) SetUserAgent(userAgent string) {
-	g.opts.userAgent = userAgent
-}
-
 //Get performs a Get from repo.Getter and returns the body.
 func (g *HTTPGetter) Get(href string) (*bytes.Buffer, error) {
 	return g.get(href)
@@ -79,13 +68,8 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 	return buf, err
 }
 
-// newHTTPGetter constructs a valid http/https client as Getter
-func newHTTPGetter(options ...Option) (Getter, error) {
-	return NewHTTPGetter(options...)
-}
-
-// NewHTTPGetter constructs a valid http/https client as HTTPGetter
-func NewHTTPGetter(options ...Option) (*HTTPGetter, error) {
+// NewHTTPGetter constructs a valid http/https client as a Getter
+func NewHTTPGetter(options ...Option) (Getter, error) {
 	var client HTTPGetter
 
 	for _, opt := range options {

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -28,22 +28,22 @@ import (
 )
 
 func TestHTTPGetter(t *testing.T) {
-	g, err := newHTTPGetter(WithURL("http://example.com"))
+	g, err := NewHTTPGetter(WithURL("http://example.com"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if hg, ok := g.(*HTTPGetter); !ok {
-		t.Fatal("Expected newHTTPGetter to produce an httpGetter")
+		t.Fatal("Expected NewHTTPGetter to produce an *HTTPGetter")
 	} else if hg.client != http.DefaultClient {
-		t.Fatal("Expected newHTTPGetter to return a default HTTP client.")
+		t.Fatal("Expected NewHTTPGetter to return a default HTTP client.")
 	}
 
 	// Test with SSL:
 	cd := "../../testdata"
 	join := filepath.Join
 	ca, pub, priv := join(cd, "ca.pem"), join(cd, "crt.pem"), join(cd, "key.pem")
-	g, err = newHTTPGetter(
+	g, err = NewHTTPGetter(
 		WithURL("http://example.com"),
 		WithTLSClientConfig(pub, priv, ca),
 	)
@@ -53,23 +53,28 @@ func TestHTTPGetter(t *testing.T) {
 
 	hg, ok := g.(*HTTPGetter)
 	if !ok {
-		t.Fatal("Expected newHTTPGetter to produce an httpGetter")
+		t.Fatal("Expected NewHTTPGetter to produce an *HTTPGetter")
 	}
 
 	transport, ok := hg.client.Transport.(*http.Transport)
 	if !ok {
-		t.Errorf("Expected newHTTPGetter to set up an HTTP transport")
+		t.Errorf("Expected NewHTTPGetter to set up an HTTP transport")
 	}
 
 	test.AssertGoldenString(t, transport.TLSClientConfig.ServerName, "output/httpgetter-servername.txt")
 
 	// Test other options
-	hg, err = NewHTTPGetter(
+	g, err = NewHTTPGetter(
 		WithBasicAuth("I", "Am"),
 		WithUserAgent("Groot"),
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	hg, ok = g.(*HTTPGetter)
+	if !ok {
+		t.Fatal("expected NewHTTPGetter to produce an *HTTPGetter")
 	}
 
 	if hg.opts.username != "I" {

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -40,7 +40,7 @@ func collectPlugins(settings cli.EnvSettings) (Providers, error) {
 		for _, downloader := range plugin.Metadata.Downloaders {
 			result = append(result, Provider{
 				Schemes: downloader.Protocols,
-				New: newPluginGetter(
+				New: NewPluginGetter(
 					downloader.Command,
 					settings,
 					plugin.Metadata.Name,
@@ -82,8 +82,8 @@ func (p *pluginGetter) Get(href string) (*bytes.Buffer, error) {
 	return buf, nil
 }
 
-// newPluginGetter constructs a valid plugin getter
-func newPluginGetter(command string, settings cli.EnvSettings, name, base string) Constructor {
+// NewPluginGetter constructs a valid plugin getter
+func NewPluginGetter(command string, settings cli.EnvSettings, name, base string) Constructor {
 	return func(options ...Option) (Getter, error) {
 		result := &pluginGetter{
 			command:  command,

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -77,7 +77,7 @@ func TestPluginGetter(t *testing.T) {
 	os.Setenv("HELM_HOME", "")
 
 	env := hh(false)
-	pg := newPluginGetter("echo", env, "test", ".")
+	pg := NewPluginGetter("echo", env, "test", ".")
 	g, err := pg()
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +105,7 @@ func TestPluginSubCommands(t *testing.T) {
 	os.Setenv("HELM_HOME", "")
 
 	env := hh(false)
-	pg := newPluginGetter("echo -n", env, "test", ".")
+	pg := NewPluginGetter("echo -n", env, "test", ".")
 	g, err := pg()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Built on top of #5917 and #5918.

This restores the ability to pass in parameters at runtime to the ChartDownloader, enabling users to pass in parameters like the `--username` and `--password` flags. This also adds a test case to cover that scenario, as it was previously untested.

I also had to introduce a `WithMiddleware` function to the test server. That way the tests could inject HTTP basic auth headers into the server to test this PR.

cc'ing @mattfarina, as he raised this concern in https://github.com/helm/helm/pull/5918#discussion_r295825504 which this PR addresses (and adds a test case to help confirm).