### PR TITLE
fix(search/repo): fix typo in help text

### DIFF
--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -44,13 +44,13 @@ supply a version number with the '--version' flag.
 
 Examples: 
 	# Searches only for stable releases, prerelease versions will be skipped
-	helm repo search 
+	helm search repo 
  
 	# Searches for releases and prereleases (alpha, beta, and release candidate releases)
-	helm repo search --devel
+	helm search repo --devel
 
-	# searches only for release in version 1.0.0
-	helm repo search --version 1.0.0
+	# Searches only for release in version 1.0.0
+	helm search repo --version 1.0.0
 
 Repositories are managed with 'helm repo' commands.
 `


### PR DESCRIPTION
**Description**

- Fix example commands in the help text for `helm search`, 
   which I introduced in this PR https://github.com/helm/helm/pull/6778 🤦‍♂ 

Signed-off-by: Mateusz Szostok <szostok.mateusz@gmail.com>