### PR TITLE
Install issues with v3.0.0-beta.1

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -590,6 +590,8 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		Options: []getter.Option{
 			getter.WithBasicAuth(c.Username, c.Password),
 		},
+		RepositoryConfig: settings.RepositoryConfig,
+		RepositoryCache:  settings.RepositoryCache,
 	}
 	if c.Verify {
 		dl.Verify = downloader.VerifyAlways


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

I can no longer install charts with v3.  Maybe I'm doing something wrong, or I'm running a different scenario?

The proposed fix makes sense to me as some new fields recently added had not been initialized.

Here's what I'm doing to trigger the problem:
```
# I start from an empty Helm Environment
> ls $HOME/Library/Caches/helm  $HOME/Library/Preferences/helm  $HOME/Library/helm
ls: /Users/marckhouzam/Library/Caches/helm: No such file or directory
ls: /Users/marckhouzam/Library/Preferences/helm: No such file or directory
ls: /Users/marckhouzam/Library/helm: No such file or directory

# Add a repo
> bin/helm repo add stable https://kubernetes-charts.storage.googleapis.com
"stable" has been added to your repositories

# Repo is there
> bin/helm repo list
NAME  	URL
stable	https://kubernetes-charts.storage.googleapis.com

# Correct directories have been modified
> ls $HOME/Library/Caches/helm  $HOME/Library/Preferences/helm  $HOME/Library/helm
ls: /Users/marckhouzam/Library/helm: No such file or directory
/Users/marckhouzam/Library/Caches/helm:
repository

/Users/marckhouzam/Library/Preferences/helm:
repositories.yaml

> bin/helm install nginx stable/nginx-ingress
Error: failed to download "stable/nginx-ingress" (hint: running `helm repo update` may help)

> bin/helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈

> bin/helm install nginx stable/nginx-ingress
Error: failed to download "stable/nginx-ingress" (hint: running `helm repo update` may help)
```