### PR TITLE
v3: Performance: Batch kube API operations

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -273,8 +273,16 @@ func perform(infos ResourceList, fn func(*resource.Info) error) error {
 		return ErrNoObjectsVisited
 	}
 
+	errs := make(chan error)
 	for _, info := range infos {
-		if err := fn(info); err != nil {
+		go func(i *resource.Info) {
+			errs <- fn(i)
+		}(info)
+	}
+
+	for range infos {
+		err := <-errs
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -286,7 +286,7 @@ func perform(infos ResourceList, fn func(*resource.Info) error) error {
 	return nil
 }
 
-func batchPerform(infos Result, fn ResourceActorFunc, errs chan<- error) {
+func batchPerform(infos ResourceList, fn func(*resource.Info) error, errs chan<- error) {
 	var kind string
 	var wg sync.WaitGroup
 	for _, info := range infos {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -286,6 +286,10 @@ func perform(infos ResourceList, fn func(*resource.Info) error) error {
 }
 
 func batchPerform(infos Result, fn ResourceActorFunc, errs chan<- error) {
+	if len(infos) == 0 {
+		return
+	}
+
 	finished := make(chan bool, 10000)
 	kind := infos[0].Object.GetObjectKind().GroupVersionKind().Kind
 	counter := 0


### PR DESCRIPTION
Signed-off-by: Charlie Getzen <charlie.getzen@procore.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This cuts down tiller's time creating resources. In our tests, we create ~180 resources in a release. Before this change it took approximately 120 seconds to create these resources. It now takes around 45 seconds.

**Special notes for your reviewer**:
v3 port of https://github.com/helm/helm/pull/5611

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
