### PR TITLE
fix(*): Helm v3 handling of APIVersion v1 charts dependencies

### DIFF
--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -182,7 +182,7 @@ func TestDependencyUpdateCmd_DontDeleteOldChartsOnError(t *testing.T) {
 func createTestingMetadata(name, baseURL string) *chart.Chart {
 	return &chart.Chart{
 		Metadata: &chart.Metadata{
-			APIVersion: chart.APIVersionV1,
+			APIVersion: chart.APIVersionV2,
 			Name:       name,
 			Version:    "1.2.3",
 			Dependencies: []*chart.Dependency{

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -114,11 +114,17 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if err := yaml.Unmarshal(f.Data, c.Metadata); err != nil {
 				return c, errors.Wrap(err, "cannot load requirements.yaml")
 			}
+			if c.Metadata.APIVersion == chart.APIVersionV1 {
+				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
+			}
 		// Deprecated: requirements.lock is deprecated use Chart.lock.
 		case f.Name == "requirements.lock":
 			c.Lock = new(chart.Lock)
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {
 				return c, errors.Wrap(err, "cannot load requirements.lock")
+			}
+			if c.Metadata.APIVersion == chart.APIVersionV1 {
+				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
 			}
 
 		case strings.HasPrefix(f.Name, "templates/"):

--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -42,7 +42,16 @@ func LoadChartfile(filename string) (*chart.Metadata, error) {
 //
 // 'filename' should be the complete path and filename ('foo/Chart.yaml')
 func SaveChartfile(filename string, cf *chart.Metadata) error {
+	// Pull out the dependencies of a v1 Chart, since there's no way
+	// to tell the serialiser to skip a field for just this use case
+	savedDependencies := cf.Dependencies
+	if cf.APIVersion == chart.APIVersionV1 {
+		cf.Dependencies = nil
+	}
 	out, err := yaml.Marshal(cf)
+	if cf.APIVersion == chart.APIVersionV1 {
+		cf.Dependencies = savedDependencies
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -141,8 +141,17 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	base := filepath.Join(prefix, c.Name())
 
+	// Pull out the dependencies of a v1 Chart, since there's no way
+	// to tell the serialiser to skip a field for just this use case
+	savedDependencies := c.Metadata.Dependencies
+	if c.Metadata.APIVersion == chart.APIVersionV1 {
+		c.Metadata.Dependencies = nil
+	}
 	// Save Chart.yaml
 	cdata, err := yaml.Marshal(c.Metadata)
+	if c.Metadata.APIVersion == chart.APIVersionV1 {
+		c.Metadata.Dependencies = savedDependencies
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -163,7 +163,7 @@ func (m *Manager) Update() error {
 	}
 
 	// Finally, we need to write the lockfile.
-	return writeLock(m.ChartPath, lock)
+	return writeLock(m.ChartPath, lock, c.Metadata.APIVersion == chart.APIVersionV1)
 }
 
 func (m *Manager) loadChartDir() (*chart.Chart, error) {
@@ -634,12 +634,16 @@ func (m *Manager) loadChartRepositories() (map[string]*repo.ChartRepository, err
 }
 
 // writeLock writes a lockfile to disk
-func writeLock(chartpath string, lock *chart.Lock) error {
+func writeLock(chartpath string, lock *chart.Lock, legacyLockfile bool) error {
 	data, err := yaml.Marshal(lock)
 	if err != nil {
 		return err
 	}
-	dest := filepath.Join(chartpath, "Chart.lock")
+	lockfileName := "Chart.lock"
+	if legacyLockfile {
+		lockfileName = "requirements.lock"
+	}
+	dest := filepath.Join(chartpath, lockfileName)
 	return ioutil.WriteFile(dest, data, 0644)
 }
 

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -211,7 +211,7 @@ func TestUpdateBeforeBuild(t *testing.T) {
 		Metadata: &chart.Metadata{
 			Name:       "with-dependency",
 			Version:    "0.1.0",
-			APIVersion: "v1",
+			APIVersion: "v2",
 			Dependencies: []*chart.Dependency{{
 				Name:       d.Metadata.Name,
 				Version:    ">=0.1.0",
@@ -285,7 +285,7 @@ func checkBuildWithOptionalFields(t *testing.T, chartName string, dep chart.Depe
 		Metadata: &chart.Metadata{
 			Name:         chartName,
 			Version:      "0.1.0",
-			APIVersion:   "v1",
+			APIVersion:   "v2",
 			Dependencies: []*chart.Dependency{&dep},
 		},
 	}


### PR DESCRIPTION
This fixes unexpected changes in APIVersion1 (Helm v2) Charts when they are operated on by Helm v3 using `package` or `dependency update`.

The fixes:
- `requirements.yaml` was being unconditionally merged into `Chart.yaml`, which produced packages which failed `helm lint`.
- `requirements.lock` was being converted into `Chart.lock` by `helm dep up` on an APIVersion1 chart.
- The code that loads `requirements.lock` and `requirements.yaml` in APIVersion1 charts for backwards compatibility, was incorrectly excluding those files from `helm package` and the `Files` collection in templates. As well as `Files` behaviour changing, this also broke sub-chart aliases for Helm v2 as those are stored in `requirements.yaml`.

Helm v3 incorrectly reads aliases from `Chart.yaml`'s `dependencies` map in APIVersion1 charts, but I didn't change that, as `helm lint` warns you that this is an unexpected combination already, and it's *as well as* `requirements.yaml` so doesn't break anything.

The changes in the third commit (ae74c91) are possibly not go-idiomatic, and I specifically welcome feedback or suggested improvements.

Fixes: #6974 