### PR TITLE
Helm3: fix list showing multiple revisions of release

### DIFF
--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -56,6 +56,16 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
+				Status:       release.StatusFailed,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "starlord",
+			Version:   3,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp1,
 				Status:       release.StatusDeployed,
 			},
 			Chart: chartInfo,

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -5,6 +5,5 @@ groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chi
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0
-starlord   	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0
 thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date-reversed.txt
+++ b/cmd/helm/testdata/output/list-date-reversed.txt
@@ -2,4 +2,4 @@ NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-date.txt
+++ b/cmd/helm/testdata/output/list-date.txt
@@ -1,5 +1,5 @@
 NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-filter.txt
+++ b/cmd/helm/testdata/output/list-filter.txt
@@ -2,4 +2,4 @@ NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-offset.txt
+++ b/cmd/helm/testdata/output/list-offset.txt
@@ -1,4 +1,4 @@
 NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
 iguana  	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
 rocket  	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
-starlord	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-reverse.txt
+++ b/cmd/helm/testdata/output/list-reverse.txt
@@ -1,5 +1,5 @@
 NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list-superseded.txt
+++ b/cmd/helm/testdata/output/list-superseded.txt
@@ -1,3 +1,2 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS    	CHART          
-gamora  	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0
-starlord	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS    	CHART          
+gamora	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0

--- a/cmd/helm/testdata/output/list.txt
+++ b/cmd/helm/testdata/output/list.txt
@@ -2,4 +2,4 @@ NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0
+starlord   	default  	3       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -81,7 +81,7 @@ func (cfgmaps *ConfigMaps) Get(key string) (*rspb.Release, error) {
 	return r, nil
 }
 
-// List fetches all releases and returns the list releases such
+// List fetches all latest releases and returns the list releases such
 // that filter(release) == true. An error is returned if the
 // configmap fails to retrieve the releases.
 func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
@@ -94,7 +94,7 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 		return nil, err
 	}
 
-	var results []*rspb.Release
+	releases := make([]*rspb.Release, 0, len(list.Items))
 
 	// iterate over the configmaps object list
 	// and decode each release
