### PR TITLE
v3: fix(completion): Redirect stderr must be before pipes

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -103,7 +103,7 @@ __helm_list_repos()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
     local out
-    if out=$(helm repo list | tail +2 | cut -f1 2>/dev/null); then
+    if out=$(helm repo list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -111,7 +111,7 @@ __helm_list_plugins()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
     local out
-    if out=$(helm plugin list | tail +2 | cut -f1 2>/dev/null); then
+    if out=$(helm plugin list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }


### PR DESCRIPTION
Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Redirecting stderr from Helm must be done before piping.
Without this, if there are no repos defined completion will show the error message.
```
> h3 repo remove <TAB>
h3 repo remove ......Error: no repositories to show
```

Tests added for this bug in https://github.com/helm/acceptance-testing/pull/44