### PR TITLE
fix(v3): `helm template` output should include hooks by default

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -56,6 +56,12 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(out, strings.TrimSpace(rel.Manifest))
+			if !client.DisableHooks {
+				for _, m := range rel.Hooks {
+					fmt.Fprintf(out, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)
+				}
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
This fixes `helm template [--no-hooks]` to work like proposed in #6443

Manually tested with running `helm template` against `stable/mysql` chart with helm 2, helm 3.0.0-beta.3, and helm 3 after this fix.

The manual test report follows. It assumes `helmv3` is 3.0.0-beta.3 and `helmv3-nohooksfix` is the binary build from this PR.

```
$ helmv3 fetch stable/mysql

$ helmv3 template mysql-1.3.1.tgz > helm-template-mysql-helm-3.yaml

$ helmv3-nohooksfix template mysql-1.3.1.tgz > helm-template-mysql-helm-3-with-fix.yaml

$ helmv3-nohooksfix template --no-hooks mysql-1.3.1.tgz > helm-template-mysql-helm-3-with-fix-nohooks-enabled.yaml
```

The example below shows that this fix changes `helm template` to output hooks by default:

```
$ diff --unified helm-template-mysql-helm-3{,-with-fix}.yaml
--- helm-template-mysql-helm-3.yaml	2019-09-17 22:21:38.000000000 +0900
+++ helm-template-mysql-helm-3-with-fix.yaml	2019-09-17 22:21:53.000000000 +0900
@@ -13,10 +13,10 @@
 type: Opaque
 data:

-  mysql-root-password: "VGtybWh5N3JnWA=="
+  mysql-root-password: "aGpHN2VEbnhvVA=="

-  mysql-password: "OTNQSXdNVURBYw=="
+  mysql-password: "UmpwQkVuMHpoQQ=="
 ---
 # Source: mysql/templates/tests/test-configmap.yaml
 apiVersion: v1
@@ -167,3 +167,48 @@
           claimName: RELEASE-NAME-mysql
       # - name: extras
       #   emptyDir: {}
+---
+# Source: mysql/templates/tests/test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: RELEASE-NAME-mysql-test
+  namespace: default
+  labels:
+    app: RELEASE-NAME-mysql
+    chart: "mysql-1.3.1"
+    heritage: "Helm"
+    release: "RELEASE-NAME"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: "dduportal/bats:0.4.0"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: RELEASE-NAME-test
+      image: "mysql:5.7.14"
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: RELEASE-NAME-mysql-test
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never
```

The example below shows that `helm template --no-hooks` can be used for excluding hooks:

```
$ diff --unified helm-template-mysql-helm-3{,-with-fix-nohooks-enabled}.yaml
--- helm-template-mysql-helm-3.yaml	2019-09-17 22:21:38.000000000 +0900
+++ helm-template-mysql-helm-3-with-fix-nohooks-enabled.yaml	2019-09-17 22:22:03.000000000 +0900
@@ -13,10 +13,10 @@
 type: Opaque
 data:

-  mysql-root-password: "VGtybWh5N3JnWA=="
+  mysql-root-password: "Zk1LYUd6OWgzaQ=="

-  mysql-password: "OTNQSXdNVURBYw=="
+  mysql-password: "OTZPZU9hdlFORg=="
 ---
 # Source: mysql/templates/tests/test-configmap.yaml
 apiVersion: v1
```

Fixes #6443