### PR TITLE
fix file mode,it should be octal expressed

### DIFF
--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -241,7 +241,7 @@ func TestWriteFile(t *testing.T) {
 		t.Errorf("failed to create test-file (%v)", err)
 	}
 	defer os.Remove(repoFile.Name())
-	if err := sampleRepository.WriteFile(repoFile.Name(), 744); err != nil {
+	if err := sampleRepository.WriteFile(repoFile.Name(), 0744); err != nil {
 		t.Errorf("failed to write file (%v)", err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
FIleMode is usually octal express, 0744 is correct, 744 is decimal express, the filemode will be wrong in file system.
