### PR TITLE
fix lint not failing in windows for bad template yamls

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -100,7 +100,8 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		// NOTE: disabled for now, Refs https://github.com/helm/helm/issues/1037
 		// linter.RunLinterRule(support.WarningSev, path, validateQuotes(string(preExecutedTemplate)))
 
-		renderedContent := renderedContentMap[filepath.Join(chart.Name(), fileName)]
+		templatePath := filepath.Join(chart.Name(), fileName)
+		renderedContent := renderedContentMap[filepath.ToSlash(templatePath)]
 		var yamlStruct K8sYamlStruct
 		// Even though K8sYamlStruct only defines Metadata namespace, an error in any other
 		// key will be raised as well


### PR DESCRIPTION
Fixes #6527 
Port of #6523 (v2 fix)

**What this PR does / why we need it**:
It fixes lint not failing in windows for bad template yamls

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
