### PR TITLE
Experimental content trust verification using TUF

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -156,6 +156,17 @@
   revision = "577dee27f20dd8f1a529f82210094af593be12bd"
 
 [[projects]]
+  branch = "master"
+  digest = "1:7996950d6e7d367ff77af55a45a5f59aba0d15ecd4ae74697b1bda8e9f2e66ab"
+  name = "github.com/agl/ed25519"
+  packages = [
+    ".",
+    "edwards25519",
+  ]
+  pruneopts = "T"
+  revision = "5312a61534124124185d41f09206b9fef1d88403"
+
+[[projects]]
   digest = "1:297a3c21bf1d3b4695a222e43e982bb52b4b9e156ca2eadbe32b898d0a1ae551"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
@@ -391,6 +402,14 @@
   pruneopts = "T"
   revision = "5241b46610f2491efdf9d1c85f1ddf5b02f6d962"
   version = "v0.6.1"
+
+[[projects]]
+  digest = "1:78d55c8a6d82624d6518995a14e872265166e4bca8b53f92c970740664571638"
+  name = "github.com/docker/go"
+  packages = ["canonical/json"]
+  pruneopts = "T"
+  revision = "62e5ec7cf43f795986ec658df7cb317255772993"
+  version = "v1.5.1-1"
 
 [[projects]]
   digest = "1:b64eea95d41af3792092af9c951efcd2d8d8bfd2335c851f7afaf54d6be12c66"
@@ -784,6 +803,14 @@
   revision = "0d29b283ac0f967dd3a02739bf26a22702210d7a"
 
 [[projects]]
+  digest = "1:99baec2d9e1a471dd5f9196447a2cf46202111456deaf34834967ab644dd91fb"
+  name = "github.com/miekg/pkcs11"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "210dc1e16747c5ba98a03bcbcf728c38086ea357"
+  version = "v1.0.3"
+
+[[projects]]
   digest = "1:abf08734a6527df70ed361d7c369fb580e6840d8f7a6012e5f609fdfd93b4e48"
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
@@ -960,6 +987,29 @@
   pruneopts = "T"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
+
+[[projects]]
+  digest = "1:d30c1fb06a1564b78447922a70b18026612ef4a56dc50ab63333e060fd81a666"
+  name = "github.com/theupdateframework/notary"
+  packages = [
+    ".",
+    "client",
+    "client/changelist",
+    "cryptoservice",
+    "passphrase",
+    "storage",
+    "trustmanager",
+    "trustmanager/yubikey",
+    "trustpinning",
+    "tuf",
+    "tuf/data",
+    "tuf/signed",
+    "tuf/utils",
+    "tuf/validation",
+  ]
+  pruneopts = "T"
+  revision = "d6e1431feb32348e0650bf7551ac5cffd01d857b"
+  version = "v0.6.1"
 
 [[projects]]
   branch = "master"
@@ -1821,23 +1871,26 @@
     "github.com/asaskevich/govalidator",
     "github.com/containerd/containerd/content",
     "github.com/containerd/containerd/errdefs",
-    "github.com/containerd/containerd/reference",
     "github.com/containerd/containerd/remotes",
     "github.com/deislabs/oras/pkg/auth",
     "github.com/deislabs/oras/pkg/auth/docker",
     "github.com/deislabs/oras/pkg/content",
     "github.com/deislabs/oras/pkg/context",
     "github.com/deislabs/oras/pkg/oras",
+    "github.com/docker/cli/cli/config",
+    "github.com/docker/cli/cli/config/types",
     "github.com/docker/distribution/configuration",
     "github.com/docker/distribution/registry",
     "github.com/docker/distribution/registry/auth/htpasswd",
+    "github.com/docker/distribution/registry/client/auth",
+    "github.com/docker/distribution/registry/client/auth/challenge",
+    "github.com/docker/distribution/registry/client/transport",
     "github.com/docker/distribution/registry/storage/driver/inmemory",
     "github.com/docker/docker/pkg/term",
     "github.com/docker/go-units",
     "github.com/evanphx/json-patch",
     "github.com/gobwas/glob",
     "github.com/gosuri/uitable",
-    "github.com/gosuri/uitable/util/strutil",
     "github.com/mattn/go-shellwords",
     "github.com/opencontainers/go-digest",
     "github.com/opencontainers/image-spec/specs-go",
