### PR TITLE
feat(helm:create): allow absolute paths when specifying starter template path [dev-v3]

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -67,7 +67,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the named Helm starter scaffold")
+	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "The name or absolute path to Helm starter scaffold")
 	return cmd
 }
 
@@ -87,6 +87,10 @@ func (o *createOptions) run(out io.Writer) error {
 	if o.starter != "" {
 		// Create from the starter
 		lstarter := filepath.Join(settings.Home.Starters(), o.starter)
+		// If path is absolute, we dont want to prefix it with helm starters folder
+		if filepath.IsAbs(o.starter) {
+			lstarter = o.starter
+		}
 		return chartutil.CreateFrom(cfile, filepath.Dir(o.name), lstarter)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If starter template path is an absolute path, it shouldn't be prefixed with c.home.Starters() but rather be used as is. This way we can use templates that might not be in home directory but inside a specific project.

PR to `master` branch is #5978 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
