### PR TITLE
fix(test): restore --cleanup

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -116,7 +116,9 @@ func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.Hoo
 			return errors.Wrapf(err, "unable to build kubernetes object for deleting hook %s", h.Path)
 		}
 		_, errs := cfg.KubeClient.Delete(resources)
-		return errors.New(joinErrors(errs))
+		if len(errs) > 0 {
+			return errors.New(joinErrors(errs))
+		}
 	}
 	return nil
 }

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -66,10 +66,10 @@ func (r *ReleaseTesting) Run(name string) error {
 				if e == release.HookTest {
 					hookResource, err := r.cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest))
 					if err != nil {
-						return errors.Wrapf(err, "unable to build kubernetes object for %s hook %s", h, h.Path)
+						return errors.Wrapf(err, "unable to build kubernetes object for %v hook %s", h, h.Path)
 					}
 					if _, errs := r.cfg.KubeClient.Delete(hookResource); errs != nil {
-						return fmt.Errorf("unable to delete kubernetes object for %s hook %s: %s", h, h.Path, joinErrors(errs))
+						return fmt.Errorf("unable to delete kubernetes object for %v hook %s: %s", h, h.Path, joinErrors(errs))
 					}
 				}
 			}


### PR DESCRIPTION
#6054 removed `--cleanup`. This restores that functionality.

One thing to test would be `test-success` hooks that define a hook deletion policy, since those will now be cleaned up prior to `--cleanup`. We want to make sure Helm doesn't error out in those cases. Giving that a spin now; figured I'd PR the fix first though.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
