### PR TITLE
Add a function to set namespace of envsetting

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -67,7 +67,7 @@ func main() {
 	actionConfig := new(action.Configuration)
 	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 
-	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace, os.Getenv("HELM_DRIVER"), debug); err != nil {
 		debug("%+v", err)
 		os.Exit(1)
 	}

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -205,7 +205,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	client.Namespace = settings.Namespace()
+	client.Namespace = settings.Namespace
 	return client.Run(chartRequested, vals)
 }
 

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -186,4 +186,17 @@ func TestInstall(t *testing.T) {
 	}
 
 	runTestActionCmd(t, tests)
+
+	settings.Namespace = "halo"
+	nsTests := []cmdTestCase{
+		// Install to halo ns without --namespace flag
+		{
+			name: "install to halo ns without --namespace flag",
+			cmd:  "install halo testdata/testcharts/empty",
+			//wantError: true,
+			golden: "output/install-with-ns-setting.txt",
+		},
+	}
+
+	runTestActionCmd(t, nsTests)
 }

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -51,7 +51,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				paths = args
 			}
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.Namespace
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -46,7 +46,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Long:  releaseTestHelp,
 		Args:  require.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.Namespace
 			rel, runErr := client.Run(args[0])
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs

--- a/cmd/helm/testdata/output/install-with-ns-setting.txt
+++ b/cmd/helm/testdata/output/install-with-ns-setting.txt
@@ -1,0 +1,6 @@
+NAME: halo
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: halo
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -71,7 +71,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.Namespace
 
 			if client.Version == "" && client.Devel {
 				debug("setting version to >0.0.0-0")

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -38,7 +38,7 @@ import (
 
 // EnvSettings describes all of the environment settings.
 type EnvSettings struct {
-	namespace  string
+	Namespace  string
 	config     genericclioptions.RESTClientGetter
 	configOnce sync.Once
 
@@ -61,7 +61,7 @@ type EnvSettings struct {
 func New() *EnvSettings {
 
 	env := EnvSettings{
-		namespace:        os.Getenv("HELM_NAMESPACE"),
+		Namespace:        os.Getenv("HELM_NAMESPACE"),
 		KubeContext:      os.Getenv("HELM_KUBECONTEXT"),
 		PluginsDirectory: envOr("HELM_PLUGINS", helmpath.DataPath("plugins")),
 		RegistryConfig:   envOr("HELM_REGISTRY_CONFIG", helmpath.ConfigPath("registry.json")),
@@ -74,7 +74,7 @@ func New() *EnvSettings {
 
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace scope for this request")
+	fs.StringVarP(&s.Namespace, "namespace", "n", s.Namespace, "namespace scope for this request")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", "", "path to the kubeconfig file")
 	fs.StringVar(&s.KubeContext, "kube-context", s.KubeContext, "name of the kubeconfig context to use")
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "enable verbose output")
@@ -98,7 +98,7 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_REGISTRY_CONFIG":   s.RegistryConfig,
 		"HELM_REPOSITORY_CACHE":  s.RepositoryCache,
 		"HELM_REPOSITORY_CONFIG": s.RepositoryConfig,
-		"HELM_NAMESPACE":         s.Namespace(),
+		"HELM_NAMESPACE":         s.Namespace,
 		"HELM_KUBECONTEXT":       s.KubeContext,
 	}
 
@@ -109,27 +109,24 @@ func (s *EnvSettings) EnvVars() map[string]string {
 	return envvars
 }
 
-//Namespace gets the namespace from the configuration
-func (s *EnvSettings) Namespace() string {
-	if s.namespace != "" {
-		return s.namespace
+//GetNamespace return the namespace from configuration
+func (s *EnvSettings) GetNamespace() string {
+
+	if s.Namespace != "" {
+		return s.Namespace
 	}
 
 	if ns, _, err := s.RESTClientGetter().ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}
-	return "default"
-}
 
-//set the namespace of envsetting, provide easier integration for non-cli projects
-func (s *EnvSettings) SetNameSpace(ns string) {
-	s.namespace = ns
+	return "default"
 }
 
 //RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {
-		s.config = kube.GetConfig(s.KubeConfig, s.KubeContext, s.namespace)
+		s.config = kube.GetConfig(s.KubeConfig, s.KubeContext, s.Namespace)
 	})
 	return s.config
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -121,6 +121,11 @@ func (s *EnvSettings) Namespace() string {
 	return "default"
 }
 
+//set the namespace of envsetting, provide easier integration for non-cli projects
+func (s *EnvSettings) SetNameSpace(ns string) {
+	s.namespace = ns
+}
+
 //RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -78,8 +78,8 @@ func TestEnvSettings(t *testing.T) {
 			if settings.Debug != tt.debug {
 				t.Errorf("expected debug %t, got %t", tt.debug, settings.Debug)
 			}
-			if settings.Namespace() != tt.ns {
-				t.Errorf("expected namespace %q, got %q", tt.ns, settings.Namespace())
+			if settings.GetNamespace() != tt.ns {
+				t.Errorf("expected namespace %q, got %q", tt.ns, settings.GetNamespace())
 			}
 			if settings.KubeContext != tt.kcontext {
 				t.Errorf("expected kube-context %q, got %q", tt.kcontext, settings.KubeContext)


### PR DESCRIPTION
Add a function to set namespace of envsetting, to provide easier integration for non-cli projects.

We have a micro-service using helm-v3 package.
Recently we upgraded the pkg from dev-v3 branch to v3.0.0.0-rc.2, then we found that "Namespace" of env setting changed to a function and the attribute is not accessible any more other than AddFlags function. But we are not a cli tool, we don't want to construct a flagset when we serving requests.

Add the function could make non-cli projects integration with helm api much more easier.
