### PR TITLE
Use repository-cache if specified

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -129,7 +129,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-
+	r.CachePath = settings.RepositoryCache
 	if _, err := r.DownloadIndexFile(); err != nil {
 		return errors.Wrapf(err, "looks like %q is not a valid chart repository or cannot be reached", o.url)
 	}

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
-	"path/filepath"
 )
 
 type repoAddOptions struct {

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
+	"path/filepath"
 )
 
 type repoAddOptions struct {

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -66,6 +66,7 @@ func (o *repoUpdateOptions) run(out io.Writer) error {
 	var repos []*repo.ChartRepository
 	for _, cfg := range f.Repositories {
 		r, err := repo.NewChartRepository(cfg, getter.All(settings))
+		r.CachePath = settings.RepositoryCache
 		if err != nil {
 			return err
 		}
@@ -82,6 +83,7 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer) {
 	for _, re := range repos {
 		wg.Add(1)
 		go func(re *repo.ChartRepository) {
+			debug("using path %s for cache", re.CachePath)
 			defer wg.Done()
 			if _, err := re.DownloadIndexFile(); err != nil {
 				fmt.Fprintf(out, "...Unable to get an update from the %q chart repository (%s):\n\t%s\n", re.Config.Name, re.Config.URL, err)

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -66,10 +66,10 @@ func (o *repoUpdateOptions) run(out io.Writer) error {
 	var repos []*repo.ChartRepository
 	for _, cfg := range f.Repositories {
 		r, err := repo.NewChartRepository(cfg, getter.All(settings))
-		r.CachePath = settings.RepositoryCache
 		if err != nil {
 			return err
 		}
+		r.CachePath = settings.RepositoryCache
 		repos = append(repos, r)
 	}
 

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -18,15 +18,16 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"helm.sh/helm/v3/internal/test/ensure"
-	"helm.sh/helm/v3/pkg/getter"
-	"helm.sh/helm/v3/pkg/repo"
-	"helm.sh/helm/v3/pkg/repo/repotest"
 	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"helm.sh/helm/v3/internal/test/ensure"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
+	"helm.sh/helm/v3/pkg/repo/repotest"
 )
 
 func TestUpdateCmd(t *testing.T) {


### PR DESCRIPTION
Fixes #7141 
Use cache path specified by `--repository-cache` when running `repo update`. 
Added debug logging of path