### PR TITLE
Add a function to set namespace of envsetting

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -121,6 +121,14 @@ func (s *EnvSettings) Namespace() string {
 	return "default"
 }
 
+/*
+Set the namespace for service integration purpose
+provide a way to set namespace for easier integration with non-cli projects
+ */
+func (s *EnvSettings) SetNamespace(ns string) {
+	s.namespace = ns
+}
+
 //RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {


### PR DESCRIPTION
Add a function to set namespace of envsetting, to provied easier integration for non-cli projects.

We have a micro-service using helm-v3 package.
Recently we upgraded the pkg from dev-v3 branch to v3.0.0.0-rc.2, then we found that "Namespace" of env setting changed to a function and the attribute is not accessible any more other than AddFlags function. But we are not a cli tool, we don't want to construct a flagset when we serving requests.

Add the function could make non-cli projects integration with helm api much more easier.