### PR TITLE
Fix(chartutil): Update ingress API group in scaffold chart

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -179,7 +179,7 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Ingress API group should be `networking.k8s.io/v1beta1`

**What this PR does / why we need it**:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#ingress-v1beta1-networking-k8s-io

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
