### PR TITLE
print gvk information on existing resource conflict

### DIFF
--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -33,7 +33,8 @@ func existingResourceConflict(resources kube.ResourceList) error {
 		}
 
 		helper := resource.NewHelper(info.Client, info.Mapping)
-		if _, err := helper.Get(info.Namespace, info.Name, info.Export); err != nil {
+		existing, err := helper.Get(info.Namespace, info.Name, info.Export)
+		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
@@ -41,7 +42,7 @@ func existingResourceConflict(resources kube.ResourceList) error {
 			return errors.Wrap(err, "could not get information about the resource")
 		}
 
-		return fmt.Errorf("existing resource conflict: kind: %s, namespace: %s, name: %s", info.Mapping.GroupVersionKind.Kind, info.Namespace, info.Name)
+		return fmt.Errorf("existing resource conflict: namespace: %s, name: %s, existing: [gvk: %s, ] / new: [gvk: %s]", info.Namespace, info.Name, existing.GetObjectKind().GroupVersionKind(), info.Mapping.GroupVersionKind)
 	})
 	return err
 }

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -42,7 +42,7 @@ func existingResourceConflict(resources kube.ResourceList) error {
 			return errors.Wrap(err, "could not get information about the resource")
 		}
 
-		return fmt.Errorf("existing resource conflict: namespace: %s, name: %s, existing: [gvk: %s, ] / new: [gvk: %s]", info.Namespace, info.Name, existing.GetObjectKind().GroupVersionKind(), info.Mapping.GroupVersionKind)
+		return fmt.Errorf("existing resource conflict: namespace: %s, name: %s, existing_kind: %s, new_kind: %s", info.Namespace, info.Name, existing.GetObjectKind().GroupVersionKind(), info.Mapping.GroupVersionKind)
 	})
 	return err
 }


### PR DESCRIPTION
This PR adds additional information to resource conflict error messages.
We were facing some issues due to API version changes and had difficulties on finding the reason of the conflict.
Adding group and version helps a lot, since the id's of resources are compared with all this data.

Signed-off-by: Marc Brugger <github@bakito.ch>