### PR TITLE
fix(comp): helm plugin 'remove' is now 'uninstall'

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -286,7 +286,7 @@ __helm_custom_func()
             __helm_list_repos
             return
             ;;
-        helm_plugin_remove | helm_plugin_update)
+        helm_plugin_uninstall | helm_plugin_update)
             __helm_list_plugins
             return
             ;;


### PR DESCRIPTION
Fix for dynamic completion of `helm plugin uninstall` since it is no longer `helm plugin remove`

cc: @bacongobbler 