### PR TITLE
Add missing k8s objects to InstallOrder

### DIFF
--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -26,8 +26,11 @@ type KindSortOrder []string
 // Those occurring earlier in the list get installed before those occurring later in the list.
 var InstallOrder KindSortOrder = []string{
 	"Namespace",
+	"NetworkPolicy",
 	"ResourceQuota",
 	"LimitRange",
+	"PodSecurityPolicy",
+	"PodDisruptionBudget",
 	"Secret",
 	"ConfigMap",
 	"StorageClass",
@@ -88,8 +91,11 @@ var UninstallOrder KindSortOrder = []string{
 	"StorageClass",
 	"ConfigMap",
 	"Secret",
+	"PodDisruptionBudget",
+	"PodSecurityPolicy",
 	"LimitRange",
 	"ResourceQuota",
+	"NetworkPolicy",
 	"Namespace",
 }
 

--- a/pkg/releaseutil/kind_sorter_test.go
+++ b/pkg/releaseutil/kind_sorter_test.go
@@ -80,6 +80,10 @@ func TestKindSorter(t *testing.T) {
 			Head: &SimpleHead{Kind: "Namespace"},
 		},
 		{
+			Name: "A",
+			Head: &SimpleHead{Kind: "NetworkPolicy"},
+		},
+		{
 			Name: "f",
 			Head: &SimpleHead{Kind: "PersistentVolume"},
 		},
@@ -90,6 +94,14 @@ func TestKindSorter(t *testing.T) {
 		{
 			Name: "o",
 			Head: &SimpleHead{Kind: "Pod"},
+		},
+		{
+			Name: "3",
+			Head: &SimpleHead{Kind: "PodDisruptionBudget"},
+		},
+		{
+			Name: "C",
+			Head: &SimpleHead{Kind: "PodSecurityPolicy"},
 		},
 		{
 			Name: "q",
@@ -154,8 +166,8 @@ func TestKindSorter(t *testing.T) {
 		order       KindSortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "abcde1fgh2iIjJkKlLmnopqrxstuvw!"},
-		{"uninstall", UninstallOrder, "wvmutsxrqponLlKkJjIi2hgf1edcba!"},
+		{"install", InstallOrder, "aAbcC3de1fgh2iIjJkKlLmnopqrxstuvw!"},
+		{"uninstall", UninstallOrder, "wvmutsxrqponLlKkJjIi2hgf1ed3CcbAa!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it:**
Added NetworkPolicy, PodDisruptionBudget, and PodSecurityPolicy to InstallOrder

**Special notes for your reviewer**:
This PR is a port of #6266 #4769 #3899 to Helm 3.

- [x] this PR contains unit tests
