### PR TITLE
fix golint issues reported by make test

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -314,7 +314,14 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 	return buf.String(), nil
 }
 
-// Deprecated; use UpdateWithOptions instead
+// Update reads the current configuration and a target configuration from io.reader
+// and creates resources that don't already exist, updates resources that have been modified
+// in the target configuration and deletes resources from the current configuration that are
+// not present in the target configuration.
+//
+// Namespace will set the namespaces.
+//
+// Deprecated: use UpdateWithOptions instead.
 func (c *Client) Update(namespace string, originalReader, targetReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return c.UpdateWithOptions(namespace, originalReader, targetReader, UpdateOptions{
 		Force:      force,
@@ -334,12 +341,13 @@ type UpdateOptions struct {
 	CleanupOnFail bool
 }
 
-// UpdateWithOptions reads in the current configuration and a target configuration from io.reader
-// and creates resources that don't already exists, updates resources that have been modified
+// UpdateWithOptions reads the current configuration and a target configuration from io.reader
+// and creates resources that don't already exist, updates resources that have been modified
 // in the target configuration and deletes resources from the current configuration that are
 // not present in the target configuration.
 //
-// Namespace will set the namespaces.
+// Namespace will set the namespaces. UpdateOptions provides additional parameters to control
+// update behavior.
 func (c *Client) UpdateWithOptions(namespace string, originalReader, targetReader io.Reader, opts UpdateOptions) error {
 	original, err := c.BuildUnstructured(namespace, originalReader)
 	if err != nil {
@@ -552,7 +560,7 @@ func (c *Client) WatchUntilReady(namespace string, reader io.Reader, timeout int
 	return perform(infos, c.watchTimeout(time.Duration(timeout)*time.Second))
 }
 
-// WatchUntilCRDEstablished polls the given CRD until it reaches the established
+// WaitUntilCRDEstablished polls the given CRD until it reaches the established
 // state. A CRD needs to reach the established state before CRs can be created.
 //
 // If a naming conflict condition is found, this function will return an error.

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -558,7 +558,7 @@ func TestWaitUntilCRDEstablished(t *testing.T) {
 					} else {
 						crd = crdWithConditions
 					}
-					requestCount += 1
+					requestCount++
 					return newResponse(200, &crd)
 				}),
 			}

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -51,7 +51,7 @@ func Chartfile(linter *support.Linter) {
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartNameDirMatch(linter.ChartDir, chartFile))
 
 	// Chart metadata
-	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartApiVersion(chartFile))
+	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartAPIVersion(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartVersion(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartEngine(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartMaintainer(chartFile))
@@ -97,7 +97,7 @@ func validateChartNameDirMatch(chartDir string, cf *chart.Metadata) error {
 	return nil
 }
 
-func validateChartApiVersion(cf *chart.Metadata) error {
+func validateChartAPIVersion(cf *chart.Metadata) error {
 	if cf.ApiVersion == "" {
 		return errors.New("apiVersion is required")
 	}

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -255,6 +255,7 @@ func (p *PrintingKubeClient) WaitAndGetCompletedPodPhase(namespace string, reade
 	return v1.PodUnknown, err
 }
 
+// WaitUntilCRDEstablished implements KubeClient WaitUntilCRDEstablished.
 func (p *PrintingKubeClient) WaitUntilCRDEstablished(reader io.Reader, timeout time.Duration) error {
 	_, err := io.Copy(p.Out, reader)
 	return err


### PR DESCRIPTION
This PR fixes the following issues when I run `make test` locally.

```
pkg/lint/rules/chartfile.go:100:6:warning: func validateChartApiVersion should be validateChartAPIVersion (golint)
pkg/tiller/environment/environment.go:258:1:warning: exported method PrintingKubeClient.WaitUntilCRDEstablished should have comment or be unexported (golint)
pkg/kube/client.go:317:1:warning: comment on exported method Client.Update should be of the form "Update ..." (golint)
pkg/kube/client.go:555:1:warning: comment on exported method Client.WaitUntilCRDEstablished should be of the form "WaitUntilCRDEstablished ..." (golint)
pkg/kube/client_test.go:561:6:warning: should replace requestCount += 1 with requestCount++ (golint)

```