### PR TITLE
fix(cli): Sort output of helm env

### DIFF
--- a/cmd/helm/env.go
+++ b/cmd/helm/env.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"helm.sh/helm/v3/pkg/cli"
 
@@ -55,8 +56,18 @@ type envOptions struct {
 }
 
 func (o *envOptions) run(out io.Writer) error {
-	for k, v := range o.settings.EnvVars() {
-		fmt.Printf("%s=\"%s\"\n", k, v)
+	envVars := o.settings.EnvVars()
+
+	// Sort the variables by alphabetical order.
+	// This allows for a constant output across calls to 'helm env'.
+	var keys []string
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Printf("%s=\"%s\"\n", k, envVars[k])
 	}
 	return nil
 }


### PR DESCRIPTION
Before this change, running 'helm env' multiple times would generate
a different order for the output each time.  This is because Go
purposely loops over hash maps in a random order.

This commit sorts the environment variables by alphabetical order before
generating the output.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>