### PR TITLE
Add helm prefix for release dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ $(GOIMPORTS):
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GOX)
-	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/helm-{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

For now, extract release pkg like helm-v3.0.0-linux-arm64.tar.gz would get a dir named as `linux-arm64`, it is hard to know that this dir belongs to helm, add "helm" prefix to optimize it.