### PR TITLE
fix(chart): add JSON tags to chart object

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -27,18 +27,18 @@ const APIVersionV2 = "v2"
 // optionally parameterizable templates, and zero or more charts (dependencies).
 type Chart struct {
 	// Metadata is the contents of the Chartfile.
-	Metadata *Metadata
+	Metadata *Metadata `json:"metadata"`
 	// LocK is the contents of Chart.lock.
-	Lock *Lock
+	Lock *Lock `json:"lock"`
 	// Templates for this chart.
-	Templates []*File
+	Templates []*File `json:"templates"`
 	// Values are default config for this template.
-	Values map[string]interface{}
+	Values map[string]interface{} `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values
-	Schema []byte
+	Schema []byte `json:"schema"`
 	// Files are miscellaneous files in a chart archive,
 	// e.g. README, LICENSE, etc.
-	Files []*File
+	Files []*File `json:"files"`
 
 	parent       *Chart
 	dependencies []*Chart

--- a/pkg/chart/file.go
+++ b/pkg/chart/file.go
@@ -21,7 +21,7 @@ package chart
 // base directory.
 type File struct {
 	// Name is the path-like name of the template.
-	Name string
+	Name string `json:"name"`
 	// Data is the template as byte data.
-	Data []byte
+	Data []byte `json:"data"`
 }


### PR DESCRIPTION
Go capitalizes field names by default. Release metadata is JSON-encoded. This wasn't an issue in Helm 2 because everything was encoded in gRPC protocol buffers over the wire. In Helm 3, the client creates the release object directly from the Release struct.

To replicate:

```
helm create foo
helm install foo ./foo
kubectl get secret sh.helm.release.v1.foo.v1 -o jsonpath='{.data.release}' | base64 -d | base64 -d | gunzip
```

Marking as a last-minute 3.0 fix as changing this after 3.0 would break compatibility.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>