### PR TITLE
fix(v3): fix type error while merging map loaded with `fromYaml` template func

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // funcMap returns a mapping of all of the functions that Engine has.

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -52,7 +52,7 @@ func TestFuncs(t *testing.T) {
 		vars:   map[string]map[string]string{"mast": {"sail": "white"}},
 	}, {
 		tpl:    `{{ fromYaml . }}`,
-		expect: "map[Error:yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into map[string]interface {}]",
+		expect: "map[Error:error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}]",
 		vars:   "- one\n- two\n",
 	}, {
 		tpl:    `{{ fromJson .}}`,
@@ -61,6 +61,18 @@ func TestFuncs(t *testing.T) {
 	}, {
 		tpl:    `{{ fromJson . }}`,
 		expect: `map[Error:json: cannot unmarshal array into Go value of type map[string]interface {}]`,
+		vars:   `["one", "two"]`,
+	}, {
+		tpl:    `{{ merge .dict (fromYaml .yaml) }}`,
+		expect: `map[a:map[b:c]]`,
+		vars:   map[string]interface{}{"dict": map[string]interface{}{"a": map[string]interface{}{"b": "c"}}, "yaml": `{"a":{"b":"d"}}`},
+	}, {
+		tpl:    `{{ merge (fromYaml .yaml) .dict }}`,
+		expect: `map[a:map[b:d]]`,
+		vars:   map[string]interface{}{"dict": map[string]interface{}{"a": map[string]interface{}{"b": "c"}}, "yaml": `{"a":{"b":"d"}}`},
+	}, {
+		tpl:    `{{ fromYaml . }}`,
+		expect: `map[Error:error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}]`,
 		vars:   `["one", "two"]`,
 	}}
 


### PR DESCRIPTION
Closes #6626

**What this PR does / why we need it**:

Helm v3 has a regression in merging dicts loaded with the `fromYaml` template function.

In my manual testing, it turned out to be due to that in #6016 we missed migrating helm-specific (non-sprig) template functions to use the new yaml package(sigs.k8s.io/yaml). Perhaps it was intentional? But the inconsistency seems to have broken it anyway.

This changes the import path to that of the new yaml package.

I've manually verified this to work as expecited, fixing the issue described in #6626.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
