### PR TITLE
POC: Add support for Release Namespace creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/xeipuuv/gojsonschema v1.1.0
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2


### PR DESCRIPTION
### Overview
Currently, in Helm3 there is no way to create Release Namespace during helm chart installation.

### Change
Implement functionality to support Release Namespace creation during helm chart install.
While this PR is marked as Proof of Concept (POC) - it attempts at a fully functional solution.
The initial purpose of this PR is to illustrate and support Proposal #6794

### Tracking
This issue and the proposed solution is captured in #6794 

### Additional Context
This issue was discussed previously in and/or partially related to #3305, #5628, #5753