### PR TITLE
Fixing link; adding AKS.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ configured to talk to a remote Kubernetes cluster.
 
 Most cloud providers enable a feature called Role-Based Access Control - RBAC for short. If your cloud provider enables this feature, you will need to create a service account for Tiller with the right roles and permissions to access resources.
 
-Check the [Kubernetes Distribution Guide](kubernetes-distribution-guide) to see if there's any further points of interest on using Helm with your cloud provider. Also check out the guide on [Tiller and Role-Based Access Control](rbac.md) for more information on how to run Tiller in an RBAC-enabled Kubernetes cluster.
+Check the [Kubernetes Distribution Guide](#kubernetes-distribution-guide) to see if there's any further points of interest on using Helm with your cloud provider. Also check out the guide on [Tiller and Role-Based Access Control](rbac.md) for more information on how to run Tiller in an RBAC-enabled Kubernetes cluster.
 
 ### Easy In-Cluster Installation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ configured to talk to a remote Kubernetes cluster.
 
 Most cloud providers enable a feature called Role-Based Access Control - RBAC for short. If your cloud provider enables this feature, you will need to create a service account for Tiller with the right roles and permissions to access resources.
 
-Check the [Kubernetes Distribution Guide](kubernetes_distros.md) to see if there's any further points of interest on using Helm with your cloud provider. Also check out the guide on [Tiller and Role-Based Access Control](rbac.md) for more information on how to run Tiller in an RBAC-enabled Kubernetes cluster.
+Check the [Kubernetes Distribution Guide](kubernetes-distribution-guide) to see if there's any further points of interest on using Helm with your cloud provider. Also check out the guide on [Tiller and Role-Based Access Control](rbac.md) for more information on how to run Tiller in an RBAC-enabled Kubernetes cluster.
 
 ### Easy In-Cluster Installation
 

--- a/docs/kubernetes_distros.md
+++ b/docs/kubernetes_distros.md
@@ -22,6 +22,10 @@ Google's GKE hosted Kubernetes platform enables RBAC by default. You will need t
 
 See [Tiller and role-based access control](https://docs.helm.sh/using_helm/#role-based-access-control) for more information.
 
+## AKS
+
+Helm works with [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm). If using an RBAC-enabled AKS cluster, you need [a service account and role binding for the Tiller service](https://helm.sh/docs/using_helm/#tiller-namespaces-and-rbac).
+
 ## Ubuntu with 'kubeadm'
 
 Kubernetes bootstrapped with `kubeadm` is known to work on the following Linux

--- a/docs/kubernetes_distros.md
+++ b/docs/kubernetes_distros.md
@@ -24,7 +24,7 @@ See [Tiller and role-based access control](https://docs.helm.sh/using_helm/#role
 
 ## AKS
 
-Helm works with [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm). If using an RBAC-enabled AKS cluster, you need [a service account and role binding for the Tiller service](https://helm.sh/docs/using_helm/#tiller-namespaces-and-rbac).
+Helm works with [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm). If using an RBAC-enabled AKS cluster, you need [a service account and role binding for the Tiller service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm#create-a-service-account).
 
 ## Ubuntu with 'kubeadm'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

AKS was missing from the list of environments where people use Helm:
https://helm.sh/docs/using_helm/#kubernetes-distribution-guide - when I went to add AKS, I noticed that the link on the installation guide which used to point to this page is now being redirected (https://github.com/helm/helm-www/blob/master/gulpfile.js#L129), which is fine, but we shouldn't have a page (https://helm.sh/docs/using_helm/) that links to itself.

**Special notes for your reviewer**:

I'm only putting this change in for v2 docs right now. I'll figure out the right place for it to go in v3, but the Tiller part won't apply there.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
