### PR TITLE
(nit) Add namespace option to example kubectl command

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -324,7 +324,7 @@ const defaultNotes = `1. Get the application URL by running these commands:
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "<CHARTNAME>.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
 {{- end }}
 `
 


### PR DESCRIPTION
Helm emits sample commands for accessing a release. Unfortunately it does not have the `--namespace` option in the example `kubectl port-forward` command which trips one up if the deployment was not to the default ns.