### PR TITLE
Helm 3 - OCI: Use alt destination for chart export etc.

### DIFF
--- a/cmd/helm/chart_export.go
+++ b/cmd/helm/chart_export.go
@@ -34,7 +34,9 @@ and check into source control if desired.
 `
 
 func newChartExportCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return &cobra.Command{
+	client := action.NewChartExport(cfg)
+
+	cmd := &cobra.Command{
 		Use:    "export [ref]",
 		Short:  "export a chart to directory",
 		Long:   chartExportDesc,
@@ -42,7 +44,12 @@ func newChartExportCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Hidden: !FeatureGateOCI.IsEnabled(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
-			return action.NewChartExport(cfg).Run(out, ref)
+			return client.Run(out, ref)
 		},
 	}
+
+	f := cmd.Flags()
+	f.StringVarP(&client.Destination, "destination", "d", ".", "location to write the chart.")
+
+	return cmd
 }

--- a/cmd/helm/chart_save.go
+++ b/cmd/helm/chart_save.go
@@ -50,7 +50,7 @@ func newChartSaveCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
-			ch, err := loader.LoadDir(path)
+			ch, err := loader.Load(path)
 			if err != nil {
 				return err
 			}

--- a/pkg/action/chart_export.go
+++ b/pkg/action/chart_export.go
@@ -19,6 +19,7 @@ package action
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"helm.sh/helm/internal/experimental/registry"
 	"helm.sh/helm/pkg/chartutil"
@@ -27,6 +28,8 @@ import (
 // ChartExport performs a chart export operation.
 type ChartExport struct {
 	cfg *Configuration
+
+	Destination string
 }
 
 // NewChartExport creates a new ChartExport object with the given configuration.
@@ -48,13 +51,13 @@ func (a *ChartExport) Run(out io.Writer, ref string) error {
 		return err
 	}
 
-	// Save the chart to local directory
-	// TODO: make destination dir configurable
-	err = chartutil.SaveDir(ch, ".")
+	// Save the chart to local destination directory
+	err = chartutil.SaveDir(ch, a.Destination)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(out, "Exported to %s/\n", ch.Metadata.Name)
+	d := filepath.Join(a.Destination, ch.Metadata.Name)
+	fmt.Fprintf(out, "Exported chart to %s/\n", d)
 	return nil
 }

--- a/pkg/gates/gates.go
+++ b/pkg/gates/gates.go
@@ -34,5 +34,5 @@ func (g Gate) IsEnabled() bool {
 }
 
 func (g Gate) Error() error {
-	return fmt.Errorf("this feature has been marked as experimental and is not enabled by default. Please set $%s in your environment to use this feature", g.String())
+	return fmt.Errorf("this feature has been marked as experimental and is not enabled by default. Please set %s=1 in your environment to use this feature", g.String())
 }

--- a/pkg/gates/gates_test.go
+++ b/pkg/gates/gates_test.go
@@ -27,13 +27,13 @@ func TestIsEnabled(t *testing.T) {
 	g := Gate(name)
 
 	if g.IsEnabled() {
-		t.Errorf("feature gate shows as available, but the environment variable $%s was not set", name)
+		t.Errorf("feature gate shows as available, but the environment variable %s was not set", name)
 	}
 
 	os.Setenv(name, "1")
 
 	if !g.IsEnabled() {
-		t.Errorf("feature gate shows as disabled, but the environment variable $%s was set", name)
+		t.Errorf("feature gate shows as disabled, but the environment variable %s was set", name)
 	}
 }
 
@@ -41,7 +41,7 @@ func TestError(t *testing.T) {
 	os.Unsetenv(name)
 	g := Gate(name)
 
-	if g.Error().Error() != "this feature has been marked as experimental and is not enabled by default. Please set $HELM_EXPERIMENTAL_FEATURE in your environment to use this feature" {
+	if g.Error().Error() != "this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_FEATURE=1 in your environment to use this feature" {
 		t.Errorf("incorrect error message. Received %s", g.Error().Error())
 	}
 }


### PR DESCRIPTION
Some small updates here related to OCI work. Still making progress on another branch to address #6068 and #6185, hoping to land pre-beta..

The adds the -d flag to "helm chart export" to save chart to different directory (was previously a TODO).

Also some other miscellaneous things:

- allow loading with "helm chart save" from both dir and tarball, using `Load()` method vs. `LoadDir()`
- Switch experimental error to `Please set HELM_EXPERIMENTAL_FEATURE=1 ... ` to be more copy-paste friendly