### PR TITLE
fix(list): scrub list returned from .List()

### DIFF
--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -5,6 +5,5 @@ groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chi
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0
-starlord   	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0
 starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0
 thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0


### PR DESCRIPTION
This way only the latest release is displayed with `helm list`. This is the same apprach taken in Helm 2; it just wasn't ported over. See https://github.com/helm/helm/blob/7a0bbe16a06de14a6f29131cdfe9ae9299d4bef7/cmd/helm/list.go#L182

closes #6356
supercedes #6391

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
