### PR TITLE
test(pkg): add unit tests for tar file edge cases

### DIFF
--- a/pkg/chart/loader/archive_test.go
+++ b/pkg/chart/loader/archive_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+func TestLoadArchiveFiles(t *testing.T) {
+	tcs := []struct {
+		name     string
+		generate func(w *tar.Writer)
+		check    func(t *testing.T, files []*BufferedFile, err error)
+	}{
+		{
+			name:     "empty input should return no files",
+			generate: func(w *tar.Writer) {},
+			check: func(t *testing.T, files []*BufferedFile, err error) {
+				if err.Error() != "no files in chart archive" {
+					t.Fatalf(`expected "no files in chart archive", got [%#v]`, err)
+				}
+			},
+		},
+		{
+			name: "should ignore files with XGlobalHeader type",
+			generate: func(w *tar.Writer) {
+				// simulate the presence of a `pax_global_header` file like you would get when
+				// processing a GitHub release archive.
+				_ = w.WriteHeader(&tar.Header{
+					Typeflag: tar.TypeXGlobalHeader,
+					Name:     "pax_global_header",
+				})
+
+				// we need to have at least one file, otherwise we'll get the "no files in chart archive" error
+				_ = w.WriteHeader(&tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     "dir/empty",
+				})
+			},
+			check: func(t *testing.T, files []*BufferedFile, err error) {
+				if err != nil {
+					t.Fatalf(`got unwanted error [%#v] for tar file with pax_global_header content`, err)
+				}
+
+				if len(files) != 1 {
+					t.Fatalf(`expected to get one file but got [%v]`, files)
+				}
+			},
+		},
+		{
+			name: "should ignore files with TypeXHeader type",
+			generate: func(w *tar.Writer) {
+				// simulate the presence of a `pax_header` file like you might get when
+				// processing a GitHub release archive.
+				_ = w.WriteHeader(&tar.Header{
+					Typeflag: tar.TypeXHeader,
+					Name:     "pax_header",
+				})
+
+				// we need to have at least one file, otherwise we'll get the "no files in chart archive" error
+				_ = w.WriteHeader(&tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     "dir/empty",
+				})
+			},
+			check: func(t *testing.T, files []*BufferedFile, err error) {
+				if err != nil {
+					t.Fatalf(`got unwanted error [%#v] for tar file with pax_header content`, err)
+				}
+
+				if len(files) != 1 {
+					t.Fatalf(`expected to get one file but got [%v]`, files)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			gzw := gzip.NewWriter(buf)
+			tw := tar.NewWriter(gzw)
+
+			tc.generate(tw)
+
+			_ = tw.Close()
+			_ = gzw.Close()
+
+			files, err := LoadArchiveFiles(buf)
+			tc.check(t, files, err)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR adds unit tests for an issue that has come up multiple times where the archive processing code doesn't take into account the `tar.TypeXHeader` / `tar.TypeXGlobalHeader` entries that GitHub adds when creating a release archive for a chart, for example `https://github.com/org/repo/master.tar.gz`.

Depends on #7085.
Related: #5198.