### PR TITLE
ref(pkg/chartutil): Dry up file and path names

### DIFF
--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -59,14 +59,14 @@ func IsChartDir(dirName string) (bool, error) {
 		return false, errors.Errorf("%q is not a directory", dirName)
 	}
 
-	chartYaml := filepath.Join(dirName, "Chart.yaml")
+	chartYaml := filepath.Join(dirName, ChartfileName)
 	if _, err := os.Stat(chartYaml); os.IsNotExist(err) {
-		return false, errors.Errorf("no Chart.yaml exists in directory %q", dirName)
+		return false, errors.Errorf("no %s exists in directory %q", ChartfileName, dirName)
 	}
 
 	chartYamlContent, err := ioutil.ReadFile(chartYaml)
 	if err != nil {
-		return false, errors.Errorf("cannot read Chart.Yaml in directory %q", dirName)
+		return false, errors.Errorf("cannot read %s in directory %q", ChartfileName, dirName)
 	}
 
 	chartContent := new(chart.Metadata)
@@ -74,10 +74,10 @@ func IsChartDir(dirName string) (bool, error) {
 		return false, err
 	}
 	if chartContent == nil {
-		return false, errors.New("chart metadata (Chart.yaml) missing")
+		return false, errors.Errorf("chart metadata (%s) missing", ChartfileName)
 	}
 	if chartContent.Name == "" {
-		return false, errors.New("invalid chart (Chart.yaml): name must not be empty")
+		return false, errors.Errorf("invalid chart (%s): name must not be empty", ChartfileName)
 	}
 
 	return true, nil

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -136,7 +136,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, base+"/Chart.yaml", cdata); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata); err != nil {
 		return err
 	}
 
@@ -145,7 +145,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, base+"/values.yaml", ydata); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ValuesfileName), ydata); err != nil {
 		return err
 	}
 
@@ -167,7 +167,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 
 	// Save dependencies
 	for _, dep := range c.Dependencies() {
-		if err := writeTarContents(out, dep, base+"/charts"); err != nil {
+		if err := writeTarContents(out, dep, filepath.Join(base, ChartsDir)); err != nil {
 			return err
 		}
 	}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -19,6 +19,7 @@ package chartutil
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestSaveDir(t *testing.T) {
 			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
 		},
 		Templates: []*chart.File{
-			{Name: "templates/nested/dir/thing.yaml", Data: []byte("abc: {{ .Values.abc }}")},
+			{Name: filepath.Join(TemplatesDir, "nested", "dir", "thing.yaml"), Data: []byte("abc: {{ .Values.abc }}")},
 		},
 	}
 
@@ -101,7 +102,7 @@ func TestSaveDir(t *testing.T) {
 		t.Fatalf("Expected chart archive to have %q, got %q", c.Name(), c2.Name())
 	}
 
-	if len(c2.Templates) != 1 || c2.Templates[0].Name != "templates/nested/dir/thing.yaml" {
+	if len(c2.Templates) != 1 || c2.Templates[0].Name != filepath.Join(TemplatesDir, "nested", "dir", "thing.yaml") {
 		t.Fatal("Templates data did not match")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It makes the code more robust and maintainable by reusing file and directory names from `create.go` instead of hardcoding them as string literals, and by using `filepath.Join` instead of literal slashes.

Incidentally, it also fixes an actual bug caused by the [WET](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself#DRY_vs_WET_solutions)ness it removes. Prior to this commit, the user would be presented with this error if `Chart.yaml` could not be read:

    cannot read Chart.Yaml in directory "my-chart"

(Note the capital `Y`.)