### PR TITLE
Update Ingress API group in scaffold chart

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -151,7 +151,11 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Change ingress manifest generated by scaffold chart to have the newest API group.

**What this PR does / why we need it**:
`networking.k8s.io/v1beta1` API, serving Ingress since v1.14.  `extensions/v1beta1` API group will be deprecated in K8s v1.20. (https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
