### PR TITLE
fix for #6378

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -131,9 +131,8 @@ func (s *Storage) DeployedAll(name string) ([]*rspb.Release, error) {
 	s.Log("getting deployed releases from %q history", name)
 
 	ls, err := s.Driver.Query(map[string]string{
-		"name":   name,
-		"owner":  "helm",
-		"status": "deployed",
+		"name":  name,
+		"owner": "helm",
 	})
 	if err == nil {
 		return ls, nil


### PR DESCRIPTION
only run replace after patch failed

This fixes the Issue #6378, that `helm upgrade --force` doesn’t work anymore 