### PR TITLE
feat(wait): Ports ingress wait to v3

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -27,6 +27,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -173,6 +174,14 @@ func (w *waiter) waitForResources(created ResourceList) error {
 					return false, err
 				}
 				if !w.statefulSetReady(sts) {
+					return false, nil
+				}
+			case *extensionsv1beta1.Ingress, *networkingv1beta1.Ingress:
+				ing, err := w.c.NetworkingV1beta1().Ingresses(v.Namespace).Get(v.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if !w.ingressReady(ing) {
 					return false, nil
 				}
 
@@ -340,6 +349,14 @@ func (w *waiter) statefulSetReady(sts *appsv1.StatefulSet) bool {
 
 	if int(sts.Status.ReadyReplicas) != replicas {
 		w.log("StatefulSet is not ready: %s/%s. %d out of %d expected pods are ready", sts.Namespace, sts.Name, sts.Status.ReadyReplicas, replicas)
+		return false
+	}
+	return true
+}
+
+func (w *waiter) ingressReady(ing *networkingv1beta1.Ingress) bool {
+	if len(ing.Status.LoadBalancer.Ingress) == 0 {
+		w.log("Ingress is not ready: %s/%s", ing.GetNamespace(), ing.GetName())
 		return false
 	}
 	return true


### PR DESCRIPTION
This is a port of #5264 with extra support for the networking/v1beta1 API. I tested this with nginx-ingress using both ingress objects from extensions and networking APIs