### PR TITLE
fix(engine): Fix eating too many colons during template execution

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -81,10 +81,12 @@ type renderable struct {
 	basePath string
 }
 
-var warnRegex = regexp.MustCompile(`HELM\[(.*)\]HELM`)
+const warnStartDelim = "HELM_ERR_START"
+const warnEndDelim = "HELM_ERR_END"
+var warnRegex = regexp.MustCompile(warnStartDelim + `(.*)` + warnEndDelim)
 
 func warnWrap(warn string) string {
-	return fmt.Sprintf("HELM[%s]HELM", warn)
+	return warnStartDelim + warn + warnEndDelim
 }
 
 // initFunMap creates the Engine's FuncMap and adds context-specific functions.


### PR DESCRIPTION
This fixes #6044, in which error parsing is greedily eating too many
colons, preventing users from using colons in their warning messages to
the `required` function

Signed-off-by: Ian Howell <ian.howell0@gmail.com>

**What this PR does / why we need it**:
Closes #6044 

**Special notes for your reviewer**:
I've arbitrarily decided to use the regex `HELM\[.*\]HELM`. This should probably be changed to something more unique, but works for a POC.

It should also be noted that the `parseTemplateError` has been split into two functions: one for parse errors, the other for execution errors. This lines up with the current usage of the `text/template` package.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
