### PR TITLE
feat(comp): Dynamic completion for --output flag

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -52,6 +52,8 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 // value to the given format pointer
 func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {
 	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o", fmt.Sprintf("prints the output in the specified format. Allowed values: %s, %s, %s", output.Table, output.JSON, output.YAML))
+	// Setup shell completion for the flag
+	cmd.MarkFlagCustom(outputFlag, "__helm_output_options")
 }
 
 type outputValue output.Format

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -89,6 +89,12 @@ __helm_get_namespaces()
     fi
 }
 
+__helm_output_options()
+{
+    __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    COMPREPLY+=( $( compgen -W "table json yaml" -- "$cur" ) )
+}
+
 __helm_binary_name()
 {
     local helm_binary


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds shell completion for the `--output` flag.  For example a user could now do:
```
helm repo list --output <TAB>
```
and will then be given the choices:
```
json   table  yaml
```
This works for the `--output` flag of any command that supports it.

**Special notes for your reviewer**:

I don't like that the three values `json table yaml` are hard-coded in the completion logic.  If a new format is ever added, it is likely that the completion code will be forgotten and not updated.  I would have preferred to create the list of choices by looping through the "enum" of formats.  However, I don't believe this is feasible with the current implementation of the output formats which are unrelated string contants.  Doing something with `iota` would be possible, but would require multiple changes in the output format code.

What I did instead is that the acceptance test will generate the expected completion (`json table yaml`  for now) output based on the help text of the `--output` flag.  I feel this help text has a better chance of being updated than the completion code.  So, if an extra format is added, the acceptance tests will fail if the completion code is not matching the help text for the `--output` flag.

**If applicable**:
- this PR has been tested for backwards compatibility through the acceptance-testing repo
- new tests for this feature have been prepared in https://github.com/helm/acceptance-testing/pull/51
