### PR TITLE
Clone the vals map for every path to avoid mutation

### DIFF
--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+name: multiplecharts-lint-chart-1
+version: 1
+icon: ""

--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/templates/configmap.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+metadata:
+    name: multicharttest-chart1-configmap
+data:
+    dat: |
+    {{ .Values.config | indent 4 }}

--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/values.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1/values.yaml
@@ -1,0 +1,1 @@
+config: "Test"

--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+name: multiplecharts-lint-chart-2
+version: 1
+icon: ""

--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/templates/configmap.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/templates/configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+metadata:
+    name: multicharttest-chart2-configmap
+data:
+    {{ toYaml .Values.config | indent 4 }}

--- a/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/values.yaml
+++ b/cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2/values.yaml
@@ -1,0 +1,2 @@
+config:
+    test: "Test"

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -59,15 +59,22 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 
 	result := &LintResult{}
 	for _, path := range paths {
-		if linter, err := lintChart(path, vals, l.Namespace, l.Strict); err != nil {
+		linter, err := lintChart(path, vals, l.Namespace, l.Strict)
+		if err != nil {
 			if err == errLintNoChart {
+				result.Errors = append(result.Errors, err)
+			}
+			if linter.HighestSeverity >= lowestTolerance {
 				result.Errors = append(result.Errors, err)
 			}
 		} else {
 			result.Messages = append(result.Messages, linter.Messages...)
 			result.TotalChartsLinted++
-			if linter.HighestSeverity >= lowestTolerance {
-				result.Errors = append(result.Errors, err)
+			for _, msg := range linter.Messages {
+				if msg.Severity == support.ErrorSev {
+					result.Errors = append(result.Errors, msg.Err)
+					result.Messages = append(result.Messages, msg)
+				}
 			}
 		}
 	}

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -77,6 +77,10 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 func lintChart(path string, vals map[string]interface{}, namespace string, strict bool) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
+	currentVals := make(map[string]interface{}, len(vals))
+	for key, value := range vals {
+		currentVals[key] = value
+	}
 
 	if strings.HasSuffix(path, ".tgz") {
 		tempDir, err := ioutil.TempDir("", "helm-lint")
@@ -110,5 +114,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, stric
 		return linter, errLintNoChart
 	}
 
-	return lint.All(chartPath, vals, namespace, strict), nil
+	return lint.All(chartPath, currentVals, namespace, strict), nil
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -31,6 +31,8 @@ var (
 	chartMissingManifest         = "../../cmd/helm/testdata/testcharts/chart-missing-manifest"
 	chartSchema                  = "../../cmd/helm/testdata/testcharts/chart-with-schema"
 	chartSchemaNegative          = "../../cmd/helm/testdata/testcharts/chart-with-schema-negative"
+	chart1MultipleChartLint      = "../../cmd/helm/testdata/testcharts/multiplecharts-lint-chart-1"
+	chart2MultipleChartLint      = "../../cmd/helm/testdata/testcharts/multiplecharts-lint-chart-2"
 )
 
 func TestLintChart(t *testing.T) {
@@ -55,4 +57,13 @@ func TestLintChart(t *testing.T) {
 	if _, err := lintChart(chartSchemaNegative, values, namespace, strict); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestLint_MultipleCharts(t *testing.T) {
+	testCharts := []string{chart2MultipleChartLint, chart1MultipleChartLint}
+	testLint := NewLint()
+	if result := testLint.Run(testCharts, values); len(result.Errors) == 0 {
+		t.Error(result.Errors)
+	}
+
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -62,8 +62,15 @@ func TestLintChart(t *testing.T) {
 func TestLint_MultipleCharts(t *testing.T) {
 	testCharts := []string{chart2MultipleChartLint, chart1MultipleChartLint}
 	testLint := NewLint()
-	if result := testLint.Run(testCharts, values); len(result.Errors) == 0 {
+	if result := testLint.Run(testCharts, values); len(result.Errors) > 0 {
 		t.Error(result.Errors)
 	}
+}
 
+func TestLint_EmptyResultErrors(t *testing.T) {
+	testCharts := []string{chart2MultipleChartLint}
+	testLint := NewLint()
+	if result := testLint.Run(testCharts, values); len(result.Errors) > 0 {
+		t.Error("Expected no error, got more")
+	}
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -61,9 +61,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	}
 	valuesToRender, err := chartutil.ToRenderValues(chart, cvals, options, nil)
 	if err != nil {
-		// FIXME: This seems to generate a duplicate, but I can't find where the first
-		// error is coming from.
-		//linter.RunLinterRule(support.ErrorSev, err)
+		linter.RunLinterRule(support.ErrorSev, path, err)
 		return
 	}
 	var e engine.Engine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes https://github.com/helm/helm/issues/6079 
`vals` was getting mutated when multiple charts were provided for linting.
Cloning `vals` for every `path` sees to it that every `path` has it's own unmutated set of `vals`.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
