### PR TITLE
feat(test): add ability to store releases in multiple namespaces in the memory storage driver

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -88,7 +88,7 @@ func runTestActionCmd(t *testing.T, tests []cmdTestCase) {
 }
 
 func storageFixture() *storage.Storage {
-	return storage.Init(driver.NewMemory())
+	return storage.Init(driver.NewMemory("default"))
 }
 
 func executeActionCommandC(store *storage.Storage, cmd string) (*cobra.Command, string, error) {

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -236,7 +236,7 @@ func (c *Configuration) Init(envSettings *cli.EnvSettings, allNamespaces bool, h
 		d.Log = log
 		store = storage.Init(d)
 	case "memory":
-		d := driver.NewMemory()
+		d := driver.NewMemory(namespace)
 		store = storage.Init(d)
 	default:
 		// Not sure what to do here.

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -77,7 +77,7 @@ func actionConfigFixture(t *testing.T) *Configuration {
 	}
 
 	return &Configuration{
-		Releases:       storage.Init(driver.NewMemory()),
+		Releases:       storage.Init(driver.NewMemory("default")),
 		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
 		Capabilities:   chartutil.DefaultCapabilities,
 		RegistryClient: registryClient,

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -179,7 +179,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		i.cfg.Capabilities = chartutil.DefaultCapabilities
 		i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
 		i.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
-		i.cfg.Releases = storage.Init(driver.NewMemory())
+		i.cfg.Releases = storage.Init(driver.NewMemory(i.Namespace))
 	} else if !i.ClientOnly && len(i.APIVersions) > 0 {
 		i.cfg.Log("API Version list given outside of client only mode, this list will be ignored")
 	}

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -55,13 +55,25 @@ func tsFixtureMemory(t *testing.T) *Memory {
 		releaseStub("rls-b", 2, "default", rspb.StatusSuperseded),
 	}
 
-	mem := NewMemory()
+	mem := NewMemory("default")
 	for _, tt := range hs {
 		err := mem.Create(testKey(tt.Name, tt.Version), tt)
 		if err != nil {
 			t.Fatalf("Test setup failed to create: %s\n", err)
 		}
 	}
+
+	mem.namespace = "testing"
+	err := mem.CreateNamespace(mem.namespace)
+	if err != nil {
+		t.Fatalf("Test setup failed to create: %s\n", err)
+	}
+	anotherRls := releaseStub("rls-a", 1, "testing", rspb.StatusDeployed)
+	err = mem.Create(testKey(anotherRls.Name, anotherRls.Version), anotherRls)
+	if err != nil {
+		t.Fatalf("Test setup failed to create: %s\n", err)
+	}
+
 	return mem
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -227,7 +227,7 @@ func makeKey(rlsname string, version int) string {
 func Init(d driver.Driver) *Storage {
 	// default driver is in memory
 	if d == nil {
-		d = driver.NewMemory()
+		d = driver.NewMemory("default")
 	}
 	return &Storage{
 		Driver: d,

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestStorageCreate(t *testing.T) {
 	// initialize storage
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	// create fake release
 	rls := ReleaseTestData{
@@ -49,7 +49,7 @@ func TestStorageCreate(t *testing.T) {
 
 func TestStorageUpdate(t *testing.T) {
 	// initialize storage
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	// create fake release
 	rls := ReleaseTestData{
@@ -76,7 +76,7 @@ func TestStorageUpdate(t *testing.T) {
 
 func TestStorageDelete(t *testing.T) {
 	// initialize storage
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	// create fake release
 	rls := ReleaseTestData{
@@ -117,7 +117,7 @@ func TestStorageDelete(t *testing.T) {
 
 func TestStorageList(t *testing.T) {
 	// initialize storage
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	// setup storage with test releases
 	setup := func() {
@@ -166,7 +166,7 @@ func TestStorageList(t *testing.T) {
 }
 
 func TestStorageDeployed(t *testing.T) {
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	const name = "angry-bird"
 	const vers = 4
@@ -206,7 +206,7 @@ func TestStorageDeployed(t *testing.T) {
 }
 
 func TestStorageHistory(t *testing.T) {
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	const name = "angry-bird"
 
@@ -237,7 +237,7 @@ func TestStorageHistory(t *testing.T) {
 }
 
 func TestStorageRemoveLeastRecent(t *testing.T) {
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 	storage.Log = t.Logf
 
 	// Make sure that specifying this at the outset doesn't cause any bugs.
@@ -294,7 +294,7 @@ func TestStorageRemoveLeastRecent(t *testing.T) {
 }
 
 func TestStorageLast(t *testing.T) {
-	storage := Init(driver.NewMemory())
+	storage := Init(driver.NewMemory("default"))
 
 	const name = "angry-bird"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This will be useful to test things that involves multiple namespaces. Like listing releases in all namespaces. I have done this as a lot of unit tests currently depend on the memory storage driver to test things. 

**Special notes for your reviewer**:
This was initially part of PR https://github.com/helm/helm/pull/6662 , later we thought we would use configmap / secrets mock instead of memory storage to test #6662 PR. Some parts of the implementation don't look very neat - I can see that. Let me know what you folks think. We can discuss more on that while reviewing but this is the best I could come up with what's currently available. There was some struggle around "how to set namespace" and also store records of all namespaces. In a real world scenario for secrets and configmaps - k8s has state, and it stores everything and for communication with k8s, we set namespace just once, or don't set one for denoting all namespaces, at least that's how it looks. Doesn't seem straight forward to do the same for memory storage and write tests too

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