@@ -1850,6 +1903,13 @@
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
+    "github.com/theupdateframework/notary",
+    "github.com/theupdateframework/notary/client",
+    "github.com/theupdateframework/notary/cryptoservice",
+    "github.com/theupdateframework/notary/passphrase",
+    "github.com/theupdateframework/notary/trustmanager",
+    "github.com/theupdateframework/notary/tuf/data",
+    "github.com/theupdateframework/notary/tuf/utils",
     "github.com/xeipuuv/gojsonschema",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/crypto/openpgp",

--- a/cmd/helm/chart_pull.go
+++ b/cmd/helm/chart_pull.go
@@ -17,12 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
+	"path/filepath"
+
+	"helm.sh/helm/internal/experimental/registry"
 
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/cmd/helm/require"
+	"helm.sh/helm/internal/experimental/tuf"
 	"helm.sh/helm/pkg/action"
+	"helm.sh/helm/pkg/helmpath"
 )
 
 const chartPullDesc = `
@@ -32,7 +38,8 @@ This will store the chart in the local registry cache to be used later.
 `
 
 func newChartPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return &cobra.Command{
+	opts := &signOpts{}
+	cmd := &cobra.Command{
 		Use:    "pull [ref]",
 		Short:  "pull a chart from remote",
 		Long:   chartPullDesc,
@@ -40,7 +47,47 @@ func newChartPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Hidden: !FeatureGateOCI.IsEnabled(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
-			return action.NewChartPull(cfg).Run(out, ref)
+			err := action.NewChartPull(cfg).Run(out, ref)
+			if err != nil {
+				return err
+			}
+
+			if opts.signature {
+				sha, err := tuf.GetSHA(opts.trustDir, opts.trustServer, ref, opts.tlscacert, opts.rootkey)
+				if err != nil {
+					return err
+				}
+
+				r, err := registry.ParseReference(ref)
+				if err != nil {
+					return err
+				}
+
+				c, err := registry.NewCache(
+					registry.CacheOptWriter(out),
+					registry.CacheOptRoot(filepath.Join(helmpath.Registry(), registry.CacheRootDir)))
+
+				cs, err := c.FetchReference(r)
+				if err != nil {
+					return err
+				}
+
+				if cs.Digest.Hex() != sha {
+					fmt.Fprintf(out, "digests do not match: %v and %v", cs.Digest.Hex(), sha)
+					_, err = c.DeleteReference(r)
+					return err
+				}
+			}
+			return nil
 		},
 	}
+
+	td := filepath.Join(helmpath.Registry(), "trust")
+	cmd.Flags().StringVarP(&opts.trustDir, "trustdir", "", td, "Directory where the trust data is persisted to")
+	cmd.Flags().StringVarP(&opts.trustServer, "server", "", "", "The trust server to use")
+	cmd.Flags().StringVarP(&opts.tlscacert, "tlscacert", "", "", "Trust certs signed only by this CA")
+	cmd.Flags().StringVarP(&opts.rootkey, "rootkey", "", "", "Root key to initialize the repository with")
+	cmd.Flags().BoolVarP(&opts.signature, "signature", "", false, "Root key to initialize the repository with")
+
+	return cmd
 }

