### PR TITLE
feat(helm): Port helm get notes command

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -71,6 +71,7 @@ func newGetCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	cmd.AddCommand(newGetValuesCmd(cfg, out))
 	cmd.AddCommand(newGetManifestCmd(cfg, out))
 	cmd.AddCommand(newGetHooksCmd(cfg, out))
+	cmd.AddCommand(newGetNotesCmd(cfg, out))
 
 	return cmd
 }

--- a/cmd/helm/get_notes.go
+++ b/cmd/helm/get_notes.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+var getNotesHelp = `
+This command shows notes provided by the chart of a named release.
+`
+
+func newGetNotesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	client := action.NewGet(cfg)
+
+	cmd := &cobra.Command{
+		Use:   "notes [flags] RELEASE_NAME",
+		Short: "displays the notes of the named release",
+		Long:  getNotesHelp,
+		Args:  require.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res, err := client.Run(args[0])
+			if err != nil {
+				return err
+			}
+			if len(res.Info.Notes) > 0 {
+				fmt.Fprintf(out, "NOTES:\n%s\n", res.Info.Notes)
+			}
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.IntVar(&client.Version, "revision", 0, "get the named release with revision")
+
+	return cmd
+}

--- a/cmd/helm/get_notes_test.go
+++ b/cmd/helm/get_notes_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func TestGetNotesCmd(t *testing.T) {
+	tests := []cmdTestCase{{
+		name:   "get notes of a deployed release",
+		cmd:    "get notes the-limerick",
+		golden: "output/get-notes.txt",
+		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "the-limerick"})},
+	}, {
+		name:      "get notes without args",
+		cmd:       "get notes",
+		golden:    "output/get-notes-no-args.txt",
+		wantError: true,
+	}}
+	runTestCmd(t, tests)
+}

--- a/cmd/helm/testdata/output/get-notes-no-args.txt
+++ b/cmd/helm/testdata/output/get-notes-no-args.txt
@@ -1,0 +1,3 @@
+Error: "helm get notes" requires 1 argument
+
+Usage:  helm get notes [flags] RELEASE_NAME

--- a/cmd/helm/testdata/output/get-notes.txt
+++ b/cmd/helm/testdata/output/get-notes.txt
@@ -1,0 +1,2 @@
+NOTES:
+Some mock release notes!

--- a/cmd/helm/testdata/output/get-release.txt
+++ b/cmd/helm/testdata/output/get-release.txt
@@ -24,3 +24,5 @@ kind: Secret
 metadata:
   name: fixture
 
+NOTES:
+Some mock release notes!

--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -90,6 +90,7 @@ func Mock(opts *MockReleaseOptions) *Release {
 		LastDeployed:  date,
 		Status:        scode,
 		Description:   "Release mock",
+		Notes:         "Some mock release notes!",
 	}
 
 	return &Release{


### PR DESCRIPTION
Port #4078 from Helm v2.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
