### PR TITLE
v3: fix(plugin): Avoid crash on missing flag

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -151,8 +151,11 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 		case "--debug":
 			known = append(known, a)
 		case isKnown(a):
-			known = append(known, a, args[i+1])
+			known = append(known, a)
 			i++
+			if i < len(args) {
+				known = append(known, args[i])
+			}
 		default:
 			if knownArg(a) {
 				known = append(known, a)


### PR DESCRIPTION
When calling a plugin, if a global flag requiring a parameter was missing the parameter, helm would crash.
For example:
```
$ h3 2to3 --namespace
panic: runtime error: index out of range

goroutine 1 [running]:
main.manuallyProcessArgs(0xc0002affc0, 0x1, 0x1, 0xc0006b3b38, 0xa0, 0xa0, 0xc00044b040, 0x7, 0xd)
	/Users/marckhouzam/go/src/helm.sh/helm/cmd/helm/load_plugins.go:144 +0xb4d
main.loadPlugins.func1(0xc0005cc000, 0xc0002affc0, 0x1, 0x1, 0xa0, 0x2382940, 0x1, 0xc0002a4ed0, 0xc0006b3c40)
	/Users/marckhouzam/go/src/helm.sh/helm/cmd/helm/load_plugins.go:57 +0x49
main.loadPlugins.func2(0xc0005cc000, 0xc0002affc0, 0x1, 0x1, 0x0, 0x0)
	/Users/marckhouzam/go/src/helm.sh/helm/cmd/helm/load_plugins.go:77 +0x9b
github.com/spf13/cobra.(*Command).execute(0xc0005cc000, 0xc0002affc0, 0x1, 0x1, 0xc0005cc000, 0xc0002affc0)
	/Users/marckhouzam/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x465
github.com/spf13/cobra.(*Command).ExecuteC(0xc00031fb80, 0x2848f40, 0xc00017a2c0, 0x2580a82)
	/Users/marckhouzam/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/marckhouzam/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/Users/marckhouzam/go/src/helm.sh/helm/cmd/helm/helm.go:75 +0x206
```

This PR checks if the parameter is present before accessing it.
