### PR TITLE
Add HelmVersion to Capabilities

### DIFF
--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -20,6 +20,8 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	helmversion "helm.sh/helm/v3/internal/version"
 )
 
 var (
@@ -34,6 +36,7 @@ var (
 			Minor:   "18",
 		},
 		APIVersions: DefaultVersionSet,
+		HelmVersion: helmversion.Get(),
 	}
 )
 
@@ -43,6 +46,8 @@ type Capabilities struct {
 	KubeVersion KubeVersion
 	// APIversions are supported Kubernetes API versions.
 	APIVersions VersionSet
+	// HelmVersion is the build information for this helm version
+	HelmVersion helmversion.BuildInfo
 }
 
 // KubeVersion is the Kubernetes version.

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -58,3 +58,11 @@ func TestDefaultCapabilities(t *testing.T) {
 		t.Errorf("Expected default KubeVersion.Minor to be 16, got %q", kv.Minor)
 	}
 }
+
+func TestDefaultCapabilitiesHelmVersion(t *testing.T) {
+	hv := DefaultCapabilities.HelmVersion
+
+	if hv.Version != "v3.2" {
+		t.Errorf("Expected default HelmVerison to be v3.2, got %q", hv.Version)
+	}
+}


### PR DESCRIPTION
## Context
Adds the HelmVersion the Capabilities so that templates can query against helm minor versions.

From the linked issue
```
In Helm v2 the Capabilities included TillerVersion which would allow you to target and work with different minor versions of Helm. When Tiller went away so did the ability to detect the minor version of Helm.

The idea is to add this back as HelmVersion and available though Capabilities.
```

## Linked issues
Fixes #6689

## Notes
I am unsure if the test I added is satisfactory, as it seems brittle. Is there another approach that would be preferred?
* This test would need to be updated when 3.1 is released
* All of the other BuildInfo fields are empty strings currently