### PR TITLE
Helm 3: Add sub-command support to plugin downloader

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -170,6 +170,11 @@ The defined command will be invoked with the following scheme:
 repo definition, stored in `$HELM_HOME/repository/repositories.yaml`. Downloader
 plugin is expected to dump the raw content to stdout and report errors on stderr.
 
+The downloader command also supports sub-commands or arguments, allowing you to specify
+for example `bin/mydownloader subcommand -d` in the `plugin.yaml`. This is useful
+if you want to use the same executable for the main plugin command and the downloader
+command, but with a different sub-command for each.
+
 ## Environment Variables
 
 When Helm executes a plugin, it passes the outer environment to the plugin, and

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -63,8 +64,9 @@ type pluginGetter struct {
 
 // Get runs downloader plugin command
 func (p *pluginGetter) Get(href string) (*bytes.Buffer, error) {
-	argv := []string{p.opts.certFile, p.opts.keyFile, p.opts.caFile, href}
-	prog := exec.Command(filepath.Join(p.base, p.command), argv...)
+	commands := strings.Split(p.command, " ")
+	argv := append(commands[1:], p.opts.certFile, p.opts.keyFile, p.opts.caFile, href)
+	prog := exec.Command(filepath.Join(p.base, commands[0]), argv...)
 	plugin.SetupPluginEnv(p.settings, p.name, p.base)
 	prog.Env = os.Environ()
 	buf := bytes.NewBuffer(nil)

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -94,3 +94,31 @@ func TestPluginGetter(t *testing.T) {
 		t.Errorf("Expected %q, got %q", expect, got)
 	}
 }
+
+func TestPluginSubCommands(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO: refactor this test to work on windows")
+	}
+
+	oldhh := os.Getenv("HELM_HOME")
+	defer os.Setenv("HELM_HOME", oldhh)
+	os.Setenv("HELM_HOME", "")
+
+	env := hh(false)
+	pg := newPluginGetter("echo -n", env, "test", ".")
+	g, err := pg()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := g.Get("test://foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := "   test://foo/bar"
+	got := data.String()
+	if got != expect {
+		t.Errorf("Expected %q, got %q", expect, got)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ports https://github.com/helm/helm/pull/5559 to Helm v3

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
