### PR TITLE
fix(action): Fixes ordering of variable binding

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -64,9 +64,10 @@ func initKubeLogs() {
 func main() {
 	initKubeLogs()
 
-	actionConfig, err := action.InitActionConfig(settings, false, os.Getenv("HELM_DRIVER"), debug)
+	actionConfig := new(action.Configuration)
+	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
-	if err != nil {
+	if err := actionConfig.Init(settings, false, os.Getenv("HELM_DRIVER"), debug); err != nil {
 		debug("%+v", err)
 		switch e := err.(type) {
 		case pluginError:
@@ -75,8 +76,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
-	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
 	if err := cmd.Execute(); err != nil {
 		debug("%+v", err)

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -70,7 +70,9 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if client.AllNamespaces {
-				action.InitActionConfig(settings, true, os.Getenv("HELM_DRIVER"), debug)
+				if err := cfg.Init(settings, true, os.Getenv("HELM_DRIVER"), debug); err != nil {
+					return err
+				}
 			}
 			client.SetStateMask()
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -210,9 +210,7 @@ func (c *Configuration) recordRelease(r *release.Release) {
 }
 
 // InitActionConfig initializes the action configuration
-func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log DebugLog) (*Configuration, error) {
-
-	var actionConfig Configuration
+func (c *Configuration) Init(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log DebugLog) error {
 	kubeconfig := envSettings.KubeConfig()
 
 	kc := kube.New(kubeconfig)
@@ -220,7 +218,7 @@ func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriv
 
 	clientset, err := kc.Factory.KubernetesClientSet()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	var namespace string
 	if !allNamespaces {
@@ -245,10 +243,10 @@ func InitActionConfig(envSettings *cli.EnvSettings, allNamespaces bool, helmDriv
 		panic("Unknown driver in HELM_DRIVER: " + helmDriver)
 	}
 
-	actionConfig.RESTClientGetter = kubeconfig
-	actionConfig.KubeClient = kc
-	actionConfig.Releases = store
-	actionConfig.Log = log
+	c.RESTClientGetter = kubeconfig
+	c.KubeClient = kc
+	c.Releases = store
+	c.Log = log
 
-	return &actionConfig, nil
+	return nil
 }


### PR DESCRIPTION
The recent init action config switched the order of how variables get bound
and where. This led to the namespace variable not being propagated down into
the calls to kubernetes. To manage this, we have changed the behavior of the `InitActionConfig` to be a method on the config struct called `Init`