### PR TITLE
Remove impossible condition reported by linter

### DIFF
--- a/pkg/chartutil/expand.go
+++ b/pkg/chartutil/expand.go
@@ -45,9 +45,6 @@ func Expand(dir string, r io.Reader) error {
 			if err := yaml.Unmarshal(file.Data, ch); err != nil {
 				return errors.Wrap(err, "cannot load Chart.yaml")
 			}
-			if err != nil {
-				return err
-			}
 			chartName = ch.Name
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix linter issue that makes `make test` fail.
The error I got:

```
GO111MODULE=on /Users/marckhouzam/go/bin/golangci-lint run
pkg/chartutil/expand.go:48:11: nilness: impossible condition: nil != nil (govet)
			if err != nil {
			       ^
```

