### PR TITLE
Fix values being ignored when reusing values on upgrade

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -300,7 +300,7 @@ func (u *Upgrade) upgradeRelease(current, target *release.Release) error {
 // request values are not altered.
 func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release) error {
 	if u.ResetValues {
-		// If ResetValues is set, we comletely ignore current.Config.
+		// If ResetValues is set, we completely ignore current.Config.
 		u.cfg.Log("resetting values to the chart's original version")
 		return nil
 	}
@@ -315,7 +315,7 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release) erro
 			return errors.Wrap(err, "failed to rebuild old values")
 		}
 
-		u.rawValues = chartutil.CoalesceTables(current.Config, u.rawValues)
+		u.rawValues = chartutil.CoalesceTables(u.rawValues, current.Config)
 
 		chart.Values = oldVals
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #6112 

**Special notes for your reviewer**:
This issue occurs not just for `--set`, but it will occur for any values set using `--set` , `--values`, `--set-string`. This fix resolves all of them. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
