### PR TITLE
ref(chart): replace loader.BufferedFile with chart.File

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -15,7 +15,9 @@ limitations under the License.
 
 package chart
 
-import "strings"
+import (
+	"strings"
+)
 
 // APIVersionV1 is the API version number for version 1.
 const APIVersionV1 = "v1"

--- a/pkg/chart/loader/archive.go
+++ b/pkg/chart/loader/archive.go
@@ -101,14 +101,14 @@ func ensureArchive(name string, raw *os.File) error {
 // LoadArchiveFiles reads in files out of an archive into memory. This function
 // performs important path security checks and should always be used before
 // expanding a tarball
-func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
+func LoadArchiveFiles(in io.Reader) ([]*chart.File, error) {
 	unzipped, err := gzip.NewReader(in)
 	if err != nil {
 		return nil, err
 	}
 	defer unzipped.Close()
 
-	files := []*BufferedFile{}
+	files := []*chart.File{}
 	tr := tar.NewReader(unzipped)
 	for {
 		b := bytes.NewBuffer(nil)
@@ -167,7 +167,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 			return nil, err
 		}
 
-		files = append(files, &BufferedFile{Name: n, Data: b.Bytes()})
+		files = append(files, &chart.File{Name: n, Data: b.Bytes()})
 		b.Reset()
 	}
 

--- a/pkg/chart/loader/directory.go
+++ b/pkg/chart/loader/directory.go
@@ -61,7 +61,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 	}
 	rules.AddDefaults()
 
-	files := []*BufferedFile{}
+	files := []*chart.File{}
 	topdir += string(filepath.Separator)
 
 	walk := func(name string, fi os.FileInfo, err error) error {
@@ -104,7 +104,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return errors.Wrapf(err, "error reading %s", n)
 		}
 
-		files = append(files, &BufferedFile{Name: n, Data: data})
+		files = append(files, &chart.File{Name: n, Data: data})
 		return nil
 	}
 	if err = sympath.Walk(topdir, walk); err != nil {


### PR DESCRIPTION
Using Go's gradual code migration feature to deprecate BufferedFile. load_test.go continues to work even with this refactor, and was left alone to test backwards compatibility.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>