### PR TITLE
ref(client): add overwrite option

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -147,6 +147,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Recreate, "recreate-pods", false, "performs pods restart for the resource if applicable")
 	f.MarkDeprecated("recreate-pods", "functionality will no longer be updated. Consult the documentation for other methods to recreate pods")
 	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")
+	f.BoolVar(&client.Overwrite, "overwrite", true, "overwrite all outside changes")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "disable pre/post upgrade hooks")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&client.ResetValues, "reset-values", false, "when upgrading, reset the values to the ones built into the chart")

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -159,7 +159,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		r.cfg.Log("rollback hooks disabled for %s", targetRelease.Name)
 	}
 
-	results, err := r.cfg.KubeClient.Update(current, target, r.Force)
+	results, err := r.cfg.KubeClient.Update(current, target, r.Force, true)
 
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -49,6 +49,7 @@ type Upgrade struct {
 	DisableHooks bool
 	DryRun       bool
 	Force        bool
+	Overwrite    bool
 	ResetValues  bool
 	ReuseValues  bool
 	// Recreate will (if true) recreate pods after a rollback.
@@ -236,7 +237,7 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 		u.cfg.Log("upgrade hooks disabled for %s", upgradedRelease.Name)
 	}
 
-	results, err := u.cfg.KubeClient.Update(current, target, u.Force)
+	results, err := u.cfg.KubeClient.Update(current, target, u.Force, u.Overwrite)
 	if err != nil {
 		u.cfg.recordRelease(originalRelease)
 		return u.failRelease(upgradedRelease, results.Created, err)

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -162,7 +162,7 @@ func TestUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.Update(first, second, false); err != nil {
+	if _, err := c.Update(first, second, false, true); err != nil {
 		t.Fatal(err)
 	}
 	// TODO: Find a way to test methods that use Client Set

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -75,11 +75,11 @@ func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.
 }
 
 // Update returns the configured error if set or prints
-func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
+func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool, ignoreMeToo bool) (*kube.Result, error) {
 	if f.UpdateError != nil {
 		return &kube.Result{}, f.UpdateError
 	}
-	return f.PrintingKubeClient.Update(r, modified, ignoreMe)
+	return f.PrintingKubeClient.Update(r, modified, ignoreMe, ignoreMeToo)
 }
 
 // Build returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -70,7 +70,7 @@ func (p *PrintingKubeClient) WatchUntilReady(resources kube.ResourceList, _ time
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kube.Result, error) {
+func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool, _ bool) (*kube.Result, error) {
 	_, err := io.Copy(p.Out, bufferize(modified))
 	if err != nil {
 		return nil, err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -45,7 +45,7 @@ type Interface interface {
 
 	// Update updates one or more resources or creates the resource
 	// if it doesn't exist.
-	Update(original, target ResourceList, force bool) (*Result, error)
+	Update(original, target ResourceList, force bool, overwrite bool) (*Result, error)
 
 	// Build creates a resource list from a Reader
 	//


### PR DESCRIPTION
Fixes: https://github.com/helm/helm/issues/6980

Adds a parameter called `--overwrite`. If set to false it enables the helm v2 upgrade behaviour. 

Sometimes a manifest is modified by an operator. In this cases helm should not overwrite the changes. Since this is very rarely i decide to add an optional parameter to `helm upgrade`. If overwrite is enabled, the old CreateTwoWayMergePatch like in helm 2 is used.

I used the code from https://github.com/helm/helm/pull/6124

This is my first-time contribution to this problem. Let me know if I miss something. Thanks