### PR TITLE
Ensure stable order with multiple entries in same file

### DIFF
--- a/cmd/helm/testdata/output/template-name-template.txt
+++ b/cmd/helm/testdata/output/template-name-template.txt
@@ -53,3 +53,37 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s1
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s2
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1

--- a/cmd/helm/testdata/output/template-set.txt
+++ b/cmd/helm/testdata/output/template-set.txt
@@ -53,3 +53,37 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s1
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s2
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subchart1

--- a/cmd/helm/testdata/output/template-values-files.txt
+++ b/cmd/helm/testdata/output/template-values-files.txt
@@ -53,3 +53,37 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s1
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s2
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subchart1

--- a/cmd/helm/testdata/output/template-with-api-version.txt
+++ b/cmd/helm/testdata/output/template-with-api-version.txt
@@ -54,3 +54,37 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s1
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s2
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1

--- a/cmd/helm/testdata/output/template.txt
+++ b/cmd/helm/testdata/output/template.txt
@@ -53,3 +53,37 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s1
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1
+---
+# Source: subchart1/templates/service2.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart1-s2
+  labels:
+    helm.sh/chart: "subchart1-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart1

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service2.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/templates/service2.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-s1
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-s2
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}

--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -140,7 +140,11 @@ func (k *kindSorter) Less(i, j int) bool {
 		if a.Head.Kind != b.Head.Kind {
 			return a.Head.Kind < b.Head.Kind
 		}
-		return first < second
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		// if same kind in same file, then sort by name to ensure a stable order
+		return a.Head.Metadata.Name < b.Head.Metadata.Name
 	}
 	// unknown kind is last
 	if !aok {


### PR DESCRIPTION
This is a new take on #6843, inspired by #6842 with the following differences:

- No changes are made to test code, only the test data and golden output were amended. In my experiments, `go test -race` (as invoked by `make test`) is sufficient to discover unstable sorting order.
- The last criterion for sorting is the Name of the entry (`.metadata.name`), which means that the sort order is stable even if entries are reordered within a file.