### PR TITLE
Helm init compatible with Kubernetes 1.16

### DIFF
--- a/cmd/helm/init.go
+++ b/cmd/helm/init.go
@@ -282,7 +282,7 @@ func (i *initCmd) run() error {
 				if err := i.ping(i.opts.SelectImage()); err != nil {
 					return err
 				}
-				fmt.Fprintln(i.out, "\nTiller (the Helm server-side component) has been upgraded to the current version.")
+				fmt.Fprintln(i.out, "\nTiller (the Helm server-side component) has been updated to", i.opts.SelectImage(), ".")
 			} else {
 				debug("The error received while trying to init: %s", err)
 				fmt.Fprintln(i.out, "Warning: Tiller is already installed in the cluster.\n"+

--- a/cmd/helm/init_test.go
+++ b/cmd/helm/init_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,7 +83,7 @@ func TestInitCmd_exists(t *testing.T) {
 	defer os.RemoveAll(home)
 
 	var buf bytes.Buffer
-	fc := fake.NewSimpleClientset(&v1beta1.Deployment{
+	fc := fake.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: v1.NamespaceDefault,
 			Name:      "tiller-deploy",

--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -192,7 +192,7 @@ func TestInstall(t *testing.T) {
 
 	fc := &fake.Clientset{}
 	fc.AddReactor("create", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.CreateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.CreateAction).GetObject().(*appsv1.Deployment)
 		l := obj.GetLabels()
 		if reflect.DeepEqual(l, map[string]string{"app": "helm"}) {
 			t.Errorf("expected labels = '', got '%s'", l)
@@ -239,7 +239,7 @@ func TestInstallHA(t *testing.T) {
 
 	fc := &fake.Clientset{}
 	fc.AddReactor("create", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.CreateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.CreateAction).GetObject().(*appsv1.Deployment)
 		replicas := obj.Spec.Replicas
 		if int(*replicas) != 2 {
 			t.Errorf("expected replicas = 2, got '%d'", replicas)
@@ -263,7 +263,7 @@ func TestInstall_WithTLS(t *testing.T) {
 
 	fc := &fake.Clientset{}
 	fc.AddReactor("create", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.CreateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.CreateAction).GetObject().(*appsv1.Deployment)
 		l := obj.GetLabels()
 		if reflect.DeepEqual(l, map[string]string{"app": "helm"}) {
 			t.Errorf("expected labels = '', got '%s'", l)
@@ -331,7 +331,7 @@ func TestInstall_WithTLS(t *testing.T) {
 func TestInstall_canary(t *testing.T) {
 	fc := &fake.Clientset{}
 	fc.AddReactor("create", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.CreateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.CreateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != "gcr.io/kubernetes-helm/tiller:canary" {
 			t.Errorf("expected canary image, got '%s'", i)
@@ -369,7 +369,7 @@ func TestUpgrade(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
@@ -408,7 +408,7 @@ func TestUpgrade_serviceNotFound(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
@@ -453,7 +453,7 @@ func TestUgrade_newerVersion(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
@@ -513,7 +513,7 @@ func TestUpgrade_identical(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
@@ -554,7 +554,7 @@ func TestUpgrade_canaryClient(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)
@@ -595,7 +595,7 @@ func TestUpgrade_canaryServer(t *testing.T) {
 		return true, existingDeployment, nil
 	})
 	fc.AddReactor("update", "deployments", func(action testcore.Action) (bool, runtime.Object, error) {
-		obj := action.(testcore.UpdateAction).GetObject().(*v1beta1.Deployment)
+		obj := action.(testcore.UpdateAction).GetObject().(*appsv1.Deployment)
 		i := obj.Spec.Template.Spec.Containers[0].Image
 		if i != image {
 			t.Errorf("expected image = '%s', got '%s'", image, i)


### PR DESCRIPTION

Helm init currently creates a Deployment for Tiller which is using the deprecated extensions/v1beta1 API. This PR migrates it to apps/v1.

with this PR, helm produces the following out:
```bash
./helm init --service-account=tiller --tiller-image=gcr.io/kubernetes-helm/tiller:v2.14.3 -o yaml > apps-v1.yaml
```

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: helm
    name: tiller
  name: tiller-deploy
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: helm
      name: tiller
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: helm
        name: tiller
    spec:
      automountServiceAccountToken: true
      containers:
      - env:
        - name: TILLER_NAMESPACE
          value: kube-system
        - name: TILLER_HISTORY_MAX
          value: "0"
        image: gcr.io/kubernetes-helm/tiller:v2.14.3
        imagePullPolicy: IfNotPresent
        livenessProbe:
          httpGet:
            path: /liveness
            port: 44135
          initialDelaySeconds: 1
          timeoutSeconds: 1
        name: tiller
        ports:
        - containerPort: 44134
          name: tiller
        - containerPort: 44135
          name: http
        readinessProbe:
          httpGet:
            path: /readiness
            port: 44135
          initialDelaySeconds: 1
          timeoutSeconds: 1
        resources: {}
      serviceAccountName: tiller
status: {}

---
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app: helm
    name: tiller
  name: tiller-deploy
  namespace: kube-system
spec:
  ports:
  - name: tiller
    port: 44134
    targetPort: tiller
  selector:
    app: helm
    name: tiller
  type: ClusterIP
status:
  loadBalancer: {}

...
```

without this PR, helm init produces the following output:
```bash
helm init --service-account=tiller --tiller-image=gcr.io/kubernetes-helm/tiller:v2.14.3 -o yaml > extensions-v1beta1.yaml
```

```yaml
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: helm
    name: tiller
  name: tiller-deploy
  namespace: kube-system
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: helm
        name: tiller
    spec:
      automountServiceAccountToken: true
      containers:
      - env:
        - name: TILLER_NAMESPACE
          value: kube-system
        - name: TILLER_HISTORY_MAX
          value: "0"
        image: gcr.io/kubernetes-helm/tiller:v2.14.3
        imagePullPolicy: IfNotPresent
        livenessProbe:
          httpGet:
            path: /liveness
            port: 44135
          initialDelaySeconds: 1
          timeoutSeconds: 1
        name: tiller
        ports:
        - containerPort: 44134
          name: tiller
        - containerPort: 44135
          name: http
        readinessProbe:
          httpGet:
            path: /readiness
            port: 44135
          initialDelaySeconds: 1
          timeoutSeconds: 1
        resources: {}
      serviceAccountName: tiller
status: {}

---
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app: helm
    name: tiller
  name: tiller-deploy
  namespace: kube-system
spec:
  ports:
  - name: tiller
    port: 44134
    targetPort: tiller
  selector:
    app: helm
    name: tiller
  type: ClusterIP
status:
  loadBalancer: {}

...
```

The deployment of tiller seems to also work:
```bash
kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.0", GitCommit:"2bd9643cee5b3b3a5ecbd3af49d09018f0773c77", GitTreeState:"clean", BuildDate:"2019-09-18T14:36:53Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.0", GitCommit:"2bd9643cee5b3b3a5ecbd3af49d09018f0773c77", GitTreeState:"clean", BuildDate:"2019-09-18T14:27:17Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
```

```bash
kubectl apply -f /home/xxxxxx/kube-deployment/tiller/tiller-serviceaccount.yamli
serviceaccount/tiller unchanged
clusterrolebinding.rbac.authorization.k8s.io/tiller unchanged
```

```bash
~/src/k8s.io/helm/bin$ ./helm init --service-account=tiller --tiller-image=gcr.io/kubernetes-helm/tiller:v2.14.3
Creating /home/xxxxxx/.helm
Creating /home/xxxxxx/.helm/repository
Creating /home/xxxxxx/.helm/repository/cache
Creating /home/xxxxxx/.helm/repository/local
Creating /home/xxxxxx/.helm/plugins
Creating /home/xxxxxx/.helm/starters
Creating /home/xxxxxx/.helm/cache/archive
Creating /home/xxxxxx/.helm/repository/repositories.yaml
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
Adding local repo with URL: http://127.0.0.1:8879/charts
$HELM_HOME has been configured at /home/xxxxxx/.helm.

Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.

Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy.
To prevent this, run `helm init` with the --tiller-tls-verify flag.
For more information on securing your installation see: https://docs.helm.sh/using_helm/#securing-your-helm-installation
```
```bash
kubectl get all -n kube-system

NAME                                           READY   STATUS    RESTARTS   AGE
pod/calico-etcd-qfq9k                          1/1     Running   0          85m
pod/calico-kube-controllers-6944fb5984-85ph6   1/1     Running   0          85m
pod/calico-node-8vfc5                          1/1     Running   0          85m
pod/coredns-5644d7b6d9-khp2w                   1/1     Running   0          85m
pod/coredns-5644d7b6d9-rkrqs                   1/1     Running   0          85m
pod/etcd-kubedgesdk                            1/1     Running   0          84m
pod/kube-apiserver-kubedgesdk                  1/1     Running   0          84m
pod/kube-controller-manager-kubedgesdk         1/1     Running   0          84m
pod/kube-proxy-5m66t                           1/1     Running   0          85m
pod/kube-scheduler-kubedgesdk                  1/1     Running   0          84m
pod/tiller-deploy-77855d9dcf-6rr5r             1/1     Running   0          75s

NAME                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
service/calico-etcd     ClusterIP   10.96.232.136    <none>        6666/TCP                 85m
service/kube-dns        ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP,9153/TCP   85m
service/tiller-deploy   ClusterIP   10.100.221.194   <none>        44134/TCP                75s

NAME                         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
daemonset.apps/calico-etcd   1         1         1       1            1           node-role.kubernetes.io/master=   85m
daemonset.apps/calico-node   1         1         1       1            1           beta.kubernetes.io/os=linux       85m
daemonset.apps/kube-proxy    1         1         1       1            1           beta.kubernetes.io/os=linux       85m

NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/calico-kube-controllers   1/1     1            1           85m
deployment.apps/coredns                   2/2     2            2           85m
deployment.apps/tiller-deploy             1/1     1            1           75s

NAME                                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/calico-kube-controllers-6944fb5984   1         1         1       85m
replicaset.apps/coredns-5644d7b6d9                   2         2         2       85m
replicaset.apps/tiller-deploy-77855d9dcf             1         1         1       75s
```
