### PR TITLE
fix(chartutil): restore .Release.Revision

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -200,6 +200,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	options := chartutil.ReleaseOptions{
 		Name:      i.ReleaseName,
 		Namespace: i.Namespace,
+		Revision:  1,
 		IsInstall: true,
 	}
 	valuesToRender, err := chartutil.ToRenderValues(chrt, vals, options, caps)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -147,6 +147,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	options := chartutil.ReleaseOptions{
 		Name:      name,
 		Namespace: currentRelease.Namespace,
+		Revision:  revision,
 		IsUpgrade: true,
 	}
 

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -130,6 +130,7 @@ func ReadValuesFile(filename string) (Values, error) {
 type ReleaseOptions struct {
 	Name      string
 	Namespace string
+	Revision  int
 	IsUpgrade bool
 	IsInstall bool
 }
@@ -149,6 +150,7 @@ func ToRenderValues(chrt *chart.Chart, chrtVals map[string]interface{}, options 
 			"Namespace": options.Namespace,
 			"IsUpgrade": options.IsUpgrade,
 			"IsInstall": options.IsInstall,
+			"Revision":  options.Revision,
 			"Service":   "Helm",
 		},
 	}

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -99,6 +99,8 @@ func TestToRenderValues(t *testing.T) {
 
 	o := ReleaseOptions{
 		Name:      "Seven Voyages",
+		Namespace: "default",
+		Revision:  1,
 		IsInstall: true,
 	}
 
@@ -114,6 +116,12 @@ func TestToRenderValues(t *testing.T) {
 	relmap := res["Release"].(map[string]interface{})
 	if name := relmap["Name"]; name.(string) != "Seven Voyages" {
 		t.Errorf("Expected release name 'Seven Voyages', got %q", name)
+	}
+	if namespace := relmap["Namespace"]; namespace.(string) != "default" {
+		t.Errorf("Expected namespace 'default', got %q", namespace)
+	}
+	if revision := relmap["Revision"]; revision.(int) != 1 {
+		t.Errorf("Expected revision '1', got %d", revision)
 	}
 	if relmap["IsUpgrade"].(bool) {
 		t.Error("Expected upgrade to be false.")


### PR DESCRIPTION
As discussed in the dev call this morning, there are use cases where the release revision was important to chart hooks, such as when the user needs to fetch the correct backup during a rollback operation.

I also added back a missing test case for `.Release.Namespace`.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
