### PR TITLE
fix(action): strip file extensions from name

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -564,6 +564,10 @@ func (i *Install) NameAndChart(args []string) (string, string, error) {
 	if base == "." || base == "" {
 		base = "chart"
 	}
+	// if present, strip out the file extension from the name
+	if idx := strings.Index(base, "."); idx != -1 {
+		base = base[0:idx]
+	}
 
 	return fmt.Sprintf("%s-%d", base, time.Now().Unix()), args[0], nil
 }


### PR DESCRIPTION
This PR fixes an issue where `helm install mychart.tgz --generate-name` generates an invalid name with the file extension present. This also adds a ton of unit test coverage around `NameAndChart` that wasn't there before.

closes #6600

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>