### PR TITLE
fix(install): use ca file for install (#7140)

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -648,6 +648,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		Getters: getter.All(settings),
 		Options: []getter.Option{
 			getter.WithBasicAuth(c.Username, c.Password),
+			getter.WithTLSClientConfig(c.CertFile, c.KeyFile, c.CaFile),
 		},
 		RepositoryConfig: settings.RepositoryConfig,
 		RepositoryCache:  settings.RepositoryCache,

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -181,8 +181,10 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		c.Options = append(
 			c.Options,
 			getter.WithURL(rc.URL),
-			getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile),
 		)
+		if rc.CertFile != "" || rc.KeyFile != "" || rc.CAFile != "" {
+			getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile)
+		}
 		if rc.Username != "" && rc.Password != "" {
 			c.Options = append(
 				c.Options,
@@ -210,12 +212,14 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	if err != nil {
 		return u, err
 	}
-	if r != nil && r.Config != nil && r.Config.Username != "" && r.Config.Password != "" {
-		c.Options = append(c.Options, getter.WithBasicAuth(r.Config.Username, r.Config.Password))
-	}
 
-	if r.Config.CertFile != "" || r.Config.KeyFile != "" || r.Config.CAFile != "" {
-		c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+	if r != nil && r.Config != nil {
+		if r.Config.CertFile != "" || r.Config.KeyFile != "" || r.Config.CAFile != "" {
+			c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+		}
+		if r.Config.Username != "" && r.Config.Password != "" {
+			c.Options = append(c.Options, getter.WithBasicAuth(r.Config.Username, r.Config.Password))
+		}
 	}
 
 	// Next, we need to load the index, and actually look up the chart.
@@ -254,9 +258,6 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		// TODO add user-agent
 		if _, err := getter.NewHTTPGetter(getter.WithURL(rc.URL)); err != nil {
 			return repoURL, err
-		}
-		if r != nil && r.Config != nil && r.Config.Username != "" && r.Config.Password != "" {
-			c.Options = append(c.Options, getter.WithBasicAuth(r.Config.Username, r.Config.Password))
 		}
 		return u, err
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -183,7 +183,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 			getter.WithURL(rc.URL),
 		)
 		if rc.CertFile != "" || rc.KeyFile != "" || rc.CAFile != "" {
-			getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile)
+			c.Options = append(c.Options, getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile))
 		}
 		if rc.Username != "" && rc.Password != "" {
 			c.Options = append(


### PR DESCRIPTION
Fixes a few bugs related to tls config when installing charts:

1. When installing via relative path, tls config for the selected
repository was not being set.

2. The `--ca-file` flag was not being passed when constructing the
downloader.

3. Setting tls config was not checking for zero value in repo
config, causing flag to get overwritten with empty string.

There's still a few oddities here. I would expect that the flag
passed in on the command line would override the repo config, but
that's not currently the case. Also, we always set the cert, key
and ca files as a trio, when they should be set individually
depending on combination of flags / repo config.

Signed-off-by: James McElwain <jmcelwain@gmail.com>