### PR TITLE
fix(pkg/chartutil): include values.schema.json in packaged chart

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -35,6 +35,8 @@ const (
 	ChartfileName = "Chart.yaml"
 	// ValuesfileName is the default values file name.
 	ValuesfileName = "values.yaml"
+	// SchemafileName is the default values schema file name.
+	SchemafileName = "values.schema.json"
 	// TemplatesDir is the relative directory name for templates.
 	TemplatesDir = "templates"
 	// ChartsDir is the relative directory name for charts dependencies.

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -133,6 +133,7 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 
 	if err := writeTarContents(twriter, c, ""); err != nil {
 		rollback = true
+		return filename, err
 	}
 	return filename, err
 }


### PR DESCRIPTION
When playing around with new Helm 3 features, we noticed that `values.yaml` is not validated when running `helm install`, even though [the docs say it should be](https://v3.helm.sh/docs/topics/charts/#schema-files):

> Validation occurs when any of the following commands are invoked:
> 
> * `helm install`
> * `helm upgrade`
> * `helm lint`
> * `helm template`

The reason is that `values.schema.json` is not included in the tarball created by `helm package`, so `helm lint` cannot lint the tarball properly, even if it can lint the chart directory:

    $ helm lint my-chart            # Finds errors in values.yaml
    $ helm package my-chart
    $ helm lint my-chart-1.0.0.tgz  # Does not find errors in values.yaml