### PR TITLE
Fix documentation to use existing chart in the stable repository

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -107,7 +107,7 @@ $HELM_HOME has been configured at /Users/awesome-user/.helm.
 
 Tiller (the Helm server side component) has been installed into your Kubernetes Cluster.
 
-$ helm install nginx --tiller-namespace tiller-world --namespace tiller-world
+$ helm install stable/lamp --tiller-namespace tiller-world --namespace tiller-world
 NAME:   wayfaring-yak
 LAST DEPLOYED: Mon Aug  7 16:00:16 2017
 NAMESPACE: tiller-world


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation currently references a chart that doesn't exist. This replaces the non-existent chart with one of the commonly used stable charts. closes #5988 
**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
