### PR TITLE
v3: helm list no longer reporting cluster not reachable

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -77,12 +77,15 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.SetStateMask()
 
 			results, err := client.Run()
+			if err != nil {
+				return err
+			}
 
 			if client.Short {
 				for _, res := range results {
 					fmt.Fprintln(out, res.Name)
 				}
-				return err
+				return nil
 			}
 
 			return outfmt.Write(out, newReleaseListWriter(results))


### PR DESCRIPTION
If the cluster is not reachable, `helm list` no longer reported that error.
This regression was introduced about a month ago.

Before this PR:
```
$ h3 list
NAME	NAMESPACE	REVISION	UPDATED	STATUS	CHART	APP VERSION
```
After:
```
$ h3 list
NAME	NAMESPACE	REVISION	UPDATED	STATUS	CHART	APP VERSION
Error: Kubernetes cluster unreachable
```
**Note to maintainers**

I did the simplest fix here.

However, to be thorough, let me mention that I don't quite get why there is not a `if err != nil` check right after the call to `client.Run()`.  My guess is that it is an attempt to print whatever releases might have been fetched even when an error is received.  However, looking at the `client.Run()` code in `pkg/action/list.go` and digging into the 3 helm storage classes, it does not seem possible to get both an error and a list of releases.  

It would then seem less error-prone to have the `if err != nil` check right after the `client.Run()`

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>