### PR TITLE
fix(helm): Port accept dependency in requirements.yaml from charts directory

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -53,6 +53,19 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 	locked := make([]*chart.Dependency, len(reqs))
 	missing := []string{}
 	for i, d := range reqs {
+		if d.Repository == "" {
+			// Local chart subfolder
+			if _, err := GetLocalPath(filepath.Join("charts", d.Name), r.chartpath); err != nil {
+				return nil, err
+			}
+
+			locked[i] = &chart.Dependency{
+				Name:       d.Name,
+				Repository: "",
+				Version:    d.Version,
+			}
+			continue
+		}
 		if strings.HasPrefix(d.Repository, "file://") {
 
 			if _, err := GetLocalPath(d.Repository, r.chartpath); err != nil {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -97,7 +97,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
-			name: "repo from valid path under charts path",
+			name: "repo from invalid path under charts path",
 			req: []*chart.Dependency{
 				{Name: "nonexistentdependency", Repository: "", Version: "0.1.0"},
 			},

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -85,6 +85,29 @@ func TestResolve(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			name: "repo from valid path under charts path",
+			req: []*chart.Dependency{
+				{Name: "localdependency", Repository: "", Version: "0.1.0"},
+			},
+			expect: &chart.Lock{
+				Dependencies: []*chart.Dependency{
+					{Name: "localdependency", Repository: "", Version: "0.1.0"},
+				},
+			},
+		},
+		{
+			name: "repo from valid path under charts path",
+			req: []*chart.Dependency{
+				{Name: "nonexistentdependency", Repository: "", Version: "0.1.0"},
+			},
+			expect: &chart.Lock{
+				Dependencies: []*chart.Dependency{
+					{Name: "nonexistentlocaldependency", Repository: "", Version: "0.1.0"},
+				},
+			},
+			err: true,
+		},
 	}
 
 	repoNames := map[string]string{"alpine": "kubernetes-charts", "redis": "kubernetes-charts"}

--- a/internal/resolver/testdata/chartpath/charts/localdependency/Chart.yaml
+++ b/internal/resolver/testdata/chartpath/charts/localdependency/Chart.yaml
@@ -1,0 +1,3 @@
+description: A Helm chart for Kubernetes
+name: localdependency
+version: 0.1.0

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -147,6 +147,13 @@ func TestGetRepoNames(t *testing.T) {
 			},
 			expect: map[string]string{"oedipus-rex": "testing"},
 		},
+		{
+			name: "repo from local chart under charts path",
+			req: []*chart.Dependency{
+				{Name: "local-subchart", Repository: ""},
+			},
+			expect: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/downloader/testdata/local-subchart/Chart.yaml
+++ b/pkg/downloader/testdata/local-subchart/Chart.yaml
@@ -1,0 +1,3 @@
+description: A Helm chart for Kubernetes
+name: local-subchart
+version: 0.1.0


### PR DESCRIPTION
This is a port of #6578 from Helm v2 with modifications to integrate with v3 infrastructure.

**What this PR does / why we need it**:

**Special notes for your reviewer**:
For manual testing, use steps similar to the following:
- Create chart `foo`
- Create chart `sub-foo`
- Move `sub-foo` to `foo/charts`
- Add the following dependencies to `foo/Chart.yaml`:
```console
dependencies:
- name: sub-foo
  version: 0.1.0
- name: mysql
  version: "1.3.2"
  repository: "https://kubernetes-charts.storage.googleapis.com"
```
- Do a dependency update: `helm dep up foo`

It should fail similar to the following without the PR:
```console
$ helm dep up foo
Error: no repository definition for . Please add them via 'helm repo add'
Note that repositories must be URLs or aliases. For example, to refer to the "example"
repository, use "https://charts.example.com/" or "@example" instead of
"example". Don't forget to add the repo, too ('helm repo add').
```

PR should fix it similar to the following:
```console
$ helm dep update foo
Hang tight while we grab the latest from your chart repositories...
..Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 2 charts
Dependency sub-foo did not declare a repository. Assuming it exists in the charts directory
Downloading mysql from repo https://kubernetes-charts.storage.googleapis.com
Deleting outdated charts

$ ls -lrt foo/charts/
total 20
drwxr-xr-x 4 usr1 usr1  4096 Oct  8 20:02 sub-foo
-rw-rw-r-- 1 usr1 usr1  2739 Oct  8 20:05 sub-foo-0.1.0.tgz
-rw-r--r-- 1 usr1 usr1 10635 Oct  8 20:37 mysql-1.3.2.tgz
```
**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
