### PR TITLE
Revert "chartutil.ReadValues is forced to unmarshal numbers into json.Number"

### DIFF
--- a/pkg/chartutil/testdata/coleridge.yaml
+++ b/pkg/chartutil/testdata/coleridge.yaml
@@ -10,4 +10,3 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
-    temperature: 1234567890

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,7 +17,6 @@ limitations under the License.
 package chartutil
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -106,10 +105,7 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
-		d.UseNumber()
-		return d
-	})
+	err = yaml.Unmarshal(data, &vals)
 	if len(vals) == 0 {
 		vals = Values{}
 	}

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -45,7 +45,6 @@ water:
   water:
     where: "everywhere"
     nor: "any drop to drink"
-    temperature: 1234567890
 `
 
 	data, err := ReadValues([]byte(doc))
@@ -245,12 +244,6 @@ func matchValues(t *testing.T, data map[string]interface{}) {
 		t.Errorf(".water.water.where: %s", err)
 	} else if o != "everywhere" {
 		t.Errorf("Expected water water everywhere")
-	}
-
-	if o, err := ttpl("{{.water.water.temperature}}", data); err != nil {
-		t.Errorf(".water.water.temperature: %s", err)
-	} else if o != "1234567890" {
-		t.Errorf("Expected water water temperature: 1234567890, got: %s", o)
 	}
 }
 


### PR DESCRIPTION
This reverts commit f94bac0643ad5d39c740c57c6c8ea6a4569a1db0.

Due to a major numeric regression detected in dev-v2 reported in #6708,
we believe the master branch (former dev-v3) is also impacted by this
change and will expose the same set of problems. In order to not
jeopardize the stability of helm3 this commit is reverted in favor of a
better fix in the future.