### PR TITLE
Helm 3: Use chart version as default tag when saving

### DIFF
--- a/pkg/action/chart_save.go
+++ b/pkg/action/chart_save.go
@@ -48,10 +48,9 @@ func (a *ChartSave) Run(out io.Writer, path, ref string) error {
 		return err
 	}
 
-	r, err := registry.ParseReference(ref)
+	r, err := registry.ParseReferenceWithChartDefaults(ref, ch)
 	if err != nil {
 		return err
 	}
-
 	return a.cfg.RegistryClient.SaveChart(ch, r)
 }

--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -142,7 +142,7 @@ func (cache *filesystemCache) ChartToLayers(ch *chart.Chart) ([]ocispec.Descript
 }
 
 func (cache *filesystemCache) LoadReference(ref *Reference) ([]ocispec.Descriptor, error) {
-	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tagOrDefault(ref.Tag))
+	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", ref.Tag)
 
 	// add meta layer
 	metaJSONRaw, err := getSymlinkDestContent(filepath.Join(tagDir, "meta"))
@@ -170,8 +170,7 @@ func (cache *filesystemCache) LoadReference(ref *Reference) ([]ocispec.Descripto
 }
 
 func (cache *filesystemCache) StoreReference(ref *Reference, layers []ocispec.Descriptor) (bool, error) {
-	tag := tagOrDefault(ref.Tag)
-	tagDir := mkdir(filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tag))
+	tagDir := mkdir(filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", ref.Tag))
 
 	// Retrieve just the meta and content layers
 	metaLayer, contentLayer, err := extractLayers(layers)
@@ -244,7 +243,7 @@ func (cache *filesystemCache) StoreReference(ref *Reference, layers []ocispec.De
 }
 
 func (cache *filesystemCache) DeleteReference(ref *Reference) error {
-	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", tagOrDefault(ref.Tag))
+	tagDir := filepath.Join(cache.rootDir, "refs", escape(ref.Repo), "tags", ref.Tag)
 	if _, err := os.Stat(tagDir); os.IsNotExist(err) {
 		return errors.New("ref not found")
 	}
@@ -399,14 +398,6 @@ func byteCountBinary(b int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
-}
-
-// tagOrDefault returns the tag if present, if not the default tag
-func tagOrDefault(tag string) string {
-	if tag != "" {
-		return tag
-	}
-	return HelmChartDefaultTag
 }
 
 // shortDigest returns first 7 characters of a sha256 digest

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -91,7 +91,6 @@ func (c *Client) Logout(hostname string) error {
 
 // PushChart uploads a chart to a registry
 func (c *Client) PushChart(ref *Reference) error {
-	c.setDefaultTag(ref)
 	fmt.Fprintf(c.out, "The push refers to repository [%s]\n", ref.Repo)
 	layers, err := c.cache.LoadReference(ref)
 	if err != nil {
@@ -113,7 +112,6 @@ func (c *Client) PushChart(ref *Reference) error {
 
 // PullChart downloads a chart from a registry
 func (c *Client) PullChart(ref *Reference) error {
-	c.setDefaultTag(ref)
 	fmt.Fprintf(c.out, "%s: Pulling from %s\n", ref.Tag, ref.Repo)
 	_, layers, err := oras.Pull(c.newContext(), c.resolver, ref.String(), c.cache.store, oras.WithAllowedMediaTypes(KnownMediaTypes()))
 	if err != nil {
@@ -133,7 +131,6 @@ func (c *Client) PullChart(ref *Reference) error {
 
 // SaveChart stores a copy of chart in local cache
 func (c *Client) SaveChart(ch *chart.Chart, ref *Reference) error {
-	c.setDefaultTag(ref)
 	layers, err := c.cache.ChartToLayers(ch)
 	if err != nil {
 		return err
@@ -148,7 +145,6 @@ func (c *Client) SaveChart(ch *chart.Chart, ref *Reference) error {
 
 // LoadChart retrieves a chart object by reference
 func (c *Client) LoadChart(ref *Reference) (*chart.Chart, error) {
-	c.setDefaultTag(ref)
 	layers, err := c.cache.LoadReference(ref)
 	if err != nil {
 		return nil, err
@@ -159,7 +155,6 @@ func (c *Client) LoadChart(ref *Reference) (*chart.Chart, error) {
 
 // RemoveChart deletes a locally saved chart
 func (c *Client) RemoveChart(ref *Reference) error {
-	c.setDefaultTag(ref)
 	err := c.cache.DeleteReference(ref)
 	if err != nil {
 		return err
@@ -182,13 +177,6 @@ func (c *Client) PrintChartTable() error {
 	}
 	fmt.Fprintln(c.out, table.String())
 	return nil
-}
-
-func (c *Client) setDefaultTag(ref *Reference) {
-	if ref.Tag == "" {
-		ref.Tag = HelmChartDefaultTag
-		fmt.Fprintf(c.out, "Using default tag: %s\n", HelmChartDefaultTag)
-	}
 }
 
 // disable verbose logging coming from ORAS unless debug is enabled

--- a/pkg/registry/constants.go
+++ b/pkg/registry/constants.go
@@ -17,9 +17,6 @@ limitations under the License.
 package registry // import "helm.sh/helm/pkg/registry"
 
 const (
-	// HelmChartDefaultTag is the default tag used when storing a chart reference with no tag
-	HelmChartDefaultTag = "latest"
-
 	// HelmChartConfigMediaType is the reserved media type for the Helm chart manifest config
 	HelmChartConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
 

--- a/pkg/registry/reference.go
+++ b/pkg/registry/reference.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/reference"
+
+	"helm.sh/helm/pkg/chart"
 )
 
 var (
@@ -57,6 +59,22 @@ func ParseReference(s string) (*Reference, error) {
 	}
 
 	return &ref, nil
+}
+
+// ParseReferenceWithChartDefaults converts a string to a Reference,
+// using values from a given chart as defaults
+func ParseReferenceWithChartDefaults(s string, ch *chart.Chart) (*Reference, error) {
+	ref, err := ParseReference(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no tag is present, use the chart version
+	if ref.Tag == "" {
+		ref.Tag = ch.Metadata.Version
+	}
+
+	return ref, nil
 }
 
 // setExtraFields adds the Repo and Tag fields to a Reference

--- a/pkg/registry/reference_test.go
+++ b/pkg/registry/reference_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/pkg/chart"
 )
 
-func TestReference(t *testing.T) {
+func TestParseReference(t *testing.T) {
 	is := assert.New(t)
 
 	// bad refs
@@ -86,4 +88,29 @@ func TestReference(t *testing.T) {
 	is.NoError(err)
 	is.Equal("my.host.com/my/nested/repo", ref.Repo)
 	is.Equal("1.2.3", ref.Tag)
+}
+
+func TestParseReferenceWithChartDefaults(t *testing.T) {
+	is := assert.New(t)
+
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:    "mychart",
+			Version: "1.5.0",
+		},
+	}
+
+	// If tag provided, use tag (1.2.3)
+	s := "my.host.com/my/nested/repo:1.2.3"
+	ref, err := ParseReferenceWithChartDefaults(s, ch)
+	is.NoError(err)
+	is.Equal("my.host.com/my/nested/repo", ref.Repo)
+	is.Equal("1.2.3", ref.Tag)
+
+	// If tag NOT provided, use version from chart (1.5.0)
+	s = "my.host.com/my/nested/repo"
+	ref, err = ParseReferenceWithChartDefaults(s, ch)
+	is.NoError(err)
+	is.Equal("my.host.com/my/nested/repo", ref.Repo)
+	is.Equal("1.5.0", ref.Tag)
 }


### PR DESCRIPTION
Fixes #5752 

This change essentially always enforces a tag, by using a chart's metadata version

For example:
```
$ cat harbor/Chart.yaml | grep version:
version: 1.1.1
```

```
$ bin/helm chart save harbor/ mysite.io/mylib/harbor
Name: harbor
Version: 1.1.1
Meta: sha256:5666f9e9f89e109a28af426e8947b00fbf22592b0ba79d61d460784744da6f19
Content: sha256:d75af1601a514fe2168b59069b5aec6ea4c73b7792c029adebd79407544eb13a
1.1.1: saved
```

```
$ bin/helm chart list
REF                         	NAME  	VERSION	DIGEST 	SIZE    	CREATED
mysite.io/mylib/harbor:1.1.1	harbor	1.1.1  	d75af16	28.2 KiB	3 seconds
```

cc @nphmuller @muehlburger @bacongobbler @hickeyma 