### PR TITLE
use sigs.k8s.io/yaml instead of gopkg.in/yaml.v2

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/getter"


### PR DESCRIPTION
Fixes #7151 

this is for consistency as everywhere we use sigs.k8s.io/yaml package

Signed-off-by: Karuppiah Natarajan <karuppiah7890@gmail.com>