### PR TITLE
Updated README to link to install from script instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ If you want to use a package manager:
 
 If you want to install helm from script:
 
-- [Script](https://github.com/helm/helm/blob/master/docs/install.md#from-script) instructions to install from script on a new instance without Helm. For example, you want to install on a container, cluster, etc. Note: GCP console comes with `Helm` installed by default.
+- [Script](https://helm.sh/docs/using_helm/#from-script)
+instructions to install from script on a new instance without Helm. For example, you want to install on a container, cluster, etc. Note: GCP console comes with `helm` installed by default.
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you want to use a package manager:
 - [Snap](https://snapcraft.io/) users can use `sudo snap install helm
   --classic`.
 
+If you want to install helm from script:
+
+- [Script](https://github.com/helm/helm/blob/master/docs/install.md#from-script) instructions to install from script on a new instance without Helm. For example, you want to install on a container, cluster, etc. Note: GCP console comes with `Helm` installed by default.
+
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
 
 See the [installation guide](https://docs.helm.sh/using_helm/#installing-helm) for more options,


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #6423 

Needed because the documentation to install on a fresh instance that does have **Helm** installed by default is really well hidden. For example, if you wanted to install **Helm** on a new image somewhere it takes a bit of Googling to figure out how to do so. I just think this installation should be clearer on the main documentation page rather than hidden deep in a doc file.

**Special notes for your reviewer**:
I found this issue when I was taking @StephenGrider's course on Kubernetes. It was not easy to figure out how to get Helm installed. There are a lot of students that take this course and come to this repository so I think this would be **REALLY** helpful.

**If applicable**:
✅this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
