### PR TITLE
fix: Helm 3 "helm repo add" should use correct client to download index.yaml

### DIFF
--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -66,6 +66,7 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 	client, err := getterConstructor(
 		getter.WithURL(cfg.URL),
 		getter.WithTLSClientConfig(cfg.CertFile, cfg.KeyFile, cfg.CAFile),
+		getter.WithBasicAuth(cfg.Username, cfg.Password),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not construct protocol handler for: %s", u.Scheme)
@@ -124,15 +125,7 @@ func (r *ChartRepository) DownloadIndexFile(cachePath string) error {
 
 	indexURL = parsedURL.String()
 	// TODO add user-agent
-	g, err := getter.NewHTTPGetter(
-		getter.WithURL(indexURL),
-		getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile),
-		getter.WithBasicAuth(r.Config.Username, r.Config.Password),
-	)
-	if err != nil {
-		return err
-	}
-	resp, err := g.Get(indexURL)
+	resp, err := r.Client.Get(indexURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a regression in Helm 3 where adding a Helm repo using scheme provided by Helm plugins (for example `gs://` provided by plugin https://github.com/hayorov/helm-gcs) fails.

```
helm repo add test-gsc gs://some-gcs-bucket
Error: looks like "gs://some-gcs-bucket" is not a valid chart repository or cannot be reached: Get gs://some-gcs-bucket/index.yaml: unsupported protocol scheme "gs"
```

Closes #6089 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Signed-off-by: hd-rk <hdn314159@gmail.com>