### PR TITLE
Use same output format for hooks as for manifest

### DIFF
--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -46,7 +46,7 @@ func newGetHooksCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 			for _, hook := range res.Hooks {
-				fmt.Fprintf(out, "---\n# %s\n%s", hook.Name, hook.Manifest)
+				fmt.Fprintf(out, "---\n# Source: %s\n%s\n", hook.Path, hook.Manifest)
 			}
 			return nil
 		},

--- a/cmd/helm/testdata/output/get-hooks.txt
+++ b/cmd/helm/testdata/output/get-hooks.txt
@@ -1,7 +1,8 @@
 ---
-# pre-install-hook
+# Source: pre-install-hook.yaml
 apiVersion: v1
 kind: Job
 metadata:
   annotations:
     "helm.sh/hook": pre-install
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the same output format in `get hooks` as in `get manifest`.
Additionally it adds a missing line break before the yaml separator.

**Special notes for your reviewer**:
I didn't fix the hooks in the `get` output as this will be done in #6550 
