### PR TITLE
fix(coverage): fix usage of coverage.sh

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,6 @@ linters-settings:
   gofmt:
     simplify: true
   goimports:
-    local-prefixes: helm.sh/helm
+    local-prefixes: helm.sh/helm/v3
   dupl:
     threshold: 400

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -20,8 +20,10 @@ covermode=${COVERMODE:-atomic}
 coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
 profile="${coverdir}/cover.out"
 
+pushd /
 hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
 hash godir 2>/dev/null || go get github.com/Masterminds/godir
+popd
 
 generate_cover_data() {
   for d in $(godir) ; do

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -22,11 +22,10 @@ profile="${coverdir}/cover.out"
 
 pushd /
 hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
-hash godir 2>/dev/null || go get github.com/Masterminds/godir
 popd
 
 generate_cover_data() {
-  for d in $(godir) ; do
+  for d in $(go list ./...) ; do
     (
       local output="${coverdir}/${d//\//-}.cover"
       go test -coverprofile="${output}" -covermode="$covermode" "$d"


### PR DESCRIPTION
Without this fix, `godir` is being added to the go modules file.

closes #6746 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>