### PR TITLE
Fix a parsing issue with command line arguments

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -119,6 +119,11 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 
 	settings.AddFlags(flags)
 
+	// We can safely ignore any errors that flags.Parse encounters since
+	// those errors will be caught later during the call to cmd.Execution.
+	// This call is required to gather configuration information prior to
+	// execution.
+	flags.ParseErrorsWhitelist.UnknownFlags = true
 	flags.Parse(args)
 
 	// set defaults from environment


### PR DESCRIPTION
Prior to now, helm has been silently ignoring any errors while parsing
the root Persistent flags. This causes an issue when a global flag comes
later on the command line than a localized flag for a subcommand, in
which the value for that global flag is never set. The solution is to
simply tell the Persistent flagset to ignore any unknown flags, since a
later command will process it

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Closes #6073 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
