### PR TITLE
fix(action): return nil if no errors occurred

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -262,7 +262,9 @@ func deleteHookByPolicy(client kube.Interface, h *release.Hook, policy string) e
 			return errors.Wrapf(err, "unable to build kubernetes object for deleting hook %s", h.Path)
 		}
 		_, errs := client.Delete(resources)
-		return errors.New(joinErrors(errs))
+		if len(errs) > 0 {
+			return errors.New(joinErrors(errs))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Any time a chart had a delete hook policy defined, the chart would fail to install, even if there was no error reported.

closes #6182 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
