### PR TITLE
Chart cache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -35,6 +35,7 @@ type options struct {
 	username  string
 	password  string
 	userAgent string
+	cachePath string
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -70,6 +71,14 @@ func WithTLSClientConfig(certFile, keyFile, caFile string) Option {
 		opts.certFile = certFile
 		opts.keyFile = keyFile
 		opts.caFile = caFile
+	}
+}
+
+// WithCache will wrap all HTTP requests through the local file system cache.
+// Charts are cached in a flat structure with name equal to the chart digest.
+func WithCache(digest string) Option {
+	return func(opts *options) {
+		opts.cachePath = path.Join(helmpath.ChartCachePath(), digest) // new?
 	}
 }
 


### PR DESCRIPTION
This is a first step to implementing https://github.com/helm/helm/issues/4618

Please note I have not done any real Go development, so my questions may seem very basic. Ideally I can get some validation on if I'm putting things logically in the right place and can iterate from there.

Anyone is welcome to contribute code or help to this PR. I will gladly give contrib access.

Basic plan (does this make sense?):

0. Ensure there is a `helmpath` method for `$helmChartCache` that creates the cache directory
1. Add a `WithCache` function to `getter.go` that sets `cachePath = $helmChartCache/$digest`
2. Add some kind of option in Helm that would be passed as an option to `ChartDownloader` to toggle the cache: `type CacheStrategy int` (where to put this option?)
3. If this option is set, have the `ChartDownloader` function `DownloadTo` invoke `WithCache`, passing the `digest` from the chart manifest (if available, otherwise do not invoke).
4. Implement (somewhere) the actual cache wrapping behaviour when `opts.cachePath` has been set (save to `cachePath` whenever it downloads something, check `cachePath` before it downloads something)
5. Ensure this does not interfere with the verification step: it should happen every time if requested, even on files returned from the cache.
6. What path should be returned by the Getter? Should it always be the cached file or will the cached file be copied to wherever it would have normally downloaded it?