### PR TITLE
fixes resetting os env after test run

### DIFF
--- a/pkg/helm/environment/environment_test.go
+++ b/pkg/helm/environment/environment_test.go
@@ -106,8 +106,8 @@ func TestEnvSettings(t *testing.T) {
 		"HELM_TLS_ENABLE":   "",
 	}
 
-	resetEnv(allEnvvars)
-	defer resetEnv(allEnvvars)
+	reset := resetEnv(allEnvvars)
+	defer reset()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

**What this PR does / why we need it**:
The `resetEnv` captured the os env and returned a function to restore them.   It is assumed that the defer function to restore the os env but it needed to invoke the function returned by reset.
This will maintain the end users env.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
