### PR TITLE
fix(pkg/downloader): Resolve repo alias before checking digests on build

### DIFF
--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -181,7 +181,8 @@ func TestGetRepoNames(t *testing.T) {
 	}
 }
 
-// This function is the skeleton test code of failing tests for #6416 and bugs due to #5874.
+// This function is the skeleton test code of failing tests for #6416 and #6871 and bugs due to #5874.
+//
 // This function is used by below tests that ensures success of build operation
 // with optional fields, alias, condition, tags, and even with ranged version.
 // Parent chart includes local-subchart 0.1.0 subchart from a fake repository, by default.
@@ -281,5 +282,13 @@ func TestBuild_WithTags(t *testing.T) {
 	// Dependency has several tags
 	checkBuildWithOptionalFields(t, "with-tags", chart.Dependency{
 		Tags: []string{"tag1", "tag2"},
+	})
+}
+
+// Failing test for #6871
+func TestBuild_WithRepositoryAlias(t *testing.T) {
+	// Dependency repository is aliased in Chart.yaml
+	checkBuildWithOptionalFields(t, "with-repository-alias", chart.Dependency{
+		Repository: "@test",
 	})
 }

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -161,7 +161,7 @@ func TestGetRepoNames(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		l, err := m.getRepoNames(tt.req)
+		l, err := m.resolveRepoNames(tt.req)
 		if err != nil {
 			if tt.err {
 				continue


### PR DESCRIPTION
Fixes #6871 
Caused by #6736 

## What this PR does / why we need it:

`Update()` gets repo names before resolving a lock file by calling `resolveRepoNames(req)`. But that method changes aliased repo URLs into the actual URLs. That makes digests from `helm update` and `helm build` be different for each other.

To make them in sync, setting actual (resolved) repo URLs into the loaded chart during `helm build` is necessary. Thus, this commit adds an extra step in the `Build()` implementation.

For comments, this commit also changes the name of `getRepoNames()` into `resolveRepoNames()` to avoid misunderstanding since getters are expected to not mutate its input data in general.

~~Also, like `Update()`, `Build()` is changed to be finished immediately if there is no dependency.~~
(Edited: remove this feature since nil chart deps & non-nil lock deps should return out-of-sync error)

- [x] this PR contains unit tests
