### PR TITLE
Add comments about release Version variable

### DIFF
--- a/pkg/action/get.go
+++ b/pkg/action/get.go
@@ -26,6 +26,7 @@ import (
 type Get struct {
 	cfg *Configuration
 
+	// Initializing Version to 0 will get the latest revision of the release.
 	Version int
 }
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -33,7 +33,7 @@ type Release struct {
 	Manifest string `json:"manifest,omitempty"`
 	// Hooks are all of the hooks declared for this release.
 	Hooks []*Hook `json:"hooks,omitempty"`
-	// Version is an int which represents the version of the release.
+	// Version is an int which represents the revision of the release.
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`


### PR DESCRIPTION
I was looking into the `get` command, and got tripped up by the
`Version` variable. It was unclear to me what Version represents, since
it's called REVISION when doing e.g., `helm list`.

But even after knowing this, it was not very clear to me why we
(implicitly) set the Version variable to 0 but never seem to use it.
`mhickey` explained to me on Slack that this gets the latest revision of
the release. Makes sense, but I added a comment about that too, to
clarify.