### PR TITLE
chartutil.ReadValues is forced to unmarshal numbers into json.Number refs #1707 [dev-v3]

### DIFF
--- a/pkg/chartutil/testdata/coleridge.yaml
+++ b/pkg/chartutil/testdata/coleridge.yaml
@@ -10,3 +10,4 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
+    temperature: 1234567890

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chartutil
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -105,7 +106,10 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals)
+	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
+		d.UseNumber()
+		return d
+	})
 	if len(vals) == 0 {
 		vals = Values{}
 	}

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -45,6 +45,7 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
+    temperature: 1234567890
 `
 
 	data, err := ReadValues([]byte(doc))
@@ -236,6 +237,12 @@ func matchValues(t *testing.T, data map[string]interface{}) {
 		t.Errorf(".water.water.where: %s", err)
 	} else if o != "everywhere" {
 		t.Errorf("Expected water water everywhere")
+	}
+
+	if o, err := ttpl("{{.water.water.temperature}}", data); err != nil {
+		t.Errorf(".water.water.temperature: %s", err)
+	} else if o != "1234567890" {
+		t.Errorf("Expected water water temperature: 1234567890, got: %s", o)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of https://github.com/helm/helm/pull/6010 to dev-v3 (the description below is a copy-paste from the original v2 branch PR). As https://github.com/helm/helm/pull/6016 is now merged to dev-v3, the change is reasonably trivial.

This change is an attempt to address the common problem of json number unmarshalling where any number is converted into a float64 and represented in a scientific notation on a marshall call. This behavior breaks things like: chart versions and image tags if not converted to yaml strings explicitly.

An example of this behavior: k8s failure to fetch an image tagged with a big number like: $IMAGE:20190612073634 after a few steps of yaml re-rendering turns into: $IMAGE:2.0190612073634e+13.

Example issue: #1707

This commit forces yaml parser to use JSON modifiers and explicitly enables interface{} unmarshalling instead of float64. The change introduced might be breaking so should be processed with an extra care.

Due to the fact helm mostly dals with human-produced data (charts), we have a decent level of confidence this change looses no functionality helm users rely upon (the scientific notation).

Relevant doc: https://golang.org/pkg/encoding/json/#Decoder.UseNumber

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:
This PR is coupled with https://github.com/helm/helm/pull/6010, which is still relevant (imo) for branch 2.  

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
