### PR TITLE
feat: Add support for a crds/ directory

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -131,6 +131,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "run helm dependency update before installing the chart")
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used")
+	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present.")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -15,6 +15,8 @@ limitations under the License.
 
 package chart
 
+import "strings"
+
 // APIVersionV1 is the API version number for version 1.
 const APIVersionV1 = "v1"
 
@@ -100,6 +102,7 @@ func (ch *Chart) ChartFullPath() string {
 	return ch.Name()
 }
 
+// Validate validates the metadata.
 func (ch *Chart) Validate() error {
 	return ch.Metadata.Validate()
 }
@@ -110,4 +113,20 @@ func (ch *Chart) AppVersion() string {
 		return ""
 	}
 	return ch.Metadata.AppVersion
+}
+
+// CRDs returns a list of File objects in the 'crds/' directory of a Helm chart.
+func (ch *Chart) CRDs() []*File {
+	files := []*File{}
+	// Find all resources in the crds/ directory
+	for _, f := range ch.Files {
+		if strings.HasPrefix(f.Name, "crds/") {
+			files = append(files, f)
+		}
+	}
+	// Get CRDs from dependencies, too.
+	for _, dep := range ch.Dependencies() {
+		files = append(files, dep.CRDs()...)
+	}
+	return files
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package chart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCRDs(t *testing.T) {
+	chrt := Chart{
+		Files: []*File{
+			{
+				Name: "crds/foo.yaml",
+				Data: []byte("hello"),
+			},
+			{
+				Name: "bar.yaml",
+				Data: []byte("hello"),
+			},
+			{
+				Name: "crds/foo/bar/baz.yaml",
+				Data: []byte("hello"),
+			},
+			{
+				Name: "crdsfoo/bar/baz.yaml",
+				Data: []byte("hello"),
+			},
+		},
+	}
+
+	is := assert.New(t)
+	crds := chrt.CRDs()
+	is.Equal(2, len(crds))
+	is.Equal("crds/foo.yaml", crds[0].Name)
+	is.Equal("crds/foo/bar/baz.yaml", crds[1].Name)
+}

--- a/pkg/chart/metadata.go
+++ b/pkg/chart/metadata.go
@@ -64,6 +64,7 @@ type Metadata struct {
 	Type string `json:"type,omitempty"`
 }
 
+// Validate checks the metadata for known issues, returning an error if metadata is not correct
 func (md *Metadata) Validate() error {
 	if md == nil {
 		return ValidationError("chart.metadata is required")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: This PR adds support for a `crds/` directory into which you may put your CRDs without fear.

Closes #587

This PR adds support for a `crds/` directory in a chart. During chart _install_ (and ONLY during install), it reads the contents of that directory and attempts to install those files before it renders the rest of the chart.

In a sense, it is a pre-install. It provides a way to add CRDs before the rest of the chart so that things that need CRDs can install them before instances of those CRDs can be created by the chart.

If a CRD is already found in the cluster, Helm will skip installing that CRD and will log this to the debug log. It will neither error out nor see if there are any differences between its version and the existing version.

This behavior can be turned off with `--skip-crds`.

Things this feature does NOT do:

- CRDs are NOT deleted with the chart. Automatic deletion of CRDs is a serious no-no, as deleting CRDs is a cluster-wide operation that deletes every single instance of that CRD. Operators must delete CRDs themselves if they want them to go away.
- CRDs are not upgraded during `helm install` or `helm upgrade`. There is no accepted practice for managing CRD upgrades (again, because they are a global resources, and an upgrade can break things in interesting ways), so we decided not to handle this case. It is up to the operator.
- It does not output CRDs as part of `helm template` or `helm OP --dry-run`. We could add this in the future, or add a separate command for printing CRDs. For example, we could create a `helm crd some_chart` may print the CRDs for that chart. *Feedback welcome.*
- CRDs are currently NOT templated. The reason for this is that we would have to run the template engine twice, but the template context would be different for each. So for our first pass, we are seeing if we can avoid using templates in CRDs. In evaluating public usage of CRDs, we believe this should be just fine.
- The `crd-install` hook is still NOT added back to Helm 3. This is an alternative that we believe is much more robust and safe. (I was the author of `crd-install`, and I am very dissatisfied with it.)

## To Get Started

1. Create a new chart
2. Add a directory in adjacent to `templates/` and `charts/` named `crds/`.
3. Create a YAML or JSON file there whose contents are a single CRD.
4. Add resources in `templates/` that use those CRDs
5. `helm install test-crds $YOURNEWCHART`
6. Profit

You should see your CRDs with `kubectl get crds`. The chart should succeed even if it references those CRDs.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
