### PR TITLE
Check connectivity to cluster for helm test run

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -46,6 +46,10 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 
 // Run executes 'helm test' against the given release.
 func (r *ReleaseTesting) Run(name string) error {
+	if err := r.cfg.KubeClient.IsReachable(); err != nil {
+		return err
+	}
+
 	if err := validateReleaseName(name); err != nil {
 		return errors.Errorf("releaseTest: Release name is invalid: %s", name)
 	}


### PR DESCRIPTION
Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Following the improvement of #6255 by @waveywaves I believe `helm test run` was forgotten.
So for consistency, here is the tiny change. 

Before this PR:
```
> helm test run hello
Error: query: failed to query with labels: 
Get https://mycluster:6443/api/v1/namespaces/default/secrets?labelSelector=name%3Dhello%2Cowner%3Dhelm: 
Get https://myopenid-configuration: dial tcp: lookup mykubehost: no such host
```
after:
```
>  h3 test run hello
Error: Kubernetes cluster unreachable
```

