### PR TITLE
fix(cli): IsReachable check for "get values"

### DIFF
--- a/pkg/action/get_values.go
+++ b/pkg/action/get_values.go
@@ -39,6 +39,10 @@ func NewGetValues(cfg *Configuration) *GetValues {
 
 // Run executes 'helm get values' against the given release.
 func (g *GetValues) Run(name string) (map[string]interface{}, error) {
+	if err := g.cfg.KubeClient.IsReachable(); err != nil {
+		return nil, err
+	}
+
 	rel, err := g.cfg.releaseContent(name, g.Version)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The command `helm get values` has its own `Run()` method in the action package. So, unlike the other 'get' variants, it needs to do its own check for the reachability of the cluster.

With an unreachable cluster, before this PR:
```
$ h3 get values hello
Error: query: failed to query with labels: Get https://127.0.0.1:6443/api/v1/namespaces/default/secrets?labelSelector=name%3Dhello%2Cowner%3Dhelm: dial tcp 127.0.0.1:6443: connect: connection refused
```
after the PR:
```
$ h3 get values hello
Error: Kubernetes cluster unreachable
```
Similar fix as PR #6920 

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>