### PR TITLE
v3: fix(completion): --flag=val breaks zsh completion

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -126,13 +126,6 @@ __helm_compgen() {
 __helm_compopt() {
 	true # don't do anything. Not supported by bashcompinit in zsh
 }
-__helm_declare() {
-	if [ "$1" == "-F" ]; then
-		whence -w "$@"
-	else
-		builtin declare "$@"
-	fi
-}
 __helm_ltrim_colon_completions()
 {
 	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
@@ -210,7 +203,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__helm_ltrim_colon_completions/g" \
 	-e "s/${LWORD}compgen${RWORD}/__helm_compgen/g" \
 	-e "s/${LWORD}compopt${RWORD}/__helm_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
 	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
 	<<'BASH_COMPLETION_EOF'


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a bug I ran into when working on Helm completion. I was surprised that it didn't happen when I was using kubectl, so I investigated and found a PR that fixed this bug in kubectl:
https://github.com/kubernetes/kubernetes/pull/48553

I duplicated the code in this commit which:

Removes `__helm_declare`, which is safe to do since `declare -F` is already replaced by `whence -w` by `__helm_convert_bash_to_zsh()`.

The problem was that calling "declare" from inside a function scopes the declaration to that function only.  So "declare" should not be called through __helm_declare() but instead directly.

To reproduce:
1- setup helm completion in zsh
2- helm --kubeconfig=$HOME/.kube/config statu\<TAB>

you will get the error:
`__helm_handle_flag:27: bad math expression: operand expected at end of string`

Co-authored-by: Kazuki Suda <kazuki.suda@gmail.com>
Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>

**Special notes for your reviewer**:

I'm working on adding dynamic completion for flags and this fix is required for completion to work with the `--kube-context` flag.

The acceptance-testing repo has a test for this bug (which is currently marked as a known failure to allow the tests to show as passed).
Once this PR is applied, the tests will pass (but be marked as failed due to an Unexpected Success. https://github.com/helm/acceptance-testing/pull/35 is ready to update the test as expected to pass).
