### PR TITLE
v2: Dynamic completion for "helm repo" and "helm plugin"

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -111,7 +111,7 @@ __helm_custom_func()
             __helm_list_releases
             return
             ;;
-        helm_repo_remove)
+        helm_repo_remove | helm_repo_update)
             __helm_list_repos
             return
             ;;

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -80,7 +80,6 @@ __helm_list_releases()
     fi
 }
 
-
 __helm_list_repos()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
@@ -88,6 +87,17 @@ __helm_list_repos()
     oflags=$(__helm_override_flags)
     __helm_debug "${FUNCNAME[0]}: __helm_override_flags are ${oflags}"
     if out=$(helm repo list ${oflags} | tail +2 | cut -f1 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
+    fi
+}
+
+__helm_list_plugins()
+{
+    __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    local out oflags
+    oflags=$(__helm_override_flags)
+    __helm_debug "${FUNCNAME[0]}: __helm_override_flags are ${oflags}"
+    if out=$(helm plugin list ${oflags} | tail +2 | cut -f1 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -100,9 +110,13 @@ __helm_custom_func()
         helm_upgrade | helm_rollback | helm_get_*)
             __helm_list_releases
             return
-			;;
+            ;;
         helm_repo_remove)
             __helm_list_repos
+            return
+            ;;
+        helm_plugin_remove | helm_plugin_update)
+            __helm_list_plugins
             return
             ;;
         *)

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	bashCompletionFunc = `
-__helm_override_flag_list=(--kubeconfig --kube-context --host --tiller-namespace)
+__helm_override_flag_list=(--kubeconfig --kube-context --host --tiller-namespace --home)
 __helm_override_flags()
 {
     local ${__helm_override_flag_list[*]##*-} two_word_of of var
@@ -80,6 +80,18 @@ __helm_list_releases()
     fi
 }
 
+
+__helm_list_repos()
+{
+    __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    local out oflags
+    oflags=$(__helm_override_flags)
+    __helm_debug "${FUNCNAME[0]}: __helm_override_flags are ${oflags}"
+    if out=$(helm repo list ${oflags} | tail +2 | cut -f1 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
+    fi
+}
+
 __helm_custom_func()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[@] is ${words[@]}"
@@ -87,6 +99,10 @@ __helm_custom_func()
         helm_delete | helm_history | helm_status | helm_test |\
         helm_upgrade | helm_rollback | helm_get_*)
             __helm_list_releases
+            return
+			;;
+        helm_repo_remove)
+            __helm_list_repos
             return
             ;;
         *)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds dynamic shell completion for the commands:
- helm repo remove \<TAB\> (which will select from the names of configured repos)
- helm repo update \<TAB\> (which will select from the names of configured repos)
- helm plugin remove \<TAB\> (which will select from the names of installed plugins)
- helm plugin update \<TAB\> (which will select from the names of installed plugins)