### PR TITLE
v3: -n= flag is mistakenly being passed to plugins

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -136,11 +136,21 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 		}
 		return false
 	}
+
+	isKnown := func(v string) string {
+		for _, i := range kvargs {
+			if i == v {
+				return v
+			}
+		}
+		return ""
+	}
+
 	for i := 0; i < len(args); i++ {
 		switch a := args[i]; a {
 		case "--debug":
 			known = append(known, a)
-		case "--kube-context", "--namespace", "-n", "--kubeconfig", "--registry-config", "--repository-cache", "--repository-config":
+		case isKnown(a):
 			known = append(known, a, args[i+1])
 			i++
 		default:

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -127,7 +127,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 func manuallyProcessArgs(args []string) ([]string, []string) {
 	known := []string{}
 	unknown := []string{}
-	kvargs := []string{"--kube-context", "--namespace", "--kubeconfig", "--registry-config", "--repository-cache", "--repository-config"}
+	kvargs := []string{"--kube-context", "--namespace", "-n", "--kubeconfig", "--registry-config", "--repository-cache", "--repository-config"}
 	knownArg := func(a string) bool {
 		for _, pre := range kvargs {
 			if strings.HasPrefix(a, pre+"=") {

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -30,14 +30,27 @@ func TestManuallyProcessArgs(t *testing.T) {
 		"--debug",
 		"--foo", "bar",
 		"--kubeconfig=/home/foo",
+		"--kubeconfig", "/home/foo",
+		"--kube-context=test1",
 		"--kube-context", "test1",
+		"-n=test2",
 		"-n", "test2",
+		"--namespace=test2",
+		"--namespace", "test2",
 		"--home=/tmp",
 		"command",
 	}
 
 	expectKnown := []string{
-		"--debug", "--kubeconfig=/home/foo", "--kube-context", "test1", "-n", "test2",
+		"--debug",
+		"--kubeconfig=/home/foo",
+		"--kubeconfig", "/home/foo",
+		"--kube-context=test1",
+		"--kube-context", "test1",
+		"-n=test2",
+		"-n", "test2",
+		"--namespace=test2",
+		"--namespace", "test2",
 	}
 
 	expectUnknown := []string{


### PR DESCRIPTION
When calling plugins, Helm converts global flags (e.g., --debug, --namespace, etc) into env variables and does **not** pass those flags to the plugin.

The "-n=" flag was forgotten from the list of global flags.  Not a huge deal, but may surprise plugins.

This PR augments the tests to fail on this bug.
Also, it was bothering me that the list of global flags was duplicated, which was the reason this error was made.  I found a way to use a single list.