### PR TITLE
Change ~/.gnupg/secring.gpg to pubring

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -55,7 +55,7 @@ use `gpg --list-secret-keys` to list the keys you have.
 **Warning:**  the GnuPG v2.1 store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
 
 ```
-$ gpg --export-secret-keys >~/.gnupg/secring.gpg
+$ gpg --export-secret-keys > ~/.gnupg/pubring.gpg
 ```
 
 At this point, you should see both `mychart-0.1.0.tgz` and `mychart-0.1.0.tgz.prov`.


### PR DESCRIPTION
**What this PR does / why we need it**:
In all other places, the code and documentation refer to pubring.gpg not secring.gpg, so I assume this was a typo.

**Special notes for your reviewer**:
If it was not a typo, please explain in the text why this one is different.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility