### PR TITLE
Fixing the ability to build v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(BINNAME) helm.sh/helm/cmd/helm
+	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(BINNAME) ./cmd/helm
 
 # ------------------------------------------------------------------------------
 #  test
@@ -134,7 +134,7 @@ $(GOIMPORTS):
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GOX)
-	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' helm.sh/helm/cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
Some elements in the change to go modules were not changed. One of those is the build of the binaries. You can see the failure at https://circleci.com/gh/helm/helm/9759. This is happening because it tries to pull in helm v2 and merge helm v2 into the build process.

If you add a `/v3` to the end of the build steps in the `Makefile` you end up with errors like...

```
GO111MODULE=on go build  -tags '' -ldflags '-w -s -X helm.sh/helm/internal/version.gitCommit=6f0235f6595c89e79e61a0ad393a150bfae886eb -X helm.sh/helm/internal/version.gitTreeState=dirty' -o /Users/mfarina/Code/helm/helm/bin/helm helm.sh/helm/cmd/helm/v3
can't load package: package helm.sh/helm/cmd/helm/v3: module helm.sh/helm@latest (v2.14.3+incompatible) found, but does not contain package helm.sh/helm/cmd/helm/v3
make: *** [/Users/mfarina/Code/helm/helm/bin/helm] Error 1
```

On our default branch we don't have the go module information so it has issues. Fun times. Instead, the paths to build are set to be relative on the filesystem which skips the remote checks.