### PR TITLE
feat(cli): Have helm env show current XDG paths

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"helm.sh/helm/v3/pkg/helmpath"
+	"helm.sh/helm/v3/pkg/helmpath/xdg"
 	"helm.sh/helm/v3/pkg/kube"
 )
 
@@ -100,6 +102,9 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_REPOSITORY_CONFIG": s.RepositoryConfig,
 		"HELM_NAMESPACE":         s.Namespace(),
 		"HELM_KUBECONTEXT":       s.KubeContext,
+		xdg.CacheHomeEnvVar:      strings.TrimSuffix(helmpath.CachePath(), "/helm"),
+		xdg.ConfigHomeEnvVar:     strings.TrimSuffix(helmpath.ConfigPath(), "/helm"),
+		xdg.DataHomeEnvVar:       strings.TrimSuffix(helmpath.DataPath(), "/helm"),
 	}
 
 	if s.KubeConfig != "" {


### PR DESCRIPTION
I believe plugins and users need to know where the XDG helm config paths are located.
To my knowledge there is no current good way of doing this when the XDG variables are unset in the user's environment.

This PR adds them to `helm env` which also makes them available to plugins.

It addresses concerns brought up in #6890 