### PR TITLE
Standardize OCI image config media type for helm charts

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -97,7 +97,8 @@ func (c *Client) PushChart(ref *Reference) error {
 	if err != nil {
 		return err
 	}
-	_, err = oras.Push(c.newContext(), c.resolver, ref.String(), c.cache.store, layers)
+	pushOpt := oras.WithConfig(c.cache.store.Add("", HelmChartConfigMediaType, []byte("{}")))
+	_, err = oras.Push(c.newContext(), c.resolver, ref.String(), c.cache.store, layers, pushOpt)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/constants.go
+++ b/pkg/registry/constants.go
@@ -20,6 +20,9 @@ const (
 	// HelmChartDefaultTag is the default tag used when storing a chart reference with no tag
 	HelmChartDefaultTag = "latest"
 
+	// HelmChartConfigMediaType is the reserved media type for Helm chart config
+	HelmChartConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
+
 	// HelmChartMetaMediaType is the reserved media type for Helm chart metadata
 	HelmChartMetaMediaType = "application/vnd.cncf.helm.chart.meta.v1+json"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Changes config media type from `application/vnd.oci.image.config.v1+json` to `application/vnd.cncf.helm.config.v1+json` when pushing a helm chart to a remote registry.

Related #5286 