### PR TITLE
fix(helm): add --description flag to helm

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -135,6 +135,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVarP(&client.GenerateName, "generate-name", "g", false, "generate the name (and omit the NAME parameter)")
 	f.StringVar(&client.NameTemplate, "name-template", "", "specify template used to name the release")
+	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "run helm dependency update before installing the chart")
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used")

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -47,11 +47,6 @@ func TestTemplateCmd(t *testing.T) {
 			golden: "output/template-name-template.txt",
 		},
 		{
-			name:   "check custom description",
-			cmd:    fmt.Sprintf(`template '%s' --description='foobar-{{ b64enc "abc" }}-baz'`, chartPath),
-			golden: "output/template-description.txt",
-		},
-		{
 			name:      "check no args",
 			cmd:       "template",
 			wantError: true,

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -47,6 +47,11 @@ func TestTemplateCmd(t *testing.T) {
 			golden: "output/template-name-template.txt",
 		},
 		{
+			name:   "check custom description",
+			cmd:    fmt.Sprintf(`template '%s' --description='foobar-{{ b64enc "abc" }}-baz'`, chartPath),
+			golden: "output/template-description.txt",
+		},
+		{
 			name:      "check no args",
 			cmd:       "template",
 			wantError: true,

--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -69,6 +69,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation")
 	f.BoolVar(&client.KeepHistory, "keep-history", false, "remove all associated resources and mark the release as deleted, but retain the release history")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
+	f.StringVar(&client.Description, "description", "", "add a custom description")
 
 	return cmd
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -156,6 +156,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVar(&client.MaxHistory, "history-max", 10, "limit the maximum number of revisions saved per release. Use 0 for no limit")
 	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this upgrade when upgrade fails")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.StringVar(&client.Description, "description", "", "add a custom description")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -79,7 +79,7 @@ type Install struct {
 	ReleaseName      string
 	GenerateName     bool
 	NameTemplate     string
-        Description      string
+	Description      string
 	OutputDir        string
 	Atomic           bool
 	SkipCRDs         bool
@@ -295,7 +295,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 
 	if len(i.Description) > 0 {
 		rel.SetStatus(release.StatusDeployed, i.Description)
-	}else{
+	} else {
 		rel.SetStatus(release.StatusDeployed, "Install complete")
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -79,6 +79,7 @@ type Install struct {
 	ReleaseName      string
 	GenerateName     bool
 	NameTemplate     string
+        Description      string
 	OutputDir        string
 	Atomic           bool
 	SkipCRDs         bool
@@ -292,7 +293,11 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		}
 	}
 
-	rel.SetStatus(release.StatusDeployed, "Install complete")
+	if len(i.Description) > 0 {
+		rel.SetStatus(release.StatusDeployed, i.Description)
+	}else{
+		rel.SetStatus(release.StatusDeployed, "Install complete")
+	}
 
 	// This is a tricky case. The release has been created, but the result
 	// cannot be recorded. The truest thing to tell the user is that the

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -37,6 +37,7 @@ type Uninstall struct {
 	DryRun       bool
 	KeepHistory  bool
 	Timeout      time.Duration
+	Description  string
 }
 
 // NewUninstall creates a new Uninstall object with the given configuration.
@@ -118,7 +119,11 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	rel.Info.Status = release.StatusUninstalled
-	rel.Info.Description = "Uninstallation complete"
+	if len(u.Description) > 0 {
+		rel.Info.Description = u.Description
+	}else{
+		rel.Info.Description = "Uninstallation complete"
+	}
 
 	if !u.KeepHistory {
 		u.cfg.Log("purge requested for %s", name)

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -121,7 +121,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	rel.Info.Status = release.StatusUninstalled
 	if len(u.Description) > 0 {
 		rel.Info.Description = u.Description
-	}else{
+	} else {
 		rel.Info.Description = "Uninstallation complete"
 	}
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -58,6 +58,7 @@ type Upgrade struct {
 	Atomic        bool
 	CleanupOnFail bool
 	SubNotes      bool
+	Description   string
 }
 
 // NewUpgrade creates a new Upgrade object with the given configuration.
@@ -218,7 +219,11 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 
 	if u.DryRun {
 		u.cfg.Log("dry run for %s", upgradedRelease.Name)
-		upgradedRelease.Info.Description = "Dry run complete"
+		if len(u.Description) > 0 {
+			upgradedRelease.Info.Description = u.Description
+		} else {
+			upgradedRelease.Info.Description = "Dry run complete"
+		}
 		return upgradedRelease, nil
 	}
 
@@ -270,7 +275,11 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 	u.cfg.recordRelease(originalRelease)
 
 	upgradedRelease.Info.Status = release.StatusDeployed
-	upgradedRelease.Info.Description = "Upgrade complete"
+	if len(u.Description) > 0 {
+		upgradedRelease.Info.Description = u.Description
+	} else {
+		upgradedRelease.Info.Description = "Upgrade complete"
+	}
 
 	return upgradedRelease, nil
 }


### PR DESCRIPTION
fix(helm): add --description flag to 'helm install', 'helm upgrade', and 'helm uninstall'

Since this feature was present on helm 2, and some existing pipelines rely heavily on it, I believe is better adding it here instead of modifying a lot of existing scripts.

When added, this flag allows us to add a custom description to the release. E.g.: 
`--description "my custom description"`

Closes #7033

Signed-off-by: Juan Matias Kungfu de la Camara Beovide <juanmatias@gmail.com>