### PR TITLE
v3: Support auto-complete of a renamed helm binary

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -88,12 +89,12 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 # to the helm completion function to handle the case where
 # the user renamed the helm binary
 if [[ $(type -t compopt) = "builtin" ]]; then
-    complete -o default -F __start_helm ` + binary + `
+    complete -o default -F __start_helm %[1]s
 else
-    complete -o default -o nospace -F __start_helm ` + binary + `
+    complete -o default -o nospace -F __start_helm %[1]s
 fi
 `
-		out.Write([]byte(renamedBinaryHook))
+		fmt.Fprintf(out, renamedBinaryHook, binary)
 	}
 
 	return err

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -16,7 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/pkg/errors"
@@ -211,9 +210,7 @@ __helm_convert_bash_to_zsh() {
 `
 	out.Write([]byte(zshInitialization))
 
-	buf := new(bytes.Buffer)
-	cmd.Root().GenBashCompletion(buf)
-	out.Write(buf.Bytes())
+	runCompletionBash(out, cmd)
 
 	zshTail := `
 BASH_COMPLETION_EOF

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -76,7 +78,25 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 }
 
 func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
-	return cmd.Root().GenBashCompletion(out)
+	err := cmd.Root().GenBashCompletion(out)
+
+	// In case the user renamed the helm binary (e.g., to be able to run
+	// both helm2 and helm3), we hook the new binary name to the completion function
+	if binary := filepath.Base(os.Args[0]); binary != "helm" {
+		renamedBinaryHook := `
+# Hook the command used to generate the completion script
+# to the helm completion function to handle the case where
+# the user renamed the helm binary
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_helm ` + binary + `
+else
+    complete -o default -o nospace -F __start_helm ` + binary + `
+fi
+`
+		out.Write([]byte(renamedBinaryHook))
+	}
+
+	return err
 }
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {


### PR DESCRIPTION


**What this PR does / why we need it**:

This is in the context of the v2 to v3 migration where a user is likely
to rename the helm binary to helm3 (see #5892). But it is a valid improvement even
outside this migration.

If a user renames the helm binary, the shell needs to be told that this
new name corresponds to the helm completion function. For example if
the user decides to rename the helm v3 binary to `helm3`, then the
following extra command would need be run by the user:
```
complete -o default -F __start_helm helm3
```
This PR automates this by adding this extra command to the generated
shell completion script by looking at what binary was used to call the
helm completion command.  For example, if the user renames the binary
to `helm3` and then calls
```
helm3 completion bash
```
the completion script will include a hook for the binary 'helm3' to the completion script.

**Special notes for your reviewer**:

This PR also has the zsh completion command call the logic of the bash completion command so as to easily get any improvements to bash completion, such as this one.

The acceptance-testing tests continue to all pass with this change.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
