### PR TITLE
Clarify operator docs wording

### DIFF
--- a/docs/chart_template_guide/functions_and_pipelines.md
+++ b/docs/chart_template_guide/functions_and_pipelines.md
@@ -159,7 +159,7 @@ Operators are implemented as functions that return a boolean value. To use `eq`,
 {{ end }}
 
 
-{{/* do not include the body of this if statement because unset variables evaluate to false and .Values.setVariable was negated with the not function. */}}
+{{/* include the body of this if statement when the variable .Values.anUnsetVariable is set or .values.aSetVariable is not set */}}
 {{ if or .Values.anUnsetVariable (not .Values.aSetVariable) }}
    {{ ... }}
 {{ end }}


### PR DESCRIPTION
Clarify operator docs wording

The original is explaining the negation, when the body would not be
included. Which would happen in the complement of the if expression,
ie. flipped by De Morgan's law's:

```
not (or .Values.anUnsetVariable (not .Values.aSetVariable))
==
and (not .Values.anUnsetVariable) .Values.aSetVariable
```

> unset variables evaluate to false

is equivalent to `not .Values.anUnsetVariable`.

> and

is equivalent to `and`.

> .Values.setVariable was negated with the not function

doesn't seem to match `.Values.aSetVariable`.
To me, that would be `not .Values.aSetVariable` instead.

Anyway, explaining the `if` expression as-is and not the negation is
clearer and parallels the first `if` operator.

Signed-off-by: Kevin Lau <kelau1993@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix confusing wording in docs.
**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
