### PR TITLE
fix: change error message to contain correct field name

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -420,7 +420,7 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 
 	if ch.Metadata.KubeVersion != "" {
 		if !chartutil.IsCompatibleRange(ch.Metadata.KubeVersion, caps.KubeVersion.String()) {
-			return hs, b, "", errors.Errorf("chart requires kubernetesVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.String())
+			return hs, b, "", errors.Errorf("chart requires kubeVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.String())
 		}
 	}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -306,7 +306,7 @@ func TestInstallRelease_KubeVersion(t *testing.T) {
 	vals = map[string]interface{}{}
 	_, err = instAction.Run(buildChart(withKube(">=99.0.0")), vals)
 	is.Error(err)
-	is.Contains(err.Error(), "chart requires kubernetesVersion")
+	is.Contains(err.Error(), "chart requires kubeVersion")
 }
 
 func TestInstallRelease_Wait(t *testing.T) {


### PR DESCRIPTION
When reporting an incompatible Kubernetes version, due to a version constraint from the kubeVersion field, the error message should report with the correct field name.

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>