### PR TITLE
cmd/*,pkg/*: move ValueOptions and decouple from SDK

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -18,26 +18,20 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
-	"net/url"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/cmd/helm/require"
 	"helm.sh/helm/pkg/action"
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chart/loader"
-	"helm.sh/helm/pkg/cli"
+	"helm.sh/helm/pkg/cli/values"
 	"helm.sh/helm/pkg/downloader"
 	"helm.sh/helm/pkg/getter"
 	"helm.sh/helm/pkg/release"
-	"helm.sh/helm/pkg/strvals"
 )
 
 const installDesc = `
@@ -104,7 +98,7 @@ charts in a repository, use 'helm search'.
 
 func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	client := action.NewInstall(cfg)
-	valueOpts := &ValueOptions{}
+	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "install [NAME] [CHART]",
@@ -126,7 +120,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *ValueOptions) {
+func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an install")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during install")
 	f.BoolVar(&client.Replace, "replace", false, "re-use the given name, even if that name is already used. This is unsafe in production")
@@ -141,7 +135,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *ValueO
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }
 
-func addValueOptionsFlags(f *pflag.FlagSet, v *ValueOptions) {
+func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 	f.StringSliceVarP(&v.ValueFiles, "values", "f", []string{}, "specify values in a YAML file or a URL(can specify multiple)")
 	f.StringArrayVar(&v.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.StringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
@@ -159,7 +153,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 	f.StringVar(&c.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 }
 
-func runInstall(args []string, client *action.Install, valueOpts *ValueOptions, out io.Writer) (*release.Release, error) {
+func runInstall(args []string, client *action.Install, valueOpts *values.Options, out io.Writer) (*release.Release, error) {
 	debug("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		debug("setting version to >0.0.0-0")
@@ -231,90 +225,4 @@ func isChartInstallable(ch *chart.Chart) (bool, error) {
 		return true, nil
 	}
 	return false, errors.Errorf("%s charts are not installable", ch.Metadata.Type)
-}
-
-type ValueOptions struct {
-	ValueFiles   []string
-	StringValues []string
-	Values       []string
-}
-
-// MergeValues merges values from files specified via -f/--values and
-// directly via --set or --set-string, marshaling them to YAML
-func (v *ValueOptions) MergeValues(settings cli.EnvSettings) (map[string]interface{}, error) {
-	base := map[string]interface{}{}
-
-	// User specified a values files via -f/--values
-	for _, filePath := range v.ValueFiles {
-		currentMap := map[string]interface{}{}
-
-		bytes, err := readFile(filePath, settings)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := yaml.Unmarshal(bytes, &currentMap); err != nil {
-			return nil, errors.Wrapf(err, "failed to parse %s", filePath)
-		}
-		// Merge with the previous map
-		base = mergeMaps(base, currentMap)
-	}
-
-	// User specified a value via --set
-	for _, value := range v.Values {
-		if err := strvals.ParseInto(value, base); err != nil {
-			return nil, errors.Wrap(err, "failed parsing --set data")
-		}
-	}
-
-	// User specified a value via --set-string
-	for _, value := range v.StringValues {
-		if err := strvals.ParseIntoString(value, base); err != nil {
-			return nil, errors.Wrap(err, "failed parsing --set-string data")
-		}
-	}
-
-	return base, nil
-}
-
-func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		if v, ok := v.(map[string]interface{}); ok {
-			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
-					out[k] = mergeMaps(bv, v)
-					continue
-				}
-			}
-		}
-		out[k] = v
-	}
-	return out
-}
-
-// readFile load a file from stdin, the local directory, or a remote file with a url.
-func readFile(filePath string, settings cli.EnvSettings) ([]byte, error) {
-	if strings.TrimSpace(filePath) == "-" {
-		return ioutil.ReadAll(os.Stdin)
-	}
-	u, _ := url.Parse(filePath)
-	p := getter.All(settings)
-
-	// FIXME: maybe someone handle other protocols like ftp.
-	getterConstructor, err := p.ByScheme(u.Scheme)
-
-	if err != nil {
-		return ioutil.ReadFile(filePath)
-	}
-
-	getter, err := getterConstructor(getter.WithURL(filePath))
-	if err != nil {
-		return []byte{}, err
-	}
-	data, err := getter.Get(filePath)
-	return data.Bytes(), err
 }

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/pkg/action"
+	"helm.sh/helm/pkg/cli/values"
 )
 
 var longLintHelp = `
@@ -38,7 +39,7 @@ or recommendation, it will emit [WARNING] messages.
 
 func newLintCmd(out io.Writer) *cobra.Command {
 	client := action.NewLint()
-	valueOpts := &ValueOptions{}
+	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "lint PATH",

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -38,6 +38,7 @@ or recommendation, it will emit [WARNING] messages.
 
 func newLintCmd(out io.Writer) *cobra.Command {
 	client := action.NewLint()
+	valueOpts := &ValueOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "lint PATH",
@@ -49,10 +50,11 @@ func newLintCmd(out io.Writer) *cobra.Command {
 				paths = args
 			}
 			client.Namespace = getNamespace()
-			if err := client.ValueOptions.MergeValues(settings); err != nil {
+			vals, err := valueOpts.MergeValues(settings)
+			if err != nil {
 				return err
 			}
-			result := client.Run(paths)
+			result := client.Run(paths, vals)
 			var message strings.Builder
 			fmt.Fprintf(&message, "%d chart(s) linted, %d chart(s) failed\n", result.TotalChartsLinted, len(result.Errors))
 			for _, err := range result.Errors {
@@ -72,7 +74,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&client.Strict, "strict", false, "fail on lint warnings")
-	addValueOptionsFlags(f, &client.ValueOptions)
+	addValueOptionsFlags(f, valueOpts)
 
 	return cmd
 }

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -43,6 +43,7 @@ Versioned chart archives are used by Helm package repositories.
 
 func newPackageCmd(out io.Writer) *cobra.Command {
 	client := action.NewPackage()
+	valueOpts := &ValueOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "package [CHART_PATH] [...]",
@@ -60,7 +61,8 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 					return errors.New("--keyring is required for signing a package")
 				}
 			}
-			if err := client.ValueOptions.MergeValues(settings); err != nil {
+			vals, err := valueOpts.MergeValues(settings)
+			if err != nil {
 				return err
 			}
 
@@ -84,7 +86,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 						return err
 					}
 				}
-				p, err := client.Run(path)
+				p, err := client.Run(path, vals)
 				if err != nil {
 					return err
 				}
@@ -102,7 +104,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&client.AppVersion, "app-version", "", "set the appVersion on the chart to this version")
 	f.StringVarP(&client.Destination, "destination", "d", ".", "location to write the chart.")
 	f.BoolVarP(&client.DependencyUpdate, "dependency-update", "u", false, `update dependencies from "Chart.yaml" to dir "charts/" before packaging`)
-	addValueOptionsFlags(f, &client.ValueOptions)
+	addValueOptionsFlags(f, valueOpts)
 
 	return cmd
 }

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/pkg/action"
+	"helm.sh/helm/pkg/cli/values"
 	"helm.sh/helm/pkg/downloader"
 	"helm.sh/helm/pkg/getter"
 )
@@ -43,7 +44,7 @@ Versioned chart archives are used by Helm package repositories.
 
 func newPackageCmd(out io.Writer) *cobra.Command {
 	client := action.NewPackage()
-	valueOpts := &ValueOptions{}
+	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "package [CHART_PATH] [...]",

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -39,6 +39,7 @@ is done.
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
 	client := action.NewInstall(cfg)
+	valueOpts := &ValueOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "template [NAME] [CHART]",
@@ -50,7 +51,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.ReleaseName = "RELEASE-NAME"
 			client.Replace = true // Skip the name check
 			client.ClientOnly = !validate
-			rel, err := runInstall(args, client, out)
+			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
 				return err
 			}
@@ -60,7 +61,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	addInstallFlags(f, client)
+	addInstallFlags(f, client, valueOpts)
 	f.StringVar(&client.OutputDir, "output-dir", "", "writes the executed templates to files in output-dir instead of stdout")
 	f.BoolVar(&validate, "validate", false, "establish a connection to Kubernetes for schema validation")
 

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/cmd/helm/require"
 	"helm.sh/helm/pkg/action"
+	"helm.sh/helm/pkg/cli/values"
 )
 
 const templateDesc = `
@@ -39,7 +40,7 @@ is done.
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
 	client := action.NewInstall(cfg)
-	valueOpts := &ValueOptions{}
+	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "template [NAME] [CHART]",

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -27,6 +27,7 @@ import (
 	"helm.sh/helm/cmd/helm/require"
 	"helm.sh/helm/pkg/action"
 	"helm.sh/helm/pkg/chart/loader"
+	"helm.sh/helm/pkg/cli/values"
 	"helm.sh/helm/pkg/storage/driver"
 )
 
@@ -57,7 +58,7 @@ set for a key called 'foo', the 'newbar' value would take precedence:
 
 func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	client := action.NewUpgrade(cfg)
-	valueOpts := &ValueOptions{}
+	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "upgrade [RELEASE] [CHART]",

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -35,8 +35,6 @@ var errLintNoChart = errors.New("no chart found for linting (missing Chart.yaml)
 //
 // It provides the implementation of 'helm lint'.
 type Lint struct {
-	ValueOptions
-
 	Strict    bool
 	Namespace string
 }
@@ -53,7 +51,7 @@ func NewLint() *Lint {
 }
 
 // Run executes 'helm Lint' against the given chart.
-func (l *Lint) Run(paths []string) *LintResult {
+func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	lowestTolerance := support.ErrorSev
 	if l.Strict {
 		lowestTolerance = support.WarningSev
@@ -61,7 +59,7 @@ func (l *Lint) Run(paths []string) *LintResult {
 
 	result := &LintResult{}
 	for _, path := range paths {
-		if linter, err := lintChart(path, l.ValueOptions.rawValues, l.Namespace, l.Strict); err != nil {
+		if linter, err := lintChart(path, vals, l.Namespace, l.Strict); err != nil {
 			if err == errLintNoChart {
 				result.Errors = append(result.Errors, err)
 			}

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -36,8 +36,6 @@ import (
 //
 // It provides the implementation of 'helm package'.
 type Package struct {
-	ValueOptions
-
 	Sign             bool
 	Key              string
 	Keyring          string
@@ -53,13 +51,13 @@ func NewPackage() *Package {
 }
 
 // Run executes 'helm package' against the given chart and returns the path to the packaged chart.
-func (p *Package) Run(path string) (string, error) {
+func (p *Package) Run(path string, vals map[string]interface{}) (string, error) {
 	ch, err := loader.LoadDir(path)
 	if err != nil {
 		return "", err
 	}
 
-	combinedVals, err := chartutil.CoalesceValues(ch, p.ValueOptions.rawValues)
+	combinedVals, err := chartutil.CoalesceValues(ch, vals)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -49,9 +49,9 @@ func TestUpgradeRelease_Wait(t *testing.T) {
 	failer.WaitError = fmt.Errorf("I timed out")
 	upAction.cfg.KubeClient = failer
 	upAction.Wait = true
-	upAction.rawValues = map[string]interface{}{}
+	vals := map[string]interface{}{}
 
-	res, err := upAction.Run(rel.Name, buildChart())
+	res, err := upAction.Run(rel.Name, buildChart(), vals)
 	req.Error(err)
 	is.Contains(res.Info.Description, "I timed out")
 	is.Equal(res.Info.Status, release.StatusFailed)
@@ -74,9 +74,9 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		failer.WatchUntilReadyError = fmt.Errorf("arming key removed")
 		upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
-		upAction.rawValues = map[string]interface{}{}
+		vals := map[string]interface{}{}
 
-		res, err := upAction.Run(rel.Name, buildChart())
+		res, err := upAction.Run(rel.Name, buildChart(), vals)
 		req.Error(err)
 		is.Contains(err.Error(), "arming key removed")
 		is.Contains(err.Error(), "atomic")
@@ -99,9 +99,9 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		failer.UpdateError = fmt.Errorf("update fail")
 		upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
-		upAction.rawValues = map[string]interface{}{}
+		vals := map[string]interface{}{}
 
-		_, err := upAction.Run(rel.Name, buildChart())
+		_, err := upAction.Run(rel.Name, buildChart(), vals)
 		req.Error(err)
 		is.Contains(err.Error(), "update fail")
 		is.Contains(err.Error(), "an error occurred while rolling back the release")
@@ -141,8 +141,7 @@ func TestUpgradeRelease_ReuseValues(t *testing.T) {
 
 		upAction.ReuseValues = true
 		// setting newValues and upgrading
-		upAction.rawValues = newValues
-		res, err := upAction.Run(rel.Name, buildChart())
+		res, err := upAction.Run(rel.Name, buildChart(), newValues)
 		is.NoError(err)
 
 		// Now make sure it is actually upgraded

--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -1,0 +1,117 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
+
+	"helm.sh/helm/pkg/cli"
+	"helm.sh/helm/pkg/getter"
+	"helm.sh/helm/pkg/strvals"
+)
+
+type Options struct {
+	ValueFiles   []string
+	StringValues []string
+	Values       []string
+}
+
+// MergeValues merges values from files specified via -f/--values and
+// directly via --set or --set-string, marshaling them to YAML
+func (opts *Options) MergeValues(settings cli.EnvSettings) (map[string]interface{}, error) {
+	base := map[string]interface{}{}
+
+	// User specified a values files via -f/--values
+	for _, filePath := range opts.ValueFiles {
+		currentMap := map[string]interface{}{}
+
+		bytes, err := readFile(filePath, settings)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(bytes, &currentMap); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse %s", filePath)
+		}
+		// Merge with the previous map
+		base = mergeMaps(base, currentMap)
+	}
+
+	// User specified a value via --set
+	for _, value := range opts.Values {
+		if err := strvals.ParseInto(value, base); err != nil {
+			return nil, errors.Wrap(err, "failed parsing --set data")
+		}
+	}
+
+	// User specified a value via --set-string
+	for _, value := range opts.StringValues {
+		if err := strvals.ParseIntoString(value, base); err != nil {
+			return nil, errors.Wrap(err, "failed parsing --set-string data")
+		}
+	}
+
+	return base, nil
+}
+
+func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = mergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// readFile load a file from stdin, the local directory, or a remote file with a url.
+func readFile(filePath string, settings cli.EnvSettings) ([]byte, error) {
+	if strings.TrimSpace(filePath) == "-" {
+		return ioutil.ReadAll(os.Stdin)
+	}
+	u, _ := url.Parse(filePath)
+	p := getter.All(settings)
+
+	// FIXME: maybe someone handle other protocols like ftp.
+	getterConstructor, err := p.ByScheme(u.Scheme)
+
+	if err != nil {
+		return ioutil.ReadFile(filePath)
+	}
+
+	getter, err := getterConstructor(getter.WithURL(filePath))
+	if err != nil {
+		return []byte{}, err
+	}
+	data, err := getter.Get(filePath)
+	return data.Bytes(), err
+}

--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeValues(t *testing.T) {
+	nestedMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": map[string]string{
+			"cool": "stuff",
+		},
+	}
+	anotherNestedMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": map[string]string{
+			"cool":    "things",
+			"awesome": "stuff",
+		},
+	}
+	flatMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": "stuff",
+	}
+	anotherFlatMap := map[string]interface{}{
+		"testing": "fun",
+	}
+
+	testMap := mergeMaps(flatMap, nestedMap)
+	equal := reflect.DeepEqual(testMap, nestedMap)
+	if !equal {
+		t.Errorf("Expected a nested map to overwrite a flat value. Expected: %v, got %v", nestedMap, testMap)
+	}
+
+	testMap = mergeMaps(nestedMap, flatMap)
+	equal = reflect.DeepEqual(testMap, flatMap)
+	if !equal {
+		t.Errorf("Expected a flat value to overwrite a map. Expected: %v, got %v", flatMap, testMap)
+	}
+
+	testMap = mergeMaps(nestedMap, anotherNestedMap)
+	equal = reflect.DeepEqual(testMap, anotherNestedMap)
+	if !equal {
+		t.Errorf("Expected a nested map to overwrite another nested map. Expected: %v, got %v", anotherNestedMap, testMap)
+	}
+
+	testMap = mergeMaps(anotherFlatMap, anotherNestedMap)
+	expectedMap := map[string]interface{}{
+		"testing": "fun",
+		"foo":     "bar",
+		"baz": map[string]string{
+			"cool":    "things",
+			"awesome": "stuff",
+		},
+	}
+	equal = reflect.DeepEqual(testMap, expectedMap)
+	if !equal {
+		t.Errorf("Expected a map with different keys to merge properly with another map. Expected: %v, got %v", expectedMap, testMap)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #5827 

This PR decouples the CLI value parsing from the various Helm SDK `action` clients that require values. It:
- Updates `ValueOptions.MergeValues()` to return merged values as a `map[string]interface{}`
- Removes `ValueOptions.rawValues`
- Removes `ValueOptions` from `action.Install`, `action.Lint`, `action.Package`, and `action.Upgrade`
- Moves `ValueOptions` to `pkg/cli/values` since it is no longer used in the `action` package
- Changes `Run()` signature for `action.Install`, `action.Lint`, `action.Package`, and `action.Upgrade` to include `vals map[string]interface{}` as an input parameter.
- Removes `action.mergeValues` function, since it seems to be unused.
- Removes `action.NewValueOptions()` constructor, since `rawValues` no longer exists.
- Updates unit tests to account for changes.

**Special notes for your reviewer**:
This PR is a breaking change for existing users of the SDK (e.g. #6008)

/cc @bacongobbler 

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>
