### PR TITLE
Friendly error message for non-existent Chart.yaml file

### DIFF
--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -194,7 +194,7 @@ icon: https://example.com/64x64.png
 	if _, err = LoadFiles([]*BufferedFile{}); err == nil {
 		t.Fatal("Expected err to be non-nil")
 	}
-	if err.Error() != "validation: chart.metadata is required" {
+	if err.Error() != "validation: Chart.yaml file is missing" {
 		t.Errorf("Expected chart metadata missing error, got '%s'", err.Error())
 	}
 }
@@ -268,7 +268,7 @@ func TestLoadInvalidArchive(t *testing.T) {
 		{"illegal-name.tgz", "./.", "chart illegally contains content outside the base directory"},
 		{"illegal-name2.tgz", "/./.", "chart illegally contains content outside the base directory"},
 		{"illegal-name3.tgz", "missing-leading-slash", "chart illegally contains content outside the base directory"},
-		{"illegal-name4.tgz", "/missing-leading-slash", "validation: chart.metadata is required"},
+		{"illegal-name4.tgz", "/missing-leading-slash", "validation: Chart.yaml file is missing"},
 		{"illegal-abspath.tgz", "//foo", "chart illegally contains absolute paths"},
 		{"illegal-abspath2.tgz", "///foo", "chart illegally contains absolute paths"},
 		{"illegal-abspath3.tgz", "\\\\foo", "chart illegally contains absolute paths"},
@@ -302,7 +302,7 @@ func TestLoadInvalidArchive(t *testing.T) {
 	illegalChart = filepath.Join(tmpdir, "abs-path2.tgz")
 	writeTar(illegalChart, "files/whatever.yaml", []byte("hello: world"))
 	_, err = Load(illegalChart)
-	if err.Error() != "validation: chart.metadata is required" {
+	if err.Error() != "validation: Chart.yaml file is missing" {
 		t.Error(err)
 	}
 

--- a/pkg/chart/metadata.go
+++ b/pkg/chart/metadata.go
@@ -67,7 +67,7 @@ type Metadata struct {
 // Validate checks the metadata for known issues, returning an error if metadata is not correct
 func (md *Metadata) Validate() error {
 	if md == nil {
-		return ValidationError("chart.metadata is required")
+		return ValidationError("Chart.yaml file is missing")
 	}
 	if md.APIVersion == "" {
 		return ValidationError("chart.metadata.apiVersion is required")

--- a/pkg/chart/metadata_test.go
+++ b/pkg/chart/metadata_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chart
+
+import "testing"
+
+func TestValidate(t *testing.T) {
+	var metadata *Metadata = nil
+	error := metadata.Validate()
+	errorMessage := "validation: Chart.yaml file is missing"
+	if error.Error() != errorMessage {
+		t.Errorf("The error message is other than '%s'", errorMessage)
+	}
+}


### PR DESCRIPTION
Fixes #6713

Have updated the error message for the missing Chart.yaml
I created a [PR](https://github.com/helm/helm/pull/6743) for this, but that got messed up, so I am creating a fresh one.
This is almost my first PR so please do let me know if there is anything wrong, I will try to fix it.
I have created test for my change for helm/pkg/chart/metadata.go in helm/pkg/chart/metadata_test.go

cc @karuppiah7890 