--- a/internal/experimental/tuf/helpers.go
+++ b/internal/experimental/tuf/helpers.go
@@ -1,0 +1,261 @@
+// Most of the helper functions are adapted from github.com/theupdateframework/notary
+//
+// Figure out the proper way of making sure we are respecting the licensing from Notary
+// While we are also vendoring Notary directly (see LICENSE in vendor/github.com/theupdateframework/notary/LICENSE),
+// copying unexported functions could fall under different licensing, so we need to make sure.
+
+package tuf
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/auth/challenge"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/cryptoservice"
+	"github.com/theupdateframework/notary/passphrase"
+	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/tuf/utils"
+)
+
+const (
+	configFileDir      = ".docker"
+	defaultIndexServer = "https://index.docker.io/v1/"
+)
+
+func makeTransport(server, gun, tlsCaCert string) (http.RoundTripper, error) {
+	modifiers := []transport.RequestModifier{
+		transport.NewHeaderRequestModifier(http.Header{
+			"User-Agent": []string{"signy"},
+		}),
+	}
+
+	base := http.DefaultTransport
+	if tlsCaCert != "" {
+		caCert, err := ioutil.ReadFile(tlsCaCert)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read cert file: %v", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		base = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		}
+	}
+
+	authTransport := transport.NewTransport(base, modifiers...)
+	pingClient := &http.Client{
+		Transport: authTransport,
+		Timeout:   5 * time.Second,
+	}
+	req, err := http.NewRequest("GET", server+"/v2/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create HTTP request: %v", err)
+	}
+
+	challengeManager := challenge.NewSimpleManager()
+	resp, err := pingClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get response from ping client: %v", err)
+	}
+	defer resp.Body.Close()
+	if err := challengeManager.AddResponse(resp); err != nil {
+		return nil, fmt.Errorf("cannot add response to challenge manager: %v", err)
+	}
+
+	defaultAuth, err := getDefaultAuth()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get default credentials: %v", err)
+	}
+
+	creds := simpleCredentialStore{auth: defaultAuth}
+	tokenHandler := auth.NewTokenHandler(base, creds, gun, "push", "pull")
+	modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler))
+
+	return transport.NewTransport(base, modifiers...), nil
+}
+
+// ensureTrustDir ensures the trust directory exists
+func ensureTrustDir(trustDir string) error {
+	return os.MkdirAll(trustDir, 0700)
+}
+
+// clearChangelist clears the notary staging changelist
+func clearChangeList(notaryRepo client.Repository) error {
+	cl, err := notaryRepo.GetChangelist()
+	if err != nil {
+		return err
+	}
+	return cl.Clear("")
+}
+
+// importRootKey imports the root key from path then adds the key to repo
+// returns key ids
+func importRootKey(rootKey string, nRepo client.Repository, retriever notary.PassRetriever) ([]string, error) {
+	var rootKeyList []string
+
+	if rootKey != "" {
+		privKey, err := readKey(data.CanonicalRootRole, rootKey, retriever)
+		if err != nil {
+			return nil, err
+		}
+		// add root key to repo
+		err = nRepo.GetCryptoService().AddKey(data.CanonicalRootRole, "", privKey)
+		if err != nil {
+			return nil, fmt.Errorf("Error importing key: %v", err)
+		}
+		rootKeyList = []string{privKey.ID()}
+	} else {
+		rootKeyList = nRepo.GetCryptoService().ListKeys(data.CanonicalRootRole)
+	}
+
+	if len(rootKeyList) > 0 {
+		// Chooses the first root key available, which is initialization specific
+		// but should return the HW one first.
+		rootKeyID := rootKeyList[0]
+		fmt.Printf("Root key found, using: %s\n", rootKeyID)
+
+		return []string{rootKeyID}, nil
+	}
+
+	return []string{}, nil
+}
+
+// // importRootCert imports the base64 encoded public certificate corresponding to the root key
+// // returns empty slice if path is empty
+// func importRootCert(certFilePath string) ([]data.PublicKey, error) {
+// 	publicKeys := make([]data.PublicKey, 0, 1)
+
+// 	if certFilePath == "" {
+// 		return publicKeys, nil
+// 	}
+
+// 	// read certificate from file
+// 	certPEM, err := ioutil.ReadFile(certFilePath)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("error reading certificate file: %v", err)
+// 	}
+// 	block, _ := pem.Decode([]byte(certPEM))
+// 	if block == nil {
+// 		return nil, fmt.Errorf("the provided file does not contain a valid PEM certificate %v", err)
+// 	}
+
+// 	// convert the file to data.PublicKey
+// 	cert, err := x509.ParseCertificate(block.Bytes)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("Parsing certificate PEM bytes to x509 certificate: %v", err)
+// 	}
+// 	publicKeys = append(publicKeys, utils.CertToKey(cert))
+
+// 	return publicKeys, nil
+// }
+
+// Attempt to read a role key from a file, and return it as a data.PrivateKey
+// If key is for the Root role, it must be encrypted
+func readKey(role data.RoleName, keyFilename string, retriever notary.PassRetriever) (data.PrivateKey, error) {
+	pemBytes, err := ioutil.ReadFile(keyFilename)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading input root key file: %v", err)
+	}
+	isEncrypted := true
+	if err = cryptoservice.CheckRootKeyIsEncrypted(pemBytes); err != nil {
+		if role == data.CanonicalRootRole {
+			return nil, err
+		}
+		isEncrypted = false
+	}
+	var privKey data.PrivateKey
+	if isEncrypted {
+		privKey, _, err = trustmanager.GetPasswdDecryptBytes(retriever, pemBytes, "", data.CanonicalRootRole.String())
+	} else {
+		privKey, err = utils.ParsePEMPrivateKey(pemBytes, "")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return privKey, nil
+}
+
+func getPassphraseRetriever() notary.PassRetriever {
+	baseRetriever := passphrase.PromptRetriever()
+	env := map[string]string{
+		"root":       os.Getenv("HELM_ROOT_PASSPHRASE"),
+		"targets":    os.Getenv("HELM_TARGETS_PASSPHRASE"),
+		"snapshot":   os.Getenv("HELM_SNAPSHOT_PASSPHRASE"),
+		"delegation": os.Getenv("HELM_DELEGATION_PASSPHRASE"),
+	}
+
+	return func(keyName string, alias string, createNew bool, numAttempts int) (string, bool, error) {
+		if v := env[alias]; v != "" {
+			return v, numAttempts > 1, nil
+		}
+		// For delegation roles, we can also try the "delegation" alias if it is specified
+		// Note that we don't check if the role name is for a delegation to allow for names like "user"
+		// since delegation keys can be shared across repositories
+		// This cannot be a base role or imported key, though.
+		if v := env["delegation"]; !data.IsBaseRole(data.RoleName(alias)) && v != "" {
+			return v, numAttempts > 1, nil
+		}
+		return baseRetriever(keyName, alias, createNew, numAttempts)
+	}
+}
+
+func getDefaultAuth() (types.AuthConfig, error) {
+	cfg, err := config.Load(defaultCfgDir())
+	if err != nil {
+		return types.AuthConfig{}, err
+	}
+
+	return cfg.AuthConfigs[defaultIndexServer], nil
+}
+
+func defaultCfgDir() string {
+	homeEnvPath := os.Getenv("HOME")
+	if homeEnvPath == "" && runtime.GOOS == "windows" {
+		homeEnvPath = os.Getenv("USERPROFILE")
+	}
+
+	return filepath.Join(homeEnvPath, configFileDir)
+}
+
+type simpleCredentialStore struct {
+	auth types.AuthConfig
+}
+
+func (scs simpleCredentialStore) Basic(u *url.URL) (string, string) {
+	return scs.auth.Username, scs.auth.Password
+}
+
+func (scs simpleCredentialStore) RefreshToken(u *url.URL, service string) string {
+	return scs.auth.IdentityToken
+}
+
+func (scs simpleCredentialStore) SetRefreshToken(*url.URL, string, string) {
+}
+
+// GetRepoAndTag only accepts refs in the format registry/repo:tag
+// TODO - Radu M
+//
+// rewrite this
+func GetRepoAndTag(ref string) (string, string) {
+	parts := strings.Split(ref, "/")
+	return strings.Split(parts[1], ":")[0], strings.Split(parts[1], ":")[1]
+}

