### PR TITLE
fix: clear the discovery cache after CRDs are installed

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -169,6 +169,15 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 				}
 				return i.failRelease(rel, err)
 			}
+
+			// Invalidate the local cache.
+			if discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient(); err != nil {
+				// On error, we don't want to bail out, since this is unlikely
+				// to impact the majority of charts.
+				i.cfg.Log("Could not clear the discovery cache: %s", err)
+			} else {
+				discoveryClient.Invalidate()
+			}
 		}
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -103,6 +103,50 @@ func NewInstall(cfg *Configuration) *Install {
 	}
 }
 
+func (i *Install) installCRDs(crds []*chart.File) error {
+	// We do these one at a time in the order they were read.
+	for _, obj := range crds {
+		// Read in the resources
+		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.Data))
+		if err != nil {
+			// We bail out immediately
+			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+		}
+		// On dry run, bail here
+		if i.DryRun {
+			i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
+			continue
+		}
+		// Send them to Kube
+		if _, err := i.cfg.KubeClient.Create(res); err != nil {
+			// If the error is CRD already exists, continue.
+			if apierrors.IsAlreadyExists(err) {
+				crdName := res[0].Name
+				i.cfg.Log("CRD %s is already present. Skipping.", crdName)
+				continue
+			}
+			return errors.Wrapf(err, "failed to instal CRD %s", obj.Name)
+		}
+
+		// Invalidate the local cache.
+		if discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient(); err != nil {
+			// On error, we don't want to bail out, since this is unlikely
+			// to impact the majority of charts.
+			i.cfg.Log("Could not clear the discovery cache: %s", err)
+		} else {
+			i.cfg.Log("Clearing discovery cache")
+			discoveryClient.Invalidate()
+			// Give time for the CRD to be recognized.
+			if err := i.cfg.KubeClient.Wait(res, 60*time.Second); err != nil {
+				i.cfg.Log("Error waiting for CRD. Continuing blindly. %s", err)
+			}
+			// Make sure to force a rebuild of the cache.
+			discoveryClient.ServerGroups()
+		}
+	}
+	return nil
+}
+
 // Run executes the installation
 //
 // If DryRun is set to true, this will prepare the release, but not install it
@@ -114,43 +158,8 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	// Pre-install anything in the crd/ directory. We do this before Helm
 	// contacts the upstream server and builds the capabilities object.
 	if crds := chrt.CRDs(); !i.ClientOnly && !i.SkipCRDs && len(crds) > 0 {
-		// We do these one at a time in the order they were read.
-		for _, obj := range crds {
-			// Read in the resources
-			res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.Data))
-			if err != nil {
-				// We bail out immediately
-				return nil, errors.Wrapf(err, "failed to install CRD %s", obj.Name)
-			}
-			// On dry run, bail here
-			if i.DryRun {
-				i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
-				continue
-			}
-			// Send them to Kube
-			if _, err := i.cfg.KubeClient.Create(res); err != nil {
-				// If the error is CRD already exists, continue.
-				if apierrors.IsAlreadyExists(err) {
-					crdName := res[0].Name
-					i.cfg.Log("CRD %s is already present. Skipping.", crdName)
-					continue
-				}
-				return nil, err
-			}
-
-			// Invalidate the local cache.
-			if discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient(); err != nil {
-				// On error, we don't want to bail out, since this is unlikely
-				// to impact the majority of charts.
-				i.cfg.Log("Could not clear the discovery cache: %s", err)
-			} else {
-				i.cfg.Log("Clearing discovery cache")
-				discoveryClient.Invalidate()
-				// Give time for the CRD to be recognized.
-				time.Sleep(5 * time.Second)
-				// Make sure to force a rebuild of the cache.
-				discoveryClient.ServerGroups()
-			}
+		if err := i.installCRDs(crds); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/resource"
 
 	"helm.sh/helm/pkg/chart"
 	"helm.sh/helm/pkg/chartutil"
@@ -104,19 +105,15 @@ func NewInstall(cfg *Configuration) *Install {
 }
 
 func (i *Install) installCRDs(crds []*chart.File) error {
-	// We do these one at a time in the order they were read.
+	// We do these one file at a time in the order they were read.
+	totalItems := []*resource.Info{}
 	for _, obj := range crds {
 		// Read in the resources
 		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.Data))
 		if err != nil {
-			// We bail out immediately
 			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
 		}
