### PR TITLE
fix BusyBox sed

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -194,7 +194,7 @@ autoload -U +X bashcompinit && bashcompinit
 # use word boundary patterns for BSD or GNU sed
 LWORD='[[:<:]]'
 RWORD='[[:>:]]'
-if sed --help 2>&1 | grep -q GNU; then
+if sed --help 2>&1 | grep -q 'GNU\|BusyBox'; then
 	LWORD='\<'
 	RWORD='\>'
 fi


### PR DESCRIPTION
BusyBox sed works the same way as GNU sed


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Code completion for zsh under alpine is not working currently because BusyBox sed is not identified as a GNU sed.
This leads to
LWORD='[[:<:]]'
RWORD='[[:>:]]'
which is not working in BusyBox sed

same as #6327 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
