### PR TITLE
feat(*): Ports `--set-file` flag to v3

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -42,7 +42,9 @@ a path to an unpacked chart directory or a URL.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line, to force
-a string value use '--set-string'.
+a string value use '--set-string'. In case a value is large and therefore
+you want not to use neither '--values' nor '--set', use '--set-file' to read the
+single large value from file.
 
 	$ helm install -f myvalues.yaml myredis ./redis
 
@@ -53,6 +55,9 @@ or
 or
 
 	$ helm install --set-string long_int=1234567890 myredis ./redis
+
+or
+	$ helm install --set-file my_script=dothings.sh myredis ./redis
 
 You can specify the '--values'/'-f' flag multiple times. The priority will be given to the
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml
@@ -140,6 +145,7 @@ func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 	f.StringSliceVarP(&v.ValueFiles, "values", "f", []string{}, "specify values in a YAML file or a URL(can specify multiple)")
 	f.StringArrayVar(&v.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.StringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.StringArrayVar(&v.FileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
 }
 
 func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -42,7 +42,9 @@ version will be specified unless the '--version' flag is set.
 
 To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line, to force string
-values, use '--set-string'.
+values, use '--set-string'. In case a value is large and therefore
+you want not to use neither '--values' nor '--set', use '--set-file' to read the
+single large value from file.
 
 You can specify the '--values'/'-f' flag multiple times. The priority will be given to the
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -358,6 +358,39 @@ func TestParseInto(t *testing.T) {
 	}
 }
 
+func TestParseIntoFile(t *testing.T) {
+	got := map[string]interface{}{}
+	input := "name1=path1"
+	expect := map[string]interface{}{
+		"name1": "value1",
+	}
+	rs2v := func(rs []rune) (interface{}, error) {
+		v := string(rs)
+		if v != "path1" {
+			t.Errorf("%s: RunesValueReader: Expected value path1, got %s", input, v)
+			return "", nil
+		}
+		return "value1", nil
+	}
+
+	if err := ParseIntoFile(input, got, rs2v); err != nil {
+		t.Fatal(err)
+	}
+
+	y1, err := yaml.Marshal(expect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	y2, err := yaml.Marshal(got)
+	if err != nil {
+		t.Fatalf("Error serializing parsed value: %s", err)
+	}
+
+	if string(y1) != string(y2) {
+		t.Errorf("%s: Expected:\n%s\nGot:\n%s", input, y1, y2)
+	}
+}
+
 func TestToYAML(t *testing.T) {
 	// The TestParse does the hard part. We just verify that YAML formatting is
 	// happening.


### PR DESCRIPTION
I made a few modifications from the original code to fit in with the new code layout and to clarify a few things. This is a port of #3758 and has been tested manually as well using the following config map:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: {{ include "mychart.fullname" . }}
data:
{{- with .Values.defaultScript }}
  defaultScript: |
  {{- . | nindent 4 }}
{{- end }}
```

You can test this out with:

```bash
$ ./bin/helm install --dry-run --generate-name --set-file defaultScript=<script-name> ./mychart
$ ./bin/helm template --set-file defaultScript=<script-name> ./mychart
```