### PR TITLE
Lookup template function

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -442,10 +442,9 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 	if c.RESTClientGetter != nil {
 		rest, err := c.RESTClientGetter.ToRESTConfig()
 		if err != nil {
-			files, err2 = engine.Render(ch, values)
-		} else {
-			files, err2 = engine.RenderWithClient(ch, values, rest)
+			return hs, b, "", err
 		}
+		files, err2 = engine.RenderWithClient(ch, values, rest)
 	} else {
 		files, err2 = engine.Render(ch, values)
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -436,13 +436,21 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 		}
 	}
 
-	rest, err := c.RESTClientGetter.ToRESTConfig()
-	if err != nil {
-		return hs, b, "", err
+	var files map[string]string
+	var err2 error
+
+	if c.RESTClientGetter != nil {
+		rest, err := c.RESTClientGetter.ToRESTConfig()
+		if err != nil {
+			files, err2 = engine.Render(ch, values)
+		} else {
+			files, err2 = engine.RenderWithClient(ch, values, rest)
+		}
+	} else {
+		files, err2 = engine.Render(ch, values)
 	}
 
-	files, err := engine.RenderWithClient(ch, values, rest)
-	if err != nil {
+	if err2 != nil {
 		return hs, b, "", err
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -436,7 +436,12 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 		}
 	}
 
-	files, err := engine.Render(ch, values)
+	rest, err := c.RESTClientGetter.ToRESTConfig()
+	if err != nil {
+		return hs, b, "", err
+	}
+
+	files, err := engine.RenderWithClient(ch, values, rest)
 	if err != nil {
 		return hs, b, "", err
 	}

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -53,7 +53,7 @@ func funcMap() template.FuncMap {
 		"fromYaml": fromYAML,
 		"toJson":   toJSON,
 		"fromJson": fromJSON,
-		"lookup" : lookup,
+		"lookup":   lookup,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -53,7 +53,6 @@ func funcMap() template.FuncMap {
 		"fromYaml": fromYAML,
 		"toJson":   toJSON,
 		"fromJson": fromJSON,
-		"lookup":   lookup,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -53,6 +53,7 @@ func funcMap() template.FuncMap {
 		"fromYaml": fromYAML,
 		"toJson":   toJSON,
 		"fromJson": fromJSON,
+		"lookup" : lookup,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var config *rest.Config
+var addLookupFunction = false
+
+func init() {
+	// try the out-cluster config, this will default to the in-cluster config is not successful
+	var kubeconfig *string
+	if home := homeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	// use the current context in kubeconfig
+	config1, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err == nil {
+		addLookupFunction = true
+		config = config1
+	}
+	return
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+
+func lookup(apiversion string, resource string, namespace string, name string) (map[string]interface{}, error) {
+	var client dynamic.ResourceInterface
+	c, err := getDynamicClientOnKind(apiversion, resource)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+	if namespace != "" {
+		client = c.Namespace(namespace)
+	} else {
+		client = c
+	}
+	if name != "" {
+		//this will return a single object
+		obj, err := client.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
+		return obj.Object, nil
+	}
+	//this will return a list
+	obj, err := client.List(metav1.ListOptions{})
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+	return obj.Object, nil
+
+}
+
+// GetDynamicClientOnUnstructured returns a dynamic client on an Unstructured type. This client can be further namespaced.
+func getDynamicClientOnKind(apiversion string, kind string) (dynamic.NamespaceableResourceInterface, error) {
+	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
+	apiRes, err := getAPIReourceForGVK(gvk)
+	if err != nil {
+		log.Printf("[ERROR] unable to get apiresource from unstructured: %s , error %s", gvk.String(), err)
+		return nil, err
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    apiRes.Group,
+		Version:  apiRes.Version,
+		Resource: apiRes.Name,
+	}
+	intf, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.Printf("[ERROR] unable to get dynamic client %s", err)
+		return nil, err
+	}
+	res := intf.Resource(gvr)
+	return res, nil
+}
+
+func getAPIReourceForGVK(gvk schema.GroupVersionKind) (metav1.APIResource, error) {
+	res := metav1.APIResource{}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		log.Printf("[ERROR] unable to create discovery client %s", err)
+		return res, err
+	}
+	resList, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		log.Printf("[ERROR] unable to retrieve resouce list for: %s , error: %s", gvk.GroupVersion().String(), err)
+		return res, err
+	}
+	for _, resource := range resList.APIResources {
+		if resource.Kind == gvk.Kind && !strings.Contains(resource.Name, "/") {
+			res = resource
+			res.Group = gvk.Group
+			res.Version = gvk.Version
+			break
+		}
+	}
+	return res, nil
+}

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -47,25 +47,18 @@ func NewLookupFunction(config *rest.Config) lookupFunc {
 			if err != nil {
 				return map[string]interface{}{}, err
 			}
-			return obj.Object, nil
+			return obj.UnstructuredContent(), nil
 		}
 		//this will return a list
 		obj, err := client.List(metav1.ListOptions{})
 		if err != nil {
 			return map[string]interface{}{}, err
 		}
-		return obj.Object, nil
+		return obj.UnstructuredContent(), nil
 	}
 }
 
