### PR TITLE
Modified the scope of Kubeconfig so it could be set outside an env va…

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -211,7 +211,7 @@ func (c *Configuration) recordRelease(r *release.Release) {
 
 // InitActionConfig initializes the action configuration
 func (c *Configuration) Init(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log DebugLog) error {
-	getter := envSettings.RestClientGetter()
+	getter := envSettings.RESTClientGetter()
 
 	kc := kube.New(getter)
 	kc.Log = log

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -211,9 +211,9 @@ func (c *Configuration) recordRelease(r *release.Release) {
 
 // InitActionConfig initializes the action configuration
 func (c *Configuration) Init(envSettings *cli.EnvSettings, allNamespaces bool, helmDriver string, log DebugLog) error {
-	kubeconfig := envSettings.KubeConfig()
+	getter := envSettings.RestClientGetter()
 
-	kc := kube.New(kubeconfig)
+	kc := kube.New(getter)
 	kc.Log = log
 
 	clientset, err := kc.Factory.KubernetesClientSet()
@@ -243,7 +243,7 @@ func (c *Configuration) Init(envSettings *cli.EnvSettings, allNamespaces bool, h
 		panic("Unknown driver in HELM_DRIVER: " + helmDriver)
 	}
 
-	c.RESTClientGetter = kubeconfig
+	c.RESTClientGetter = getter
 	c.KubeClient = kc
 	c.Releases = store
 	c.Log = log

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -38,10 +38,13 @@ import (
 
 // EnvSettings describes all of the environment settings.
 type EnvSettings struct {
-	namespace  string
-	kubeConfig string
+	namespace string
+	//kubeConfig string
 	config     genericclioptions.RESTClientGetter
 	configOnce sync.Once
+
+	// KubeConfig is the path to the kubeconfig file
+	KubeConfig string
 	// KubeContext is the name of the kubeconfig context.
 	KubeContext string
 	// Debug indicates whether or not Helm is running in Debug mode.
@@ -73,7 +76,7 @@ func New() *EnvSettings {
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace scope for this request")
-	fs.StringVar(&s.kubeConfig, "kubeconfig", "", "path to the kubeconfig file")
+	fs.StringVar(&s.KubeConfig, "kubeconfig", "", "path to the kubeconfig file")
 	fs.StringVar(&s.KubeContext, "kube-context", s.KubeContext, "name of the kubeconfig context to use")
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "enable verbose output")
 	fs.StringVar(&s.RegistryConfig, "registry-config", s.RegistryConfig, "path to the registry config file")
@@ -100,8 +103,8 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_KUBECONTEXT":       s.KubeContext,
 	}
 
-	if s.kubeConfig != "" {
-		envvars["KUBECONFIG"] = s.kubeConfig
+	if s.KubeConfig != "" {
+		envvars["KUBECONFIG"] = s.KubeConfig
 	}
 
 	return envvars
@@ -113,16 +116,16 @@ func (s *EnvSettings) Namespace() string {
 		return s.namespace
 	}
 
-	if ns, _, err := s.KubeConfig().ToRawKubeConfigLoader().Namespace(); err == nil {
+	if ns, _, err := s.RestClientGetter().ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}
 	return "default"
 }
 
 //KubeConfig gets the kubeconfig from EnvSettings
-func (s *EnvSettings) KubeConfig() genericclioptions.RESTClientGetter {
+func (s *EnvSettings) RestClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {
-		s.config = kube.GetConfig(s.kubeConfig, s.KubeContext, s.namespace)
+		s.config = kube.GetConfig(s.KubeConfig, s.KubeContext, s.namespace)
 	})
 	return s.config
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -38,8 +38,7 @@ import (
 
 // EnvSettings describes all of the environment settings.
 type EnvSettings struct {
-	namespace string
-	//kubeConfig string
+	namespace  string
 	config     genericclioptions.RESTClientGetter
 	configOnce sync.Once
 
@@ -116,14 +115,14 @@ func (s *EnvSettings) Namespace() string {
 		return s.namespace
 	}
 
-	if ns, _, err := s.RestClientGetter().ToRawKubeConfigLoader().Namespace(); err == nil {
+	if ns, _, err := s.RESTClientGetter().ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}
 	return "default"
 }
 
-//KubeConfig gets the kubeconfig from EnvSettings
-func (s *EnvSettings) RestClientGetter() genericclioptions.RESTClientGetter {
+//RESTClientGetter gets the kubeconfig from EnvSettings
+func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {
 		s.config = kube.GetConfig(s.KubeConfig, s.KubeContext, s.namespace)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
After trying to start the terraform provider again, I realized that I had no way to set the kube config now, one of the CR requests modified the scope of the variable. I change the scope of the config back to its original state and renamed the conflicting function to something more descriptive. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
