### PR TITLE
ref(cmd): Use method to list formats

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -52,14 +52,8 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 // bindOutputFlag will add the output flag to the given command and bind the
 // value to the given format pointer
 func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {
-	var formats strings.Builder
-	for index, format := range output.Formats() {
-		if index != 0 {
-			formats.WriteString(", ")
-		}
-		formats.WriteString(format.String())
-	}
-	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o", fmt.Sprintf("prints the output in the specified format. Allowed values: %s", formats.String()))
+	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o",
+		fmt.Sprintf("prints the output in the specified format. Allowed values: %s", strings.Join(output.Formats(), ", ")))
 	// Setup shell completion for the flag
 	cmd.MarkFlagCustom(outputFlag, "__helm_output_options")
 }

--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -51,7 +52,14 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 // bindOutputFlag will add the output flag to the given command and bind the
 // value to the given format pointer
 func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {
-	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o", fmt.Sprintf("prints the output in the specified format. Allowed values: %s, %s, %s", output.Table, output.JSON, output.YAML))
+	var formats strings.Builder
+	for index, format := range output.Formats() {
+		if index != 0 {
+			formats.WriteString(", ")
+		}
+		formats.WriteString(format.String())
+	}
+	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o", fmt.Sprintf("prints the output in the specified format. Allowed values: %s", formats.String()))
 	// Setup shell completion for the flag
 	cmd.MarkFlagCustom(outputFlag, "__helm_output_options")
 }

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -17,13 +17,16 @@ limitations under the License.
 package main // import "helm.sh/helm/v3/cmd/helm"
 
 import (
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/internal/experimental/registry"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli/output"
 )
 
 const (
@@ -92,7 +95,7 @@ __helm_get_namespaces()
 __helm_output_options()
 {
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
-    COMPREPLY+=( $( compgen -W "table json yaml" -- "$cur" ) )
+    COMPREPLY+=( $( compgen -W "%[1]s" -- "$cur" ) )
 }
 
 __helm_binary_name()
@@ -203,13 +206,19 @@ By default, the default directories depend on the Operating System. The defaults
 `
 
 func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) *cobra.Command {
+	var formats strings.Builder
+	for _, format := range output.Formats() {
+		formats.WriteString(format.String())
+		formats.WriteByte(' ')
+	}
+
 	cmd := &cobra.Command{
 		Use:                    "helm",
 		Short:                  "The Helm package manager for Kubernetes.",
 		Long:                   globalUsage,
 		SilenceUsage:           true,
 		Args:                   require.NoArgs,
-		BashCompletionFunction: bashCompletionFunc,
+		BashCompletionFunction: fmt.Sprintf(bashCompletionFunc, formats.String()),
 	}
 	flags := cmd.PersistentFlags()
 

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -206,19 +206,13 @@ By default, the default directories depend on the Operating System. The defaults
 `
 
 func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) *cobra.Command {
-	var formats strings.Builder
-	for _, format := range output.Formats() {
-		formats.WriteString(format.String())
-		formats.WriteByte(' ')
-	}
-
 	cmd := &cobra.Command{
 		Use:                    "helm",
 		Short:                  "The Helm package manager for Kubernetes.",
 		Long:                   globalUsage,
 		SilenceUsage:           true,
 		Args:                   require.NoArgs,
-		BashCompletionFunction: fmt.Sprintf(bashCompletionFunc, formats.String()),
+		BashCompletionFunction: fmt.Sprintf(bashCompletionFunc, strings.Join(output.Formats(), " ")),
 	}
 	flags := cmd.PersistentFlags()
 

--- a/pkg/cli/output/output.go
+++ b/pkg/cli/output/output.go
@@ -35,15 +35,15 @@ const (
 	YAML  Format = "yaml"
 )
 
-// Formats returns a list of supported formats
-func Formats() []Format {
-	return []Format{Table, JSON, YAML}
+// Formats returns a list of the string representation of the supported formats
+func Formats() []string {
+	return []string{Table.String(), JSON.String(), YAML.String()}
 }
 
 // ErrInvalidFormatType is returned when an unsupported format type is used
 var ErrInvalidFormatType = fmt.Errorf("invalid format type")
 
-// String returns the string reprsentation of the Format
+// String returns the string representation of the Format
 func (o Format) String() string {
 	return string(o)
 }

--- a/pkg/cli/output/output.go
+++ b/pkg/cli/output/output.go
@@ -35,6 +35,11 @@ const (
 	YAML  Format = "yaml"
 )
 
+// Formats returns a list of supported formats
+func Formats() []Format {
+	return []Format{Table, JSON, YAML}
+}
+
 // ErrInvalidFormatType is returned when an unsupported format type is used
 var ErrInvalidFormatType = fmt.Errorf("invalid format type")
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

There are two instances where the list of `output.format` is hard-coded outside the `output.go` file.  This breaks the rules of encapsulation and increases the risk that when adding a new format, the hard-coded lists could be forgotten.

This PR provides a method for listing the string representation of the different formats from within the `output.go` file.

