### PR TITLE
fix(rollback): fix revision argument not being handled

### DIFF
--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -55,8 +55,13 @@ func TestRollbackCmd(t *testing.T) {
 		golden: "output/rollback-wait.txt",
 		rels:   rels,
 	}, {
-		name:      "rollback a release without revision",
-		cmd:       "rollback funny-honey",
+		name:   "rollback a release without revision",
+		cmd:    "rollback funny-honey",
+		golden: "output/rollback-no-revision.txt",
+		rels:   rels,
+	}, {
+		name:      "rollback a release without release name",
+		cmd:       "rollback",
 		golden:    "output/rollback-no-args.txt",
 		rels:      rels,
 		wantError: true,

--- a/cmd/helm/testdata/output/rollback-no-args.txt
+++ b/cmd/helm/testdata/output/rollback-no-args.txt
@@ -1,3 +1,3 @@
-Error: "helm rollback" requires 2 arguments
+Error: "helm rollback" requires at least 1 argument
 
-Usage:  helm rollback [RELEASE] [REVISION] [flags]
+Usage:  helm rollback <RELEASE> [REVISION] [flags]

--- a/cmd/helm/testdata/output/rollback-no-revision.txt
+++ b/cmd/helm/testdata/output/rollback-no-revision.txt
@@ -1,0 +1,1 @@
+Rollback was a success! Happy Helming!


### PR DESCRIPTION
The revision argument that was mandatory to `helm rollback` was being ignored. The only way to roll back to an older revision was to run `helm rollback RELEASE <insert anything here> --version REVISION`.

This change respects that argument and removes the `--version` flag, which was redundant. It also makes `helm rollback`'s revision argument optional, so that `helm rollback my-release` rolls back to the previous release, [similar to the behaviour in early iterations of Helm 2](https://github.com/helm/helm/issues/1796#issuecomment-332979043).

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
