### PR TITLE
fix(chartutil): Ensure nested template dir on save

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -63,25 +63,19 @@ func SaveDir(c *chart.Chart, dest string) error {
 		}
 	}
 
-	// Save templates
-	for _, f := range c.Templates {
-		n := filepath.Join(outdir, f.Name)
-		if err := ioutil.WriteFile(n, f.Data, 0755); err != nil {
-			return err
-		}
-	}
+	// Save templates and files
+	for _, o := range [][]*chart.File{c.Templates, c.Files} {
+		for _, f := range o {
+			n := filepath.Join(outdir, f.Name)
 
-	// Save files
-	for _, f := range c.Files {
-		n := filepath.Join(outdir, f.Name)
+			d := filepath.Dir(n)
+			if err := os.MkdirAll(d, 0755); err != nil {
+				return err
+			}
 
-		d := filepath.Dir(n)
-		if err := os.MkdirAll(d, 0755); err != nil {
-			return err
-		}
-
-		if err := ioutil.WriteFile(n, f.Data, 0755); err != nil {
-			return err
+			if err := ioutil.WriteFile(n, f.Data, 0755); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -83,6 +83,9 @@ func TestSaveDir(t *testing.T) {
 		Files: []*chart.File{
 			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
 		},
+		Templates: []*chart.File{
+			{Name: "templates/nested/dir/thing.yaml", Data: []byte("abc: {{ .Values.abc }}")},
+		},
 	}
 
 	if err := SaveDir(c, tmp); err != nil {
@@ -97,6 +100,11 @@ func TestSaveDir(t *testing.T) {
 	if c2.Name() != c.Name() {
 		t.Fatalf("Expected chart archive to have %q, got %q", c.Name(), c2.Name())
 	}
+
+	if len(c2.Templates) != 1 || c2.Templates[0].Name != "templates/nested/dir/thing.yaml" {
+		t.Fatal("Templates data did not match")
+	}
+
 	if len(c2.Files) != 1 || c2.Files[0].Name != "scheherazade/shahryar.txt" {
 		t.Fatal("Files data did not match")
 	}


### PR DESCRIPTION
If a templates/ dir of a chart contained a subdirectory, for example "templates/tests/test-db.yaml", an error was being thrown on export due to missing the "templates/test" directory prior to saving the template file itself.

Example chart with nested template, stable/wordpress: https://github.com/helm/charts/blob/master/stable/wordpress/templates/tests/test-mariadb-connection.yaml

This was apparently being done for chart.Files but not chart.Templates - I've combined the logic for both fields.

Fixes #5757

cc @bacongobbler 