-		// On dry run, bail here
-		if i.DryRun {
-			i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
-			continue
-		}
+
 		// Send them to Kube
 		if _, err := i.cfg.KubeClient.Create(res); err != nil {
 			// If the error is CRD already exists, continue.
@@ -127,23 +124,22 @@ func (i *Install) installCRDs(crds []*chart.File) error {
 			}
 			return errors.Wrapf(err, "failed to instal CRD %s", obj.Name)
 		}
-
-		// Invalidate the local cache.
-		if discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient(); err != nil {
-			// On error, we don't want to bail out, since this is unlikely
-			// to impact the majority of charts.
-			i.cfg.Log("Could not clear the discovery cache: %s", err)
-		} else {
-			i.cfg.Log("Clearing discovery cache")
-			discoveryClient.Invalidate()
-			// Give time for the CRD to be recognized.
-			if err := i.cfg.KubeClient.Wait(res, 60*time.Second); err != nil {
-				i.cfg.Log("Error waiting for CRD. Continuing blindly. %s", err)
-			}
-			// Make sure to force a rebuild of the cache.
-			discoveryClient.ServerGroups()
-		}
+		totalItems = append(totalItems, res...)
 	}
+	// Invalidate the local cache, since it will not have the new CRDs
+	// present.
+	discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	i.cfg.Log("Clearing discovery cache")
+	discoveryClient.Invalidate()
+	// Give time for the CRD to be recognized.
+	if err := i.cfg.KubeClient.Wait(totalItems, 60*time.Second); err != nil {
+		return err
+	}
+	// Make sure to force a rebuild of the cache.
+	discoveryClient.ServerGroups()
 	return nil
 }
 
@@ -158,7 +154,10 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	// Pre-install anything in the crd/ directory. We do this before Helm
 	// contacts the upstream server and builds the capabilities object.
 	if crds := chrt.CRDs(); !i.ClientOnly && !i.SkipCRDs && len(crds) > 0 {
-		if err := i.installCRDs(crds); err != nil {
+		// On dry run, bail here
+		if i.DryRun {
+			i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
+		} else if err := i.installCRDs(crds); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -29,7 +29,9 @@ import (
 	"github.com/pkg/errors"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes/scheme"
 	watchtools "k8s.io/client-go/tools/watch"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -54,6 +57,10 @@ type Client struct {
 func New(getter genericclioptions.RESTClientGetter) *Client {
 	if getter == nil {
 		getter = genericclioptions.NewConfigFlags(true)
+	}
+	if err := apiextv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		// This should never happen.
+		panic(err)
 	}
 	return &Client{
 		Factory: cmdutil.NewFactory(getter),

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -58,6 +58,7 @@ func New(getter genericclioptions.RESTClientGetter) *Client {
 	if getter == nil {
 		getter = genericclioptions.NewConfigFlags(true)
 	}
+	// Add CRDs to the scheme. They are missing by default.
 	if err := apiextv1beta1.AddToScheme(scheme.Scheme); err != nil {
 		// This should never happen.
 		panic(err)

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -280,7 +280,7 @@ func (w *waiter) crdReady(crd apiextv1beta1.CustomResourceDefinition) bool {
 		case apiextv1beta1.NamesAccepted:
 			if cond.Status == apiextv1beta1.ConditionFalse {
 				// This indicates a naming conflict, but it's probably not the
-				// job of this function to faile because of that. Instead,
+				// job of this function to fail because of that. Instead,
 				// we treat it as a success, since the process should be able to
 				// continue.
 				return true

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -48,9 +48,6 @@ type waiter struct {
 // until all are ready or a timeout is reached
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
-	if err := apiextv1beta1.AddToScheme(scheme.Scheme); err != nil {
-		w.log("error adding CRDs to schema: %s", err)
-	}
 
 	return wait.Poll(2*time.Second, w.timeout, func() (bool, error) {
 		for _, v := range created {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This fixes a bug in which CRD instances could not be created in the same chart as the CRDs themselves. This invalidates the local discovery cache and forces a round-trip discovery operation with the Kubernetes API server.

**Special notes for your reviewer**:

Closes #6316 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
