### PR TITLE
improved the error message for failed package signing

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -40,6 +40,14 @@ If no path is given, this will look in the present working directory for a
 Chart.yaml file, and (if found) build the current directory into a chart.
 
 Versioned chart archives are used by Helm package repositories.
+
+To sign a chart, use the '--sign' flag. In most cases, you should also
+provide '--keyring path/to/secret/keys' and '--key keyname'.
+
+  $ helm package --sign ./mychart --key mykey --keyring ~/.gnupg/secring.gpg
+
+If '--keyring' is not specified, Helm usually defaults to the public keyring
+unless your environment is otherwise configured.
 `
 
 func newPackageCmd(out io.Writer) *cobra.Command {

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -169,7 +169,7 @@ func (s *Signatory) DecryptKey(fn PassphraseFetcher) error {
 	if s.Entity == nil {
 		return errors.New("private key not found")
 	} else if s.Entity.PrivateKey == nil {
-		return errors.New("provided key is not a private key")
+		return errors.New("provided key is not a private key. Try providing a keyring with secret keys")
 	}
 
 	// Nothing else to do if key is not encrypted.
@@ -203,7 +203,7 @@ func (s *Signatory) ClearSign(chartpath string) (string, error) {
 	if s.Entity == nil {
 		return "", errors.New("private key not found")
 	} else if s.Entity.PrivateKey == nil {
-		return "", errors.New("provided key is not a private key")
+		return "", errors.New("provided key is not a private key. Try providing a keyring with secret keys")
 	}
 
 	if fi, err := os.Stat(chartpath); err != nil {


### PR DESCRIPTION
This updates an error message and the help text for `helm package` to better help with signing.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>