### PR TITLE
fix(cli): Fixes incorrect variable reference

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -95,12 +95,12 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_REGISTRY_CONFIG":   s.RegistryConfig,
 		"HELM_REPOSITORY_CACHE":  s.RepositoryCache,
 		"HELM_REPOSITORY_CONFIG": s.RepositoryConfig,
-		"HELM_NAMESPACE":         s.Namespace,
+		"HELM_NAMESPACE":         s.Namespace(),
 		"HELM_KUBECONTEXT":       s.KubeContext,
 	}
 
-	if s.KubeConfig != "" {
-		envvars["KUBECONFIG"] = s.KubeConfig
+	if s.kubeConfig != "" {
+		envvars["KUBECONFIG"] = s.kubeConfig
 	}
 
 	return envvars


### PR DESCRIPTION
Because these were additions in #6632, git didn't pick up that the recent refactor of
env settings had changed some of the variables. This fixes those small changes