### PR TITLE
Stop multiple error messages in lint results

### DIFF
--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -73,7 +73,6 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 			for _, msg := range linter.Messages {
 				if msg.Severity == support.ErrorSev {
 					result.Errors = append(result.Errors, msg.Err)
-					result.Messages = append(result.Messages, msg)
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Have fixed a minor error in the lint action that was causing Error
messages from linting chart getting added to the returned results
multiple times.    

**Special notes for your reviewer**:

All the messages (including errors) are already being appended here https://github.com/helm/helm/pull/6296/files#diff-8254eeb06bb9f2a4e69f4176be9ef319R71 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
