### PR TITLE
fix(cli): Remove trailing space of helm env output

### DIFF
--- a/cmd/helm/env.go
+++ b/cmd/helm/env.go
@@ -56,7 +56,7 @@ type envOptions struct {
 
 func (o *envOptions) run(out io.Writer) error {
 	for k, v := range o.settings.EnvVars() {
-		fmt.Printf("%s=\"%s\" \n", k, v)
+		fmt.Printf("%s=\"%s\"\n", k, v)
 	}
 	return nil
 }


### PR DESCRIPTION
While trying to parse the output of `helm env` I noticed there was a trailing space at the end of every line. This complicates parsing unnecessarily, so this PR removes that space.

Looking at where the extra space was first put in, the review comment
https://github.com/helm/helm/pull/6244#discussion_r319517926
indicates that the code was inspired from
https://github.com/golang/go/blob/1ed932d22b7f602d3aa0a4a5ab12ff479a2c1dce/src/cmd/go/internal/envcmd/env.go#L296
which does not have such a space, so I feel the extra space was not put there on purpose.

Maybe @waveywaves can confirm if there was a reason for that extra space.