### PR TITLE
fix debug wihout release output

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -113,11 +113,15 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			rel, err := runInstall(args, client, valueOpts, out)
-			if err != nil {
+			if rel == nil && err != nil {
 				return err
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug})
+			if werr := outfmt.Write(out, &statusPrinter{rel, settings.Debug}); werr != nil {
+				err = werr
+			}
+
+			return err
 		},
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -228,7 +228,10 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 
 	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), true)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
+		err = errors.Wrap(err, "unable to build kubernetes objects from release manifest")
+		rel.SetStatus(release.StatusFailed, err.Error())
+		// Return a release with partial data so that the client can show debugging information.
+		return rel, err
 	}
 
 	// Install requires an extra validation step of checking that resources


### PR DESCRIPTION
 Fixed without resulting manifest file output, when use flags --dry-run to debug templates, in which there are some template failed to render or validated failed by kubernetes.

When I follow [Debugging Templates](https://v3.helm.sh/docs/topics/chart_template_guide/debugging/), to debug my templates, using command `helm install --dry-run --debug xxx xxx`. My templates have some problems, i get follow errors:
```
[root@55194dbd9987 test]# helm install --dry-run --debug  test ./
install.go:148: [debug] Original chart version: ""
install.go:165: [debug] CHART PATH: /home/admin/test

Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: kind not set
helm.go:76: [debug] error validating "": error validating data: kind not set
helm.sh/helm/v3/pkg/kube.scrubValidationError
	/home/circleci/helm.sh/helm/pkg/kube/client.go:520
helm.sh/helm/v3/pkg/kube.(*Client).Build
	/home/circleci/helm.sh/helm/pkg/kube/client.go:135
helm.sh/helm/v3/pkg/action.(*Install).Run
	/home/circleci/helm.sh/helm/pkg/action/install.go:229
main.runInstall
	/home/circleci/helm.sh/helm/cmd/helm/install.go:209
main.newInstallCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/install.go:115
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:75
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
unable to build kubernetes objects from release manifest
helm.sh/helm/v3/pkg/action.(*Install).Run
	/home/circleci/helm.sh/helm/pkg/action/install.go:231
main.runInstall
	/home/circleci/helm.sh/helm/cmd/helm/install.go:209
main.newInstallCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/install.go:115
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:75
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
```
It only show the Kubenertes validate error, but haven't resulting manifest file output, which is helpful for me to check which file have problem.