### PR TITLE
fix(kube): return error when object cannot be patched

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -401,7 +401,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		// send patch to server
 		obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
 		if err != nil {
-			log.Printf("Cannot patch %s: %q (%v)", kind, target.Name, err)
+			return errors.Wrapf(err, "cannot patch %q with kind %s", target.Name, kind)
 		}
 	}
 


### PR DESCRIPTION
Thanks to @databus23 for identifying the regression introduced in #6681.

fixes #6805

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>