@@ -104,6 +104,13 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			cfgmaps.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+		releases = append(releases, rls)
+	}
+
+	latestReleases := getLatestReleases(releases)
+
+	results := make([]*rspb.Release, 0, len(latestReleases))
+	for _, rls := range latestReleases {
 		if filter(rls) {
 			results = append(results, rls)
 		}

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -87,7 +87,9 @@ func TestConfigMapList(t *testing.T) {
 	cfgmaps := newTestFixtureCfgMaps(t, []*rspb.Release{
 		releaseStub("key-1", 1, "default", rspb.StatusUninstalled),
 		releaseStub("key-2", 1, "default", rspb.StatusUninstalled),
-		releaseStub("key-3", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-3", 1, "default", rspb.StatusSuperseded),
+		releaseStub("key-3", 2, "default", rspb.StatusFailed),
+		releaseStub("key-3", 3, "default", rspb.StatusDeployed),
 		releaseStub("key-4", 1, "default", rspb.StatusDeployed),
 		releaseStub("key-5", 1, "default", rspb.StatusSuperseded),
 		releaseStub("key-6", 1, "default", rspb.StatusSuperseded),
@@ -127,6 +129,18 @@ func TestConfigMapList(t *testing.T) {
 	}
 	if len(ssd) != 2 {
 		t.Errorf("Expected 2 superseded, got %d", len(ssd))
+	}
+
+	// list all deployed or failed releases
+	dplAndFail, err := cfgmaps.List(func(rel *rspb.Release) bool {
+		return rel.Info.Status == rspb.StatusDeployed || rel.Info.Status == rspb.StatusFailed
+	})
+	// check
+	if err != nil {
+		t.Errorf("Failed to list deployed/failed: %s", err)
+	}
+	if len(dplAndFail) != 2 {
+		t.Errorf("Expected 2 deployed/failed, got %d", len(dplAndFail))
 	}
 }
 

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -194,3 +194,31 @@ func TestMemoryDelete(t *testing.T) {
 	}
 
 }
+
+func TestMemory_List(t *testing.T) {
+	var tests = []struct {
+		desc       string
+		xlen       int
+		filterFunc func(*rspb.Release) bool
+	}{
+		{
+			desc: "should be 2 list results",
+			xlen: 2,
+			filterFunc: func(rls *rspb.Release) bool {
+				return true
+			},
+		},
+	}
+
+	ts := tsFixtureMemory(t)
+	for _, tt := range tests {
+		l, err := ts.List(tt.filterFunc)
+		if err != nil {
+			t.Fatalf("Failed to list: %s\n", err)
+		}
+
+		if tt.xlen != len(l) {
+			t.Fatalf("Expected %d results, actual %d\n", tt.xlen, len(l))
+		}
+	}
+}

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -46,13 +46,13 @@ func tsFixtureMemory(t *testing.T) *Memory {
 		// rls-a
 		releaseStub("rls-a", 4, "default", rspb.StatusDeployed),
 		releaseStub("rls-a", 1, "default", rspb.StatusSuperseded),
-		releaseStub("rls-a", 3, "default", rspb.StatusSuperseded),
+		releaseStub("rls-a", 3, "default", rspb.StatusFailed),
 		releaseStub("rls-a", 2, "default", rspb.StatusSuperseded),
 		// rls-b
 		releaseStub("rls-b", 4, "default", rspb.StatusDeployed),
 		releaseStub("rls-b", 1, "default", rspb.StatusSuperseded),
 		releaseStub("rls-b", 3, "default", rspb.StatusSuperseded),
-		releaseStub("rls-b", 2, "default", rspb.StatusSuperseded),
+		releaseStub("rls-b", 2, "default", rspb.StatusFailed),
 	}
 
 	mem := NewMemory()

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -74,7 +74,7 @@ func (secrets *Secrets) Get(key string) (*rspb.Release, error) {
 	return r, errors.Wrapf(err, "get: failed to decode data %q", key)
 }
 
-// List fetches all releases and returns the list releases such
+// List fetches all the latest releases and returns the list releases such
 // that filter(release) == true. An error is returned if the
 // secret fails to retrieve the releases.
 func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
@@ -86,7 +86,7 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 		return nil, errors.Wrap(err, "list: failed to list")
 	}
 
-	var results []*rspb.Release
+	releases := make([]*rspb.Release, 0, len(list.Items))
 
 	// iterate over the secrets object list
 	// and decode each release
@@ -96,6 +96,13 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			secrets.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+		releases = append(releases, rls)
+	}
+
+	latestReleases := getLatestReleases(releases)
+
+	results := make([]*rspb.Release, 0, len(latestReleases))
+	for _, rls := range latestReleases {
 		if filter(rls) {
 			results = append(results, rls)
 		}

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -51,7 +51,7 @@ func TestSecretGet(t *testing.T) {
 	}
 }
 
-func TestUNcompressedSecretGet(t *testing.T) {
+func TestUncompressedSecretGet(t *testing.T) {
 	vers := 1
 	name := "smug-pigeon"
 	namespace := "default"
@@ -87,7 +87,9 @@ func TestSecretList(t *testing.T) {
 	secrets := newTestFixtureSecrets(t, []*rspb.Release{
 		releaseStub("key-1", 1, "default", rspb.StatusUninstalled),
 		releaseStub("key-2", 1, "default", rspb.StatusUninstalled),
-		releaseStub("key-3", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-3", 1, "default", rspb.StatusSuperseded),
+		releaseStub("key-3", 2, "default", rspb.StatusFailed),
+		releaseStub("key-3", 3, "default", rspb.StatusDeployed),
 		releaseStub("key-4", 1, "default", rspb.StatusDeployed),
 		releaseStub("key-5", 1, "default", rspb.StatusSuperseded),
 		releaseStub("key-6", 1, "default", rspb.StatusSuperseded),
@@ -127,6 +129,18 @@ func TestSecretList(t *testing.T) {
 	}
 	if len(ssd) != 2 {
 		t.Errorf("Expected 2 superseded, got %d", len(ssd))
+	}
+
+	// list all deployed or failed releases
+	dplAndFail, err := secrets.List(func(rel *rspb.Release) bool {
+		return rel.Info.Status == rspb.StatusDeployed || rel.Info.Status == rspb.StatusFailed
+	})
+	// check
+	if err != nil {
+		t.Errorf("Failed to list deployed/failed: %s", err)
+	}
+	if len(dplAndFail) != 2 {
+		t.Errorf("Expected 2 deployed/failed, got %d", len(dplAndFail))
 	}
 }
 

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -83,3 +83,21 @@ func decodeRelease(data string) (*rspb.Release, error) {
 	}
 	return &rls, nil
 }
+
+// getLatestReleases returns the latest releases from the list of releases
+func getLatestReleases(releases []*rspb.Release) []*rspb.Release {
+	latestReleases := make(map[string]*rspb.Release)
+
+	for _, rls := range releases {
+		if latestRelease, exists := latestReleases[rls.Name]; exists && latestRelease.Version > rls.Version {
+			continue
+		}
+		latestReleases[rls.Name] = rls
+	}
+
+	var list = make([]*rspb.Release, 0, len(latestReleases))
+	for _, rls := range latestReleases {
+		list = append(list, rls)
+	}
+	return list
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -75,14 +75,14 @@ func (s *Storage) Delete(name string, version int) (*rspb.Release, error) {
 	return s.Driver.Delete(makeKey(name, version))
 }
 
-// ListReleases returns all releases from storage. An error is returned if the
+// ListReleases returns all latest releases from storage. An error is returned if the
 // storage backend fails to retrieve the releases.
 func (s *Storage) ListReleases() ([]*rspb.Release, error) {
-	s.Log("listing all releases in storage")
+	s.Log("listing all latest releases in storage")
 	return s.Driver.List(func(_ *rspb.Release) bool { return true })
 }
 
-// ListUninstalled returns all releases with Status == UNINSTALLED. An error is returned
+// ListUninstalled returns all latest releases with Status == UNINSTALLED. An error is returned
 // if the storage backend fails to retrieve the releases.
 func (s *Storage) ListUninstalled() ([]*rspb.Release, error) {
 	s.Log("listing uninstalled releases in storage")
@@ -91,10 +91,10 @@ func (s *Storage) ListUninstalled() ([]*rspb.Release, error) {
 	})
 }
 
-// ListDeployed returns all releases with Status == DEPLOYED. An error is returned
+// ListDeployed returns all latest releases with Status == DEPLOYED. An error is returned
 // if the storage backend fails to retrieve the releases.
 func (s *Storage) ListDeployed() ([]*rspb.Release, error) {
-	s.Log("listing all deployed releases in storage")
+	s.Log("listing all latest deployed releases in storage")
 	return s.Driver.List(func(rls *rspb.Release) bool {
 		return relutil.StatusFilter(rspb.StatusDeployed).Check(rls)
 	})

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -126,9 +126,10 @@ func TestStorageList(t *testing.T) {
 		rls1 := ReleaseTestData{Name: "livid-human", Status: rspb.StatusSuperseded}.ToRelease()
 		rls2 := ReleaseTestData{Name: "relaxed-cat", Status: rspb.StatusSuperseded}.ToRelease()
 		rls3 := ReleaseTestData{Name: "hungry-hippo", Status: rspb.StatusDeployed}.ToRelease()
-		rls4 := ReleaseTestData{Name: "angry-beaver", Status: rspb.StatusDeployed}.ToRelease()
-		rls5 := ReleaseTestData{Name: "opulent-frog", Status: rspb.StatusUninstalled}.ToRelease()
-		rls6 := ReleaseTestData{Name: "happy-liger", Status: rspb.StatusUninstalled}.ToRelease()
+		rls4 := ReleaseTestData{Name: "angry-beaver", Version: 1, Status: rspb.StatusFailed}.ToRelease()
+		rls5 := ReleaseTestData{Name: "angry-beaver", Version: 2, Status: rspb.StatusDeployed}.ToRelease()
+		rls6 := ReleaseTestData{Name: "opulent-frog", Status: rspb.StatusUninstalled}.ToRelease()
+		rls7 := ReleaseTestData{Name: "happy-liger", Status: rspb.StatusUninstalled}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'rls0'")
@@ -138,6 +139,7 @@ func TestStorageList(t *testing.T) {
 		assertErrNil(t.Fatal, storage.Create(rls4), "Storing release 'rls4'")
 		assertErrNil(t.Fatal, storage.Create(rls5), "Storing release 'rls5'")
 		assertErrNil(t.Fatal, storage.Create(rls6), "Storing release 'rls6'")
+		assertErrNil(t.Fatal, storage.Create(rls7), "Storing release 'rls7'")
 	}
 
 	var listTests = []struct {


### PR DESCRIPTION
Signed-off-by: Karuppiah Natarajan <karuppiah7890@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes #6356 

**Special notes for your reviewer**:
Everywhere list showed up all releases (old revisions and latest revisions of releases), but in this PR, only latest revisions of releases are returned by the list methods. Let me know if list was actually intended to show both latest and old revisions and if it's needed, in which case, we can fix the issue differently after discussing a different solution 😄 

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
