### PR TITLE
Fix chartutil.Save returning empty path when passing a non-existent directory (Resolves #6344)

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -93,7 +93,7 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 	filename := fmt.Sprintf("%s-%s.tgz", c.Name(), c.Metadata.Version)
 	filename = filepath.Join(outDir, filename)
 	if stat, err := os.Stat(filepath.Dir(filename)); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(filename), 0755); !os.IsExist(err) {
+		if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 			return "", err
 		}
 	} else if !stat.IsDir() {

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -19,6 +19,7 @@ package chartutil
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,37 +35,41 @@ func TestSave(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	c := &chart.Chart{
-		Metadata: &chart.Metadata{
-			APIVersion: chart.APIVersionV1,
-			Name:       "ahab",
-			Version:    "1.2.3",
-		},
-		Files: []*chart.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
-		},
-	}
+	for _, dest := range []string{tmp, path.Join(tmp, "newdir")} {
+		t.Run("outDir="+dest, func(t *testing.T) {
+			c := &chart.Chart{
+				Metadata: &chart.Metadata{
+					APIVersion: chart.APIVersionV1,
+					Name:       "ahab",
+					Version:    "1.2.3",
+				},
+				Files: []*chart.File{
+					{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+				},
+			}
 
-	where, err := Save(c, tmp)
-	if err != nil {
-		t.Fatalf("Failed to save: %s", err)
-	}
-	if !strings.HasPrefix(where, tmp) {
-		t.Fatalf("Expected %q to start with %q", where, tmp)
-	}
-	if !strings.HasSuffix(where, ".tgz") {
-		t.Fatalf("Expected %q to end with .tgz", where)
-	}
+			where, err := Save(c, dest)
+			if err != nil {
+				t.Fatalf("Failed to save: %s", err)
+			}
+			if !strings.HasPrefix(where, dest) {
+				t.Fatalf("Expected %q to start with %q", where, dest)
+			}
+			if !strings.HasSuffix(where, ".tgz") {
+				t.Fatalf("Expected %q to end with .tgz", where)
+			}
 
-	c2, err := loader.LoadFile(where)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c2.Name() != c.Name() {
-		t.Fatalf("Expected chart archive to have %q, got %q", c.Name(), c2.Name())
-	}
-	if len(c2.Files) != 1 || c2.Files[0].Name != "scheherazade/shahryar.txt" {
-		t.Fatal("Files data did not match")
+			c2, err := loader.LoadFile(where)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c2.Name() != c.Name() {
+				t.Fatalf("Expected chart archive to have %q, got %q", c.Name(), c2.Name())
+			}
+			if len(c2.Files) != 1 || c2.Files[0].Name != "scheherazade/shahryar.txt" {
+				t.Fatal("Files data did not match")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix chartutil.Save returning empty path when passing a non-existent directory, which causes `helm package --destination dir` has to be run twice when `dir` doesn't exist (#6344).


**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility