### PR TITLE
 Re-add support in scaffold chart for ingress prior to k8s 1.14

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -179,7 +179,11 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Add in API group `apiVersion: extensions/v1beta1` for ingress prior to k8s 1.14 

**What this PR does / why we need it**:
Cannot install ingress into cluster prior to k8s 1.14 from a scaffold chart (`helm create`)

**Special notes for your reviewer**:
In light of probably providing support prior to 1.14, would need to add this back in.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
