### PR TITLE
fix(wait): Adds support for waiting on v1 apiextensions for CRDs

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -126,7 +126,7 @@ func (i *Install) installCRDs(crds []*chart.File) error {
 				i.cfg.Log("CRD %s is already present. Skipping.", crdName)
 				continue
 			}
-			return errors.Wrapf(err, "failed to instal CRD %s", obj.Name)
+			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
 		}
 		totalItems = append(totalItems, res...)
 	}


### PR DESCRIPTION
This was a missed update when we updated the k8s libraries. I validated
that this works for CRD installs with v1beta1 and v1