### PR TITLE
Skip api version checks when install action is configured in client mode only

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -211,7 +211,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	rel := i.createRelease(chrt, vals)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.OutputDir, i.SubNotes)
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.OutputDir, i.SubNotes, i.ClientOnly)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()
@@ -409,7 +409,7 @@ func (i *Install) replaceRelease(rel *release.Release) error {
 }
 
 // renderResources renders the templates in a chart
-func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, outputDir string, subNotes bool) ([]*release.Hook, *bytes.Buffer, string, error) {
+func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, outputDir string, subNotes bool, clientOnly bool) ([]*release.Hook, *bytes.Buffer, string, error) {
 	hs := []*release.Hook{}
 	b := bytes.NewBuffer(nil)
 
@@ -452,7 +452,7 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 	// Sort hooks, manifests, and partials. Only hooks and manifests are returned,
 	// as partials are not used after renderer.Render. Empty manifests are also
 	// removed here.
-	hs, manifests, err := releaseutil.SortManifests(files, caps.APIVersions, releaseutil.InstallOrder)
+	hs, manifests, err := releaseutil.SortManifests(files, caps.APIVersions, releaseutil.InstallOrder, clientOnly)
 	if err != nil {
 		// By catching parse errors here, we can prevent bogus releases from going
 		// to Kubernetes.

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -170,7 +170,8 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 	}
 
 	manifests := releaseutil.SplitManifests(rel.Manifest)
-	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
+
+	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder, false)
 	if err != nil {
 		// We could instead just delete everything in no particular order.
 		// FIXME: One way to delete at this point would be to try a label-based

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -160,7 +160,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", u.SubNotes)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", u.SubNotes, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -257,7 +257,7 @@ metadata:
 		manifests[o.path] = o.manifest
 	}
 
-	_, _, err := SortManifests(manifests, chartutil.VersionSet{"v1", "v1beta1"}, InstallOrder)
+	_, _, err := SortManifests(manifests, chartutil.VersionSet{"v1", "v1beta1"}, InstallOrder, true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Hi there,

With helm 3, when an install action is run in client-mode only (`install` without `--validate`) and if your chart contains custom resources you end up hitting error that look like that.

```
apiVersion "example.com/v1" in my-app/templates/cutoms.yaml is not available
```

This PR attempt to workaround the issue by skipping entirely the check if we are in client mode as we can't be aware of any custom resource definition present on the remote cluster in advance as we don't interact with it in such mode.

Thoughts?

**Special notes for your reviewer**:

The error hit is similar to the one described in #6680 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