--- a/internal/experimental/tuf/list.go
+++ b/internal/experimental/tuf/list.go
@@ -1,0 +1,76 @@
+package tuf
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/trustpinning"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+// PrintTargets prints all the targets for a specific GUN from a trust server
+func PrintTargets(gun, trustServer, tlscacert, trustDir string) error {
+	targets, err := GetTargets(gun, trustServer, tlscacert, trustDir)
+	if err != nil {
+		return fmt.Errorf("cannot list targets:%v", err)
+	}
+
+	for _, tgt := range targets {
+		fmt.Printf("%s\t%s\n", tgt.Name, hex.EncodeToString(tgt.Hashes["sha256"]))
+	}
+	return nil
+}
+
+// GetTargetWithRole returns a single target by name from the trusted collection
+func GetTargetWithRole(gun, name, trustServer, tlscacert, trustDir string) (*client.TargetWithRole, error) {
+	targets, err := GetTargets(gun, trustServer, tlscacert, trustDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list targets:%v", err)
+	}
+
+	for _, target := range targets {
+		if target.Name == name {
+			return target, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot find target %v in trusted collection %v", name, gun)
+}
+
+// GetTargets returns all targets for a given gun from the trusted collection
+func GetTargets(gun, trustServer, tlscacert, trustDir string) ([]*client.TargetWithRole, error) {
+	if err := ensureTrustDir(trustDir); err != nil {
+		return nil, fmt.Errorf("cannot ensure trust directory: %v", err)
+	}
+
+	transport, err := makeTransport(trustServer, gun, tlscacert)
+	if err != nil {
+		return nil, fmt.Errorf("cannot make transport: %v", err)
+	}
+
+	repo, err := client.NewFileCachedRepository(
+		trustDir,
+		data.GUN(gun),
+		trustServer,
+		transport,
+		nil,
+		trustpinning.TrustPinConfig{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new file cached repository: %v", err)
+	}
+
+	return repo.ListTargets()
+}
+
+// GetSHA returns the digest stored in a trust server for a given reference
+func GetSHA(trustDir, trustServer, ref, tlscacert, rootKey string) (string, error) {
+	r, tag := GetRepoAndTag(ref)
+	target, err := GetTargetWithRole(r, tag, trustServer, tlscacert, trustDir)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(target.Hashes["sha256"]), nil
+}

--- a/internal/experimental/tuf/sign.go
+++ b/internal/experimental/tuf/sign.go
@@ -1,0 +1,76 @@
+package tuf
+
+import (
+	"fmt"
+
+	canonicaljson "github.com/docker/go/canonical/json"
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/trustpinning"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+// SignAndPublish signs an artifact, then publishes the metadata to a trust server
+func SignAndPublish(trustDir, trustServer, ref, file, tlscacert, rootKey string, custom *canonicaljson.RawMessage) (*client.Target, error) {
+	if err := ensureTrustDir(trustDir); err != nil {
+		return nil, fmt.Errorf("cannot ensure trust directory: %v", err)
+	}
+
+	r, tag := GetRepoAndTag(ref)
+
+	transport, err := makeTransport(trustServer, r, tlscacert)
+	if err != nil {
+		return nil, fmt.Errorf("cannot make transport: %v", err)
+	}
+
+	repo, err := client.NewFileCachedRepository(
+		trustDir,
+		data.GUN(r),
+		trustServer,
+		transport,
+		getPassphraseRetriever(),
+		trustpinning.TrustPinConfig{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new file cached repository: %v", err)
+	}
+
+	err = clearChangeList(repo)
+	if err != nil {
+		return nil, fmt.Errorf("cannot clear change list: %v", err)
+	}
+
+	defer clearChangeList(repo)
+
+	if _, err = repo.ListTargets(); err != nil {
+		switch err.(type) {
+		case client.ErrRepoNotInitialized, client.ErrRepositoryNotExist:
+			rootKeyIDs, err := importRootKey(rootKey, repo, getPassphraseRetriever())
+			if err != nil {
+				return nil, err
+			}
+
+			if err = repo.Initialize(rootKeyIDs); err != nil {
+				return nil, fmt.Errorf("cannot initialize repo: %v", err)
+			}
+
+		default:
+			return nil, fmt.Errorf("cannot list targets: %v", err)
+		}
+	}
+
+	target, err := client.NewTarget(tag, file, custom)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO - Radu M
+	// decide whether to allow actually passing roles as flags
+
+	// If roles is empty, we default to adding to targets
+	if err = repo.AddTarget(target, data.NewRoleList([]string{})...); err != nil {
+		return nil, err
+	}
+
+	err = repo.Publish()
+	return target, err
+}

--- a/pkg/action/chart_sign.go
+++ b/pkg/action/chart_sign.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"helm.sh/helm/internal/experimental/registry"
+	"helm.sh/helm/pkg/helmpath"
+
+	"helm.sh/helm/internal/experimental/tuf"
+)
+
+// ChartSign performs a chart sign operation
+type ChartSign struct {
+	cfg         *Configuration
+	trustDir    string
+	trustServer string
+	ref         string
+	tlscacert   string
+	rootKey     string
+}
+
+// NewChartSign creates a new ChartSign object with given configuration and trust info
+func NewChartSign(cfg *Configuration, trustDir, trustServer, ref, tlscacert, rootKey string) *ChartSign {
+	return &ChartSign{
+		cfg:         cfg,
+		trustDir:    trustDir,
+		trustServer: trustServer,
+		ref:         ref,
+		tlscacert:   tlscacert,
+		rootKey:     rootKey,
+	}
+}
+
+// Run executes the chart sign and push operation
+func (a *ChartSign) Run(out io.Writer, ref string) error {
+
+	c, err := registry.NewCache(
+		registry.CacheOptWriter(out),
+		registry.CacheOptRoot(filepath.Join(helmpath.Registry(), registry.CacheRootDir)))
+
+	r, err := registry.ParseReference(ref)
+	if err != nil {
+		return err
+	}
+
+	cs, err := c.FetchReference(r)
+	if err != nil {
+		return err
+	}
+
+	file := filepath.Join(helmpath.Registry(), registry.CacheRootDir, "blobs", "sha256", strings.Split(cs.Digest.String(), ":")[1])
+	_, err = tuf.SignAndPublish(a.trustDir, a.trustServer, ref, file, a.tlscacert, a.rootKey, nil)
+	return err
+}


### PR DESCRIPTION
This is an experiment using TUF (The Update Framework) content trust verification for Helm charts when using OCI registries.

This should probably be a plugin, but this was the easiest way to tie in to the existing infrastructure for using OCI registries with charts, and the current state of the PR is just an experiment.

Also, the current implementation is extremely naive:

- it only checks the content digest, as opposed to performing the entire workflow for verification
- it allows pulling the bundle and adding it to the cache before doing the digest verification, and removes it afterwards, if the digests do not match
- it doesn't properly handle all cases for nested registries and repositories
To test:

```
$ export HELM_EXPERIMENTAL_OCI=1

$ export HELM_ROOT_PASSPHRASE=PassPhrase#123
$ export HELM_TARGETS_PASSPHRASE=PassPhrase#123
$ export HELM_SNAPSHOT_PASSPHRASE=PassPhrase#123
$ export HELM_DELEGATION_PASSPHRASE=PassPhrase#123
$ export NOTARY_CA=$GOPATH/src/github.com/theupdateframework/notary/cmd/notary/root-ca.crt

$ cd $GOPATH/src/github.com && mkdir theupdateframework && cd theupdateframework && git clone https://github.com/theupdateframework/notary && cd notary && docker-compose up -d

Creating network "notary_mdb" with the default driver
Creating network "notary_sig" with the default driver                                                                           Creating volume "notary_notary_data" with default
Creating notary_mysql_1 ... done                                                            
Creating notary_signer_1 ... done
Creating notary_server_1 ... done

$ docker run -it -d  -p 5000:5000 registry

$ helm chart list               
REF                             NAME    VERSION DIGEST  SIZE    CREATED
localhost:5000/brigade:v1       brigade 0.0.1   a5c5ca8 4.2 KiB 5 hours

$ helm chart push localhost:5000/brigade:v1 --tlscacert=$NOTARY_CA --server=https://localhost:4443 --signature
The push refers to repository [localhost:5000/brigade]
ref:     localhost:5000/brigade:v1
digest:  a5c5ca802c0f691d8c4bdf29168afa20ee2c279bb5bba95ff7b54184bca8d159
size:    4.2 KiB
name:    brigade
version: 0.0.1
v1: pushed to remote (1 layer, 4.2 KiB total)

$ notary list brigade --tlscacert=$NOTARY_CA --server=https://localhost:4443 --trustDir ~/.cache/helm/registry/trust
NAME    DIGEST                                                              SIZE (BYTES)    ROLE
----    ------                                                              ------------    ----
v1      a5c5ca802c0f691d8c4bdf29168afa20ee2c279bb5bba95ff7b54184bca8d159    4311            targets


$ helm chart remove localhost:5000/brigade:v1         
v1: removed

$ helm chart pull localhost:5000/brigade:v1 --tlscacert=$NOTARY_CA --server=https://localhost:4443 --signature
v1: Pulling from localhost:5000/brigade
ref:     localhost:5000/brigade:v1
digest:  a5c5ca802c0f691d8c4bdf29168afa20ee2c279bb5bba95ff7b54184bca8d159
size:    4.2 KiB
name:    brigade
version: 0.0.1
Status: Downloaded newer chart for localhost:5000/brigade:v1
```

The workflow is as follows:

- when the pushing a chart to an OCI registry, if the `--signature` flag is passed, the signature is pushed to a trust server
- when pulling, if the `--signature` flag is passed, the signature is pulled from the TUF server, the chart is pulled, then the digests are checked. If they are not equal, the chart is deleted.

If this is an area we think is worth exploring, I'd be happy to clean it up and move this to a plugin.

Note on using TUF / Notary: while the current implementation is using the Notary client libraries, and is shown using a Notary server, the actual collections are TUF collections, so in theory they could be used with any TUF server.