### PR TITLE
fix(version): implement `helm version -c`, mark as hidden

### DIFF
--- a/cmd/helm/testdata/output/version-client-shorthand.txt
+++ b/cmd/helm/testdata/output/version-client-shorthand.txt
@@ -1,0 +1,1 @@
+version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/cmd/helm/testdata/output/version-client.txt
+++ b/cmd/helm/testdata/output/version-client.txt
@@ -1,0 +1,1 @@
+version.BuildInfo{Version:"v3.0+unreleased", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -61,6 +61,8 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&o.short, "short", false, "print the version number")
 	f.StringVar(&o.template, "template", "", "template for version string format")
+	f.BoolP("client", "c", true, "display client version information")
+	f.MarkHidden("client")
 
 	return cmd
 }

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -32,6 +32,14 @@ func TestVersion(t *testing.T) {
 		name:   "template",
 		cmd:    "version --template='Version: {{.Version}}'",
 		golden: "output/version-template.txt",
+	}, {
+		name:   "client",
+		cmd:    "version --client",
+		golden: "output/version-client.txt",
+	}, {
+		name:   "client shorthand",
+		cmd:    "version -c",
+		golden: "output/version-client-shorthand.txt",
 	}}
 	runTestCmd(t, tests)
 }


### PR DESCRIPTION
This has been requested by multiple users, and incurs no additional maintenance on our end, so I'm re-opening this for further discussion/debate.

Users are struggling to find a solution to this problem. No alternative solutions have been reached. This is the best solution as discussed at this time. IMO I'd rather have a half-baked solution that works for community members than no solution. Having this in for Helm 3 will reduce friction for adopting Helm 3 in third party tools like the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) and in [helmfile](https://github.com/roboll/helmfile).

this is identical to #6670, just re-opened against `master` after the big branch switch.
closes #6322

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>