### PR TITLE
fix(show): restore comments from raw values

### DIFF
--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -24,6 +24,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 )
 
 type ShowOutputFormat string
@@ -76,11 +77,11 @@ func (s *Show) Run(chartpath string) (string, error) {
 		if s.OutputFormat == ShowAll {
 			fmt.Fprintln(&out, "---")
 		}
-		b, err := yaml.Marshal(chrt.Values)
-		if err != nil {
-			return "", err
+		for _, f := range chrt.Raw {
+			if f.Name == chartutil.ValuesfileName {
+				fmt.Fprintln(&out, string(f.Data))
+			}
 		}
-		fmt.Fprintf(&out, "%s\n", b)
 	}
 
 	if s.OutputFormat == ShowReadme || s.OutputFormat == ShowAll {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -26,13 +26,18 @@ const APIVersionV2 = "v2"
 // Chart is a helm package that contains metadata, a default config, zero or more
 // optionally parameterizable templates, and zero or more charts (dependencies).
 type Chart struct {
+	// Raw contains the raw contents of the files originally contained in the chart archive.
+	//
+	// This should not be used except in special cases like `helm show values`,
+	// where we want to display the raw values, comments and all.
+	Raw []*File `json:"-"`
 	// Metadata is the contents of the Chartfile.
 	Metadata *Metadata `json:"metadata"`
 	// LocK is the contents of Chart.lock.
 	Lock *Lock `json:"lock"`
 	// Templates for this chart.
 	Templates []*File `json:"templates"`
-	// Values are default config for this template.
+	// Values are default config for this chart.
 	Values map[string]interface{} `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values
 	Schema []byte `json:"schema"`

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package chart
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,28 @@ func TestCRDs(t *testing.T) {
 	is.Equal(2, len(crds))
 	is.Equal("crds/foo.yaml", crds[0].Name)
 	is.Equal("crds/foo/bar/baz.yaml", crds[1].Name)
+}
+
+func TestSaveChartNoRawData(t *testing.T) {
+	chrt := Chart{
+		Raw: []*File{
+			{
+				Name: "fhqwhgads.yaml",
+				Data: []byte("Everybody to the Limit"),
+			},
+		},
+	}
+
+	is := assert.New(t)
+	data, err := json.Marshal(chrt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := &Chart{}
+	if err := json.Unmarshal(data, res); err != nil {
+		t.Fatal(err)
+	}
+
+	is.Equal([]*File(nil), res.Raw)
 }

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -74,6 +74,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 	subcharts := make(map[string][]*BufferedFile)
 
 	for _, f := range files {
+		c.Raw = append(c.Raw, &chart.File{Name: f.Name, Data: f.Data})
 		switch {
 		case f.Name == "Chart.yaml":
 			if c.Metadata == nil {

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -179,6 +179,10 @@ icon: https://example.com/64x64.png
 		t.Error("Expected chart values to be populated with default values")
 	}
 
+	if len(c.Raw) != 5 {
+		t.Errorf("Expected %d files, got %d", 5, len(c.Raw))
+	}
+
 	if !bytes.Equal(c.Schema, []byte("type: Values")) {
 		t.Error("Expected chart schema to be populated with default values")
 	}


### PR DESCRIPTION
`helm show values` was reading the values as marshaled from `loader.Load`, which stripped the original comments from the values file. This PR restores the `RawValues` field to `chart.Chart` to restore `helm show values`'s previous behaviour to render the raw values file, comments and all.

closes #6354