### PR TITLE
Ref/cmd output

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -227,7 +227,7 @@ func newInstallCmd(c helm.Interface, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.depUp, "dep-up", false, "Run helm dependency update before installing the chart")
 	f.BoolVar(&inst.subNotes, "render-subchart-notes", false, "Render subchart notes along with the parent")
 	f.StringVar(&inst.description, "description", "", "Specify a description for the release")
-	f.StringVarP(&inst.output, "output", "o", "table", "Prints the output in the specified format (json|table|yaml)")
+	bindOutputFlag(cmd, &inst.output)
 
 	// set defaults from environment
 	settings.InitTLS(f)
@@ -338,7 +338,7 @@ func (i *installCmd) run() error {
 		return nil
 	}
 
-	if i.output == "table" {
+	if outputFormat(i.output) == outputTable {
 		i.printRelease(rel)
 	}
 
@@ -357,15 +357,7 @@ func (i *installCmd) run() error {
 		return prettyError(err)
 	}
 
-	output, err := PrintStatusFormated(i.output, status)
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(i.out, output)
-
-	return nil
+	return write(i.out, &statusWriter{status}, outputFormat(i.output))
 }
 
 // Merges source and destination map, preferring values from the source map

--- a/cmd/helm/printer.go
+++ b/cmd/helm/printer.go
@@ -17,14 +17,29 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"text/template"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/timeconv"
+)
+
+type outputFormat string
+
+const (
+	outputFlag = "output"
+
+	outputTable outputFormat = "table"
+	outputJSON  outputFormat = "json"
+	outputYAML  outputFormat = "yaml"
 )
 
 var printReleaseTemplate = `REVISION: {{.Release.Version}}
@@ -79,4 +94,67 @@ func debug(format string, args ...interface{}) {
 		format = fmt.Sprintf("[debug] %s\n", format)
 		fmt.Printf(format, args...)
 	}
+}
+
+// bindOutputFlag will add the output flag to the given command and bind the
+// value to the given string pointer
+func bindOutputFlag(cmd *cobra.Command, varRef *string) {
+	cmd.Flags().StringVarP(varRef, outputFlag, "o", string(outputTable), fmt.Sprintf("Prints the output in the specified format. Allowed values: %s, %s, %s", outputTable, outputJSON, outputYAML))
+}
+
+type outputWriter interface {
+	WriteTable(out io.Writer) error
+	WriteJSON(out io.Writer) error
+	WriteYAML(out io.Writer) error
+}
+
+func write(out io.Writer, ow outputWriter, format outputFormat) error {
+	switch format {
+	case outputTable:
+		return ow.WriteTable(out)
+	case outputJSON:
+		return ow.WriteJSON(out)
+	case outputYAML:
+		return ow.WriteYAML(out)
+	}
+	return fmt.Errorf("unsupported format %s", format)
+}
+
+// encodeJSON is a helper function to decorate any error message with a bit more
+// context and avoid writing the same code over and over for printers
+func encodeJSON(out io.Writer, obj interface{}) error {
+	enc := json.NewEncoder(out)
+	err := enc.Encode(obj)
+	if err != nil {
+		return fmt.Errorf("unable to write JSON output: %s", err)
+	}
+	return nil
+}
+
+// encodeYAML is a helper function to decorate any error message with a bit more
+// context and avoid writing the same code over and over for printers
+func encodeYAML(out io.Writer, obj interface{}) error {
+	raw, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("unable to write YAML output: %s", err)
+	}
+	// Append a newline, as with a JSON encoder
+	raw = append(raw, []byte("\n")...)
+	_, err = out.Write(raw)
+	if err != nil {
+		return fmt.Errorf("unable to write YAML output: %s", err)
+	}
+	return nil
+}
+
+// encodeTable is a helper function to decorate any error message with a bit
+// more context and avoid writing the same code over and over for printers
+func encodeTable(out io.Writer, table *uitable.Table) error {
+	raw := table.Bytes()
+	raw = append(raw, []byte("\n")...)
+	_, err := out.Write(raw)
+	if err != nil {
+		return fmt.Errorf("unable to write table output: %s", err)
+	}
+	return nil
 }

--- a/cmd/helm/search_test.go
+++ b/cmd/helm/search_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"io"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -90,25 +89,25 @@ func TestSearchCmd(t *testing.T) {
 			name:     "search for 'maria', expect one match output json",
 			args:     []string{"maria"},
 			flags:    strings.Split("--output json", " "),
-			expected: regexp.QuoteMeta(`{"Charts":[{"Name":"testing/mariadb","Version":"0.3.0","AppVersion":"","Description":"Chart for MariaDB"}]}`),
+			expected: `[{"Name":"testing/mariadb","Version":"0.3.0","Appversion":"","Description":"Chart for MariaDB"}]`,
 		},
 		{
 			name:     "search for 'alpine', expect two matches output json",
 			args:     []string{"alpine"},
 			flags:    strings.Split("--output json", " "),
-			expected: regexp.QuoteMeta(`{"Charts":[{"Name":"testing/alpine","Version":"0.2.0","AppVersion":"2.3.4","Description":"Deploy a basic Alpine Linux pod"}]}`),
+			expected: `[{"Name":"testing/alpine","Version":"0.2.0","Appversion":"2.3.4","Description":"Deploy a basic Alpine Linux pod"}]`,
 		},
 		{
 			name:     "search for 'maria', expect one match output yaml",
 			args:     []string{"maria"},
 			flags:    strings.Split("--output yaml", " "),
-			expected: "Charts:\n- AppVersion: \"\"\n  Description: Chart for MariaDB\n  Name: testing/mariadb\n  Version: 0.3.0\n\n",
+			expected: "- AppVersion: \"\"\n  Description: Chart for MariaDB\n  Name: testing/mariadb\n  Version: 0.3.0\n\n",
 		},
 		{
 			name:     "search for 'alpine', expect two matches output yaml",
 			args:     []string{"alpine"},
 			flags:    strings.Split("--output yaml", " "),
-			expected: "Charts:\n- AppVersion: 2.3.4\n  Description: Deploy a basic Alpine Linux pod\n  Name: testing/alpine\n  Version: 0.2.0\n\n",
+			expected: "- AppVersion: 2.3.4\n  Description: Deploy a basic Alpine Linux pod\n  Name: testing/alpine\n  Version: 0.2.0\n\n",
 		},
 	}
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -182,7 +182,7 @@ func newUpgradeCmd(client helm.Interface, out io.Writer) *cobra.Command {
 	f.BoolVar(&upgrade.subNotes, "render-subchart-notes", false, "Render subchart notes along with parent")
 	f.StringVar(&upgrade.description, "description", "", "Specify the description to use for the upgrade, rather than the default")
 	f.BoolVar(&upgrade.cleanupOnFail, "cleanup-on-fail", false, "Allow deletion of new resources created in this upgrade when upgrade failed")
-	f.StringVarP(&upgrade.output, "output", "o", "table", "Prints the output in the specified format (json|table|yaml)")
+	bindOutputFlag(cmd, &upgrade.output)
 
 	f.MarkDeprecated("disable-hooks", "Use --no-hooks instead")
 
@@ -309,7 +309,7 @@ func (u *upgradeCmd) run() error {
 		printRelease(u.out, resp.Release)
 	}
 
-	if u.output == "table" {
+	if outputFormat(u.output) == outputTable {
 		fmt.Fprintf(u.out, "Release %q has been upgraded.\n", u.release)
 	}
 	// Print the status like status command does
@@ -318,13 +318,5 @@ func (u *upgradeCmd) run() error {
 		return prettyError(err)
 	}
 
-	output, err := PrintStatusFormated(u.output, status)
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(u.out, output)
-
-	return nil
+	return write(u.out, &statusWriter{status}, outputFormat(u.output))
 }

--- a/docs/helm/helm_install.md
+++ b/docs/helm/helm_install.md
@@ -93,7 +93,7 @@ helm install [CHART] [flags]
       --namespace string         Namespace to install the release into. Defaults to the current kube config namespace.
       --no-crd-hook              Prevent CRD hooks from running, but run other hooks
       --no-hooks                 Prevent hooks from running during install
-  -o, --output string            Prints the output in the specified format (json|table|yaml) (default "table")
+  -o, --output string            Prints the output in the specified format. Allowed values: table, json, yaml (default "table")
       --password string          Chart repository password where to locate the requested chart
       --render-subchart-notes    Render subchart notes along with the parent
       --replace                  Re-use the given name, even if that name is already used. This is unsafe in production

--- a/docs/helm/helm_repo_list.md
+++ b/docs/helm/helm_repo_list.md
@@ -14,7 +14,7 @@ helm repo list [flags]
 
 ```
   -h, --help            help for list
