### PR TITLE
Remove all known arguments in plugin invocations

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -127,7 +127,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 func manuallyProcessArgs(args []string) ([]string, []string) {
 	known := []string{}
 	unknown := []string{}
-	kvargs := []string{"--context", "--namespace"}
+	kvargs := []string{"--kube-context", "--namespace", "--kubeconfig", "--registry-config", "--repository-cache", "--repository-config"}
 	knownArg := func(a string) bool {
 		for _, pre := range kvargs {
 			if strings.HasPrefix(a, pre+"=") {
@@ -140,7 +140,7 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 		switch a := args[i]; a {
 		case "--debug":
 			known = append(known, a)
-		case "--context", "--namespace":
+		case "--kube-context", "--namespace", "-n", "--kubeconfig", "--registry-config", "--repository-cache", "--repository-config":
 			known = append(known, a, args[i+1])
 			i++
 		default:

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -29,13 +29,15 @@ func TestManuallyProcessArgs(t *testing.T) {
 	input := []string{
 		"--debug",
 		"--foo", "bar",
-		"--context", "test1",
+		"--kubeconfig=/home/foo",
+		"--kube-context", "test1",
+		"-n", "test2",
 		"--home=/tmp",
 		"command",
 	}
 
 	expectKnown := []string{
-		"--debug", "--context", "test1",
+		"--debug", "--kubeconfig=/home/foo", "--kube-context", "test1", "-n", "test2",
 	}
 
 	expectUnknown := []string{

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -60,6 +60,7 @@ func New() *EnvSettings {
 
 	env := EnvSettings{
 		namespace:        os.Getenv("HELM_NAMESPACE"),
+		KubeContext:      os.Getenv("HELM_KUBECONTEXT"),
 		PluginsDirectory: envOr("HELM_PLUGINS", helmpath.DataPath("plugins")),
 		RegistryConfig:   envOr("HELM_REGISTRY_CONFIG", helmpath.ConfigPath("registry.json")),
 		RepositoryConfig: envOr("HELM_REPOSITORY_CONFIG", helmpath.ConfigPath("repositories.yaml")),
@@ -73,7 +74,7 @@ func New() *EnvSettings {
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace scope for this request")
 	fs.StringVar(&s.kubeConfig, "kubeconfig", "", "path to the kubeconfig file")
-	fs.StringVar(&s.KubeContext, "kube-context", "", "name of the kubeconfig context to use")
+	fs.StringVar(&s.KubeContext, "kube-context", s.KubeContext, "name of the kubeconfig context to use")
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "enable verbose output")
 	fs.StringVar(&s.RegistryConfig, "registry-config", s.RegistryConfig, "path to the registry config file")
 	fs.StringVar(&s.RepositoryConfig, "repository-config", s.RepositoryConfig, "path to the file containing repository names and URLs")


### PR DESCRIPTION
**What this PR does / why we need it**:
Consistenly removes all arguments in plugin invocations which are passed as environment variables:
- `--context` is renamed to `--kube-context`
- added missing known arguments including short option of `--namespace`

Additional fix: Get all arguments from environment variables passed to plugins:
- `HELM_KUBECONTEXT` was the only environment variable not processed