### PR TITLE
fix(pkg): ignore pax header files in chart validation

### DIFF
--- a/pkg/chart/loader/archive.go
+++ b/pkg/chart/loader/archive.go
@@ -126,6 +126,12 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 			continue
 		}
 
+		switch hd.Typeflag {
+		// We don't want to process these extension header files.
+		case tar.TypeXGlobalHeader, tar.TypeXHeader:
+			continue
+		}
+
 		// Archive could contain \ if generated on Windows
 		delimiter := "/"
 		if strings.ContainsRune(hd.Name, '\\') {


### PR DESCRIPTION
**What this PR does / why we need it:**

this PR is to carry over the fix from helm2 https://github.com/helm/helm/pull/5198
the issue occurs again in helm3.

the validation fails when installing charts that are GitHub archives (eg. https://github.com/org/repo/master.tar.gz)

```
Error: chart illegally contains content outside the base directory: "pax_global_header"
```

Please refer to original PR #5198 if needed.
