### PR TITLE
ref(tiller): add more info when force update

### DIFF
--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -38,8 +38,10 @@ func (s *ReleaseServer) UpdateRelease(c ctx.Context, req *services.UpdateRelease
 	s.Log("preparing update for %s", req.Name)
 	currentRelease, updatedRelease, err := s.prepareUpdate(req)
 	if err != nil {
+		s.Log("failed to prepare update: %s", err)
 		if req.Force {
 			// Use the --force, Luke.
+			s.Log("performing force update for %s", req.Name)
 			return s.performUpdateForce(req)
 		}
 		return nil, err


### PR DESCRIPTION
When force update happens, tiller doesn't show detail log of the err.