### PR TITLE
fix(test): Style conformance

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -83,6 +83,7 @@ type renderable struct {
 
 const warnStartDelim = "HELM_ERR_START"
 const warnEndDelim = "HELM_ERR_END"
+
 var warnRegex = regexp.MustCompile(warnStartDelim + `(.*)` + warnEndDelim)
 
 func warnWrap(warn string) string {


### PR DESCRIPTION
Fix style conformance.

**What this PR does / why we need it**:
It is a fix that allows unit tests to run on dev env.

```console
$ make test
/home/usr1/go/bin/golangci-lint run
pkg/engine/engine.go:85: File is not `goimports`-ed (goimports)
const warnEndDelim = "HELM_ERR_END"
Makefile:81: recipe for target 'test-style' failed
make: *** [test-style] Error 1
```
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
