### PR TITLE
fix(cmd): Fixes logging on action conf init error

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -68,8 +68,7 @@ func main() {
 	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
 	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
-		debug("%+v", err)
-		os.Exit(1)
+		log.Fatalf("%+v", err)
 	}
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -68,7 +68,7 @@ func main() {
 	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
 	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
-		log.Fatalf("%+v", err)
+		log.Fatal(err)
 	}
 
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
Errors relating to initializing the action config cause helm to exit silently,
except when in debug mode. This now emits the useful error.

Closes #6863
