### PR TITLE
Feat(*): Update scaffold chart to v2 apiVersion

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -81,7 +81,7 @@ func (o *createOptions) run(out io.Writer) error {
 		Type:        "application",
 		Version:     "0.1.0",
 		AppVersion:  "0.1.0",
-		APIVersion:  chart.APIVersionV1,
+		APIVersion:  chart.APIVersionV2,
 	}
 
 	if o.starter != "" {

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -55,7 +55,7 @@ func TestCreateCmd(t *testing.T) {
 	if c.Name() != cname {
 		t.Errorf("Expected %q name, got %q", cname, c.Name())
 	}
-	if c.Metadata.APIVersion != chart.APIVersionV1 {
+	if c.Metadata.APIVersion != chart.APIVersionV2 {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 }
@@ -106,7 +106,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	if c.Name() != cname {
 		t.Errorf("Expected %q name, got %q", cname, c.Name())
 	}
-	if c.Metadata.APIVersion != chart.APIVersionV1 {
+	if c.Metadata.APIVersion != chart.APIVersionV2 {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
@@ -177,7 +177,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 	if c.Name() != cname {
 		t.Errorf("Expected %q name, got %q", cname, c.Name())
 	}
-	if c.Metadata.APIVersion != chart.APIVersionV1 {
+	if c.Metadata.APIVersion != chart.APIVersionV2 {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -18,6 +18,9 @@ package chart
 // APIVersionV1 is the API version number for version 1.
 const APIVersionV1 = "v1"
 
+// APIVersionV1 is the API version number for version 2.
+const APIVersionV2 = "v2"
+
 // Chart is a helm package that contains metadata, a default config, zero or more
 // optionally parameterizable templates, and zero or more charts (dependencies).
 type Chart struct {

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -53,7 +53,7 @@ const (
 	HelpersName = "_helpers.tpl"
 )
 
-const defaultChartfile = `apiVersion: v1
+const defaultChartfile = `apiVersion: v2
 name: %s
 description: A Helm chart for Kubernetes
 


### PR DESCRIPTION
Update scaffold chart to be apiVersion v2

Partial close for: #5907 

**What this PR does / why we need it**:
There has been changes to charts in Helm v3.  The apiVersion is therefore being updated to v2 and the scaffold chart should follow suit.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
