### PR TITLE
feat(*): Adds custom time package for better marshalling

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	stdtime "time"
 
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
@@ -37,7 +36,7 @@ import (
 	"helm.sh/helm/v3/pkg/time"
 )
 
-func testTimestamper() time.Time { return time.Time{Time: stdtime.Unix(242085845, 0).UTC()} }
+func testTimestamper() time.Time { return time.Unix(242085845, 0).UTC() }
 
 func init() {
 	action.Timestamper = testTimestamper

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
+	stdtime "time"
 
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
@@ -34,9 +34,10 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
 )
 
-func testTimestamper() time.Time { return time.Unix(242085845, 0).UTC() }
+func testTimestamper() time.Time { return time.Time{Time: stdtime.Unix(242085845, 0).UTC()} }
 
 func init() {
 	action.Timestamper = testTimestamper

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -19,7 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
-	"time"
+	stdtime "time"
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 var historyHelp = `
@@ -98,7 +99,7 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 	tbl := uitable.New()
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for _, item := range r {
-		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.Format(stdtime.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -19,7 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
-	stdtime "time"
+	"time"
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
@@ -30,7 +30,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 var historyHelp = `
@@ -77,12 +77,12 @@ func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type releaseInfo struct {
-	Revision    int       `json:"revision"`
-	Updated     time.Time `json:"updated"`
-	Status      string    `json:"status"`
-	Chart       string    `json:"chart"`
-	AppVersion  string    `json:"app_version"`
-	Description string    `json:"description"`
+	Revision    int           `json:"revision"`
+	Updated     helmtime.Time `json:"updated"`
+	Status      string        `json:"status"`
+	Chart       string        `json:"chart"`
+	AppVersion  string        `json:"app_version"`
+	Description string        `json:"description"`
 }
 
 type releaseHistory []releaseInfo
@@ -99,7 +99,7 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 	tbl := uitable.New()
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for _, item := range r {
-		tbl.AddRow(item.Revision, item.Updated.Format(stdtime.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"testing"
-	stdtime "time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
@@ -29,10 +28,10 @@ func TestListCmd(t *testing.T) {
 	defaultNamespace := "default"
 
 	sampleTimeSeconds := int64(1452902400)
-	timestamp1 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+1, 0).UTC()}
-	timestamp2 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+2, 0).UTC()}
-	timestamp3 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+3, 0).UTC()}
-	timestamp4 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+4, 0).UTC()}
+	timestamp1 := time.Unix(sampleTimeSeconds+1, 0).UTC()
+	timestamp2 := time.Unix(sampleTimeSeconds+2, 0).UTC()
+	timestamp3 := time.Unix(sampleTimeSeconds+3, 0).UTC()
+	timestamp4 := time.Unix(sampleTimeSeconds+4, 0).UTC()
 	chartInfo := &chart.Chart{
 		Metadata: &chart.Metadata{
 			Name:       "chickadee",

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -18,20 +18,21 @@ package main
 
 import (
 	"testing"
-	"time"
+	stdtime "time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 func TestListCmd(t *testing.T) {
 	defaultNamespace := "default"
 
 	sampleTimeSeconds := int64(1452902400)
-	timestamp1 := time.Unix(sampleTimeSeconds+1, 0).UTC()
-	timestamp2 := time.Unix(sampleTimeSeconds+2, 0).UTC()
-	timestamp3 := time.Unix(sampleTimeSeconds+3, 0).UTC()
-	timestamp4 := time.Unix(sampleTimeSeconds+4, 0).UTC()
+	timestamp1 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+1, 0).UTC()}
+	timestamp2 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+2, 0).UTC()}
+	timestamp3 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+3, 0).UTC()}
+	timestamp4 := time.Time{Time: stdtime.Unix(sampleTimeSeconds+4, 0).UTC()}
 	chartInfo := &chart.Chart{
 		Metadata: &chart.Metadata{
 			Name:       "chickadee",

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -18,15 +18,16 @@ package main
 
 import (
 	"testing"
-	"time"
+	stdtime "time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 func TestStatusCmd(t *testing.T) {
 	releasesMockWithStatus := func(info *release.Info, hooks ...*release.Hook) []*release.Release {
-		info.LastDeployed = time.Unix(1452902400, 0).UTC()
+		info.LastDeployed = time.Time{Time: stdtime.Unix(1452902400, 0).UTC()}
 		return []*release.Release{{
 			Name:      "flummoxed-chickadee",
 			Namespace: "default",
@@ -104,6 +105,6 @@ func TestStatusCmd(t *testing.T) {
 }
 
 func mustParseTime(t string) time.Time {
-	res, _ := time.Parse(time.RFC3339, t)
-	return res
+	res, _ := stdtime.Parse(stdtime.RFC3339, t)
+	return time.Time{Time: res}
 }

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestStatusCmd(t *testing.T) {
 	releasesMockWithStatus := func(info *release.Info, hooks ...*release.Hook) []*release.Release {
-		info.LastDeployed = time.Time{Time: stdtime.Unix(1452902400, 0).UTC()}
+		info.LastDeployed = time.Unix(1452902400, 0).UTC()
 		return []*release.Release{{
 			Name:      "flummoxed-chickadee",
 			Namespace: "default",
@@ -105,6 +105,6 @@ func TestStatusCmd(t *testing.T) {
 }
 
 func mustParseTime(t string) time.Time {
-	res, _ := stdtime.Parse(stdtime.RFC3339, t)
-	return time.Time{Time: res}
+	res, _ := time.Parse(stdtime.RFC3339, t)
+	return res
 }

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -18,16 +18,16 @@ package main
 
 import (
 	"testing"
-	stdtime "time"
+	"time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 func TestStatusCmd(t *testing.T) {
 	releasesMockWithStatus := func(info *release.Info, hooks ...*release.Hook) []*release.Release {
-		info.LastDeployed = time.Unix(1452902400, 0).UTC()
+		info.LastDeployed = helmtime.Unix(1452902400, 0).UTC()
 		return []*release.Release{{
 			Name:      "flummoxed-chickadee",
 			Namespace: "default",
@@ -104,7 +104,7 @@ func TestStatusCmd(t *testing.T) {
 	runTestCmd(t, tests)
 }
 
-func mustParseTime(t string) time.Time {
-	res, _ := time.Parse(stdtime.RFC3339, t)
+func mustParseTime(t string) helmtime.Time {
+	res, _ := helmtime.Parse(time.RFC3339, t)
 	return res
 }

--- a/cmd/helm/testdata/output/status.json
+++ b/cmd/helm/testdata/output/status.json
@@ -1,1 +1,1 @@
-{"name":"flummoxed-chickadee","info":{"first_deployed":"0001-01-01T00:00:00Z","last_deployed":"2016-01-16T00:00:00Z","deleted":"0001-01-01T00:00:00Z","status":"deployed","notes":"release notes"},"namespace":"default"}
+{"name":"flummoxed-chickadee","info":{"first_deployed":"","last_deployed":"2016-01-16T00:00:00Z","deleted":"","status":"deployed","notes":"release notes"},"namespace":"default"}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -19,7 +19,6 @@ package action
 import (
 	"path"
 	"regexp"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,12 +33,13 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // Timestamper is a function capable of producing a timestamp.Timestamper.
 //
-// By default, this is a time.Time function. This can be overridden for testing,
-// though, so that timestamps are predictable.
+// By default, this is a time.Time function from the Helm time package. This can
+// be overridden for testing though, so that timestamps are predictable.
 var Timestamper = time.Now
 
 var (

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-	"time"
 
 	dockerauth "github.com/deislabs/oras/pkg/auth/docker"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -33,6 +32,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 var verbose = flag.Bool("test.log", false, "enable test logging")

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -18,15 +18,16 @@ package action
 import (
 	"bytes"
 	"sort"
-	"time"
+	stdtime "time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // execHook executes all of the hooks for the given hook event.
-func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout time.Duration) error {
+func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout stdtime.Duration) error {
 	executingHooks := []*release.Hook{}
 
 	for _, h := range rl.Hooks {

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -18,16 +18,16 @@ package action
 import (
 	"bytes"
 	"sort"
-	stdtime "time"
+	"time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 // execHook executes all of the hooks for the given hook event.
-func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout stdtime.Duration) error {
+func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout time.Duration) error {
 	executingHooks := []*release.Hook{}
 
 	for _, h := range rl.Hooks {
@@ -61,7 +61,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 
 		// Record the time at which the hook was applied to the cluster
 		h.LastRun = release.HookExecution{
-			StartedAt: time.Now(),
+			StartedAt: helmtime.Now(),
 			Phase:     release.HookPhaseRunning,
 		}
 		cfg.recordRelease(rl)
@@ -73,7 +73,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 
 		// Create hook resources
 		if _, err := cfg.KubeClient.Create(resources); err != nil {
-			h.LastRun.CompletedAt = time.Now()
+			h.LastRun.CompletedAt = helmtime.Now()
 			h.LastRun.Phase = release.HookPhaseFailed
 			return errors.Wrapf(err, "warning: Hook %s %s failed", hook, h.Path)
 		}
@@ -81,7 +81,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		// Watch hook resources until they have completed
 		err = cfg.KubeClient.WatchUntilReady(resources, timeout)
 		// Note the time of success/failure
-		h.LastRun.CompletedAt = time.Now()
+		h.LastRun.CompletedAt = helmtime.Now()
 		// Mark hook as succeeded or failed
 		if err != nil {
 			h.LastRun.Phase = release.HookPhaseFailed

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -20,12 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	stdtime "time"
+	"time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 // Rollback is the action for rolling back to a given release.
@@ -35,7 +35,7 @@ type Rollback struct {
 	cfg *Configuration
 
 	Version       int
-	Timeout       stdtime.Duration
+	Timeout       time.Duration
 	Wait          bool
 	DisableHooks  bool
 	DryRun        bool
@@ -120,7 +120,7 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 		Config:    previousRelease.Config,
 		Info: &release.Info{
 			FirstDeployed: currentRelease.Info.FirstDeployed,
-			LastDeployed:  time.Now(),
+			LastDeployed:  helmtime.Now(),
 			Status:        release.StatusPendingRollback,
 			Notes:         previousRelease.Info.Notes,
 			// Because we lose the reference to previous version elsewhere, we set the

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
+	stdtime "time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // Rollback is the action for rolling back to a given release.
@@ -34,7 +35,7 @@ type Rollback struct {
 	cfg *Configuration
 
 	Version       int
-	Timeout       time.Duration
+	Timeout       stdtime.Duration
 	Wait          bool
 	DisableHooks  bool
 	DryRun        bool

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -18,12 +18,13 @@ package action
 
 import (
 	"strings"
-	"time"
+	stdtime "time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // Uninstall is the action for uninstalling releases.
@@ -35,7 +36,7 @@ type Uninstall struct {
 	DisableHooks bool
 	DryRun       bool
 	KeepHistory  bool
-	Timeout      time.Duration
+	Timeout      stdtime.Duration
 }
 
 // NewUninstall creates a new Uninstall object with the given configuration.

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -18,13 +18,13 @@ package action
 
 import (
 	"strings"
-	stdtime "time"
+	"time"
 
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 // Uninstall is the action for uninstalling releases.
@@ -36,7 +36,7 @@ type Uninstall struct {
 	DisableHooks bool
 	DryRun       bool
 	KeepHistory  bool
-	Timeout      stdtime.Duration
+	Timeout      time.Duration
 }
 
 // NewUninstall creates a new Uninstall object with the given configuration.
@@ -90,7 +90,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 
 	u.cfg.Log("uninstall: Deleting %s", name)
 	rel.Info.Status = release.StatusUninstalling
-	rel.Info.Deleted = time.Now()
+	rel.Info.Deleted = helmtime.Now()
 	rel.Info.Description = "Deletion in progress (or silently failed)"
 	res := &release.UninstallReleaseResponse{Release: rel}
 

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -19,7 +19,6 @@ package action
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"helm.sh/helm/v3/pkg/chart"
 
@@ -28,6 +27,7 @@ import (
 
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 func upgradeAction(t *testing.T) *Upgrade {

--- a/pkg/release/hook.go
+++ b/pkg/release/hook.go
@@ -17,7 +17,7 @@ limitations under the License.
 package release
 
 import (
-	"time"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // HookEvent specifies the hook event

--- a/pkg/release/info.go
+++ b/pkg/release/info.go
@@ -15,7 +15,9 @@ limitations under the License.
 
 package release
 
-import "time"
+import (
+	"helm.sh/helm/v3/pkg/time"
+)
 
 // Info describes release information.
 type Info struct {
@@ -24,9 +26,9 @@ type Info struct {
 	// LastDeployed is when the release was last deployed.
 	LastDeployed time.Time `json:"last_deployed,omitempty"`
 	// Deleted tracks when this object was deleted.
-	Deleted time.Time `json:"deleted,omitempty"`
+	Deleted time.Time `json:"deleted"`
 	// Description is human-friendly "log entry" about this release.
-	Description string `json:"Description,omitempty"`
+	Description string `json:"description,omitempty"`
 	// Status is the current state of the release
 	Status Status `json:"status,omitempty"`
 	// Contains the rendered templates/NOTES.txt if available

--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -18,9 +18,10 @@ package release
 
 import (
 	"math/rand"
-	"time"
+	stdtime "time"
 
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // MockHookTemplate is the hook template used for all mock release objects.
@@ -49,7 +50,7 @@ type MockReleaseOptions struct {
 
 // Mock creates a mock release object based on options set by MockReleaseOptions. This function should typically not be used outside of testing.
 func Mock(opts *MockReleaseOptions) *Release {
-	date := time.Unix(242085845, 0).UTC()
+	date := time.Time{Time: stdtime.Unix(242085845, 0).UTC()}
 
 	name := opts.Name
 	if name == "" {

--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"math/rand"
-	stdtime "time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/time"
@@ -50,7 +49,7 @@ type MockReleaseOptions struct {
 
 // Mock creates a mock release object based on options set by MockReleaseOptions. This function should typically not be used outside of testing.
 func Mock(opts *MockReleaseOptions) *Release {
-	date := time.Time{Time: stdtime.Unix(242085845, 0).UTC()}
+	date := time.Unix(242085845, 0).UTC()
 
 	name := opts.Name
 	if name == "" {

--- a/pkg/releaseutil/sorter_test.go
+++ b/pkg/releaseutil/sorter_test.go
@@ -18,10 +18,10 @@ package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
 
 import (
 	"testing"
-	stdtime "time"
+	"time"
 
 	rspb "helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/time"
+	helmtime "helm.sh/helm/v3/pkg/time"
 )
 
 // note: this test data is shared with filter_test.go.
@@ -33,8 +33,8 @@ var releases = []*rspb.Release{
 	tsRelease("vocal-dogs", 3, 6000, rspb.StatusUninstalled),
 }
 
-func tsRelease(name string, vers int, dur stdtime.Duration, status rspb.Status) *rspb.Release {
-	info := &rspb.Info{Status: status, LastDeployed: time.Now().Add(dur)}
+func tsRelease(name string, vers int, dur time.Duration, status rspb.Status) *rspb.Release {
+	info := &rspb.Info{Status: status, LastDeployed: helmtime.Now().Add(dur)}
 	return &rspb.Release{
 		Name:    name,
 		Version: vers,

--- a/pkg/releaseutil/sorter_test.go
+++ b/pkg/releaseutil/sorter_test.go
@@ -18,9 +18,10 @@ package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
 
 import (
 	"testing"
-	"time"
+	stdtime "time"
 
 	rspb "helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // note: this test data is shared with filter_test.go.
@@ -32,9 +33,8 @@ var releases = []*rspb.Release{
 	tsRelease("vocal-dogs", 3, 6000, rspb.StatusUninstalled),
 }
 
-func tsRelease(name string, vers int, dur time.Duration, status rspb.Status) *rspb.Release {
-	tmsp := time.Now().Add(dur)
-	info := &rspb.Info{Status: status, LastDeployed: tmsp}
+func tsRelease(name string, vers int, dur stdtime.Duration, status rspb.Status) *rspb.Release {
+	info := &rspb.Info{Status: status, LastDeployed: time.Time{Time: stdtime.Now().Add(dur)}}
 	return &rspb.Release{
 		Name:    name,
 		Version: vers,

--- a/pkg/releaseutil/sorter_test.go
+++ b/pkg/releaseutil/sorter_test.go
@@ -34,7 +34,7 @@ var releases = []*rspb.Release{
 }
 
 func tsRelease(name string, vers int, dur stdtime.Duration, status rspb.Status) *rspb.Release {
-	info := &rspb.Info{Status: status, LastDeployed: time.Time{Time: stdtime.Now().Add(dur)}}
+	info := &rspb.Info{Status: status, LastDeployed: time.Now().Add(dur)}
 	return &rspb.Release{
 		Name:    name,
 		Version: vers,

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package time contains a wrapper for time.Time in the standard library and
+// associated methods. This package mainly exists to workaround an issue in Go
+// where the serializer doesn't omit an empty value for time:
+// https://github.com/golang/go/issues/11939. As such, this can be removed if a
+// proposal is ever accepted for Go
+package time
+
+import (
+	"bytes"
+	"time"
+)
+
+// emptyString contains an empty JSON string value to be used as output
+var emptyString = `""`
+
+// Time is a convenience wrapper around stdlib time, but with different
+// marshalling and unmarshaling for zero values
+type Time struct {
+	time.Time
+}
+
+// Now returns the current time. It is a convenience wrapper around time.Now()
+func Now() Time {
+	return Time{time.Now()}
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.Time.IsZero() {
+		return []byte(emptyString), nil
+	}
+
+	return t.Time.MarshalJSON()
+}
+
+func (t *Time) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+	// If it is empty, we don't have to set anything since time.Time is not a
+	// pointer and will be set to the zero value
+	if bytes.Equal([]byte(emptyString), b) {
+		return nil
+	}
+
+	return t.Time.UnmarshalJSON(b)
+}

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -60,3 +60,32 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 
 	return t.Time.UnmarshalJSON(b)
 }
+
+func Parse(layout, value string) (Time, error) {
+	t, err := time.Parse(layout, value)
+	return Time{Time: t}, err
+}
+func ParseInLocation(layout, value string, loc *time.Location) (Time, error) {
+	t, err := time.ParseInLocation(layout, value, loc)
+	return Time{Time: t}, err
+}
+
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Time{Time: time.Date(year, month, day, hour, min, sec, nsec, loc)}
+}
+
+func Unix(sec int64, nsec int64) Time { return Time{Time: time.Unix(sec, nsec)} }
+
+func (t Time) Add(d time.Duration) Time { return Time{Time: t.Time.Add(d)} }
+func (t Time) AddDate(years int, months int, days int) Time {
+	return Time{Time: t.Time.AddDate(years, months, days)}
+}
+func (t Time) After(u Time) bool             { return t.Time.After(u.Time) }
+func (t Time) Before(u Time) bool            { return t.Time.Before(u.Time) }
+func (t Time) Equal(u Time) bool             { return t.Time.Equal(u.Time) }
+func (t Time) In(loc *time.Location) Time    { return Time{Time: t.Time.In(loc)} }
+func (t Time) Local() Time                   { return Time{Time: t.Time.Local()} }
+func (t Time) Round(d time.Duration) Time    { return Time{Time: t.Time.Round(d)} }
+func (t Time) Sub(u Time) time.Duration      { return t.Time.Sub(u.Time) }
+func (t Time) Truncate(d time.Duration) Time { return Time{Time: t.Time.Truncate(d)} }
+func (t Time) UTC() Time                     { return Time{Time: t.Time.UTC()} }

--- a/pkg/time/time_test.go
+++ b/pkg/time/time_test.go
@@ -23,13 +23,12 @@ import (
 )
 
 var (
-	testingTime, _    = time.Parse(time.RFC3339, "1977-09-02T22:04:05Z")
+	testingTime, _    = Parse(time.RFC3339, "1977-09-02T22:04:05Z")
 	testingTimeString = `"1977-09-02T22:04:05Z"`
 )
 
 func TestNonZeroValueMarshal(t *testing.T) {
-	myTime := Time{testingTime}
-	res, err := json.Marshal(myTime)
+	res, err := json.Marshal(testingTime)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/time/time_test.go
+++ b/pkg/time/time_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package time
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var (
+	testingTime, _    = time.Parse(time.RFC3339, "1977-09-02T22:04:05Z")
+	testingTimeString = `"1977-09-02T22:04:05Z"`
+)
+
+func TestNonZeroValueMarshal(t *testing.T) {
+	myTime := Time{testingTime}
+	res, err := json.Marshal(myTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if testingTimeString != string(res) {
+		t.Errorf("expected a marshaled value of %s, got %s", testingTimeString, res)
+	}
+}
+
+func TestZeroValueMarshal(t *testing.T) {
+	res, err := json.Marshal(Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(res) != emptyString {
+		t.Errorf("expected zero value to marshal to empty string, got %s", res)
+	}
+}
+
+func TestNonZeroValueUnmarshal(t *testing.T) {
+	var myTime Time
+	err := json.Unmarshal([]byte(testingTimeString), &myTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !myTime.Equal(testingTime) {
+		t.Errorf("expected time to be equal to %v, got %v", testingTime, myTime)
+	}
+}
+
+func TestEmptyStringUnmarshal(t *testing.T) {
+	var myTime Time
+	err := json.Unmarshal([]byte(emptyString), &myTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !myTime.IsZero() {
+		t.Errorf("expected time to be equal to zero value, got %v", myTime)
+	}
+}
+
+func TestZeroValueUnmarshal(t *testing.T) {
+	// This test ensures that we can unmarshal any time value that was output
+	// with the current go default value of "0001-01-01T00:00:00Z"
+	var myTime Time
+	err := json.Unmarshal([]byte(`"0001-01-01T00:00:00Z"`), &myTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !myTime.IsZero() {
+		t.Errorf("expected time to be equal to zero value, got %v", myTime)
+	}
+}


### PR DESCRIPTION
This package mainly exists to workaround an issue in Go where the serializer doesn't omit an empty value for time: https://github.com/golang/go/issues/11939. This replaces all release and hook object time references with the new time package so things actually marshal correctly.

I also have a second commit that wraps most of the stdlib `Time` object methods so we can use our time wrapper without any weird conventions. This can be popped off and discarded if not desired.

I fully admit this adds some code and mental overhead, but in service of good output for users of the CLI and SDK. If we consider this trade off too much, I have no problem just closing this PR. See the thread starting [here](https://github.com/helm/helm/pull/6229#issuecomment-541936523) for additional context.

Supersedes: #6229 
Fixes #6163 