### PR TITLE
doc(helmpath) move licensing info out of godoc

### DIFF
--- a/pkg/helmpath/home.go
+++ b/pkg/helmpath/home.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package helmpath calculates filesystem paths to Helm's configuration, cache and data.
 package helmpath
 
 // This helper builds paths to Helm's configuration, cache and data paths.

--- a/pkg/helmpath/lazypath.go
+++ b/pkg/helmpath/lazypath.go
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package helmpath
 
 import (

--- a/pkg/helmpath/xdg/xdg.go
+++ b/pkg/helmpath/xdg/xdg.go
@@ -1,16 +1,22 @@
-// Copyright The Helm Authors.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-// http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
+// Package xdg holds constants pertaining to XDG Base Directory Specification.
+//
+// The XDG Base Directory Specification https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+// specifies the environment variables that define user-specific base directories for various categories of files.
 package xdg
 
 const (


### PR DESCRIPTION
Add intervening line into lazypath.go, so that license is
not treated by godoc as a package description.

Standardize license comments.

Add basic package descriptions where missing.

Signed-off-by: Jakub Bielecki <jakub.bielecki@codilime.com>