### PR TITLE
fix(chart): Ports security fix for invalid paths in tarballs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/containerd/containerd v1.3.0-beta.2.0.20190823190603-4a2f61c4f2b4
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808
 	github.com/cpuguy83/go-md2man v1.0.10
+	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deislabs/oras v0.7.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -17,8 +17,15 @@ limitations under the License.
 package loader
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/pkg/chart"
 )
@@ -158,6 +165,97 @@ func TestLoadV2WithReqs(t *testing.T) {
 	}
 	verifyDependencies(t, c)
 	verifyDependenciesLock(t, c)
+}
+
+func TestLoadInvalidArchive(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "helm-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpdir)
+
+	writeTar := func(filename, internalPath string, body []byte) {
+		dest, err := os.Create(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		zipper := gzip.NewWriter(dest)
+		tw := tar.NewWriter(zipper)
+
+		h := &tar.Header{
+			Name:    internalPath,
+			Mode:    0755,
+			Size:    int64(len(body)),
+			ModTime: time.Now(),
+		}
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+		tw.Close()
+		zipper.Close()
+		dest.Close()
+	}
+
+	for _, tt := range []struct {
+		chartname   string
+		internal    string
+		expectError string
+	}{
+		{"illegal-dots.tgz", "../../malformed-helm-test", "chart illegally references parent directory"},
+		{"illegal-dots2.tgz", "/foo/../../malformed-helm-test", "chart illegally references parent directory"},
+		{"illegal-dots3.tgz", "/../../malformed-helm-test", "chart illegally references parent directory"},
+		{"illegal-dots4.tgz", "./../../malformed-helm-test", "chart illegally references parent directory"},
+		{"illegal-name.tgz", "./.", "chart illegally contains content outside the base directory"},
+		{"illegal-name2.tgz", "/./.", "chart illegally contains content outside the base directory"},
+		{"illegal-name3.tgz", "missing-leading-slash", "chart illegally contains content outside the base directory"},
+		{"illegal-name4.tgz", "/missing-leading-slash", "validation: chart.metadata is required"},
+		{"illegal-abspath.tgz", "//foo", "chart illegally contains absolute paths"},
+		{"illegal-abspath2.tgz", "///foo", "chart illegally contains absolute paths"},
+		{"illegal-abspath3.tgz", "\\\\foo", "chart illegally contains absolute paths"},
+		{"illegal-abspath3.tgz", "\\..\\..\\foo", "chart illegally references parent directory"},
+
+		// Under special circumstances, this can get normalized to things that look like absolute Windows paths
+		{"illegal-abspath4.tgz", "\\.\\c:\\\\foo", "chart contains illegally named files"},
+		{"illegal-abspath5.tgz", "/./c://foo", "chart contains illegally named files"},
+		{"illegal-abspath6.tgz", "\\\\?\\Some\\windows\\magic", "chart illegally contains absolute paths"},
+	} {
+		illegalChart := filepath.Join(tmpdir, tt.chartname)
+		writeTar(illegalChart, tt.internal, []byte("hello: world"))
+		_, err = Load(illegalChart)
+		if err == nil {
+			t.Fatal("expected error when unpacking illegal files")
+		}
+		if !strings.Contains(err.Error(), tt.expectError) {
+			t.Errorf("Expected error to contain %q, got %q for %s", tt.expectError, err.Error(), tt.chartname)
+		}
+	}
+
+	// Make sure that absolute path gets interpreted as relative
+	illegalChart := filepath.Join(tmpdir, "abs-path.tgz")
+	writeTar(illegalChart, "/Chart.yaml", []byte("hello: world"))
+	_, err = Load(illegalChart)
+	if err.Error() != "validation: chart.metadata.name is required" {
+		t.Error(err)
+	}
+
+	// And just to validate that the above was not spurious
+	illegalChart = filepath.Join(tmpdir, "abs-path2.tgz")
+	writeTar(illegalChart, "files/whatever.yaml", []byte("hello: world"))
+	_, err = Load(illegalChart)
+	if err.Error() != "validation: chart.metadata is required" {
+		t.Error(err)
+	}
+
+	// Finally, test that drive letter gets stripped off on Windows
+	illegalChart = filepath.Join(tmpdir, "abs-winpath.tgz")
+	writeTar(illegalChart, "c:\\Chart.yaml", []byte("hello: world"))
+	_, err = Load(illegalChart)
+	if err.Error() != "validation: chart.metadata.name is required" {
+		t.Error(err)
+	}
 }
 
 func verifyChart(t *testing.T, c *chart.Chart) {

--- a/pkg/chartutil/expand_test.go
+++ b/pkg/chartutil/expand_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chartutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	dest, err := ioutil.TempDir("", "helm-testing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	reader, err := os.Open("testdata/frobnitz-1.2.3.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Expand(dest, reader); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChartPath := filepath.Join(dest, "frobnitz")
+	fi, err := os.Stat(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("expected a chart directory at %s", expectedChartPath)
+	}
+
+	dir, err := os.Open(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fis, err := dir.Readdir(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectLen := 11
+	if len(fis) != expectLen {
+		t.Errorf("Expected %d files, but got %d", expectLen, len(fis))
+	}
+
+	for _, fi := range fis {
+		expect, err := os.Stat(filepath.Join("testdata", "frobnitz", fi.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size() != expect.Size() {
+			t.Errorf("Expected %s to have size %d, got %d", fi.Name(), expect.Size(), fi.Size())
+		}
+	}
+}
+
+func TestExpandFile(t *testing.T) {
+	dest, err := ioutil.TempDir("", "helm-testing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dest)
+
+	if err := ExpandFile(dest, "testdata/frobnitz-1.2.3.tgz"); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedChartPath := filepath.Join(dest, "frobnitz")
+	fi, err := os.Stat(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("expected a chart directory at %s", expectedChartPath)
+	}
+
+	dir, err := os.Open(expectedChartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fis, err := dir.Readdir(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectLen := 11
+	if len(fis) != expectLen {
+		t.Errorf("Expected %d files, but got %d", expectLen, len(fis))
+	}
+
+	for _, fi := range fis {
+		expect, err := os.Stat(filepath.Join("testdata", "frobnitz", fi.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size() != expect.Size() {
+			t.Errorf("Expected %s to have size %d, got %d", fi.Name(), expect.Size(), fi.Size())
+		}
+	}
+}


### PR DESCRIPTION
This is a port of #5165 and the small refactor in #5610. This is the issue
where carefully crafted paths can reach outside of the intended chart directory