### PR TITLE
Fix subchart value deletion

### DIFF
--- a/pkg/chartutil/testdata/moby/charts/spouter/values.yaml
+++ b/pkg/chartutil/testdata/moby/charts/spouter/values.yaml
@@ -1,1 +1,2 @@
 scope: spouter
+foo: bar

--- a/pkg/chartutil/testdata/moby/values.yaml
+++ b/pkg/chartutil/testdata/moby/values.yaml
@@ -22,3 +22,7 @@ web:
     httpGet:
       path: /api/v1/info
       port: atc
+
+# for testing deleting default values in sub charts
+spouter:
+  foo: null

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -170,10 +170,7 @@ func CoalesceValues(chrt *chart.Chart, vals *chart.Config) (Values, error) {
 		if err != nil {
 			return cvals, err
 		}
-		cvals, err = coalesce(chrt, evals)
-		if err != nil {
-			return cvals, err
-		}
+		return coalesce(chrt, evals)
 	}
 
 	return coalesceDeps(chrt, cvals)

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -475,6 +475,33 @@ func TestCoalesceTables(t *testing.T) {
 		t.Errorf("Expected boat string, got %v", dst["boat"])
 	}
 }
+
+func TestCoalesceSubchart(t *testing.T) {
+	tchart := "testdata/moby"
+	c, err := LoadDir(tchart)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tvals := &chart.Config{}
+
+	v, err := CoalesceValues(c, tvals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, _ := json.MarshalIndent(v, "", "  ")
+	t.Logf("Coalesced Values: %s", string(j))
+
+	subchartValues, ok := v["spouter"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Subchart values not found")
+	}
+
+	if _, ok := subchartValues["foo"]; ok {
+		t.Errorf("Expected key foo to be removed, still present")
+	}
+}
+
 func TestPathValue(t *testing.T) {
 	doc := `
 title: "Moby Dick"


### PR DESCRIPTION
**What this PR does / why we need it**:
Overwriting a subchart's default value with nil in the parent chart's values.yaml should delete the value (see https://github.com/helm/helm/blob/master/docs/chart_template_guide/values_files.md#deleting-a-default-key).

closes #3804

**Special notes for your reviewer**:
This is my first PR for the helm project, so please let me know if it is missing anything.

The problem seemed to be that when called with a non-nil chart.Config argument, the chartutil.CoalesceValues function called coalesceDeps twice (once via coalesce and once directly). 
The first call removed the subchart's value as expected, but the second call then re-introduced the value, because the nil value from the parent's values is gone.
Roughly like this:
coalesceDeps(values: {subchart.value=nil}, subchart values: {value=foo}) => result: {}
coalesceDeps(values: {}, subchart values: {value=foo}) => result: {subchart.value=foo})

I added a very minimalistic unit test and re-used the moby chart and one of its subcharts for this. Not sure if this should be expanded to include more use-cases.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
