### PR TITLE
modify values-test for big-int value

### DIFF
--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -285,6 +285,7 @@ right: Null
 left: NULL
 front: ~
 back: ""
+tag: 20190612073634
 
 global:
   name: Ishmael
@@ -342,6 +343,7 @@ func TestCoalesceValues(t *testing.T) {
 		tpl    string
 		expect string
 	}{
+		{"{{.tag}}", "20190612073634"},
 		{"{{.top}}", "yup"},
 		{"{{.back}}", ""},
 		{"{{.name}}", "moby"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm render uses `yaml.Unmarshal` to read yaml files, and then we manually traverse the yaml structure to convert to `chartutil.Values` which is of type `map[string]interface{}`. So any float64 values in yaml will be stringified as is without looking at their types

This PR tries to break `TestCoalesceValues` to reproduce a issue 

**Special notes for your reviewer**:
I made this PR just to reference in the issue https://github.com/helm/helm/issues/5929. Will close this immediately

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
