### PR TITLE
fix(registry): Updates registry to handle go 1.12.8 changes

### DIFF
--- a/pkg/action/chart_save_test.go
+++ b/pkg/action/chart_save_test.go
@@ -52,7 +52,7 @@ func TestChartSave(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err = registry.ParseReference("localhost:5000/test:0.1.0")
+	ref, err = registry.ParseReference("localhost:5000/test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Go 1.12.8 introduced some breaking fixes (see [here](https://github.com/golang/go/commit/3226f2d492963d361af9dfc6714ef141ba606713)) for a CVE. This broke the way we were doing registry reference parsing. This removes the call to the containerd libraries in favor of our own parsing and adds additional unit tests