### PR TITLE
fix(reame):  update links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ If you want to use a package manager:
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
 
-See the [installation guide](https://docs.helm.sh/using_helm/#installing-helm) for more options,
+See the [installation guide](https://helm.sh/docs/intro/install/) for more options,
 including installing pre-releases.
 
 ## Docs
 
-Get started with the [Quick Start guide](https://docs.helm.sh/using_helm/#quickstart-guide) or plunge into the [complete documentation](https://docs.helm.sh)
+Get started with the [Quick Start guide](https://helm.sh/docs/intro/quickstart/) or plunge into the [complete documentation](https://helm.sh/docs)
 
 ## Roadmap
 


### PR DESCRIPTION
This PR edits Readme links to point to the correct place in the v3 docs.

This **should be merged after** the `v3.helm.sh` content is shipped to `helm.sh`