### PR TITLE
fix: Helm 3 does not respect aliased sub-chart values and condition/tags

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -131,6 +131,10 @@ func (i *Install) Run(chrt *chart.Chart) (*release.Release, error) {
 		i.cfg.Releases = storage.Init(driver.NewMemory())
 	}
 
+	if err := chartutil.ProcessDependencies(chrt, i.rawValues); err != nil {
+		return nil, err
+	}
+
 	// Make sure if Atomic is set, that wait is set as well. This makes it so
 	// the user doesn't have to specify both
 	i.Wait = i.Wait || i.Atomic


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently Helm 3.0.0-alpha.2 `helm install` has 2 issues:
1. If a sub-chart has `alias`, it does not use the sub-chart's `alias` value to import from `values.yaml`, but the sub-chart's `name`. This is reported in #6001.

2. It does not process sub-chart `condition` and `tags`. This is reported in #5780.

Upon investigation, the install action misses the `chartutil.ProcessDependencies` function that is responsible for the aforementioned functionalities. This PR adds this function call to helm install.

Closes #5780 and #6001