### PR TITLE
Update get script after new main release Helm v3

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -77,17 +77,14 @@ verifySupported() {
 
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
-  if [ "x$DESIRED_VERSION" == "x" ]; then
-    # FIXME(bacongobbler): hard code the desired version for the time being.
-    # A better fix would be to filter for Helm 2 release pages.
-    TAG="v2.16.1"
-    # Get tag from release URL
-    # local latest_release_url="https://github.com/helm/helm/releases/latest"
-    # if type "curl" > /dev/null; then
-    #   TAG=$(curl -Ls -o /dev/null -w %{url_effective} $latest_release_url | grep -oE "[^/]+$" )
-    # elif type "wget" > /dev/null; then
-    #   TAG=$(wget $latest_release_url --server-response -O /dev/null 2>&1 | awk '/^  Location: /{DEST=$2} END{ print DEST}' | grep -oE "[^/]+$")
-    # fi
+  if [ "x$DESIRED_VERSION" == "x" ]; then    
+    # read latest stable v2 release from release page
+    local latest_release_url="https://github.com/helm/helm/releases/latest"
+    if type "curl" > /dev/null; then
+      TAG=$(curl -Ls https://github.com/helm/helm/releases|grep -Po '/helm/helm/releases/tag/v[0-9.-]+">Helm'|grep -Po 'v2[0-9.-]+' | sort -r | head -n 1)
+    elif type "wget" > /dev/null; then
+      TAG=$(wget -O - https://github.com/helm/helm/releases|grep -Po '/helm/helm/releases/tag/v[0-9.-]+">Helm'|grep -Po 'v2[0-9.-]+' | sort -r | head -n 1)     
+    fi
   else
     TAG=$DESIRED_VERSION
   fi


### PR DESCRIPTION
read latest v2 stable from release page html (no -rc versions)
grep for tag - href path and filter out the plain version number