### PR TITLE
fix(cmd): Standardizes all output to use lower snake_case names

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -110,13 +110,13 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type releaseElement struct {
-	Name       string
-	Namespace  string
-	Revision   string
-	Updated    string
-	Status     string
-	Chart      string
-	AppVersion string
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	Revision   string `json:"revision"`
+	Updated    string `json:"updated"`
+	Status     string `json:"status"`
+	Chart      string `json:"chart"`
+	AppVersion string `json:"app_version"`
 }
 
 type releaseListWriter struct {

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -51,8 +51,8 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 }
 
 type repositoryElement struct {
-	Name string
-	URL  string
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
 type repoListWriter struct {

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -84,10 +84,10 @@ func (o *searchHubOptions) run(out io.Writer, args []string) error {
 }
 
 type hubChartElement struct {
-	URL         string
-	Version     string
-	AppVersion  string
-	Description string
+	URL         string `json:"url"`
+	Version     string `json:"version"`
+	AppVersion  string `json:"app_version"`
+	Description string `json:"description"`
 }
 
 type hubSearchWriter struct {

--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -191,10 +191,10 @@ func (o *searchRepoOptions) buildIndex(out io.Writer) (*search.Index, error) {
 }
 
 type repoChartElement struct {
-	Name        string
-	Version     string
-	AppVersion  string
-	Description string
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	AppVersion  string `json:"app_version"`
+	Description string `json:"description"`
 }
 
 type repoSearchWriter struct {

--- a/cmd/helm/testdata/output/search-output-json.txt
+++ b/cmd/helm/testdata/output/search-output-json.txt
@@ -1,1 +1,1 @@
-[{"Name":"testing/mariadb","Version":"0.3.0","AppVersion":"","Description":"Chart for MariaDB"}]
+[{"name":"testing/mariadb","version":"0.3.0","app_version":"","description":"Chart for MariaDB"}]

--- a/cmd/helm/testdata/output/search-output-yaml.txt
+++ b/cmd/helm/testdata/output/search-output-yaml.txt
@@ -1,4 +1,4 @@
-- AppVersion: 2.3.4
-  Description: Deploy a basic Alpine Linux pod
-  Name: testing/alpine
-  Version: 0.2.0
+- app_version: 2.3.4
+  description: Deploy a basic Alpine Linux pod
+  name: testing/alpine
+  version: 0.2.0


### PR DESCRIPTION
After discussing similar changes in #6866, we decided to make sure all
JSON and YAML output uses lower snake case names as is generally standard practice