### PR TITLE
Add 'get notes' subcommand based on similar v2 code.

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -71,6 +71,7 @@ func newGetCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	cmd.AddCommand(newGetValuesCmd(cfg, out))
 	cmd.AddCommand(newGetManifestCmd(cfg, out))
 	cmd.AddCommand(newGetHooksCmd(cfg, out))
+	cmd.AddCommand(newGetNotesCmd(cfg, out))
 
 	return cmd
 }

--- a/cmd/helm/get_notes.go
+++ b/cmd/helm/get_notes.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+var getNotesHelp = `
+This command shows notes provided by the chart of a named release.
+`
+
+func newGetNotesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	client := action.NewGet(cfg)
+
+	cmd := &cobra.Command{
+		Use:   "notes RELEASE_NAME [flags]",
+		Short: "Displays the notes of the named release",
+		Long:  getNotesHelp,
+		Args:  require.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res, err := client.Run(args[0])
+			if err != nil {
+				return err
+			}
+			if len(res.Info.Notes) > 0 {
+				fmt.Fprintf(out, "NOTES:\n%s\n", res.Info.Notes)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&client.Version, "revision", 0, "get the named release with revision")
+
+	return cmd
+}

--- a/cmd/helm/get_notes_test.go
+++ b/cmd/helm/get_notes_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func TestGetNotesCmd(t *testing.T) {
+	tests := []cmdTestCase{
+		{
+			name:   "get notes of a deployed release",
+			cmd:    "get notes flummoxed-chickadee",
+			golden: "output/get-notes.txt",
+			rels: []*release.Release{
+				release.Mock(&release.MockReleaseOptions{
+					Name:  "flummoxed-chickadee",
+					Notes: "Release notes",
+				}),
+			},
+		},
+		{
+			name:      "get notes requires release name arg",
+			cmd:       "get notes",
+			golden:    "output/get-notes-no-args.txt",
+			wantError: true,
+		},
+	}
+	runTestCmd(t, tests)
+}

--- a/cmd/helm/testdata/output/get-notes-no-args.txt
+++ b/cmd/helm/testdata/output/get-notes-no-args.txt
@@ -1,0 +1,3 @@
+Error: "helm get notes" requires 1 argument
+
+Usage:  helm get notes RELEASE_NAME [flags]

--- a/cmd/helm/testdata/output/get-notes.txt
+++ b/cmd/helm/testdata/output/get-notes.txt
@@ -1,0 +1,2 @@
+NOTES:
+Release notes

--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -45,6 +45,7 @@ type MockReleaseOptions struct {
 	Chart     *chart.Chart
 	Status    Status
 	Namespace string
+	Notes     string
 }
 
 // Mock creates a mock release object based on options set by MockReleaseOptions. This function should typically not be used outside of testing.
@@ -90,6 +91,7 @@ func Mock(opts *MockReleaseOptions) *Release {
 		LastDeployed:  date,
 		Status:        scode,
 		Description:   "Release mock",
+		Notes:         opts.Notes,
 	}
 
 	return &Release{


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

I don't see a related issue, but @james-w pointed me at a slack conversation [1] which requested a PR moving the `helm get notes` command across to v3.

Local output:
```
(add-get-notes) ~/dev/helm$ ./bin/helm get notes mnelson-wordpress                                                                 
NOTES:
1. Get the WordPress URL:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        Watch the status with: 'kubectl get svc --namespace mnelson -w mnelson-wordpress'
  export SERVICE_IP=$(kubectl get svc --namespace mnelson mnelson-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
  echo "WordPress URL: http://$SERVICE_IP/"
  echo "WordPress Admin URL: http://$SERVICE_IP/admin"

2. Login with the following credentials to see your blog

  echo Username: user
  echo Password: $(kubectl get secret --namespace mnelson mnelson-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
```

Note: I see the same templating within the notes when installing the chart, so assume this unrelated to the `get notes` command itself.

[1] https://kubernetes.slack.com/archives/C0NH30761/p1570553119149000

**What this PR does / why we need it**:
See [1] above.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
