### PR TITLE
Update example to set selector labels

### DIFF
--- a/docs/examples/nginx/templates/deployment.yaml
+++ b/docs/examples/nginx/templates/deployment.yaml
@@ -19,6 +19,10 @@ metadata:
     app.kubernetes.io/name: {{ template "nginx.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "nginx.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       {{- if .Values.podAnnotations }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the `nginx` example to be functional. Without the `selector` block configured correctly, the following error is produced

```
Error: release fuzzy-horse failed: Deployment.apps "fuzzy-horse-nginx" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/instance":"fuzzy-horse", "app.kubernetes.io/name":"nginx"}: `selector` does not match template `labels`]
```
