### PR TITLE
bump version to v2.15

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
 	// Increment patch number for critical fixes to existing releases.
-	Version = "v2.14"
+	Version = "v2.15"
 
 	// BuildMetadata is extra build time data
 	BuildMetadata = "unreleased"


### PR DESCRIPTION
As per the release checklist, cherry-picking 7afbddf from the `release-2.15` branch to `master`.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
