### PR TITLE
fix stack overflow error

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -93,11 +93,19 @@ func warnWrap(warn string) string {
 // initFunMap creates the Engine's FuncMap and adds context-specific functions.
 func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]renderable) {
 	funcMap := funcMap()
+	includedNames := make([]string, 0)
 
 	// Add the 'include' function here so we can close over t.
 	funcMap["include"] = func(name string, data interface{}) (string, error) {
 		var buf strings.Builder
+		for _, n := range includedNames {
+			if n == name {
+				return "", errors.Wrapf(fmt.Errorf("unable to excute template"), "rendering template in a loop, name: %s", name)
+			}
+		}
+		includedNames = append(includedNames, name)
 		err := t.ExecuteTemplate(&buf, name, data)
+		includedNames = includedNames[:len(includedNames)-1]
 		return buf.String(), err
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -100,7 +100,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 		var buf strings.Builder
 		for _, n := range includedNames {
 			if n == name {
-				return "", errors.Wrapf(fmt.Errorf("unable to excute template"), "rendering template in a loop, name: %s", name)
+				return "", errors.Wrapf(fmt.Errorf("unable to excute template"), "rendering template has a nested reference name: %s", name)
 			}
 		}
 		includedNames = append(includedNames, name)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -460,6 +460,15 @@ func TestAlterFuncMap_include(t *testing.T) {
 		},
 	}
 
+	// Check nested reference in include FuncMap
+	d := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "nested"},
+		Templates: []*chart.File{
+			{Name: "templates/quote", Data: []byte(`{{include "nested/templates/quote" . | indent 2}} dead.`)},
+			{Name: "templates/_partial", Data: []byte(`{{.Release.Name}} - he`)},
+		},
+	}
+
 	v := chartutil.Values{
 		"Values": "",
 		"Chart":  c.Metadata,
@@ -476,6 +485,12 @@ func TestAlterFuncMap_include(t *testing.T) {
 	expect := "  Mistah Kurtz - he dead."
 	if got := out["conrad/templates/quote"]; got != expect {
 		t.Errorf("Expected %q, got %q (%v)", expect, got, out)
+	}
+
+	out, err = Render(d, v)
+	expectErrName := "nested/templates/quote"
+	if err == nil {
+		t.Errorf("Expected err of nested reference name: %v", expectErrName)
 	}
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -487,7 +487,7 @@ func TestAlterFuncMap_include(t *testing.T) {
 		t.Errorf("Expected %q, got %q (%v)", expect, got, out)
 	}
 
-	out, err = Render(d, v)
+	_, err = Render(d, v)
 	expectErrName := "nested/templates/quote"
 	if err == nil {
 		t.Errorf("Expected err of nested reference name: %v", expectErrName)


### PR DESCRIPTION
fix #7111

I found that when a circular reference existed in template "include" function, an endless loop happened in rendering until stack overflow.

My solution is recording the name which is included in a slice. Check the name when the next render comes, if it has been in the recorded slice, throw an error. If not, execute template and pop it out.