### PR TITLE
ignore coveralls internal server errors

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -36,7 +36,7 @@ generate_cover_data() {
 }
 
 push_to_coveralls() {
-  goveralls -coverprofile="${profile}" -service=circle-ci
+  goveralls -coverprofile="${profile}" -service=circle-ci -shallow
 }
 
 generate_cover_data


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
Refs #6533
 
**What this PR does / why we need it**:
This PR adds the `-shallow` flag to the execution of `goveralls` to prevent the circle-ci build from failing if coveralls returns a 500.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
