### PR TITLE
fs_test.go: Assume non-root user instead of failing the test.

### DIFF
--- a/internal/third_party/dep/fs/fs_test.go
+++ b/internal/third_party/dep/fs/fs_test.go
@@ -35,7 +35,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -175,13 +174,9 @@ func TestCopyDirFail_SrcInaccessible(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -214,13 +209,9 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -314,13 +305,9 @@ func TestCopyDirFailOpen(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -483,13 +470,9 @@ func TestCopyFileFail(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -574,13 +557,9 @@ func setupInaccessibleDir(t *testing.T, op func(dir string) error) func() {
 
 func TestIsDir(t *testing.T) {
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -631,13 +610,9 @@ func TestIsDir(t *testing.T) {
 
 func TestIsSymlink(t *testing.T) {
 
-	var currentUser, err = user.Current()
+	var currentUID = os.Getuid()
 
-	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+	if currentUID == 0 {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}


### PR DESCRIPTION
When the unit tests are run in a container as a random-like user ID (e.g. in Kubernetes or OpenShift) or the user ID is not mentioned in `/etc/passwd` the tests fail complaining like:
```
--- FAIL: TestCopyDirFail_SrcInaccessible (0.00s)
    fs_test.go:181: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyDirFail_DstInaccessible (0.00s)
    fs_test.go:220: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyDirFailOpen (0.00s)
    fs_test.go:320: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyFileFail (0.00s)
    fs_test.go:489: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestIsDir (0.00s)
    fs_test.go:580: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestIsSymlink (0.00s)
    fs_test.go:637: Failed to get name of current user: user: unknown userid 1026330000
```

The `currentUser` here is really only used to check if it is `root` and the very same function that is used here to get the current user (`user.Current()`) is not used anywhere else in the codebase. It should be sufficient to try to get the current user and if that fails, assume the user is a non-root and go on without actually failing the unit test.

This makes the unit tests less flaky.