### PR TITLE
fix(releaseutil): Removes API version checks from kind sorter

### DIFF
--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -129,10 +129,6 @@ func (file *manifestFile) sort(result *result) error {
 			return errors.Wrapf(err, "YAML parse error on %s", file.path)
 		}
 
-		if entry.Version != "" && !file.apis.Has(entry.Version) {
-			return errors.Errorf("apiVersion %q in %s is not available", entry.Version, file.path)
-		}
-
 		if !hasAnyAnnotation(entry) {
 			result.generic = append(result.generic, Manifest{
 				Name:    file.path,


### PR DESCRIPTION
The sorting method for manifests contained a check to see if the API
version existed. This violates separation of concerns as the sorter
should just sort and leave validation to other parts of the code.

I validated that things work as intended, I had a chart with this manifest in it:
```yaml
kind: Foo
apiVersion: foo.bar/v1
spec:
  foo: bar
```

When I run a `helm template` without `--validate`, it outputs templates successfully.

When I run it with `--validate`, I get the following output:

```shell
$ ./bin/helm template failme --validate
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Foo" in version "foo.bar/v1"
```

This will supersede #6811 if accepted