### PR TITLE
fix(cmd): Add release name to install examples

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -81,15 +81,15 @@ file MUST pass all verification steps.
 
 There are five different ways you can express the chart you want to install:
 
-1. By chart reference: helm install example/mariadb
-2. By path to a packaged chart: helm install ./nginx-1.2.3.tgz
-3. By path to an unpacked chart directory: helm install ./nginx
-4. By absolute URL: helm install https://example.com/charts/nginx-1.2.3.tgz
-5. By chart reference and repo url: helm install --repo https://example.com/charts/ nginx
+1. By chart reference: helm install mymaria example/mariadb
+2. By path to a packaged chart: helm install mynginx ./nginx-1.2.3.tgz
+3. By path to an unpacked chart directory: helm install mynginx ./nginx
+4. By absolute URL: helm install mynginx https://example.com/charts/nginx-1.2.3.tgz
+5. By chart reference and repo url: helm install --repo https://example.com/charts/ mynginx nginx
 
 CHART REFERENCES
 
-A chart reference is a convenient way of reference a chart in a chart repository.
+A chart reference is a convenient way of referencing a chart in a chart repository.
 
 When you use a chart reference with a repo prefix ('example/mariadb'), Helm will look in the local
 configuration for a chart repository named 'example', and will then look for a


### PR DESCRIPTION
**What this PR does / why we need it**:

The `helm install` help text gives examples of an install command with different chart references.  Those commands don't actually work with v3 because v3 now requires a release name parameter.

This PR adds the release name to those examples.
