### PR TITLE
fix install storing computed values in release instead of user supplied values

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -166,6 +166,13 @@ func buildChart(opts ...chartOption) *chart.Chart {
 	return c.Chart
 }
 
+func withSampleValues() chartOption {
+	values := map[string]interface{}{"someKey": "someValue"}
+	return func(opts *chartOptions) {
+		opts.Values = values
+	}
+}
+
 func withNotes(notes string) chartOption {
 	return func(opts *chartOptions) {
 		opts.Templates = append(opts.Templates, &chart.File{

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -83,10 +83,6 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 func lintChart(path string, vals map[string]interface{}, namespace string, strict bool) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
-	currentVals := make(map[string]interface{}, len(vals))
-	for key, value := range vals {
-		currentVals[key] = value
-	}
 
 	if strings.HasSuffix(path, ".tgz") {
 		tempDir, err := ioutil.TempDir("", "helm-lint")
@@ -120,5 +116,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, stric
 		return linter, errLintNoChart
 	}
 
-	return lint.All(chartPath, currentVals, namespace, strict), nil
+	return lint.All(chartPath, vals, namespace, strict), nil
 }

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -34,13 +34,13 @@ import (
 //	- A chart has access to all of the variables for it, as well as all of
 //		the values destined for its dependencies.
 func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (Values, error) {
-	if vals == nil {
-		vals = make(map[string]interface{})
+	// create a copy of vals and then pass it to coalesce
+	// and coalesceDeps, as both will mutate the passed values
+	valsCopy := copyMap(vals)
+	if _, err := coalesce(chrt, valsCopy); err != nil {
+		return valsCopy, err
 	}
-	if _, err := coalesce(chrt, vals); err != nil {
-		return vals, err
-	}
-	return coalesceDeps(chrt, vals)
+	return coalesceDeps(chrt, valsCopy)
 }
 
 // coalesce coalesces the dest values and the chart values, giving priority to the dest values.

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -19,6 +19,8 @@ package chartutil
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // ref: http://www.yaml.org/spec/1.2/spec.html#id2803362
@@ -48,11 +50,20 @@ pequod:
 `)
 
 func TestCoalesceValues(t *testing.T) {
+	is := assert.New(t)
 	c := loadChart(t, "testdata/moby")
 
 	vals, err := ReadValues(testCoalesceValuesYaml)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// taking a copy of the values before passing it
+	// to CoalesceValues as argument, so that we can
+	// use it for asserting later
+	valsCopy := make(Values, len(vals))
+	for key, value := range vals {
+		valsCopy[key] = value
 	}
 
 	v, err := CoalesceValues(c, vals)
@@ -102,6 +113,9 @@ func TestCoalesceValues(t *testing.T) {
 			t.Errorf("Expected key %q to be removed, still present", nullKey)
 		}
 	}
+
+	// CoalesceValues should not mutate the passed arguments
+	is.Equal(valsCopy, vals)
 }
 
 func TestCoalesceTables(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Karuppiah Natarajan <karuppiah7890@gmail.com>

**What this PR does / why we need it**:
Fixes #6358 

**Special notes for your reviewer**:
I also removed the some code added by #6241 which fixed #6079 . Reason - As noticed [here](https://github.com/helm/helm/issues/6079#issuecomment-521298928) the issue was due to `CoalesceValues` mutating values. But for some reason, I oversaw the root cause and suggested to fix at a higher level and not at the lower level in `CoalesceValues` which is the root cause of the issue #6079 and since we fixed it at a higher level in the `lint` code alone, by cloning values, the root problem was affecting other code too, like #6358 . I checked all the places where the `CoalesceValues` code was being used. Looks like install was clearly the only place that was affected due to the mutation. I also wanted to check `CoalesceTables` which does some mutation, but left it for now. Will dig on it too sometime to look for bugs 😄 

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
