### PR TITLE
override kube namespace with install/upgrade ns

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -54,7 +54,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			return err
 		}
 
-		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), true)
+		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), true, "")
 		if err != nil {
 			return errors.Wrapf(err, "unable to build kubernetes object for %s hook %s", hook, h.Path)
 		}
@@ -126,7 +126,7 @@ func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.Hoo
 		return nil
 	}
 	if hookHasDeletePolicy(h, policy) {
-		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), false)
+		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), false, "")
 		if err != nil {
 			return errors.Wrapf(err, "unable to build kubernetes object for deleting hook %s", h.Path)
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -113,7 +113,7 @@ func (i *Install) installCRDs(crds []*chart.File) error {
 	totalItems := []*resource.Info{}
 	for _, obj := range crds {
 		// Read in the resources
-		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.Data), false)
+		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.Data), false, i.Namespace)
 		if err != nil {
 			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
 		}
@@ -226,7 +226,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	// Mark this release as in-progress
 	rel.SetStatus(release.StatusPendingInstall, "Initial install underway")
 
-	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), true)
+	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), true, i.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
 	}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -141,11 +141,11 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		return targetRelease, nil
 	}
 
-	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), false)
+	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), false, "")
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
-	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), false)
+	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), false, "")
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -189,7 +189,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 	for _, file := range filesToDelete {
 		builder.WriteString("\n---\n" + file.Content)
 	}
-	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), false)
+	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), false, "")
 	if err != nil {
 		return "", []error{errors.Wrap(err, "unable to build kubernetes objects for delete")}
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -190,11 +190,11 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 }
 
 func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Release) (*release.Release, error) {
-	current, err := u.cfg.KubeClient.Build(bytes.NewBufferString(originalRelease.Manifest), false)
+	current, err := u.cfg.KubeClient.Build(bytes.NewBufferString(originalRelease.Manifest), false, u.Namespace)
 	if err != nil {
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
-	target, err := u.cfg.KubeClient.Build(bytes.NewBufferString(upgradedRelease.Manifest), true)
+	target, err := u.cfg.KubeClient.Build(bytes.NewBufferString(upgradedRelease.Manifest), true, u.Namespace)
 	if err != nil {
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}
@@ -373,7 +373,7 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release, newV
 }
 
 func validateManifest(c kube.Interface, manifest []byte) error {
-	_, err := c.Build(bytes.NewReader(manifest), true)
+	_, err := c.Build(bytes.NewReader(manifest), true, "")
 	return err
 }
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -122,16 +122,21 @@ func (c *Client) newBuilder() *resource.Builder {
 }
 
 // Build validates for Kubernetes objects and returns unstructured infos.
-func (c *Client) Build(reader io.Reader, validate bool) (ResourceList, error) {
+func (c *Client) Build(reader io.Reader, validate bool, namespace string) (ResourceList, error) {
 	schema, err := c.Factory.Validator(validate)
 	if err != nil {
 		return nil, err
 	}
-	result, err := c.newBuilder().
+	builder := c.newBuilder().
 		Unstructured().
 		Schema(schema).
-		Stream(reader, "").
-		Do().Infos()
+		Stream(reader, "")
+
+	if namespace != "" {
+		builder = builder.NamespaceParam(namespace)
+	}
+
+	result, err := builder.Do().Infos()
 	return result, scrubValidationError(err)
 }
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -153,11 +153,11 @@ func TestUpdate(t *testing.T) {
 			}
 		}),
 	}
-	first, err := c.Build(objBody(&listA), false)
+	first, err := c.Build(objBody(&listA), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := c.Build(objBody(&listB), false)
+	second, err := c.Build(objBody(&listB), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test for an invalid manifest
-			infos, err := c.Build(tt.reader, false)
+			infos, err := c.Build(tt.reader, false, "")
 			if err != nil && !tt.err {
 				t.Errorf("Got error message when no error should have occurred: %v", err)
 			} else if err != nil && strings.Contains(err.Error(), "--validate=false") {
@@ -266,7 +266,7 @@ func TestPerform(t *testing.T) {
 			}
 
 			c := newTestClient()
-			infos, err := c.Build(tt.reader, false)
+			infos, err := c.Build(tt.reader, false, "")
 			if err != nil && err.Error() != tt.errMessage {
 				t.Errorf("Error while building manifests: %v", err)
 			}
@@ -289,7 +289,7 @@ func TestPerform(t *testing.T) {
 func TestReal(t *testing.T) {
 	t.Skip("This is a live test, comment this line to run")
 	c := New(nil)
-	resources, err := c.Build(strings.NewReader(guestbookManifest), false)
+	resources, err := c.Build(strings.NewReader(guestbookManifest), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestReal(t *testing.T) {
 
 	testSvcEndpointManifest := testServiceManifest + "\n---\n" + testEndpointManifest
 	c = New(nil)
-	resources, err = c.Build(strings.NewReader(testSvcEndpointManifest), false)
+	resources, err = c.Build(strings.NewReader(testSvcEndpointManifest), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestReal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resources, err = c.Build(strings.NewReader(testEndpointManifest), false)
+	resources, err = c.Build(strings.NewReader(testEndpointManifest), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestReal(t *testing.T) {
 		t.Fatal(errs)
 	}
 
-	resources, err = c.Build(strings.NewReader(testSvcEndpointManifest), false)
+	resources, err = c.Build(strings.NewReader(testSvcEndpointManifest), false, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -83,11 +83,11 @@ func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool)
 }
 
 // Build returns the configured error if set or prints
-func (f *FailingKubeClient) Build(r io.Reader, _ bool) (kube.ResourceList, error) {
+func (f *FailingKubeClient) Build(r io.Reader, _ bool, _ string) (kube.ResourceList, error) {
 	if f.BuildError != nil {
 		return []*resource.Info{}, f.BuildError
 	}
-	return f.PrintingKubeClient.Build(r, false)
+	return f.PrintingKubeClient.Build(r, false, "")
 }
 
 // WaitAndGetCompletedPodPhase returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -82,7 +82,7 @@ func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kub
 }
 
 // Build implements KubeClient Build.
-func (p *PrintingKubeClient) Build(_ io.Reader, _ bool) (kube.ResourceList, error) {
+func (p *PrintingKubeClient) Build(_ io.Reader, _ bool, _ string) (kube.ResourceList, error) {
 	return []*resource.Info{}, nil
 }
 

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -53,7 +53,7 @@ type Interface interface {
 	// by "\n---\n")
 	//
 	// Validates against OpenAPI schema if validate is true.
-	Build(reader io.Reader, validate bool) (ResourceList, error)
+	Build(reader io.Reader, validate bool, namespace string) (ResourceList, error)
 
 	// WaitAndGetCompletedPodPhase waits up to a timeout until a pod enters a completed phase
 	// and returns said phase (PodSucceeded or PodFailed qualify).


### PR DESCRIPTION
The `Namespace` flag of the `Install` and `Upgrade` actions does not fix the kube namespace.
This PR enable the `Namespace` flag to specify the NS in which the object are being installed/upgraded

Fixes #7135 

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>