### PR TITLE
Moving initActionConfig to pkg

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -205,7 +205,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	client.Namespace = action.GetNamespace()
+	client.Namespace = action.GetNamespace(settings)
 	return client.Run(chartRequested, vals)
 }
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -205,7 +205,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	client.Namespace = getNamespace()
+	client.Namespace = action.GetNamespace()
 	return client.Run(chartRequested, vals)
 }
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -205,7 +205,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	client.Namespace = action.GetNamespace(settings)
+	client.Namespace = settings.Namespace()
 	return client.Run(chartRequested, vals)
 }
 

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -51,7 +51,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				paths = args
 			}
-			client.Namespace = getNamespace()
+			client.Namespace = action.GetNamespace()
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -51,7 +51,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				paths = args
 			}
-			client.Namespace = action.GetNamespace(settings)
+			client.Namespace = settings.Namespace()
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -51,7 +51,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				paths = args
 			}
-			client.Namespace = action.GetNamespace()
+			client.Namespace = action.GetNamespace(settings)
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 
 	"github.com/gosuri/uitable"
@@ -69,7 +70,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if client.AllNamespaces {
-				initActionConfig(cfg, true)
+				action.InitActionConfig(settings, true, os.Getenv("HELM_DRIVER"), debug)
 			}
 			client.SetStateMask()
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -71,7 +71,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = action.GetNamespace(settings)
+			client.Namespace = settings.Namespace()
 
 			if client.Version == "" && client.Devel {
 				debug("setting version to >0.0.0-0")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -71,7 +71,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = action.GetNamespace()
+			client.Namespace = action.GetNamespace(settings)
 
 			if client.Version == "" && client.Devel {
 				debug("setting version to >0.0.0-0")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -71,7 +71,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = getNamespace()
+			client.Namespace = action.GetNamespace()
 
 			if client.Version == "" && client.Devel {
 				debug("setting version to >0.0.0-0")

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -56,7 +56,6 @@ var (
 
 	config     genericclioptions.RESTClientGetter
 	configOnce sync.Once
-	settings   *cli.EnvSettings
 )
 
 // ValidName is a regular expression for names.
@@ -215,11 +214,10 @@ func (c *Configuration) recordRelease(r *release.Release) {
 }
 
 // InitActionConfig initializes the action configuration
-func InitActionConfig(envsettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log debug) (*Configuration, error) {
-	settings = envsettings
+func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log debug) (*Configuration, error) {
 
 	var actionConfig Configuration
-	kubeconfig := kubeConfig()
+	kubeconfig := kubeConfig(envSettings)
 
 	kc := kube.New(kubeconfig)
 	kc.Log = log
@@ -230,7 +228,7 @@ func InitActionConfig(envsettings *cli.EnvSettings, allNamespaces bool, helmDriv
 	}
 	var namespace string
 	if !allNamespaces {
-		namespace = GetNamespace()
+		namespace = GetNamespace(envSettings)
 	}
 
 	var store *storage.Storage
@@ -259,15 +257,15 @@ func InitActionConfig(envsettings *cli.EnvSettings, allNamespaces bool, helmDriv
 	return &actionConfig, nil
 }
 
-func kubeConfig() genericclioptions.RESTClientGetter {
+func kubeConfig(envSettings *cli.EnvSettings) genericclioptions.RESTClientGetter {
 	configOnce.Do(func() {
-		config = kube.GetConfig(settings.KubeConfig, settings.KubeContext, settings.Namespace)
+		config = kube.GetConfig(envSettings.KubeConfig, envSettings.KubeContext, envSettings.Namespace)
 	})
 	return config
 }
 
 //GetNamespace gets the namespace from the configuration
-func GetNamespace() string {
+func GetNamespace(envSettings *cli.EnvSettings) string {
 	if envSettings.Namespace != "" {
 		return envSettings.Namespace
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -96,7 +96,8 @@ type RESTClientGetter interface {
 	ToRESTMapper() (meta.RESTMapper, error)
 }
 
-type debug func(format string, v ...interface{})
+// DebugLog sets the logger that writes debug strings
+type DebugLog func(format string, v ...interface{})
 
 // capabilities builds a Capabilities from discovery information.
 func (c *Configuration) getCapabilities() (*chartutil.Capabilities, error) {
@@ -214,7 +215,7 @@ func (c *Configuration) recordRelease(r *release.Release) {
 }
 
 // InitActionConfig initializes the action configuration
-func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log debug) (*Configuration, error) {
+func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log DebugLog) (*Configuration, error) {
 
 	var actionConfig Configuration
 	kubeconfig := kubeConfig(envSettings)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -35,7 +35,7 @@ import (
 	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
-	"helm.sh/helm/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 // Timestamper is a function capable of producing a timestamp.Timestamper.

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -40,6 +40,8 @@ import (
 type EnvSettings struct {
 	namespace  string
 	kubeConfig string
+	config     genericclioptions.RESTClientGetter
+	configOnce sync.Once
 	// KubeContext is the name of the kubeconfig context.
 	KubeContext string
 	// Debug indicates whether or not Helm is running in Debug mode.
@@ -53,11 +55,6 @@ type EnvSettings struct {
 	// PluginsDirectory is the path to the plugins directory.
 	PluginsDirectory string
 }
-
-var (
-	config     genericclioptions.RESTClientGetter
-	configOnce sync.Once
-)
 
 func New() *EnvSettings {
 
@@ -115,8 +112,8 @@ func (s *EnvSettings) Namespace() string {
 
 //KubeConfig gets the kubeconfig from EnvSettings
 func (s *EnvSettings) KubeConfig() genericclioptions.RESTClientGetter {
-	configOnce.Do(func() {
-		config = kube.GetConfig(s.kubeConfig, s.KubeContext, s.namespace)
+	s.configOnce.Do(func() {
+		s.config = kube.GetConfig(s.kubeConfig, s.KubeContext, s.namespace)
 	})
-	return config
+	return s.config
 }

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -38,7 +38,7 @@ func TestEnvSettings(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			ns:   "",
+			ns:   "default",
 		},
 		{
 			name:  "with flags set",
@@ -78,8 +78,8 @@ func TestEnvSettings(t *testing.T) {
 			if settings.Debug != tt.debug {
 				t.Errorf("expected debug %t, got %t", tt.debug, settings.Debug)
 			}
-			if settings.Namespace != tt.ns {
-				t.Errorf("expected namespace %q, got %q", tt.ns, settings.Namespace)
+			if settings.Namespace() != tt.ns {
+				t.Errorf("expected namespace %q, got %q", tt.ns, settings.Namespace())
 			}
 			if settings.KubeContext != tt.kcontext {
 				t.Errorf("expected kube-context %q, got %q", tt.kcontext, settings.KubeContext)


### PR DESCRIPTION
Moved initActionConfig to pkg to make it easier to instantiate the configuration for projects consuming helm

closes #6333 

Signed-off-by: Aaron Mell <amell@lumindigital.com>

**What this PR does / why we need it**:
I was trying migrate the terraform helm provider to v3 beta. Realized that I was basically copying most of the logic in cmd/helm/helm.go to instantiate the configuration. Figured other people would have to do the same, and it should be easier to create the config without knowing about the internals of helm. 

**Special notes for your reviewer**:
I'm pretty new to go, so I'd appreciate candid feedback.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
