### PR TITLE
[v3] Introducing tests for chartutils/errors.go

### DIFF
--- a/pkg/chartutil/errors.go
+++ b/pkg/chartutil/errors.go
@@ -21,11 +21,15 @@ import (
 )
 
 // ErrNoTable indicates that a chart does not have a matching table.
-type ErrNoTable string
+type ErrNoTable struct {
+	Key string
+}
 
-func (e ErrNoTable) Error() string { return fmt.Sprintf("%q is not a table", e) }
+func (e ErrNoTable) Error() string { return fmt.Sprintf("%q is not a table", e.Key) }
 
 // ErrNoValue indicates that Values does not contain a key with a value
-type ErrNoValue string
+type ErrNoValue struct {
+	Key string
+}
 
-func (e ErrNoValue) Error() string { return fmt.Sprintf("%q is not a value", e) }
+func (e ErrNoValue) Error() string { return fmt.Sprintf("%q is not a value", e.Key) }

--- a/pkg/chartutil/errors_test.go
+++ b/pkg/chartutil/errors_test.go
@@ -1,5 +1,3 @@
-package chartutil
-
 /*
 Copyright The Helm Authors.
 
@@ -16,28 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package chartutil
+
 import (
 	"testing"
 )
 
 func TestErrorNoTableDoesntPanic(t *testing.T) {
-
-	defer recover()
-
 	x := "empty"
 
-	y := ErrNoTable(x)
+	y := ErrNoTable{x}
 
 	t.Logf("error is: %s", y)
 }
 
 func TestErrorNoValueDoesntPanic(t *testing.T) {
-
-	defer recover()
-
 	x := "empty"
 
-	y := ErrNoValue(x)
+	y := ErrNoValue{x}
 
 	t.Logf("error is: %s", y)
 }

--- a/pkg/chartutil/errors_test.go
+++ b/pkg/chartutil/errors_test.go
@@ -1,0 +1,43 @@
+package chartutil
+
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"testing"
+)
+
+func TestErrorNoTableDoesntPanic(t *testing.T) {
+
+	defer recover()
+
+	x := "empty"
+
+	y := ErrNoTable(x)
+
+	t.Logf("error is: %s", y)
+}
+
+func TestErrorNoValueDoesntPanic(t *testing.T) {
+
+	defer recover()
+
+	x := "empty"
+
+	y := ErrNoValue(x)
+
+	t.Logf("error is: %s", y)
+}

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -88,7 +88,7 @@ func (v Values) Encode(w io.Writer) error {
 func tableLookup(v Values, simple string) (Values, error) {
 	v2, ok := v[simple]
 	if !ok {
-		return v, ErrNoTable(simple)
+		return v, ErrNoTable{simple}
 	}
 	if vv, ok := v2.(map[string]interface{}); ok {
 		return vv, nil
@@ -101,7 +101,7 @@ func tableLookup(v Values, simple string) (Values, error) {
 		return vv, nil
 	}
 
-	return Values{}, ErrNoTable(simple)
+	return Values{}, ErrNoTable{simple}
 }
 
 // ReadValues will parse YAML byte data into a Values.
@@ -193,20 +193,20 @@ func (v Values) pathValue(path []string) (interface{}, error) {
 		if _, ok := v[path[0]]; ok && !istable(v[path[0]]) {
 			return v[path[0]], nil
 		}
-		return nil, ErrNoValue(path[0])
+		return nil, ErrNoValue{path[0]}
 	}
 
 	key, path := path[len(path)-1], path[:len(path)-1]
 	// get our table for table path
 	t, err := v.Table(joinPath(path...))
 	if err != nil {
-		return nil, ErrNoValue(key)
+		return nil, ErrNoValue{key}
 	}
 	// check table for key and ensure value is not a table
 	if k, ok := t[key]; ok && !istable(k) {
 		return k, nil
 	}
-	return nil, ErrNoValue(key)
+	return nil, ErrNoValue{key}
 }
 
 func parsePath(key string) []string { return strings.Split(key, ".") }


### PR DESCRIPTION
- Should panic on string recursion error

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
A stack overflow exists when the `ErrNoTable` or `ErrNoValue` types in `pkg/chartutil` are serialized to strings. This PR introduces failing tests which will be address as a second commit to this PR with a small refactor to not have the string recursion error.

Fixes #6673 

Signed-off-by: Ken Perkins <ken@perkins.io>