### PR TITLE
fix charts.md line 82 "char" to "charting";

### DIFF
--- a/docs/charts.md
+++ b/docs/charts.md
@@ -479,7 +479,7 @@ Furthermore, A is dependent on chart B that creates objects
 - replicaset "B-ReplicaSet"
 - service "B-Service"
 
-After installation/upgrade of chart A a single Helm release is created/modified. The release will
+After installation/upgrade of charting A a single Helm release is created/modified. The release will
 create/update all of the above Kubernetes objects in the following order:
 
 - A-Namespace

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -658,7 +658,7 @@ func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.P
 	// Get a versioned object
 	versionedObject, err := asVersioned(target)
 
-	// Unstructured objects, such as CRDs, may not have an not registered error
+	// Unstructured objects, such as CRDs, may not have a not registered error
 	// returned from ConvertToVersion. Anything that's unstructured should
 	// use the jsonpatch.CreateMergePatch. Strategic Merge Patch is not supported
 	// on objects like CRDs.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -50,7 +50,7 @@ func (s *Storage) Get(name string, version int32) (*rspb.Release, error) {
 
 // Create creates a new storage entry holding the release. An
 // error is returned if the storage driver failed to store the
-// release, or a release with identical an key already exists.
+// release, or a release with identical a key already exists.
 func (s *Storage) Create(rls *rspb.Release) error {
 	s.Log("creating release %q", makeKey(rls.Name, rls.Version))
 	if s.MaxHistory > 0 {


### PR DESCRIPTION
Signed-off-by: 928234269 longfei.shang@daocloud.io
fix storage.go line 53 "an key" to "a key"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes a simple typo in docs/charts.md and  pkg/storage/storage.go .
**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
