### PR TITLE
pass username and password to pluginGetter

### DIFF
--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -154,6 +154,9 @@ func (r *ChartRepository) setCredentials() {
 	if t, ok := r.Client.(*getter.HttpGetter); ok {
 		t.SetCredentials(r.Config.Username, r.Config.Password)
 	}
+	if t, ok := r.Client.(*getter.PluginGetter); ok {
+		t.SetCredentials(r.Config.Username, r.Config.Password)
+	}
 }
 
 // Index generates an index for the chart repository and writes an index.yaml file.


### PR DESCRIPTION
**What this PR does / why we need it**:
When we're adding a new repo, we should pass username and password to pluginGetter, then our plugin can get the repo index. If we do not pass, there is no way we can add a repo by plugin.


**Special notes for your reviewer**:
close #6103 
I haven't attached testcase and docs yet, for reviewing only.




