### PR TITLE
fix(cmd/helm): Remove mention of init from help

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -83,13 +83,7 @@ __helm_custom_func()
 
 var globalUsage = `The Kubernetes package manager
 
-To begin working with Helm, run the 'helm init' command:
-
-	$ helm init
-
-This will set up any necessary local configuration.
-
-Common actions from this point include:
+Common actions for Helm:
 
 - helm search:    search for charts
 - helm fetch:     download a chart to your local directory to view


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the mention of the `init` command from the help text for v3.

Maybe another introductory sentence should be put in its place instead of simply removing it like I did?

