### PR TITLE
Fix/6287: Set config path in repo update command

### DIFF
--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -51,6 +51,7 @@ func newRepoUpdateCmd(out io.Writer) *cobra.Command {
 		Long:    updateDesc,
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			o.repoFile = settings.RepositoryConfig
 			return o.run(out)
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Signed-off-by: Akash Shinde akashshinde159@gmail.com

**What this PR does / why we need it**:
Closes #6287 

**Special notes for your reviewer**:
This bug was introduced because repo file path was not being shared to the `helm repo update` run.

