### PR TITLE
v3: 'helm show' -> 'helm show all' and 'helm get' -> 'helm get all'

### DIFF
--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -23,51 +23,27 @@ import (
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/cli/output"
 )
 
 var getHelp = `
-This command shows the details of a named release.
-
-It can be used to get extended information about the release, including:
+This command consists of multiple subcommands which can be used to
+get extended information about the release, including:
 
   - The values used to generate the release
-  - The chart used to generate the release
   - The generated manifest file
-
-By default, this prints a human readable collection of information about the
-chart, the supplied values, and the generated manifest file.
+  - The notes provided by the chart of the release
+  - The hooks associated with the release
 `
 
 func newGetCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	var template string
-	client := action.NewGet(cfg)
-
 	cmd := &cobra.Command{
-		Use:   "get RELEASE_NAME",
-		Short: "download a named release",
+		Use:   "get",
+		Short: "download extended information of a named release",
 		Long:  getHelp,
-		Args:  require.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			res, err := client.Run(args[0])
-			if err != nil {
-				return err
-			}
-			if template != "" {
-				data := map[string]interface{}{
-					"Release": res,
-				}
-				return tpl(template, data, out)
-			}
-
-			return output.Table.Write(out, &statusPrinter{res, true})
-		},
+		Args:  require.NoArgs,
 	}
 
-	f := cmd.Flags()
-	f.IntVar(&client.Version, "revision", 0, "get the named release with revision")
-	f.StringVar(&template, "template", "", "go template for formatting the output, eg: {{.Release.Name}}")
-
+	cmd.AddCommand(newGetAllCmd(cfg, out))
 	cmd.AddCommand(newGetValuesCmd(cfg, out))
 	cmd.AddCommand(newGetManifestCmd(cfg, out))
 	cmd.AddCommand(newGetHooksCmd(cfg, out))

--- a/cmd/helm/get_all_test.go
+++ b/cmd/helm/get_all_test.go
@@ -24,19 +24,19 @@ import (
 
 func TestGetCmd(t *testing.T) {
 	tests := []cmdTestCase{{
-		name:   "get with a release",
-		cmd:    "get thomas-guide",
+		name:   "get all with a release",
+		cmd:    "get all thomas-guide",
 		golden: "output/get-release.txt",
 		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "thomas-guide"})},
 	}, {
-		name:   "get with a formatted release",
-		cmd:    "get elevated-turkey --template {{.Release.Chart.Metadata.Version}}",
+		name:   "get all with a formatted release",
+		cmd:    "get all elevated-turkey --template {{.Release.Chart.Metadata.Version}}",
 		golden: "output/get-release-template.txt",
 		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "elevated-turkey"})},
 	}, {
-		name:      "get requires release name arg",
-		cmd:       "get",
-		golden:    "output/get-no-args.txt",
+		name:      "get all requires release name arg",
+		cmd:       "get all",
+		golden:    "output/get-all-no-args.txt",
 		wantError: true,
 	}}
 	runTestCmd(t, tests)

--- a/cmd/helm/testdata/output/get-all-no-args.txt
+++ b/cmd/helm/testdata/output/get-all-no-args.txt
@@ -1,0 +1,3 @@
+Error: "helm get all" requires 1 argument
+
+Usage:  helm get all RELEASE_NAME [flags]

--- a/cmd/helm/testdata/output/get-no-args.txt
+++ b/cmd/helm/testdata/output/get-no-args.txt
@@ -1,3 +1,0 @@
-Error: "helm get" requires 1 argument
-
-Usage:  helm get RELEASE_NAME [flags]

--- a/cmd/helm/testdata/output/get-notes-no-args.txt
+++ b/cmd/helm/testdata/output/get-notes-no-args.txt
@@ -1,3 +1,3 @@
 Error: "helm get notes" requires 1 argument
 
-Usage:  helm get notes [flags] RELEASE_NAME
+Usage:  helm get notes RELEASE_NAME [flags]


### PR DESCRIPTION
Closes #6552

**What this PR does / why we need it**:

Replace `helm show` with `helm show all`
Replace `helm get` with `helm get all`

Thid is a break in compatibility because `helm show` and `helm get` are no longer valid commands on their own; what they used to do is now achieved with `helm show all` ans `helm get all` respectively.

This change avoids confusion between chart reference/release name and subcommands.
It also allows dynamic shell completion to work properly.

See #6552 for more details.

**Special notes for your reviewer**:

This is an approved break in command compatibility.

There are also a couple of small changes in help messages to standardize across subcommands (e.g. for `helm get notes`)

**If applicable**:
- [x] this PR contains documentation (assuming help messages count as documentation)
- [x] this PR contains unit tests (modification to naming of existing tests)
