### PR TITLE
fix: catch one additional discovery client warning

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -167,8 +167,8 @@ func (c *Configuration) releaseContent(name string, version int) (*release.Relea
 // GetVersionSet retrieves a set of available k8s API versions
 func GetVersionSet(client discovery.ServerResourcesInterface) (chartutil.VersionSet, error) {
 	groups, resources, err := client.ServerGroupsAndResources()
-	if err != nil {
-		return chartutil.DefaultVersionSet, err
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+		return chartutil.DefaultVersionSet, errors.Wrap(err, "could not get apiVersions from Kubernetes")
 	}
 
 	// FIXME: The Kubernetes test fixture for cli appears to always return nil


### PR DESCRIPTION
In comments on #6908 it was suggested that there is a second place where we should catch the discovery client's error. I have not been able to find or reproduce an error that triggers the aforementioned behavior... however, the fix was easy enough.

Can someone who can reproduce the error either (a) provide me a way to reproduce, or (b) test this out and let me know if it fixes the error? *This should not be merged until we know it solves the problem.*

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>