### PR TITLE
fix(kube): replace rather than delete/create on `helm install --force`

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -146,7 +146,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an upgrade")
 	f.BoolVar(&client.Recreate, "recreate-pods", false, "performs pods restart for the resource if applicable")
 	f.MarkDeprecated("recreate-pods", "functionality will no longer be updated. Consult the documentation for other methods to recreate pods")
-	f.BoolVar(&client.Force, "force", false, "force resource update through delete/recreate if needed")
+	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "disable pre/post upgrade hooks")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&client.ResetValues, "reset-values", false, "when upgrading, reset the values to the ones built into the chart")

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -181,7 +181,7 @@ func TestUpdate(t *testing.T) {
 		"/namespaces/default/pods/starfish:PATCH",
 		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/otter:GET",
-		"/namespaces/default/pods/otter:PATCH",
+		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/dolphin:GET",
 		"/namespaces/default/pods:POST",
 		"/namespaces/default/pods/squid:DELETE",


### PR DESCRIPTION
fixes a sub-issue in #6642 by replacing the object with another, forcing an overwrite. This ends in the same result, just with less API calls (and with no need to wait for a resource to be deleted before creating another object).

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>