### PR TITLE
v3: fix(cmd) have history use global output flag

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -53,5 +53,5 @@ func bindOutputFlag(cmd *cobra.Command, varRef *string) {
 	// NOTE(taylor): A possible refactor here is that we can implement all the
 	// validation for the OutputFormat type here so we don't have to do the
 	// parsing and checking in the command
-	cmd.Flags().StringVarP(varRef, outputFlag, "o", string(action.Table), fmt.Sprintf("Prints the output in the specified format. Allowed values: %s, %s, %s", action.Table, action.JSON, action.YAML))
+	cmd.Flags().StringVarP(varRef, outputFlag, "o", string(action.Table), fmt.Sprintf("prints the output in the specified format. Allowed values: %s, %s, %s", action.Table, action.JSON, action.YAML))
 }

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -73,8 +73,8 @@ func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&client.OutputFormat, "output", "o", action.Table.String(), "prints the output in the specified format (json|table|yaml)")
 	f.IntVar(&client.Max, "max", 256, "maximum number of revision to include in history")
+	bindOutputFlag(cmd, &client.OutputFormat)
 
 	return cmd
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

PR #6504 add the `--output` flag to multiple commands in a centralized fashion.
The `helm history` command already had an `--output` flag.  This PR moves it to use the new global handling.

Also, it seems that for helm v3, the description of flags all start with a lowercase, so this PR changes the first letter of the description of the `--output` flag to a lowercase.
