### PR TITLE
fix(v3): Add `--client-only` and fix `--validate` for `helm template`

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -44,6 +44,7 @@ faked locally. Additionally, none of the server-side testing of chart validity
 
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
+	var clientOnly bool
 	client := action.NewInstall(cfg)
 	valueOpts := &values.Options{}
 	var extraAPIs []string
@@ -58,7 +59,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.DryRun = true
 			client.ReleaseName = "RELEASE-NAME"
 			client.Replace = true // Skip the name check
-			client.ClientOnly = !validate
+			client.NoValidate = !validate
+			client.ClientOnly = clientOnly
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
@@ -119,7 +121,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	addInstallFlags(f, client, valueOpts)
 	f.StringArrayVarP(&showFiles, "show-only", "s", []string{}, "only show manifests rendered from the given templates")
 	f.StringVar(&client.OutputDir, "output-dir", "", "writes the executed templates to files in output-dir instead of stdout")
-	f.BoolVar(&validate, "validate", false, "establish a connection to Kubernetes for schema validation")
+	f.BoolVar(&validate, "validate", true, "Runs schema validation")
+	f.BoolVar(&clientOnly, "client-only", true, "Prevents establishing a connection to Kubernetes for schema validation")
 	f.StringArrayVarP(&extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
 
 	return cmd

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -160,7 +160,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", u.SubNotes)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", u.SubNotes, RenderOptions{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
A.k.a "allow `helm template` to optionally skip api versions check while keeping existing use-cases and features as-is"

This introduces a new flag `--client-only` to `helm template`, so that (1)we can optionally disable the validation at all, (2)while keeping the ability to switch what are validated.

(1) is achieved by changing the semantics of the existing flag `--validate=[true|false]` new in v3 and (2) is achieved by adding `--client-only=[true|false]` that mostly the same as the former `--validate`.

This should address all the three use-cases listed in https://github.com/helm/helm/pull/6729#issuecomment-547249311 after fixing other related bugs.

Closes #6505
Replaces #6729

---

Even though the semantics of the existing flag `--validate` has changed, the existing and default behavior of `helm template` is maintained. That is, `helm template` without any flags means `do client-only validation` before/after this change.

Regarding changes in the `--validate`, as you can see from the existing code-base and the description of the flag, unlike it's name, it had been used for toggling the client-only mode of the validation. For instance, `helm template [--validate=false]` had been left api versions check running even though, `--validate=false` or omitting the flag would had disabled the whole validation according to it's name.

This change adds `--client-only` so that we can toggle the validation and the client-only mode separately, which allows more granular control, and more specifically, support the `do not validate at all` scenario.