### PR TITLE
In get script, use specified path to helm binary for helm version check

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -94,7 +94,7 @@ checkDesiredVersion() {
 # if it needs to be changed.
 checkHelmInstalledVersion() {
   if [[ -f "${HELM_INSTALL_DIR}/${PROJECT_NAME}" ]]; then
-    local version=$(helm version -c | grep '^Client' | cut -d'"' -f2)
+    local version=$("${HELM_INSTALL_DIR}/${PROJECT_NAME}" version -c | grep '^Client' | cut -d'"' -f2)
     if [[ "$version" == "$TAG" ]]; then
       echo "Helm ${version} is already ${DESIRED_VERSION:-latest}"
       return 0


### PR DESCRIPTION
closes #6366 

**What this PR does / why we need it**:
Updates the `get` script to check the version of `helm` using the binary located at `HELM_INSTALL_DIR` instead of the default one on `PATH`. See this issue for more information: https://github.com/helm/helm/issues/6366

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
