### PR TITLE
fix(client): Fixes a timing issue with reading client flags

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -65,14 +65,20 @@ func initKubeLogs() {
 
 func main() {
 	initKubeLogs()
-	cmd := newRootCmd(newActionConfig(false), os.Stdout, os.Args[1:])
+
+	actionConfig := new(action.Configuration)
+	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
+
+	// Initialize the rest of the actionConfig
+	initActionConfig(actionConfig, false)
+
 	if err := cmd.Execute(); err != nil {
 		logf("%+v", err)
 		os.Exit(1)
 	}
 }
 
-func newActionConfig(allNamespaces bool) *action.Configuration {
+func initActionConfig(actionConfig *action.Configuration, allNamespaces bool) {
 	kc := kube.New(kubeConfig())
 	kc.Log = logf
 
@@ -104,12 +110,10 @@ func newActionConfig(allNamespaces bool) *action.Configuration {
 		panic("Unknown driver in HELM_DRIVER: " + os.Getenv("HELM_DRIVER"))
 	}
 
-	return &action.Configuration{
-		RESTClientGetter: kubeConfig(),
-		KubeClient:       kc,
-		Releases:         store,
-		Log:              logf,
-	}
+	actionConfig.RESTClientGetter = kubeConfig()
+	actionConfig.KubeClient = kc
+	actionConfig.Releases = store
+	actionConfig.Log = logf
 }
 
 func kubeConfig() genericclioptions.RESTClientGetter {

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -64,7 +64,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if client.AllNamespaces {
-				client.SetConfiguration(newActionConfig(true))
+				initActionConfig(cfg, true)
 			}
 			client.SetStateMask()
 


### PR DESCRIPTION
This fixes an issue where the kubernetes client was being created using
command line flags before those flags had been parsed, causing the
client to always use the default values.

**What this PR does / why we need it**:

Addresses https://github.com/helm/helm/issues/5950

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
