### PR TITLE
feat(helm): Add map of cmds that req actionConfig

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -67,9 +67,15 @@ func main() {
 	actionConfig := new(action.Configuration)
 	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
-	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
-		debug("%+v", err)
+	subCmd, _, err := cmd.Find(os.Args[1:])
+	if err != nil {
 		os.Exit(1)
+	}
+	actionConfigRequired := action.ActionConfigRequired(subCmd.Use)
+	if actionConfigRequired {
+		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+			log.Fatalf("%+v", err)
+		}
 	}
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -71,7 +71,7 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-	actionConfigRequired := action.ActionConfigRequired(subCmd.Use)
+	actionConfigRequired := action.ConfigRequired(subCmd.Use)
 	if actionConfigRequired {
 		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
 			log.Fatalf("%+v", err)

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -71,7 +71,7 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-	actionConfigRequired := action.ConfigRequired(subCmd.Use)
+	actionConfigRequired := action.ConfigRequired(subCmd.Name())
 	if actionConfigRequired {
 		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
 			log.Fatalf("%+v", err)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -245,7 +245,7 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 	return nil
 }
 
-func ActionConfigRequired(command string) bool {
+func ConfigRequired(command string) bool {
 	var actionConfigRequired = map[string]bool{
 		// release commands
 		"get":         true,

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -244,3 +244,44 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 
 	return nil
 }
+
+func ActionConfigRequired(command string) bool {
+	var actionConfigRequired = map[string]bool{
+		// release commands
+		"get":         true,
+		"history":     true,
+		"install":     true,
+		"list":        true,
+		"releaseTest": true,
+		"rollback":    true,
+		"status":      true,
+		"template":    true,
+		"uninstall":   true,
+		"upgrade":     true,
+
+		//registry commands
+		"registry": true,
+		"chart":    true,
+
+		// chart commands
+		"create":     false,
+		"dependency": false,
+		"pull":       false,
+		"show":       false,
+		"lint":       false,
+		"package":    false,
+		"repo":       false,
+		"search":     false,
+		"verify":     false,
+		"completion": false,
+		"env":        false,
+		"plugin":     false,
+		"version":    false,
+		"docs":       false,
+
+		//root
+		"helm": false,
+	}
+
+	return actionConfigRequired[command]
+}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -283,5 +283,9 @@ func ConfigRequired(command string) bool {
 		"helm": false,
 	}
 
-	return actionConfigRequired[command]
+	if val, ok := actionConfigRequired[command]; ok {
+		return val
+	}
+	// Assume commands not present in the map require the config by default
+	return true
 }


### PR DESCRIPTION
Most commands unrelated to release do not require actionConfig. This
provides a way to differentiate between commands that use it and those
that do not, so that a user doesn't need to worry about their kubeconfig
if they are running `helm version` for example.

This feature was suggested in #6863 .

Signed-off-by: Jorge Gasca <jorge.ignacio.gasca@gmail.com>