### PR TITLE
omit deleted for release info when not set

### DIFF
--- a/cmd/helm/testdata/output/status.json
+++ b/cmd/helm/testdata/output/status.json
@@ -1,1 +1,1 @@
-{"name":"flummoxed-chickadee","info":{"first_deployed":"0001-01-01T00:00:00Z","last_deployed":"2016-01-16T00:00:00Z","deleted":"0001-01-01T00:00:00Z","status":"deployed","notes":"release notes"},"namespace":"default"}
+{"name":"flummoxed-chickadee","info":{"first_deployed":"0001-01-01T00:00:00Z","last_deployed":"2016-01-16T00:00:00Z","status":"deployed","notes":"release notes"},"namespace":"default"}

--- a/cmd/helm/testdata/output/status.yaml
+++ b/cmd/helm/testdata/output/status.yaml
@@ -1,5 +1,4 @@
 info:
-  deleted: "0001-01-01T00:00:00Z"
   first_deployed: "0001-01-01T00:00:00Z"
   last_deployed: "2016-01-16T00:00:00Z"
   resources: |

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -72,6 +72,7 @@ func TestInstallRelease(t *testing.T) {
 	is.NotEqual(len(rel.Manifest), 0)
 	is.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world")
 	is.Equal(rel.Info.Description, "Install complete")
+	is.Nil(rel.Info.Deleted)
 }
 
 func TestInstallReleaseClientOnly(t *testing.T) {

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -85,7 +85,8 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 
 	u.cfg.Log("uninstall: Deleting %s", name)
 	rel.Info.Status = release.StatusUninstalling
-	rel.Info.Deleted = time.Now()
+	deleted := time.Now()
+	rel.Info.Deleted = &deleted
 	rel.Info.Description = "Deletion in progress (or silently failed)"
 	res := &release.UninstallReleaseResponse{Release: rel}
 

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -55,6 +55,7 @@ func TestUpgradeRelease_Wait(t *testing.T) {
 	req.Error(err)
 	is.Contains(res.Info.Description, "I timed out")
 	is.Equal(res.Info.Status, release.StatusFailed)
+	is.Nil(res.Info.Deleted)
 }
 
 func TestUpgradeRelease_Atomic(t *testing.T) {

--- a/pkg/release/info.go
+++ b/pkg/release/info.go
@@ -24,7 +24,7 @@ type Info struct {
 	// LastDeployed is when the release was last deployed.
 	LastDeployed time.Time `json:"last_deployed,omitempty"`
 	// Deleted tracks when this object was deleted.
-	Deleted time.Time `json:"deleted,omitempty"`
+	Deleted *time.Time `json:"deleted,omitempty"`
 	// Description is human-friendly "log entry" about this release.
 	Description string `json:"Description,omitempty"`
 	// Status is the current state of the release


### PR DESCRIPTION
**What this PR does / why we need it**:
This bug fix omits deleted from release info when it is not set. This pull request closes #6163.

**Special notes for your reviewer**:
N/A

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Signed-off-by: Nicholas Brink <nbrink7@gmail.com>