-// func homeDir() string {
-// 	if h := os.Getenv("HOME"); h != "" {
-// 		return h
-// 	}
-// 	return os.Getenv("USERPROFILE") // windows
-// }
-
-// GetDynamicClientOnUnstructured returns a dynamic client on an Unstructured type. This client can be further namespaced.
+// getDynamicClientOnUnstructured returns a dynamic client on an Unstructured type. This client can be further namespaced.
 func getDynamicClientOnKind(apiversion string, kind string, config *rest.Config) (dynamic.NamespaceableResourceInterface, bool, error) {
 	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
 	apiRes, err := getAPIReourceForGVK(gvk, config)
@@ -100,6 +93,7 @@ func getAPIReourceForGVK(gvk schema.GroupVersionKind, config *rest.Config) (meta
 		return res, err
 	}
 	for _, resource := range resList.APIResources {
+		//if a resource contains a "/" it's referencing a subresource. we don't support suberesource for now.
 		if resource.Kind == gvk.Kind && !strings.Contains(resource.Name, "/") {
 			res = resource
 			res.Group = gvk.Group

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -16,7 +16,6 @@ import (
 )
 
 var config *rest.Config
-var addLookupFunction = false
 
 func init() {
 	// try the out-cluster config, this will default to the in-cluster config is not successful
@@ -31,10 +30,8 @@ func init() {
 	// use the current context in kubeconfig
 	config1, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err == nil {
-		addLookupFunction = true
 		config = config1
 	}
-	return
 }
 
 func homeDir() string {
@@ -103,7 +100,7 @@ func getAPIReourceForGVK(gvk schema.GroupVersionKind) (metav1.APIResource, error
 	}
 	resList, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
-		log.Printf("[ERROR] unable to retrieve resouce list for: %s , error: %s", gvk.GroupVersion().String(), err)
+		log.Printf("[ERROR] unable to retrieve resource list for: %s , error: %s", gvk.GroupVersion().String(), err)
 		return res, err
 	}
 	for _, resource := range resList.APIResources {

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package engine
 
 import (

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -64,7 +65,7 @@ func getDynamicClientOnKind(apiversion string, kind string, config *rest.Config)
 	apiRes, err := getAPIReourceForGVK(gvk, config)
 	if err != nil {
 		log.Printf("[ERROR] unable to get apiresource from unstructured: %s , error %s", gvk.String(), err)
-		return nil, false, err
+		return nil, false, errors.Wrapf(err, "unable to get apiresource from unstructured: %s , error %s", gvk.String())
 	}
 	gvr := schema.GroupVersionResource{
 		Group:    apiRes.Group,

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -65,7 +65,7 @@ func getDynamicClientOnKind(apiversion string, kind string, config *rest.Config)
 	apiRes, err := getAPIReourceForGVK(gvk, config)
 	if err != nil {
 		log.Printf("[ERROR] unable to get apiresource from unstructured: %s , error %s", gvk.String(), err)
-		return nil, false, errors.Wrapf(err, "unable to get apiresource from unstructured: %s , error %s", gvk.String())
+		return nil, false, errors.Wrapf(err, "unable to get apiresource from unstructured: %s", gvk.String())
 	}
 	gvr := schema.GroupVersionResource{
 		Group:    apiRes.Group,


### PR DESCRIPTION
I created a lookup template function to address #949 .
The lookup up function takes for string parameters:

1. the apiVersion, mandatory
2. the Kind, mandatory
3. the namespace, optional
4. the name, optional

and returns a `map[string]interface{}`

if namespace is missing the lookup function assumes we are looking up a cluster resource.
if name is missing the lookup function assumes we are looking up an list of resources.

for example the expression to lookup the value of a loadbalancer service would be:

`{{ (index (lookup "v1" "Service" "mynamespace" "myservice").status.loadBalancer.ingress 0).ip }}`
 
The way the lookup function works is the following:
1. at init time the restClient is initialized. I assume helm has already a way to initialized the rest client, so I'd gladly reuse that approach is someone can indicate to me how to do it.
2. the lookup function is added to the template functions and can therefore be used.

This is a work in progress and I being a new contributor request some assistance (and patience) while I comply with all the rules.