### PR TITLE
Revert "[Makefile] Support reproducible builds"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TAGS       :=
 TESTS      := .
 TESTFLAGS  :=
 LDFLAGS    := -w -s
-GOFLAGS    := -trimpath
+GOFLAGS    :=
 SRC        := $(shell find . -type f -name '*.go' -print)
 
 # Required for globs to work correctly


### PR DESCRIPTION
Reverts helm/helm#6831. Currently `gox` [doesn't support this new flag](https://github.com/mitchellh/gox/pull/138). It looks like there is a work around in the gox issue or we can wait until support is merged.

/cc @Foxboron