### PR TITLE
Create file locking directory if it does not exist

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -78,6 +79,12 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 }
 
 func (o *repoAddOptions) run(out io.Writer) error {
+	//Ensure the file directory exists as it is required for file locking
+	err := os.MkdirAll(filepath.Dir(o.repoFile), os.ModePerm)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
 	// Lock the repository file for concurrent goroutines or processes synchronization
 	fileLock := flock.New(o.repoFile)
 	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -92,14 +92,22 @@ func TestRepoAdd(t *testing.T) {
 
 func TestRepoAddConcurrentGoRoutines(t *testing.T) {
 	const testName = "test-name"
+	repoFile := filepath.Join(ensure.TempDir(t), "repositories.yaml")
+	repoAddConcurrent(t, testName, repoFile)
+}
 
+func TestRepoAddConcurrentDirNotExist(t *testing.T) {
+	const testName = "test-name-2"
+	repoFile := filepath.Join(ensure.TempDir(t), "foo", "repositories.yaml")
+	repoAddConcurrent(t, testName, repoFile)
+}
+
+func repoAddConcurrent(t *testing.T, testName, repoFile string) {
 	ts, err := repotest.NewTempServer("testdata/testserver/*.*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
-
-	repoFile := filepath.Join(ensure.TempDir(t), "repositories.yaml")
 
 	var wg sync.WaitGroup
 	wg.Add(3)


### PR DESCRIPTION
As Helm v3 uses lazy creation for configuration, directories and files are not created until required. File locking when doing repo add was introduced in v2 and ported to v3 in #6492. It locks on the config directory where the repo file resides and therefore needs the directory to exist. This fix adds the directory if it doesn't exist.

Closes #6521 

**What this PR does / why we need it**:
This fixes the issue where user cannot add the first repository. Bug was introduced in #6492.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
