### PR TITLE
v2: feat(comp) Dynamic completion to use same binary as main call

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -69,13 +69,22 @@ __helm_override_flags()
     done
 }
 
+__helm_binary_name()
+{
+    local helm_binary
+    helm_binary="${words[0]}"
+    __helm_debug "${FUNCNAME[0]}: helm_binary is ${helm_binary}"
+    echo ${helm_binary}
+}
+
 __helm_list_releases()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
     local out filter
     # Use ^ to map from the start of the release name
     filter="^${words[c]}"
-    if out=$(helm list $(__helm_override_flags) -a -q ${filter} 2>/dev/null); then
+    # Use eval in case helm_binary_name or __helm_override_flags contains a variable (e.g., $HOME/bin/h2)
+    if out=$(eval $(__helm_binary_name) list $(__helm_override_flags) -a -q -m 1000 ${filter} 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -86,7 +95,8 @@ __helm_list_repos()
     local out oflags
     oflags=$(__helm_override_flags)
     __helm_debug "${FUNCNAME[0]}: __helm_override_flags are ${oflags}"
-    if out=$(helm repo list ${oflags} | tail +2 | cut -f1 2>/dev/null); then
+    # Use eval in case helm_binary_name contains a variable (e.g., $HOME/bin/h2)
+    if out=$(eval $(__helm_binary_name) repo list ${oflags} 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
@@ -97,7 +107,8 @@ __helm_list_plugins()
     local out oflags
     oflags=$(__helm_override_flags)
     __helm_debug "${FUNCNAME[0]}: __helm_override_flags are ${oflags}"
-    if out=$(helm plugin list ${oflags} | tail +2 | cut -f1 2>/dev/null); then
+    # Use eval in case helm_binary_name contains a variable (e.g., $HOME/bin/h2)
+    if out=$(eval $(__helm_binary_name) plugin list ${oflags} 2>/dev/null | tail +2 | cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }


### PR DESCRIPTION
The binary of Helm to use for dynamic completion should be the same
as the actual Helm binary being used.  For example, if PATH points
to a version of helm v3, but the user calls a binary named helm2 to
use a renamed v2 version, then dynamic completion should also use helm2.
If not, in this example, the dynamic completion will use the
information returned by helm v3.

This improvement is particularly useful for users that will run both
helm v2 and helm v3 at the same time.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
