### PR TITLE
feat(template): Ports api-versions flag to v3

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
 
@@ -40,6 +41,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
 	client := action.NewInstall(cfg)
 	valueOpts := &values.Options{}
+	var extraAPIs []string
 
 	cmd := &cobra.Command{
 		Use:   "template [NAME] [CHART]",
@@ -51,6 +53,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.ReleaseName = "RELEASE-NAME"
 			client.Replace = true // Skip the name check
 			client.ClientOnly = !validate
+			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
 				return err
@@ -70,6 +73,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	addInstallFlags(f, client, valueOpts)
 	f.StringVar(&client.OutputDir, "output-dir", "", "writes the executed templates to files in output-dir instead of stdout")
 	f.BoolVar(&validate, "validate", false, "establish a connection to Kubernetes for schema validation")
+	f.StringArrayVarP(&extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
 
 	return cmd
 }

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -74,6 +74,11 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf("template '%s'", "testdata/testcharts/chart-with-template-lib-archive-dep"),
 			golden: "output/template-chart-with-template-lib-archive-dep.txt",
 		},
+		{
+			name:   "check kube api versions",
+			cmd:    fmt.Sprintf("template --api-versions helm.k8s.io/test '%s'", chartPath),
+			golden: "output/template-with-api-version.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/template-name-template.txt
+++ b/cmd/helm/testdata/output/template-name-template.txt
@@ -42,8 +42,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "foobar-YWJj-baz"
     kube-version/major: "1"
-    kube-version/minor: "14"
-    kube-version/version: "v1.14.0"
+    kube-version/minor: "16"
+    kube-version/version: "v1.16.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-set.txt
+++ b/cmd/helm/testdata/output/template-set.txt
@@ -42,8 +42,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "14"
-    kube-version/version: "v1.14.0"
+    kube-version/minor: "16"
+    kube-version/version: "v1.16.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-values-files.txt
+++ b/cmd/helm/testdata/output/template-values-files.txt
@@ -42,8 +42,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "14"
-    kube-version/version: "v1.14.0"
+    kube-version/minor: "16"
+    kube-version/version: "v1.16.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-with-api-version.txt
+++ b/cmd/helm/testdata/output/template-with-api-version.txt
@@ -44,6 +44,7 @@ metadata:
     kube-version/major: "1"
     kube-version/minor: "16"
     kube-version/version: "v1.16.0"
+    kube-api-version/test: v1
 spec:
   type: ClusterIP
   ports:

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -84,6 +84,9 @@ type Install struct {
 	SkipCRDs         bool
 	OutputFormat     string
 	SubNotes         bool
+	// APIVersions allows a manual set of supported API Versions to be passed
+	// (for things like templating). These are ignored if ClientOnly is false
+	APIVersions chartutil.VersionSet
 }
 
 // ChartPathOptions captures common options used for controlling chart paths
@@ -175,8 +178,11 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		// Add mock objects in here so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
 		i.cfg.Capabilities = chartutil.DefaultCapabilities
+		i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
 		i.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
 		i.cfg.Releases = storage.Init(driver.NewMemory())
+	} else if !i.ClientOnly && len(i.APIVersions) > 0 {
+		i.cfg.Log("API Version list given outside of client only mode, this list will be ignored")
 	}
 
 	if err := chartutil.ProcessDependencies(chrt, vals); err != nil {

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -26,9 +26,9 @@ var (
 	// DefaultCapabilities is the default set of capabilities.
 	DefaultCapabilities = &Capabilities{
 		KubeVersion: KubeVersion{
-			Version: "v1.14.0",
+			Version: "v1.16.0",
 			Major:   "1",
-			Minor:   "14",
+			Minor:   "16",
 		},
 		APIVersions: DefaultVersionSet,
 	}

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -42,19 +42,19 @@ func TestDefaultVersionSet(t *testing.T) {
 
 func TestDefaultCapabilities(t *testing.T) {
 	kv := DefaultCapabilities.KubeVersion
-	if kv.String() != "v1.14.0" {
-		t.Errorf("Expected default KubeVersion.String() to be v1.14.0, got %q", kv.String())
+	if kv.String() != "v1.16.0" {
+		t.Errorf("Expected default KubeVersion.String() to be v1.16.0, got %q", kv.String())
 	}
-	if kv.Version != "v1.14.0" {
-		t.Errorf("Expected default KubeVersion.Version to be v1.14.0, got %q", kv.Version)
+	if kv.Version != "v1.16.0" {
+		t.Errorf("Expected default KubeVersion.Version to be v1.16.0, got %q", kv.Version)
 	}
-	if kv.GitVersion() != "v1.14.0" {
-		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.14.0, got %q", kv.Version)
+	if kv.GitVersion() != "v1.16.0" {
+		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.16.0, got %q", kv.Version)
 	}
 	if kv.Major != "1" {
 		t.Errorf("Expected default KubeVersion.Major to be 1, got %q", kv.Major)
 	}
-	if kv.Minor != "14" {
-		t.Errorf("Expected default KubeVersion.Minor to be 14, got %q", kv.Minor)
+	if kv.Minor != "16" {
+		t.Errorf("Expected default KubeVersion.Minor to be 16, got %q", kv.Minor)
 	}
 }

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     kube-version/major: "{{ .Capabilities.KubeVersion.Major }}"
     kube-version/minor: "{{ .Capabilities.KubeVersion.Minor }}"
     kube-version/version: "v{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}.0"
+{{- if .Capabilities.APIVersions.Has "helm.k8s.io/test" }}
+    kube-api-version/test: v1
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This is a port of #5392. It also takes care of the small chore to update the default k8s
version to 1.16, which is the latest supported version.