### PR TITLE
fix(charts): Create charts directory for scaffold chart

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -452,6 +452,10 @@ func Create(name, dir string) (string, error) {
 			return cdir, err
 		}
 	}
+	// Need to add the ChartsDir explicitly as it does not contain any file OOTB
+	if err := os.MkdirAll(filepath.Join(cdir, ChartsDir), 0755); err != nil {
+		return cdir, err
+	}
 	return cdir, nil
 }
 


### PR DESCRIPTION
This is a fix to create the `charts` directory during a scaffold chart creation (`helm create`). It was removed inadvertently during some refactoring.

Closes #6515 

**What this PR does / why we need it**:
The `charts` sub-directory in a chart is used for chart dependencies.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
