### PR TITLE
fix(cmd): clean up helpstring formatting

### DIFF
--- a/cmd/helm/chart.go
+++ b/cmd/helm/chart.go
@@ -26,9 +26,7 @@ import (
 const chartHelp = `
 This command consists of multiple subcommands to work with the chart cache.
 
-It can be used to push, pull, tag, list, or remove Helm charts.
-Example usage:
-    $ helm chart pull [URL]
+The subcommands can be used to push, pull, tag, list, or remove Helm charts.
 `
 
 func newChartCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -30,11 +30,11 @@ Generate autocompletions script for Helm for the specified shell (bash or zsh).
 
 This command can generate shell autocompletions. e.g.
 
-	$ helm completion bash
+    $ helm completion bash
 
 Can be sourced as such
 
-	$ source <(helm completion bash)
+    $ source <(helm completion bash)
 `
 
 var (

--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -35,8 +35,6 @@ This command can generate documentation for Helm in the following formats:
 - Man pages
 
 It can also generate bash autocompletions.
-
-	$ helm docs markdown -dir mydocs/
 `
 
 type docsOptions struct {

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -29,10 +29,10 @@ var getHelp = `
 This command consists of multiple subcommands which can be used to
 get extended information about the release, including:
 
-  - The values used to generate the release
-  - The generated manifest file
-  - The notes provided by the chart of the release
-  - The hooks associated with the release
+- The values used to generate the release
+- The generated manifest file
+- The notes provided by the chart of the release
+- The hooks associated with the release
 `
 
 func newGetCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -41,7 +41,7 @@ configures the maximum length of the revision list returned.
 
 The historical release set is printed as a formatted table, e.g:
 
-    $ helm history angry-bird --max=4
+    $ helm history angry-bird
     REVISION    UPDATED                     STATUS          CHART             APP VERSION     DESCRIPTION
     1           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Initial install
     2           Mon Oct 3 10:15:13 2016     superseded      alpine-0.1.0      1.0             Upgraded successfully

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -47,30 +47,30 @@ a string value use '--set-string'. In case a value is large and therefore
 you want not to use neither '--values' nor '--set', use '--set-file' to read the
 single large value from file.
 
-	$ helm install -f myvalues.yaml myredis ./redis
+    $ helm install -f myvalues.yaml myredis ./redis
 
 or
 
-	$ helm install --set name=prod myredis ./redis
+    $ helm install --set name=prod myredis ./redis
 
 or
 
-	$ helm install --set-string long_int=1234567890 myredis ./redis
+    $ helm install --set-string long_int=1234567890 myredis ./redis
 
 or
-	$ helm install --set-file my_script=dothings.sh myredis ./redis
+    $ helm install --set-file my_script=dothings.sh myredis ./redis
 
 You can specify the '--values'/'-f' flag multiple times. The priority will be given to the
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml
 contained a key called 'Test', the value set in override.yaml would take precedence:
 
-	$ helm install -f myvalues.yaml -f override.yaml  myredis ./redis
+    $ helm install -f myvalues.yaml -f override.yaml  myredis ./redis
 
 You can specify the '--set' flag multiple times. The priority will be given to the
 last (right-most) set specified. For example, if both 'bar' and 'newbar' values are
 set for a key called 'foo', the 'newbar' value would take precedence:
 
-	$ helm install --set foo=bar --set foo=newbar  myredis ./redis
+    $ helm install --set foo=bar --set foo=newbar  myredis ./redis
 
 
 To check the generated manifests of a release without installing the chart,
@@ -93,8 +93,8 @@ A chart reference is a convenient way of referencing a chart in a chart reposito
 
 When you use a chart reference with a repo prefix ('example/mariadb'), Helm will look in the local
 configuration for a chart repository named 'example', and will then look for a
-chart in that repository whose name is 'mariadb'. It will install the latest stable version of that chart 
-until you specify '--devel' flag to also include development version (alpha, beta, and release candidate releases), or  
+chart in that repository whose name is 'mariadb'. It will install the latest stable version of that chart
+until you specify '--devel' flag to also include development version (alpha, beta, and release candidate releases), or
 supply a version number with the '--version' flag.
 
 To see the list of chart repositories, use 'helm repo list'. To search for

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -45,9 +45,9 @@ If the --filter flag is provided, it will be treated as a filter. Filters are
 regular expressions (Perl compatible) that are applied to the list of releases.
 Only items that match the filter will be returned.
 
-	$ helm list --filter 'ara[a-z]+'
-	NAME            	UPDATED                 	CHART
-	maudlin-arachnid	Mon May  9 16:07:08 2016	alpine-0.1.0
+    $ helm list --filter 'ara[a-z]+'
+    NAME                UPDATED                     CHART
+    maudlin-arachnid    Mon May  9 16:07:08 2016    alpine-0.1.0
 
 If no results are found, 'helm list' will exit 0, but with no output (or in
 the case of no '-q' flag, only headers).

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -33,9 +33,6 @@ type pluginInstallOptions struct {
 
 const pluginInstallDesc = `
 This command allows you to install a plugin from a url to a VCS repo or a local path.
-
-Example usage:
-    $ helm plugin install https://github.com/technosophos/helm-template
 `
 
 func newPluginInstallCmd(out io.Writer) *cobra.Command {

--- a/cmd/helm/registry.go
+++ b/cmd/helm/registry.go
@@ -25,10 +25,6 @@ import (
 
 const registryHelp = `
 This command consists of multiple subcommands to interact with registries.
-
-It can be used to login to or logout from a registry.
-Example usage:
-    $ helm registry login [URL]
 `
 
 func newRegistryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -30,8 +30,6 @@ var repoHelm = `
 This command consists of multiple subcommands to interact with chart repositories.
 
 It can be used to add, remove, list, and index chart repositories.
-Example usage:
-    $ helm repo add [NAME] [REPO_URL]
 `
 
 func newRepoCmd(out io.Writer) *cobra.Command {

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -282,14 +282,14 @@ __helm_custom_func()
             __helm_list_releases
             return
             ;;
-		helm_repo_remove)
-			__helm_list_repos
-			return
-			;;
-		helm_plugin_remove | helm_plugin_update)
-			__helm_list_plugins
-			return
-			;;
+        helm_repo_remove)
+            __helm_list_repos
+            return
+            ;;
+        helm_plugin_remove | helm_plugin_update)
+            __helm_list_plugins
+            return
+            ;;
         *)
             ;;
     esac
@@ -311,17 +311,22 @@ var globalUsage = `The Kubernetes package manager
 Common actions for Helm:
 
 - helm search:    search for charts
-- helm fetch:     download a chart to your local directory to view
+- helm pull:      download a chart to your local directory to view
 - helm install:   upload the chart to Kubernetes
 - helm list:      list releases of charts
 
-Environment:
-  $XDG_CACHE_HOME     set an alternative location for storing cached files.
-  $XDG_CONFIG_HOME    set an alternative location for storing Helm configuration.
-  $XDG_DATA_HOME      set an alternative location for storing Helm data.
-  $HELM_DRIVER        set the backend storage driver. Values are: configmap, secret, memory
-  $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
-  $KUBECONFIG         set an alternative Kubernetes configuration file (default "~/.kube/config")
+Environment variables:
+
++------------------+-----------------------------------------------------------------------------+
+| Name             | Description                                                                 |
++------------------+-----------------------------------------------------------------------------+
+| $XDG_CACHE_HOME  | set an alternative location for storing cached files.                       |
+| $XDG_CONFIG_HOME | set an alternative location for storing Helm configuration.                 |
+| $XDG_DATA_HOME   | set an alternative location for storing Helm data.                          |
+| $HELM_DRIVER     | set the backend storage driver. Values are: configmap, secret, memory       |
+| $HELM_NO_PLUGINS | disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.                  |
+| $KUBECONFIG      | set an alternative Kubernetes configuration file (default "~/.kube/config") |
++------------------+-----------------------------------------------------------------------------+
 
 Helm stores configuration based on the XDG base directory specification, so
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -51,13 +51,13 @@ You can specify the '--values'/'-f' flag multiple times. The priority will be gi
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml
 contained a key called 'Test', the value set in override.yaml would take precedence:
 
-	$ helm upgrade -f myvalues.yaml -f override.yaml redis ./redis
+    $ helm upgrade -f myvalues.yaml -f override.yaml redis ./redis
 
 You can specify the '--set' flag multiple times. The priority will be given to the
 last (right-most) set specified. For example, if both 'bar' and 'newbar' values are
 set for a key called 'foo', the 'newbar' value would take precedence:
 
-	$ helm upgrade --set foo=bar --set foo=newbar redis ./redis
+    $ helm upgrade --set foo=bar --set foo=newbar redis ./redis
 `
 
 func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {


### PR DESCRIPTION
- use tabs instead of spaces for `--help` output
- fixed a place in the bash autocompletion script that partially indents using tabs instead of spaces
- remove redundant usage examples, as `cobra` displays that information to the user
- place environment variable information into a table for clearer formatting

I decided to make the environment variables displayed in table format instead of the list format used in Helm 2 via #5644. This way, the help output is more consistent with the XDG default directory table shown lower in the help text.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>