### PR TITLE
fix(get): install Helm v2.16.1

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -187,7 +187,7 @@ testVersion() {
 help () {
   echo "Accepted cli arguments are:"
   echo -e "\t[--help|-h ] ->> prints this help"
-  echo -e "\t[--version|-v <desired_version>]"
+  echo -e "\t[--version|-v <desired_version>] . When not defined it defaults to latest"
   echo -e "\te.g. --version v2.4.0  or -v latest"
   echo -e "\t[--no-sudo]  ->> install without sudo"
 }
@@ -213,9 +213,7 @@ while [[ $# -gt 0 ]]; do
     '--version'|-v)
        shift
        if [[ $# -ne 0 ]]; then
-          # FIXME(bacongobbler): hard code the desired version for the time being.
-          # A better fix would be to filter for Helm 2 release pages.
-           export DESIRED_VERSION="${1:="v2.16.1"}"
+           export DESIRED_VERSION="${1}"
        else
            echo -e "Please provide the desired version. e.g. --version v2.4.0 or -v latest"
            exit 0


### PR DESCRIPTION
This is a temporary fix. This prevents the get script from installing Helm 3 as soon as it's released, potentially causing disruption to users that were expecting a Helm 2 release.

A `get-helm-3` script is also supplied, which is identical to the previous `get` script. That way, Helm 3 users also have an equivalent way to install Helm 3.

Will update the Helm 3 documentation as a follow-up. This does not affect users for Helm 2.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>