### PR TITLE
Allow tests to run on s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOPATH        = $(shell go env GOPATH)
 DEP           = $(GOPATH)/bin/dep
 GOX           = $(GOPATH)/bin/gox
 GOIMPORTS     = $(GOPATH)/bin/goimports
+ARCH          = $(shell uname -p)
 
 ACCEPTANCE_DIR:=$(GOPATH)/src/helm.sh/acceptance-testing
 # To specify the subset of acceptance tests to run. '.' means all tests
@@ -63,7 +64,11 @@ $(BINDIR)/$(BINNAME): $(SRC)
 
 .PHONY: test
 test: build
+ifeq ($(ARCH),s390x)
+test: TESTFLAGS += -v
+else
 test: TESTFLAGS += -race -v
+endif
 test: test-style
 test: test-unit
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -87,6 +87,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
 			PlatformCommand: []PlatformCommand{
 				{OperatingSystem: "linux", Architecture: "i386", Command: "echo -n linux-i386"},
 				{OperatingSystem: "linux", Architecture: "amd64", Command: "echo -n linux-amd64"},
+				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
 			},
 		},
@@ -98,6 +99,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
 		osStrCmp = "linux-i386"
 	} else if os == "linux" && arch == "amd64" {
 		osStrCmp = "linux-amd64"
+	} else if os == "linux" && arch == "s390x" {
+		osStrCmp = "linux-s390x"
 	} else if os == "windows" && arch == "amd64" {
 		osStrCmp = "win-64"
 	} else {


### PR DESCRIPTION
In addition to https://github.com/helm/helm/pull/6988, this will allow tests to run on s390x.