### PR TITLE
Set default hook deletion policy to before-hook-creation

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -119,6 +119,11 @@ func (x hookByWeight) Less(i, j int) bool {
 
 // deleteHookByPolicy deletes a hook if the hook policy instructs it to
 func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.HookDeletePolicy) error {
+	// Never delete CustomResourceDefinitions; this could cause lots of
+	// cascading garbage collection.
+	if h.Kind == "CustomResourceDefinition" {
+		return nil
+	}
 	if hookHasDeletePolicy(h, policy) {
 		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), false)
 		if err != nil {

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -40,6 +40,15 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	sort.Sort(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
+		// Set default delete policy to before-hook-creation
+		if h.DeletePolicies == nil || len(h.DeletePolicies) == 0 {
+			// TODO(jlegrone): Only apply before-hook-creation delete policy to run to completion
+			//                 resources. For all other resource types update in place if a
+			//                 resource with the same name already exists and is owned by the
+			//                 current release.
+			h.DeletePolicies = []release.HookDeletePolicy{release.HookBeforeHookCreation}
+		}
+
 		if err := cfg.deleteHookByPolicy(h, release.HookBeforeHookCreation); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Set the hook deletion policy to `before-hook-creation` if no deletion policies exist. This makes hook executions idempotent by default.

A special case has been added for `CustomResourceDefinition`; we don't want to delete these by default if someone adds a hook annotation!

Before the GA release of Helm 3.0.0 we should switch to defaulting only run to completion resource types (Jobs, Pods) to `before-hook-creation`, and gracefully update all other resource types without deletion (this is noted in a todo comment and will be a followup PR).

Related to https://github.com/helm/helm/issues/6020

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
