### PR TITLE
Fix reachability check which must be disabled for `helm template` (unless `--validate` is specified)

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -147,8 +147,11 @@ func (i *Install) installCRDs(crds []*chart.File) error {
 //
 // If DryRun is set to true, this will prepare the release, but not install it
 func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.Release, error) {
-	if err := i.cfg.KubeClient.IsReachable(); err != nil {
-		return nil, err
+	// Check reachability of cluster unless in client-only mode (e.g. `helm template` without `--validate`)
+	if !i.ClientOnly {
+		if err := i.cfg.KubeClient.IsReachable(); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := i.availableName(); err != nil {


### PR DESCRIPTION
closes #6404 

**What this PR does / why we need it**:

See #6404 (my duplicate: #6417). `helm template` should only generate output from a template and not connect anywhere, but a change in beta2..beta3 added a cluster reachability check unconditionally. This makes `helm template` work again without a cluster, while still checking reachability in case of `helm template --validate`.

**Special notes for your reviewer**:

If there's a way to unit-test or integration-test this, please point me to the place in the codebase and I will ensure this bug won't come up again.