### PR TITLE
fix(kube): Fixes missing API versions

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -57,7 +57,6 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/validation"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/get"
 )
@@ -269,7 +268,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 		for i := range podItems {
 			pod := &core.Pod{}
 
-			legacyscheme.Scheme.Convert(&podItems[i], pod, nil)
+			scheme.Scheme.Convert(&podItems[i], pod, nil)
 			if objs[key+"(related)"] == nil {
 				objs[key+"(related)"] = make(map[string]runtime.Object)
 			}
@@ -882,7 +881,7 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 // This operates on an event returned from a watcher.
 func (c *Client) waitForJob(e watch.Event, name string) (bool, error) {
 	job := &batch.Job{}
-	err := legacyscheme.Scheme.Convert(e.Object, job, nil)
+	err := scheme.Scheme.Convert(e.Object, job, nil)
 	if err != nil {
 		return true, err
 	}
@@ -1043,5 +1042,5 @@ func asVersioned(info *resource.Info) (runtime.Object, error) {
 
 func asInternal(info *resource.Info) (runtime.Object, error) {
 	groupVersioner := info.Mapping.GroupVersionKind.GroupKind().WithVersion(runtime.APIVersionInternal).GroupVersion()
-	return legacyscheme.Scheme.ConvertToVersion(info.Object, groupVersioner)
+	return scheme.Scheme.ConvertToVersion(info.Object, groupVersioner)
 }


### PR DESCRIPTION
In several of the job checks and other conversions we were using legacyscheme.
I don't know why it was working before, but I am guessing something changed
between k8s 1.15 and 1.16 with which types were registered. To fix I changed the references to use the default scheme in client-go

Closes #6894 