### PR TITLE
Simplify chart installable check

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -176,8 +176,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, err
 	}
 
-	validInstallableChart, err := isChartInstallable(chartRequested)
-	if !validInstallableChart {
+	if err := checkIfInstallable(chartRequested); err != nil {
 		return nil, err
 	}
 
@@ -209,13 +208,13 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	return client.Run(chartRequested, vals)
 }
 
-// isChartInstallable validates if a chart can be installed
+// checkIfInstallable validates if a chart can be installed
 //
 // Application chart type is only installable
-func isChartInstallable(ch *chart.Chart) (bool, error) {
+func checkIfInstallable(ch *chart.Chart) error {
 	switch ch.Metadata.Type {
 	case "", "application":
-		return true, nil
+		return nil
 	}
-	return false, errors.Errorf("%s charts are not installable", ch.Metadata.Type)
+	return errors.Errorf("%s charts are not installable", ch.Metadata.Type)
 }


### PR DESCRIPTION
The error conveys at least as much information as the boolean, so the latter seems redundant, especially from a type-driven perspective: How should a return value like `false, nil` be interpreted, for example? (Of course it "should never happen"™, but the typechecker won't help with that.) Cheers! :slightly_smiling_face: 