### PR TITLE
Add crd_install hook

### DIFF
--- a/pkg/release/hook.go
+++ b/pkg/release/hook.go
@@ -27,6 +27,7 @@ type HookEvent string
 const (
 	HookPreInstall   HookEvent = "pre-install"
 	HookPostInstall  HookEvent = "post-install"
+	HookCRDInstall   HookEvent = "crd-install"
 	HookPreDelete    HookEvent = "pre-delete"
 	HookPostDelete   HookEvent = "post-delete"
 	HookPreUpgrade   HookEvent = "pre-upgrade"

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -61,6 +61,7 @@ var events = map[string]release.HookEvent{
 	release.HookPreRollback.String():  release.HookPreRollback,
 	release.HookPostRollback.String(): release.HookPostRollback,
 	release.HookTest.String():         release.HookTest,
+	release.HookCRDInstall.String():   release.HookCRDInstall,
 	// Support test-success for backward compatibility with Helm 2 tests
 	"test-success": release.HookTest,
 }


### PR DESCRIPTION
Signed-off-by: Vibhav Bobade <vibhav.bobde@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Duplicate of https://github.com/helm/helm/pull/6207
Closed by mistake due to merge conflicts

I came accross this bug whiel working on https://github.com/helm/helm/pull/6212 #5958  as charts with the crd_install hook error out with a warning saying that `there is no such hook as crd_install`.

After checking the tiller source, this was one of the hooks present. Has this been removed by design or by mistake ?

Added hook CRD install which was missing as it was breaking backwards compatibility

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
