### PR TITLE
fix(registry): change mediatype for chart content layer

### DIFF
--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -122,9 +122,13 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 					contentLayer = &layer
 				}
 			}
-			if contentLayer.Size == 0 {
+			if contentLayer == nil {
 				return &r, errors.New(
 					fmt.Sprintf("manifest does not contain a layer with mediatype %s", HelmChartContentLayerMediaType))
+			}
+			if contentLayer.Size == 0 {
+				return &r, errors.New(
+					fmt.Sprintf("manifest layer with mediatype %s is of size 0", HelmChartContentLayerMediaType))
 			}
 			r.ContentLayer = contentLayer
 			info, err := cache.ociStore.Info(ctx(cache.out, cache.debug), contentLayer.Digest)

--- a/internal/experimental/registry/constants.go
+++ b/internal/experimental/registry/constants.go
@@ -21,7 +21,7 @@ const (
 	HelmChartConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
 
 	// HelmChartContentLayerMediaType is the reserved media type for Helm chart package content
-	HelmChartContentLayerMediaType = "application/vnd.cncf.helm.chart.content.layer.v1+tar"
+	HelmChartContentLayerMediaType = "application/tar+gzip"
 )
 
 // KnownMediaTypes returns a list of layer mediaTypes that the Helm client knows about


### PR DESCRIPTION
Mediatype changed to application/tar+gzip. Please see the
following OCI mailing list item for more info:
https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/pdc1lucm_Ak

Also, improved check for invalid manifests, a nil reference error was
occurring when upgrading from existing cache with old mediatype.