### PR TITLE
Fixing the code of conduct pointer

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
-# Kubernetes Community Code of Conduct
+# Community Code of Conduct
 
-Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)
+Helm follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
When the v3 branch was started the code of conduct pointed to the
Kubernetes one which pointed to the CNCF. Helm moved to be a CNCF
project and the v2 code of conduct was pointed directly at the
CNCF one. This was missed on the v3 branch. This updates the
pointer.