### PR TITLE
ref(pkg/engine): cleanup of development `hack`

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -223,11 +223,7 @@ func (e Engine) renderWithReferences(tpls, referenceTpls map[string]renderable) 
 		// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 		// is set. Since missing=error will never get here, we do not need to handle
 		// the Strict case.
-		f := &chart.File{
-			Name: strings.ReplaceAll(filename, "/templates", "/manifests"),
-			Data: []byte(strings.ReplaceAll(buf.String(), "<no value>", "")),
-		}
-		rendered[filename] = string(f.Data)
+		rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
 	}
 
 	return rendered, nil


### PR DESCRIPTION
This was left in from some of the chart builder work.  I forgot to remove it.