### PR TITLE
Replaced ghodss/yaml with sigs.k8s.io/yaml [dev-v3]

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -112,3 +112,7 @@
 [[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.4"
+
+[[constraint]]
+  name = "sigs.k8s.io/yaml"
+  version = "1.1.0"

--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -23,9 +23,9 @@ import (
 	"os"
 
 	"github.com/Masterminds/semver"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/cmd/helm/require"
 	"helm.sh/helm/pkg/getter"

--- a/cmd/helm/printer.go
+++ b/cmd/helm/printer.go
@@ -21,7 +21,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chartutil"
 	"helm.sh/helm/pkg/release"

--- a/pkg/action/get_values.go
+++ b/pkg/action/get_values.go
@@ -17,7 +17,7 @@ limitations under the License.
 package action
 
 import (
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chartutil"
 )

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -31,8 +31,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chartutil"

--- a/pkg/action/output.go
+++ b/pkg/action/output.go
@@ -1,11 +1,11 @@
 package action
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/gosuri/uitable"
+	"sigs.k8s.io/yaml"
 )
 
 // OutputFormat is a type for capturing supported output formats

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 )

--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 )

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"

--- a/pkg/chartutil/jsonschema.go
+++ b/pkg/chartutil/jsonschema.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 )

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 )

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -22,8 +22,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 )

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart/loader"
 	"helm.sh/helm/pkg/chartutil"

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	helm_env "helm.sh/helm/pkg/cli"
 )

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -25,11 +25,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/clearsign"
 	"golang.org/x/crypto/openpgp/packet"
+	"sigs.k8s.io/yaml"
 
 	hapi "helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"

--- a/pkg/releasetesting/test_suite.go
+++ b/pkg/releasetesting/test_suite.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/hooks"
 	"helm.sh/helm/pkg/release"

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chartutil"
 	"helm.sh/helm/pkg/hooks"

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chartutil"
 	"helm.sh/helm/pkg/release"

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart/loader"
 	"helm.sh/helm/pkg/getter"

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // ErrRepoOutOfDate indicates that the repository file is out of date, but

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/helmpath"
 	"helm.sh/helm/pkg/repo"

--- a/pkg/repo/repotest/server_test.go
+++ b/pkg/repo/repotest/server_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/pkg/repo"
 )

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // ErrNotList indicates that a non-list was treated as a list.

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -18,7 +18,7 @@ package strvals
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSetIndex(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR proposes a replacement of github.com/ghodss/yaml with it's forked version maintained by SIG community. The replaceable library has low-to-none support activity unlike the latter. The SIG version is marked as a permanent fork. We believe the new Helm branch (v3) could benefit from using the Kubernetes community-maintained version on a long-term run as yaml parser is a key component of Helm chart rendering engine.

This commit locks sigs.k8s.io/yaml dependency version on 1.1.0 which is backwards compatible with ghodss/yaml 1.0.0 (this statement needs a remark: strictly speaking, the change **is** breaking: see the relevant comments: https://github.com/ghodss/yaml/issues/50#issuecomment-465777941 and https://github.com/ghodss/yaml/issues/50#issuecomment-511004721, but after a deep dive, Helm and it's dependencies are believed to be backwards compatible with the change).

This change also resolves the outdated dependency version lock for ghodss/yaml (currently 1.0.0) and makes it possible to port changes from https://github.com/helm/helm/pull/6010 to dev-v3.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>

**Special notes for your reviewer**:
I was asked to port changes from https://github.com/helm/helm/pull/6010 to dev-v3. If this change makes sense, porting the fix would be a pretty trivial follow-up step.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
