### PR TITLE
Fix error in the installation with repo

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -584,9 +584,11 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	}
 
 	dl := downloader.ChartDownloader{
-		Out:     os.Stdout,
-		Keyring: c.Keyring,
-		Getters: getter.All(settings),
+		Out:              os.Stdout,
+		Keyring:          c.Keyring,
+		Getters:          getter.All(settings),
+		RepositoryConfig: settings.RepositoryConfig,
+		RepositoryCache:  settings.RepositoryCache,
 		Options: []getter.Option{
 			getter.WithBasicAuth(c.Username, c.Password),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Helm 3 cannot install the charts through repo.
Here is the comments to reproduce the problem.
```
helm repo add jetstack https://charts.jetstack.io
helm repo update
helm install cert-manager --namespace cert-manager --version v0.9.1 jetstack/cert-manager
```
Downloader will not be able to locate the repo due to the lack of definition in RepositoryConfig and RepositoryCache in the initialization.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
