### PR TITLE
feat-v3(cli): Dynamic completion for global flags

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -126,13 +126,6 @@ __helm_compgen() {
 __helm_compopt() {
 	true # don't do anything. Not supported by bashcompinit in zsh
 }
-__helm_declare() {
-	if [ "$1" == "-F" ]; then
-		whence -w "$@"
-	else
-		builtin declare "$@"
-	fi
-}
 __helm_ltrim_colon_completions()
 {
 	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
@@ -210,7 +203,7 @@ __helm_convert_bash_to_zsh() {
 	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__helm_ltrim_colon_completions/g" \
 	-e "s/${LWORD}compgen${RWORD}/__helm_compgen/g" \
 	-e "s/${LWORD}compopt${RWORD}/__helm_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/__helm_declare/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__helm_type/g" \
 	-e 's/aliashash\["\(.\{1,\}\)"\]/aliashash[\1]/g' \
 	<<'BASH_COMPLETION_EOF'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

New dynamic completion of global flags:
    --kube-context - where the available contexts are listed
    --namespace    - where the namespaces of the cluster are listed

For example:
```
   helm --namespace <TAB> # will provide the list of available namespaces on the cluster
```
**Special notes for your reviewer**:

Inspired greatly from kubectl code.

This PR, to work properly, is dependant and therefore built on top of #6389.

For this new completion to work, the user must have `kubectl` available.

The corresponding acceptance tests are posted in https://github.com/helm/acceptance-testing/pull/38