### PR TITLE
fix(Makefile): remove orphaned targets for documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,6 @@ test-acceptance: build build-cross
 test-acceptance-completion: ACCEPTANCE_RUN_TESTS = shells.robot
 test-acceptance-completion: test-acceptance
 
-.PHONY: verify-docs
-verify-docs: build
-	@scripts/verify-docs.sh
-
 .PHONY: coverage
 coverage:
 	@scripts/coverage.sh
@@ -153,10 +149,6 @@ checksum:
 	done
 
 # ------------------------------------------------------------------------------
-
-.PHONY: docs
-docs: build
-	@scripts/update-docs.sh
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
**Description**

This PR removes orphaned targets for checking and generating documentation. Currently, docs are not placed in helm repo but will be moved to the [helm-www project](https://github.com/helm/helm-www), so those targets are useless and misleading in the current makefile.