### PR TITLE
[Makefile] Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TAGS       :=
 TESTS      := .
 TESTFLAGS  :=
 LDFLAGS    := -w -s
-GOFLAGS    :=
+GOFLAGS    := -trimpath
 SRC        := $(shell find . -type f -name '*.go' -print)
 
 # Required for globs to work correctly


### PR DESCRIPTION
Circleci is used to build the release artifacts and embeds build paths
into the binary release. To reproduce the release binaries we then need
to also build in the same path as a result.

    $ strings linux-amd64/helm  | grep "home/circleci" | wc -l
    174

Go 1.13 introduces `-trimpath` which strips the build path from all
compiled binaries. This should enable people to reproduce the
distributed helm binaries.

https://reproducible-builds.org/docs/source-date-epoch/
https://golang.org/doc/go1.13#go-command