### PR TITLE
v3: Dynamic completion to handle env with both helm2 and helm3

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -89,19 +89,22 @@ __helm_get_namespaces()
     fi
 }
 
-__helm_list_releases()
+__helm_binary_name()
 {
-    __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    local out filter helm_binary
-
-    # Use ^ to map from the start of the release name
-    filter="^${words[c]}"
-
+    local helm_binary
     helm_binary="${words[0]}"
     __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
+    echo ${helm_binary}
+}
 
-    # Use eval in case helm_binary or __helm_override_flags contains a variable (e.g., $HOME/bin/h3)
-    if out=$(eval ${helm_binary} list $(__helm_override_flags) -a -q -m 1000 -f ${filter} 2>/dev/null); then
+__helm_list_releases()
+{
+	__helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+	local out filter
+	# Use ^ to map from the start of the release name
+	filter="^${words[c]}"
+    # Use eval in case helm_binary_name or __helm_override_flags contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval $(__helm_binary_name) list $(__helm_override_flags) -a -q -m 1000 -f ${filter} 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -109,13 +112,9 @@ __helm_list_releases()
 __helm_list_repos()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    local out helm_binary
-
-    helm_binary="${words[0]}"
-    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
-
-    # Use eval in case helm_binary contains a variable (e.g., $HOME/bin/h3)
-    if out=$(eval ${helm_binary} repo list 2>/dev/null | tail +2 | cut -f1); then
+    local out
+    # Use eval in case helm_binary_name contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval $(__helm_binary_name) repo list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -123,13 +122,9 @@ __helm_list_repos()
 __helm_list_plugins()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    local out helm_binary
-
-    helm_binary="${words[0]}"
-    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
-
-    # Use eval in case helm_binary contains a variable (e.g., $HOME/bin/h3)
-    if out=$(eval ${helm_binary} plugin list 2>/dev/null | tail +2 | cut -f1); then
+    local out
+    # Use eval in case helm_binary_name contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval $(__helm_binary_name) plugin list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -91,30 +91,49 @@ __helm_get_namespaces()
 
 __helm_list_releases()
 {
-	__helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-	local out filter
-	# Use ^ to map from the start of the release name
-	filter="^${words[c]}"
-    if out=$(helm list $(__helm_override_flags) -a -q -m 1000 -f ${filter} 2>/dev/null); then
+    __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    local out filter helm_binary
+
+    # Use ^ to map from the start of the release name
+    filter="^${words[c]}"
+
+    helm_binary="${words[0]}"
+    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
+
+    # Use eval in case helm_binary or __helm_override_flags contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval ${helm_binary} list $(__helm_override_flags) -a -q -m 1000 -f ${filter} 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
+
 __helm_list_repos()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    local out
-    if out=$(helm repo list 2>/dev/null | tail +2 | cut -f1); then
+    local out helm_binary
+
+    helm_binary="${words[0]}"
+    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
+
+    # Use eval in case helm_binary contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval ${helm_binary} repo list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
+
 __helm_list_plugins()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    local out
-    if out=$(helm plugin list 2>/dev/null | tail +2 | cut -f1); then
+    local out helm_binary
+
+    helm_binary="${words[0]}"
+    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
+
+    # Use eval in case helm_binary contains a variable (e.g., $HOME/bin/h3)
+    if out=$(eval ${helm_binary} plugin list 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
+
 __helm_custom_func()
 {
 	__helm_debug "${FUNCNAME[0]}: last_command is $last_command"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

As people migrate to helm3, I believe the expectation is that they may run both helm2 and helm3 for a while.

Currently, the dynamic completion (e.g., `helm status <TAB>`) uses the command `helm` to get the necessary info such as the list of releases.  With both helm2 and helm3 installed, which helm will be used when the dynamic completion calls `helm` will be dependent on the users environment.  If the wrong helm is called (helm3 when the user is using helm2 or vice versa), the wrong list of releases will be provided to the user by the completion.  

To solve this, this PR changes the dynamic completion calls so that instead of blindly calling `helm`, they will call whatever helm was used by the user.  For example, if the user called `helm3 status <TAB>` then the dynamic completion will use `helm3`; if the user called `bin/helm status <TAB>` the dynamic completion will also call `bin/helm`.  This will work for all cases, i.e. if helm is accessed by an alias, a different binary name, an absolute path or a relative path.
  
**Special notes for your reviewer**:

Tests added in https://github.com/helm/acceptance-testing/pull/45.
