### PR TITLE
feat(template): introduce --validate

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -172,6 +172,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 		newReleaseTestCmd(actionConfig, out),
 		newRollbackCmd(actionConfig, out),
 		newStatusCmd(actionConfig, out),
+		newTemplateCmd(actionConfig, out),
 		newUninstallCmd(actionConfig, out),
 		newUpgradeCmd(actionConfig, out),
 
@@ -179,7 +180,6 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 		newHomeCmd(out),
 		newInitCmd(out),
 		newPluginCmd(out),
-		newTemplateCmd(out),
 		newVersionCmd(out),
 
 		// Hidden documentation generator command: 'helm docs'


### PR DESCRIPTION
This feature flag allows `helm template` to be used against a live cluster. Some charts need CRDs to be applied to the cluster before calling `helm install`. This allows users to validate their templates will render with those resources set.

For steps to test this functionality:

```
><> kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
><> kubectl create namespace cert-manager
><> kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
><> kubectl config set-context minikube --namespace=cert-manager
><> ./bin/helm template cert-manager jetstack/cert-manager --version v0.8.0
```

Observe that the chart fails to template due to missing CRDs:

```
Error: apiVersion "apiregistration.k8s.io/v1beta1" in cert-manager/charts/webhook/templates/apiservice.yaml is not available
```

Use the `--validate` flag and observe that the resources now are templated out:

```
><> ./bin/helm template cert-manager2 jetstack/cert-manager --version v0.8.0 --validate
---
# Source: cert-manager/charts/cainjector/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
[...]
```

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>