### PR TITLE
Fixes #7055 helm pull ca file usage

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -63,6 +63,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		Getters: getter.All(p.Settings),
 		Options: []getter.Option{
 			getter.WithBasicAuth(p.Username, p.Password),
+			getter.WithTLSClientConfig(p.CertFile, p.KeyFile, p.CaFile),
 		},
 		RepositoryConfig: p.Settings.RepositoryConfig,
 		RepositoryCache:  p.Settings.RepositoryCache,

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -214,7 +214,9 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		c.Options = append(c.Options, getter.WithBasicAuth(r.Config.Username, r.Config.Password))
 	}
 
-	c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+	if r.Config.CertFile != "" || r.Config.KeyFile != "" || r.Config.CAFile != "" {
+		c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+	}
 
 	// Next, we need to load the index, and actually look up the chart.
 	idxFile := filepath.Join(c.RepositoryCache, helmpath.CacheIndexFile(r.Config.Name))

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -214,6 +214,8 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		c.Options = append(c.Options, getter.WithBasicAuth(r.Config.Username, r.Config.Password))
 	}
 
+	c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+
 	// Next, we need to load the index, and actually look up the chart.
 	idxFile := filepath.Join(c.RepositoryCache, helmpath.CacheIndexFile(r.Config.Name))
 	i, err := repo.LoadIndexFile(idxFile)

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -135,7 +135,7 @@ func TestResolveChartOpts(t *testing.T) {
 			continue
 		}
 
-		if got != expect {
+		if *(got.(*getter.HTTPGetter)) != *(expect.(*getter.HTTPGetter)) {
 			t.Errorf("%s: expected %s, got %s", tt.name, expect, got)
 		}
 	}

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -87,7 +87,7 @@ func TestResolveChartOpts(t *testing.T) {
 	}{
 		{
 			name: "repo with CA-file",
-			ref: "testing-ca-file/foo",
+			ref:  "testing-ca-file/foo",
 			expect: []getter.Option{
 				getter.WithURL("https://example.com/foo-1.2.3.tgz"),
 				getter.WithTLSClientConfig("cert", "key", "ca"),
@@ -106,11 +106,11 @@ func TestResolveChartOpts(t *testing.T) {
 	}
 
 	// snapshot options
-	snapshot_opts := c.Options
+	snapshotOpts := c.Options
 
 	for _, tt := range tests {
 		// reset chart downloader options for each test case
-		c.Options = snapshot_opts
+		c.Options = snapshotOpts
 
 		expect, err := getter.NewHTTPGetter(tt.expect...)
 		if err != nil {
@@ -128,7 +128,7 @@ func TestResolveChartOpts(t *testing.T) {
 			append(
 				c.Options,
 				getter.WithURL(u.String()),
-			)...
+			)...,
 		)
 		if err != nil {
 			t.Errorf("%s: failed to create http client: %s", tt.name, err)

--- a/pkg/downloader/testdata/repositories.yaml
+++ b/pkg/downloader/testdata/repositories.yaml
@@ -16,3 +16,8 @@ repositories:
     url: "http://example.com/helm"
   - name: testing-relative-trailing-slash
     url: "http://example.com/helm/"
+  - name: testing-ca-file
+    url: "https://example.com"
+    certFile: "cert"
+    keyFile: "key"
+    caFile: "ca"

--- a/pkg/downloader/testdata/repository/testing-ca-file-index.yaml
+++ b/pkg/downloader/testdata/repository/testing-ca-file-index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  foo:
+    - name: foo
+      description: Foo Chart
+      home: https://helm.sh/helm
+      keywords: []
+      maintainers: []
+      sources:
+        - https://github.com/helm/charts
+      urls:
+        - https://example.com/foo-1.2.3.tgz
+      version: 1.2.3
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d


### PR DESCRIPTION
Added test case for chart_download to verify http TLS options.

Did not find any tests for the cli pull action, but fixed it in place without test coverage.
