### PR TITLE
Reverted changes introduced in #6010

### DIFF
--- a/cmd/helm/installer/install_test.go
+++ b/cmd/helm/installer/install_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package installer // import "k8s.io/helm/cmd/helm/installer"
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -717,32 +716,9 @@ func TestDeployment_WithSetValues(t *testing.T) {
 
 		// convert our expected value to match the result type for comparison
 		ev := tt.expect
-		intType := reflect.TypeOf(int64(0))
-		floatType := reflect.TypeOf(float64(0))
-
 		switch pvt := pv.(type) {
-		case json.Number:
-			evv := reflect.ValueOf(ev)
-			evv = reflect.Indirect(evv)
-			switch ev.(type) {
-			case float32, float64:
-				evv = evv.Convert(floatType)
-				if fpv, err := pv.(json.Number).Float64(); err != nil {
-					t.Errorf("Failed to convert json number to float: %s", err)
-				} else if fpv != evv.Float() {
-					t.Errorf("%s: expected float value %q, got %f", tt.name, tt.expect, fpv)
-				}
-			case byte, int, int32, int64:
-				evv = evv.Convert(intType)
-				if ipv, err := pv.(json.Number).Int64(); err != nil {
-					t.Errorf("Failed to convert json number to int: %s", err)
-				} else if ipv != evv.Int() {
-					t.Errorf("%s: expected int value %q, got %d", tt.name, tt.expect, ipv)
-				}
-			default:
-				t.Errorf("Unknown primitive type: %s", reflect.TypeOf(ev))
-			}
 		case float64:
+			floatType := reflect.TypeOf(float64(0))
 			v := reflect.ValueOf(ev)
 			v = reflect.Indirect(v)
 			if !v.Type().ConvertibleTo(floatType) {

--- a/pkg/chartutil/requirements_test.go
+++ b/pkg/chartutil/requirements_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package chartutil
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -312,10 +311,6 @@ func verifyRequirementsImportValues(t *testing.T, c *chart.Chart, v *chart.Confi
 		}
 
 		switch pv.(type) {
-		case json.Number:
-			if s := pv.(json.Number).String(); s != vv {
-				t.Errorf("Failed to match imported number value %v with expected %v", s, vv)
-			}
 		case float64:
 			s := strconv.FormatFloat(pv.(float64), 'f', -1, 64)
 			if s != vv {

--- a/pkg/chartutil/testdata/coleridge.yaml
+++ b/pkg/chartutil/testdata/coleridge.yaml
@@ -10,4 +10,3 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
-    temperature: 1234567890

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,7 +17,6 @@ limitations under the License.
 package chartutil
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -133,10 +132,7 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
-		d.UseNumber()
-		return d
-	})
+	err = yaml.Unmarshal(data, &vals)
 	if len(vals) == 0 {
 		vals = Values{}
 	}

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -53,7 +53,6 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
-    temperature: 1234567890
 `
 
 	data, err := ReadValues([]byte(doc))
@@ -266,12 +265,6 @@ func matchValues(t *testing.T, data map[string]interface{}) {
 		t.Errorf(".water.water.where: %s", err)
 	} else if o != "everywhere" {
 		t.Errorf("Expected water water everywhere")
-	}
-
-	if o, err := ttpl("{{.water.water.temperature}}", data); err != nil {
-		t.Errorf(".water.water.temperature: %s", err)
-	} else if o != "1234567890" {
-		t.Errorf("Expected water water temperature: 1234567890, got: %s", o)
 	}
 }
 


### PR DESCRIPTION
This commit reverts changes introduced in #6010 due to a massive
regression reported in #6708. An attempt to fix the problem in
https://github.com/helm/helm/pull/6709 seems to be unreasonably clumzy
and hacky, therefore reverting the offensive change seems to be the most
pragmatic solution.

This reverts commits:
  * 70cd32c4cebac2af67f4da3934e141f0f0c00842.
  * 9014bd9c502d92fb78bfee553abdba5cf35e878f.