### PR TITLE
fix(action): invalidate discovery client cache on startup

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -91,6 +91,8 @@ func (c *Configuration) getCapabilities() (*chartutil.Capabilities, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get Kubernetes discovery client")
 	}
+	// force a discovery cache invalidation to always fetch the latest server version/capabilities.
+	dc.Invalidate()
 	kubeVersion, err := dc.ServerVersion()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get server version from Kubernetes")


### PR DESCRIPTION
We want to force a cache invalidation to ensure that the Capabilities object always has the latest information from the server (Kubernetes server version, available API versions, etc). `kubectl version` forces a cache invalidation every time it's invoked, so this seems like a safe change that is identical to kubectl's behaviour.

closes #6452

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
