### PR TITLE
fix (cmd): Output format when installing on helm upgrade

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -241,6 +241,7 @@ func (u *upgradeCmd) run() error {
 				wait:         u.wait,
 				description:  u.description,
 				atomic:       u.atomic,
+				output:       u.output,
 			}
 			return ic.run()
 		}


### PR DESCRIPTION
Set the output format when installing on an `helm upgrade`

Fixes #6718 

**What this PR does / why we need it**:
`helm upgrade --install` output fails with the following error when it performs an install: 
```
Release "chrt-6718" does not exist. Installing it now.
Error: unsupported format 
```
The chart does install but the output is in error and misleading. It will work on `upgrade` and `install` only.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
