### PR TITLE
fix(tests): mapfile is not available on MacOS

### DIFF
--- a/scripts/validate-license.sh
+++ b/scripts/validate-license.sh
@@ -27,14 +27,16 @@ find_files() {
   \( -name '*.go' -o -name '*.sh' \)
 }
 
-mapfile -t failed_license_header < <(find_files | xargs grep -L 'Licensed under the Apache License, Version 2.0 (the "License")')
+# Use "|| :" to ignore the error code when grep returns empty
+failed_license_header=($(find_files | xargs grep -L 'Licensed under the Apache License, Version 2.0 (the "License")' || :))
 if (( ${#failed_license_header[@]} > 0 )); then
   echo "Some source files are missing license headers."
   printf '%s\n' "${failed_license_header[@]}"
   exit 1
 fi
 
-mapfile -t failed_copyright_header < <(find_files | xargs grep -L 'Copyright The Helm Authors.')
+# Use "|| :" to ignore the error code when grep returns empty
+failed_copyright_header=($(find_files | xargs grep -L 'Copyright The Helm Authors.' || :))
 if (( ${#failed_copyright_header[@]} > 0 )); then
   echo "Some source files are missing the copyright header."
   printf '%s\n' "${failed_copyright_header[@]}"


### PR DESCRIPTION
The mapfile command is not available on a standard MacOS install. To faciliate doing `make test` which runs `validate-license.sh`, let's use an array instead of mapfile.

