### PR TITLE
Change release storage name to use helm storage type as prefix

### DIFF
--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -49,7 +49,8 @@ func (mem *Memory) Name() string {
 func (mem *Memory) Get(key string) (*rspb.Release, error) {
 	defer unlock(mem.rlock())
 
-	switch elems := strings.Split(key, ".v"); len(elems) {
+	keyWithoutPrefix := strings.TrimPrefix(key, "sh.helm.release.v1.")
+	switch elems := strings.Split(keyWithoutPrefix, ".v"); len(elems) {
 	case 2:
 		name, ver := elems[0], elems[1]
 		if _, err := strconv.Atoi(ver); err != nil {
@@ -138,7 +139,8 @@ func (mem *Memory) Update(key string, rls *rspb.Release) error {
 func (mem *Memory) Delete(key string) (*rspb.Release, error) {
 	defer unlock(mem.wlock())
 
-	elems := strings.Split(key, ".v")
+	keyWithoutPrefix := strings.TrimPrefix(key, "sh.helm.release.v1.")
+	elems := strings.Split(keyWithoutPrefix, ".v")
 
 	if len(elems) != 2 {
 		return nil, ErrInvalidKey

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -228,7 +228,17 @@ func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, er
 	lbs.set("status", rls.Info.Status.String())
 	lbs.set("version", strconv.Itoa(rls.Version))
 
-	// create and return secret object
+	// create and return secret object.
+	// Helm 3 introduced setting the 'Type' field
+	// in the Kubernetes storage object.
+	// Helm defines the field content as follows:
+	// <helm_domain>/<helm_object>.v<helm_object_version>
+	// Type field for Helm 3: helm.sh/release.v1
+	// Note: Version starts at 'v1' for Helm 3 and
+	// should be incremented if the release object
+	// metadata is modified.
+	// This would potentially be a breaking change
+	// and should only happen between major versions.
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   key,

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -234,7 +234,7 @@ func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, er
 			Name:   key,
 			Labels: lbs.toMap(),
 		},
-		Type: "helm.sh/release",
+		Type: "helm.sh/release.v1",
 		Data: map[string][]byte{"release": []byte(s)},
 	}, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -27,6 +27,11 @@ import (
 	"helm.sh/helm/pkg/storage/driver"
 )
 
+// The type field of the Kubernetes storage object which stores the Helm release
+// version. It is modified slightly replacing the '/': sh.helm/release.v1
+// Note: The version 'v1' is incremented if the release object metadata is
+// modified between major releases.
+// This constant is used as a prefix for the Kubernetes storage object name.
 const HelmStorageType = "sh.helm.release.v1"
 
 // Storage represents a storage engine for a Release.
@@ -207,9 +212,9 @@ func (s *Storage) Last(name string) (*rspb.Release, error) {
 	return h[0], nil
 }
 
-// makeKey concatenates the helm type, a release name and version into a
-// string with format:```<helm_storage_type>.<release_name>.v<version>```.
-// The Helm type is prepended to keep name uniqueness between different
+// makeKey concatenates the Kubernetes storage object type, a release name and version
+// into a string with format:```<helm_storage_type>.<release_name>.v<release_version>```.
+// The storage type is prepended to keep name uniqueness between different
 // release storage types. An example of clash when not using the type:
 // https://github.com/helm/helm/issues/6435.
 // This key is used to uniquely identify storage objects.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -27,6 +27,8 @@ import (
 	"helm.sh/helm/pkg/storage/driver"
 )
 
+const HelmStorageType = "sh.helm.release.v1"
+
 // Storage represents a storage engine for a Release.
 type Storage struct {
 	driver.Driver
@@ -205,11 +207,14 @@ func (s *Storage) Last(name string) (*rspb.Release, error) {
 	return h[0], nil
 }
 
-// makeKey concatenates a release name and version into
-// a string with format ```<release_name>#v<version>```.
+// makeKey concatenates the helm type, a release name and version into a
+// string with format:```<helm_storage_type>.<release_name>.v<version>```.
+// The Helm type is prepended to keep name uniqueness between different
+// release storage types. An example of clash when not using the type:
+// https://github.com/helm/helm/issues/6435.
 // This key is used to uniquely identify storage objects.
 func makeKey(rlsname string, version int) string {
-	return fmt.Sprintf("%s.v%d", rlsname, version)
+	return fmt.Sprintf("%s.%s.v%d", HelmStorageType, rlsname, version)
 }
 
 // Init initializes a new storage backend with the driver d.


### PR DESCRIPTION
Updating the release version name in storage to use the storage type as prefix:
` sh.helm.release.v1.<release_name>.v<version>`

Example:
```console
$ kubectl get secret --all-namespaces -l "owner=helm"
NAMESPACE   NAME                              TYPE              DATA   AGE
default     sh.helm.release.v1.chrt-6435.v1   helm.sh/release   1      6m34s
default     sh.helm.release.v1.chrt-6435.v2   helm.sh/release   1      5m58s
default     sh.helm.release.v1.chrt-6435.v3   helm.sh/release   1      5m53s
default     sh.helm.release.v1.chrt-6435.v4   helm.sh/release   1      40s
default     sh.helm.release.v1.chrt-next.v1   helm.sh/release   1      9s
```

Closes #6435 

**What this PR does / why we need it**:
Helm v2 stores release versions both as ConfigMaps (default) and Secrets under the Tiller namespace and `TILLER` ownership (type is Opaque). The naming convention used is: `<release_name>.v<version>`. This naming convention ensues uniqueness for Helm v2.

Helm v3  stores release versions as Secrets under the user namespace, `helm` ownership and type `helm.sh/release`. 

Helm v3 therefore cannot read Helm v2 releases because of different ownership and type. This is expected behaviour because Helm v2 and Helm v3 release objects are incompatible.

However, if:
- Helm v3 uses the same release version naming conventions as Helm v2 AND
- Helm v2 stores release object(s) as secrets under the namespace of the release (using the Tiller namespace for release) 

Then there will be a conflict:
- If Helm v3 tries to create a release with name already used by Helm v2 even though Helm v3 can't read it but the secret already exists OR
- Migrate Helm v3 releases over to Helm v3 because the 2 versions exist at same time until removed

This PR is to ensue uniqueness across Helm v2 and Helm v3 release versions in storage.

**Special notes for your reviewer**:
This is a breaking change to the current pre Helm 3 GA releases. Is this considered breaking as Helm 3 is not GA yet?  

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
