### PR TITLE
v3: Make helm upgrade check if the cluster is reachable

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -91,8 +91,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			}
 
 			if client.Install {
-				// If a release does not exist, install it. If another error occurs during
-				// the check, ignore the error and continue with the upgrade.
+				// If a release does not exist, install it.
 				histClient := action.NewHistory(cfg)
 				histClient.Max = 1
 				if _, err := histClient.Run(args[0]); err == driver.ErrReleaseNotFound {
@@ -119,6 +118,8 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						return err
 					}
 					return outfmt.Write(out, &statusPrinter{rel, settings.Debug})
+				} else if err != nil {
+					return err
 				}
 			}
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -75,6 +75,10 @@ func NewUpgrade(cfg *Configuration) *Upgrade {
 
 // Run executes the upgrade on the given release.
 func (u *Upgrade) Run(name string, chart *chart.Chart, vals map[string]interface{}) (*release.Release, error) {
+	if err := u.cfg.KubeClient.IsReachable(); err != nil {
+		return nil, err
+	}
+
 	// Make sure if Atomic is set, that wait is set as well. This makes it so
 	// the user doesn't have to specify both
 	u.Wait = u.Wait || u.Atomic


### PR DESCRIPTION
The 'helm upgrade' command was not checking if the cluster was reachable.

Before the PR:
```
$ h3 upgrade nginx stable/nginx-ingress
Error: UPGRADE FAILED: query: failed to query with labels: Get https://blabla:6443/api/v1/namespaces/default/secrets?labelSelector=name%3Dnginx%2Cowner%3Dhelm%2Cstatus%3Ddeployed: Get https://moreblabla: dial tcp 10.17.10.20:443: i/o timeout
$ h3 upgrade --install nginx stable/nginx-ingress
Error: UPGRADE FAILED: query: failed to query with labels: Get https://blabla:6443/api/v1/namespaces/default/secrets?labelSelector=name%3Dnginx%2Cowner%3Dhelm%2Cstatus%3Ddeployed: Get https://moreblabla: dial tcp 10.17.10.20:443: i/o timeout
```
After the PR:
```
$ h3 upgrade nginx stable/nginx-ingress
Error: UPGRADE FAILED: Kubernetes cluster unreachable
$ h3 upgrade --install nginx stable/nginx-ingress
Error: Kubernetes cluster unreachable
```
Also, `helm upgrade --install` first checks if the release exists already.  If that check fails because the cluster is not reachable, there is no point in continuing the upgrade.  This optimization avoids
a second timeout of 30 seconds when trying to do the upgrade (one to check the release existence, the other to try the upgrade).

**Notes to maintainers**

~~This change creates a new API: `kube.ErrClusterUnreachable`.
Also, it imports `helm.sh/helm/v3/pkg/kube` from `cmd/helm/upgrade.go`.
This may not be desirable, I don't know.  Maybe the public error should be put in another package?~~