-  -o, --output string   Prints the output in the specified format (json|table|yaml) (default "table")
+  -o, --output string   Prints the output in the specified format. Allowed values: table, json, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/helm/helm_search.md
+++ b/docs/helm/helm_search.md
@@ -20,7 +20,7 @@ helm search [keyword] [flags]
 ```
       --col-width uint   Specifies the max column width of output (default 60)
   -h, --help             help for search
-  -o, --output string    Prints the output in the specified format (json|table|yaml) (default "table")
+  -o, --output string    Prints the output in the specified format. Allowed values: table, json, yaml (default "table")
   -r, --regexp           Use regular expressions for searching
   -v, --version string   Search using semantic versioning constraints
   -l, --versions         Show the long listing, with each version of each chart on its own line

--- a/docs/helm/helm_status.md
+++ b/docs/helm/helm_status.md
@@ -23,7 +23,7 @@ helm status [flags] RELEASE_NAME
 
 ```
   -h, --help                  help for status
-  -o, --output string         Prints the output in the specified format (json|table|yaml) (default "table")
+  -o, --output string         Prints the output in the specified format. Allowed values: table, json, yaml (default "table")
       --revision int32        If set, display the status of the named release with revision
       --tls                   Enable TLS for request
       --tls-ca-cert string    Path to TLS CA certificate file (default "$HELM_HOME/ca.pem")

--- a/docs/helm/helm_upgrade.md
+++ b/docs/helm/helm_upgrade.md
@@ -79,7 +79,7 @@ helm upgrade [RELEASE] [CHART] [flags]
       --keyring string           Path to the keyring that contains public signing keys (default "~/.gnupg/pubring.gpg")
       --namespace string         Namespace to install the release into (only used if --install is set). Defaults to the current kube config namespace
       --no-hooks                 Disable pre/post upgrade hooks
-  -o, --output string            Prints the output in the specified format (json|table|yaml) (default "table")
+  -o, --output string            Prints the output in the specified format. Allowed values: table, json, yaml (default "table")
       --password string          Chart repository password where to locate the requested chart
       --recreate-pods            Performs pods restart for the resource if applicable
       --render-subchart-notes    Render subchart notes along with parent


### PR DESCRIPTION
**What this PR does / why we need it**:
This refactors the work done in #5593 by @deschmih into some more encapsulated functions to improve code reuse. It also restores the unexported `PrintStatus` function to be exported again

**Special notes for your reviewer**:
Please DO NOT merge this until #5593 is merged and I rebase on master
