### PR TITLE
fix(v3): fix regression on non-zero plugin exist status

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -69,17 +69,17 @@ func main() {
 
 	if err := actionConfig.Init(settings, false, os.Getenv("HELM_DRIVER"), debug); err != nil {
 		debug("%+v", err)
+		os.Exit(1)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		debug("%+v", err)
 		switch e := err.(type) {
 		case pluginError:
 			os.Exit(e.code)
 		default:
 			os.Exit(1)
 		}
-	}
-
-	if err := cmd.Execute(); err != nil {
-		debug("%+v", err)
-		os.Exit(1)
 	}
 }
 

--- a/cmd/helm/testdata/helmhome/helm/plugins/exitwith/exitwith.sh
+++ b/cmd/helm/testdata/helmhome/helm/plugins/exitwith/exitwith.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit $*

--- a/cmd/helm/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
+++ b/cmd/helm/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
@@ -1,0 +1,4 @@
+name: exitwith
+usage: "exitwith code"
+description: "This exits with the specified exit code"
+command: "$HELM_PLUGIN_DIR/exitwith.sh"


### PR DESCRIPTION
Fixes the regression in helm-3.0.0-beta.5 that swallows and rounds any non-zero exit status greater than 1 from a helm plugin to `1`.

This, for example, breaks `helm-diff` which relies on helm able to return `2` when `helm-diff` returned `2`.

Closese #6788