### PR TITLE
Networkpolicy kind sort

### DIFF
--- a/pkg/tiller/kind_sorter.go
+++ b/pkg/tiller/kind_sorter.go
@@ -28,6 +28,7 @@ type SortOrder []string
 // Those occurring earlier in the list get installed before those occurring later in the list.
 var InstallOrder SortOrder = []string{
 	"Namespace",
+	"NetworkPolicy",
 	"ResourceQuota",
 	"LimitRange",
 	"PodSecurityPolicy",
@@ -96,6 +97,7 @@ var UninstallOrder SortOrder = []string{
 	"PodSecurityPolicy",
 	"LimitRange",
 	"ResourceQuota",
+	"NetworkPolicy",
 	"Namespace",
 }
 

--- a/pkg/tiller/kind_sorter_test.go
+++ b/pkg/tiller/kind_sorter_test.go
@@ -157,6 +157,10 @@ func TestKindSorter(t *testing.T) {
 			Name: "x",
 			Head: &util.SimpleHead{Kind: "HorizontalPodAutoscaler"},
 		},
+		{
+			Name: "B",
+			Head: &util.SimpleHead{Kind: "NetworkPolicy"},
+		},
 	}
 
 	for _, test := range []struct {
@@ -164,8 +168,8 @@ func TestKindSorter(t *testing.T) {
 		order       SortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "abc3zde1fgh2iIjJkKlLmnopqrxstuvw!"},
-		{"uninstall", UninstallOrder, "wvmutsxrqponLlKkJjIi2hgf1edz3cba!"},
+		{"install", InstallOrder, "aBbc3zde1fgh2iIjJkKlLmnopqrxstuvw!"},
+		{"uninstall", UninstallOrder, "wvmutsxrqponLlKkJjIi2hgf1edz3cbBa!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
closes helm#4199

**What this PR does / why we need it**:

This PR add NetworkPolicy in tiller kind sorter, without that, NetworkPolicy is created before Namespace and the helm install fail.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
