### PR TITLE
Allow missing trailing '/' in --repo url

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -83,6 +83,7 @@ type renderable struct {
 
 const warnStartDelim = "HELM_ERR_START"
 const warnEndDelim = "HELM_ERR_END"
+
 var warnRegex = regexp.MustCompile(warnStartDelim + `(.*)` + warnEndDelim)
 
 func warnWrap(warn string) string {

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -267,5 +267,7 @@ func ResolveReferenceURL(baseURL, refURL string) (string, error) {
 		return "", errors.Wrapf(err, "failed to parse %s as URL", refURL)
 	}
 
+	// We need a trailing slash for ResolveReference to work, but make sure there isn't already one
+	parsedBaseURL.Path = strings.TrimSuffix(parsedBaseURL.Path, "/") + "/"
 	return parsedBaseURL.ResolveReference(parsedRefURL).String(), nil
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -348,6 +348,14 @@ func TestResolveReferenceURL(t *testing.T) {
 		t.Errorf("%s", chartURL)
 	}
 
+	chartURL, err = ResolveReferenceURL("http://localhost:8123/charts-with-no-trailing-slash", "nginx-0.2.0.tgz")
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if chartURL != "http://localhost:8123/charts-with-no-trailing-slash/nginx-0.2.0.tgz" {
+		t.Errorf("%s", chartURL)
+	}
+
 	chartURL, err = ResolveReferenceURL("http://localhost:8123", "https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz")
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #6113 

**Special notes for your reviewer**:
This is port of https://github.com/helm/helm/pull/4956 

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
