### PR TITLE
ref(version): lift "unreleased" status

### DIFF
--- a/cmd/helm/testdata/output/version-short.txt
+++ b/cmd/helm/testdata/output/version-short.txt
@@ -1,1 +1,1 @@
-v3.0+unreleased
+v3.0

--- a/cmd/helm/testdata/output/version-template.txt
+++ b/cmd/helm/testdata/output/version-template.txt
@@ -1,1 +1,1 @@
-Version: v3.0+unreleased
+Version: v3.0

--- a/cmd/helm/testdata/output/version.txt
+++ b/cmd/helm/testdata/output/version.txt
@@ -1,1 +1,1 @@
-version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:""}
+version.BuildInfo{Version:"v3.0", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -33,7 +33,7 @@ var (
 	version = "v3.0"
 
 	// metadata is extra build time data
-	metadata = "unreleased"
+	metadata = ""
 	// gitCommit is the git sha1
 	gitCommit = ""
 	// gitTreeState is the state of the git tree


### PR DESCRIPTION
cherry-picked from the `release-3.0` branch.

DO NOT MERGE into master until Helm 3.0.0 has been released.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>