### PR TITLE
Skip waiting for paused deployments

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -69,6 +69,10 @@ func (w *waiter) waitForResources(created ResourceList) error {
 				if err != nil {
 					return false, err
 				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
+				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, w.c.AppsV1())
 				if err != nil || newReplicaSet == nil {
@@ -81,6 +85,10 @@ func (w *waiter) waitForResources(created ResourceList) error {
 				currentDeployment, err := w.c.AppsV1().Deployments(value.Namespace).Get(value.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
+				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
 				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, w.c.AppsV1())
@@ -95,6 +103,10 @@ func (w *waiter) waitForResources(created ResourceList) error {
 				if err != nil {
 					return false, err
 				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
+				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, w.c.AppsV1())
 				if err != nil || newReplicaSet == nil {
@@ -107,6 +119,10 @@ func (w *waiter) waitForResources(created ResourceList) error {
 				currentDeployment, err := w.c.AppsV1().Deployments(value.Namespace).Get(value.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
+				}
+				// If paused deployment will never be ready
+				if currentDeployment.Spec.Paused {
+					continue
 				}
 				// Find RS associated with deployment
 				newReplicaSet, err := deploymentutil.GetNewReplicaSet(currentDeployment, w.c.AppsV1())


### PR DESCRIPTION
Signed-off-by: Per Hermansson <perher1@gmail.com>

**What this PR does / why we need it**:
This is based on original PR for v2: #5789 
When Deployments are set to paused Helm will wait forever for them to be upgraded when using the --wait flag.

**Special notes for your reviewer**:
Might conflict with #6449

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
