### PR TITLE
Updating to newer versions of dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 277f7be1b21149bc06b361fa61c0a2ff81a7f00c59a6e35c21b6516f6ddfd9f7
-updated: 2019-07-03T21:59:06.87934+02:00
+hash: 13c07a8e64f0777d08cd03d5edba6f254621ec1ee8e3c7b3ef26efc682b643ce
+updated: 2019-09-18T12:07:21.888497-04:00
 imports:
 - name: cloud.google.com/go
   version: 0ebda48a7f143b1cce9eb37a8c1106ac762a3430
@@ -121,7 +121,7 @@ imports:
 - name: github.com/google/gofuzz
   version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
 - name: github.com/google/uuid
-  version: 064e2069ce9c359c118179501254f67d7d37ba24
+  version: 0cd6bf5da1e1c83f8b45653022c74f71af0538a4
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -183,11 +183,11 @@ imports:
 - name: github.com/Masterminds/goutils
   version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/Masterminds/semver
-  version: c7af12943936e8c39859482e61f0574c2fd7fc75
+  version: 805c489aa98f412e79eb308a37996bf9d8b1c91e
 - name: github.com/Masterminds/sprig
-  version: 258b00ffa7318e8b109a141349980ffbd30a35db
+  version: 2691a9cba2adee8d9a60100a1bc49e770f97b7db
 - name: github.com/Masterminds/vcs
-  version: 3084677c2c188840777bff30054f2b553729d329
+  version: f94282d8632a0620f79f0c6ff0e82604e8c5c85b
 - name: github.com/mattn/go-runewidth
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -247,7 +247,7 @@ imports:
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 298182f68c66c05229eb03ac171abe6e309ee79a
+  version: e8f29969b682c41a730f8f08b76033b120498464
 - name: github.com/technosophos/moniker
   version: a5dbd03a2245d554160e3ae6bfdcf969fe58b431
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,8 +21,9 @@ import:
   - package: github.com/Masterminds/sprig
     version: ^2.20.0
   - package: github.com/ghodss/yaml
+    version: c7ce16629ff4cd059ed96ed06419dd3856fd3577
   - package: github.com/Masterminds/semver
-    version: ~1.4.2
+    version: ^1.4.2
   - package: github.com/technosophos/moniker
     version: ~0.2
   - package: github.com/golang/protobuf

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -55,7 +55,7 @@ func TestBadChart(t *testing.T) {
 			}
 		}
 		if msg.Severity == support.ErrorSev {
-			if strings.Contains(msg.Err.Error(), "version 0.0.0 is less than or equal to 0") {
+			if strings.Contains(msg.Err.Error(), "version '0.0.0.0' is not a valid SemVer") {
 				e = true
 			}
 			if strings.Contains(msg.Err.Error(), "name is required") {

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -120,7 +120,7 @@ func validateChartVersion(cf *chart.Metadata) error {
 		return fmt.Errorf("version '%s' is not a valid SemVer", cf.Version)
 	}
 
-	c, err := semver.NewConstraint("> 0")
+	c, err := semver.NewConstraint(">0.0.0-0")
 	if err != nil {
 		return err
 	}

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -106,7 +106,7 @@ func TestValidateChartVersion(t *testing.T) {
 		ErrorMsg string
 	}{
 		{"", "version is required"},
-		{"0", "0 is less than or equal to 0"},
+		{"1.2.3.4", "version '1.2.3.4' is not a valid SemVer"},
 		{"waps", "'waps' is not a valid SemVer"},
 		{"-3", "'-3' is not a valid SemVer"},
 	}
@@ -252,7 +252,7 @@ func TestChartfile(t *testing.T) {
 		t.Errorf("Unexpected message 2: %s", msgs[2].Err)
 	}
 
-	if !strings.Contains(msgs[3].Err.Error(), "version 0.0.0 is less than or equal to 0") {
+	if !strings.Contains(msgs[3].Err.Error(), "version '0.0.0.0' is not a valid SemVer") {
 		t.Errorf("Unexpected message 3: %s", msgs[2].Err)
 	}
 

--- a/pkg/lint/rules/testdata/badchartfile/Chart.yaml
+++ b/pkg/lint/rules/testdata/badchartfile/Chart.yaml
@@ -1,3 +1,3 @@
 description: A Helm chart for Kubernetes
-version: 0.0.0
+version: 0.0.0.0
 home: ""

--- a/pkg/tiller/release_install_test.go
+++ b/pkg/tiller/release_install_test.go
@@ -502,7 +502,7 @@ func TestInstallRelease_KubeVersion(t *testing.T) {
 	rs := rsFixture()
 
 	req := installRequest(
-		withChart(withKube(">=0.0.0")),
+		withChart(withKube(">=0.0.0-0")),
 	)
 	_, err := rs.InstallRelease(c, req)
 	if err != nil {


### PR DESCRIPTION
* This was initiated by new versions from Masterminds
* Linting was set to check for the same chart version as the other
  checks of this were. >0.0.0-0. The -0 is important to pull in
  prereleases. The latest version of semver Validate now finds
  errors here properly where some were missed before
* 0.0.0 is a valid semantic version. Instead of expecting it to be
  invalid in the tests to check validation now using an invalid
  semantic version

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
