### PR TITLE
fix(sympath): walk symbolic links one once

### DIFF
--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -73,9 +73,10 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		if info, err = os.Lstat(resolved); err != nil {
 			return err
 		}
-		if err := symwalk(resolved, info, walkFn); err != nil && err != filepath.SkipDir {
+		if err := symwalk(path, info, walkFn); err != nil && err != filepath.SkipDir {
 			return err
 		}
+		return nil
 	}
 
 	if err := walkFn(path, info, nil); err != nil {


### PR DESCRIPTION
Symbolic links will now only be walked once.

The tests reflect this: node `c` is marked on its own as a regular file, then it is marked a second time through node `d`. Previously, `c` would be marked 3 times: once on its own, and twice from the symbolic link on the resolved path and source path.

In practice, this would mean charts that included a symbolic link would include that symbolic link twice in the package.

Simple test to reproduce this error:

```
$ helm create foo
$ echo "hello!" > hello.txt
$ ln -s $PWD/hello.txt foo/README.txt
$ helm package foo
$ tar ztf foo-0.1.0.tgz
foo/Chart.yaml
foo/values.yaml
foo/templates/NOTES.txt
foo/templates/_helpers.tpl
foo/templates/deployment.yaml
foo/templates/ingress.yaml
foo/templates/service.yaml
foo/templates/serviceaccount.yaml
foo/templates/tests/test-connection.yaml
foo/.helmignore
foo/home/bacongobbler/code/go/src/helm.sh/helm/hello.txt
foo/README.txt
```

With this fix:

```
$ tar ztf foo-0.1.0.tgz
foo/Chart.yaml
foo/values.yaml
foo/templates/NOTES.txt
foo/templates/_helpers.tpl
foo/templates/deployment.yaml
foo/templates/ingress.yaml
foo/templates/service.yaml
foo/templates/serviceaccount.yaml
foo/templates/tests/test-connection.yaml
foo/.helmignore
foo/README.txt
$ cat foo/README.txt
hello!
```

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>