### PR TITLE
feat(*): Ports `--cleanup-on-fail` to v3

### DIFF
--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -71,6 +71,7 @@ func newRollbackCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during rollback")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
+	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this rollback when rollback fails")
 
 	return cmd
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -155,6 +155,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, upgrade process rolls back changes made in case of failed upgrade. The --wait flag will be set automatically if --atomic is used")
 	f.IntVar(&client.MaxHistory, "history-max", 10, "limit the maximum number of revisions saved per release. Use 0 for no limit.")
+	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this upgrade when upgrade fails")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -77,7 +77,7 @@ func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.
 // Update returns the configured error if set or prints
 func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
 	if f.UpdateError != nil {
-		return nil, f.UpdateError
+		return &kube.Result{}, f.UpdateError
 	}
 	return f.PrintingKubeClient.Update(r, modified, ignoreMe)
 }


### PR DESCRIPTION
This ports the functionality of cleanup on fail to v3 as introduced in #4871. This has been tested manually and would be a good candidate for a new acceptance test.

