### PR TITLE
Reintroduce --is-upgrade to template command

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -129,6 +129,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.OutputDir, "output-dir", "", "writes the executed templates to files in output-dir instead of stdout")
 	f.BoolVar(&validate, "validate", false, "validate your manifests against the Kubernetes cluster you are currently pointing at. This is the same validation performed on an install")
 	f.BoolVar(&includeCrds, "include-crds", false, "include CRDs in the templated output")
+	f.BoolVar(&client.IsUpgrade, "is-upgrade", false, "set .Release.IsUpgrade instead of .Release.IsInstall")
 	f.StringArrayVarP(&extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
 
 	return cmd


### PR DESCRIPTION
This PR improves the correctness of `helm template` when rendering charts for the "upgrade" case.

This is an attempt to fix issues reported by multiple uses of the helm diff plugin: https://github.com/databus23/helm-diff/issues/165

Currently it is not possible to properly diff upgrades when templates make use of `.Capabilites` or `.Release.IsUpgrade`.
Mostly because the plugin can't  use the `--validate` flag at the moment because of this: https://github.com/helm/helm/issues/6663#issuecomment-547526721

Adding this flag would allow the plugin to render charts correctly using `helm template --validate --is-upgrade`.

