### PR TITLE
Helm upgrades with --reuse-values and nil user values

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -180,7 +180,10 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}) {
 //
 // dest is considered authoritative.
 func CoalesceTables(dst, src map[string]interface{}) map[string]interface{} {
-	if dst == nil || src == nil {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
 		return src
 	}
 	// Because dest has higher precedence than src, dest values override src


### PR DESCRIPTION
This PR allows helm charts to have an upgrade with `--reuse-values` when the chart has no modifications already.

Gives priority to dst when the src parameter is nil.

Resolves #6899