### PR TITLE
fix(install): log the error when recording the release

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -301,7 +301,9 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	//
 	// One possible strategy would be to do a timed retry to see if we can get
 	// this stored in the future.
-	i.recordRelease(rel)
+	if err := i.recordRelease(rel); err != nil {
+		i.cfg.Log("failed to record the release: %s", err)
+	}
 
 	return rel, nil
 }


### PR DESCRIPTION
this appears to be the only place where we don't log the error when `--debug` is provided. An informative error message should help others when debugging issues like #6939.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>