### PR TITLE
fix(ci): pin golangci-lint to v1.21.0

### DIFF
--- a/.circleci/bootstrap.sh
+++ b/.circleci/bootstrap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+curl -sSL https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VERSION/golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64.tar.gz | tar xz
+sudo mv golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64/golangci-lint /usr/local/bin/golangci-lint
+rm -rf golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,13 @@ jobs:
 
     environment:
       GOCACHE: "/tmp/go/cache"
+      GOLANGCI_LINT_VERSION: "1.21.0"
 
     steps:
       - checkout
+      - run:
+          name: install test dependencies
+          command: .circleci/bootstrap.sh
       - run:
           name: test style
           command: make test-style

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ GOPATH        = $(shell go env GOPATH)
 DEP           = $(GOPATH)/bin/dep
 GOX           = $(GOPATH)/bin/gox
 GOIMPORTS     = $(GOPATH)/bin/goimports
-GOLANGCI_LINT = $(GOPATH)/bin/golangci-lint
 
 ACCEPTANCE_DIR:=$(GOPATH)/src/helm.sh/acceptance-testing
 # To specify the subset of acceptance tests to run. '.' means all tests
@@ -81,8 +80,8 @@ test-coverage:
 	@ ./scripts/coverage.sh
 
 .PHONY: test-style
-test-style: $(GOLANGCI_LINT)
-	GO111MODULE=on $(GOLANGCI_LINT) run
+test-style:
+	GO111MODULE=on golangci-lint run
 	@scripts/validate-license.sh
 
 .PHONY: test-acceptance
@@ -117,9 +116,6 @@ format: $(GOIMPORTS)
 
 $(GOX):
 	(cd /; GO111MODULE=on go get -u github.com/mitchellh/gox)
-
-$(GOLANGCI_LINT):
-	(cd /; GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint)
 
 $(GOIMPORTS):
 	(cd /; GO111MODULE=on go get -u golang.org/x/tools/cmd/goimports)


### PR DESCRIPTION
should fix the issue in master with building golangci-lint during a CI run. See #6941.

Will need to cherry-pick this into the 3.0 branch to ensure CI runs will succeed.

https://github.com/golangci/golangci-lint#go-get

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>