### PR TITLE
fix stack overflow error in helm template.

### DIFF
--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -305,8 +305,15 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		if err != nil {
 			return list, errors.Wrap(err, "error parsing index")
 		}
+		var crtList []interface{}
+		if len(list) > i {
+			// If nested list already exists, take the value of list to next cycle.
+			crtList = list[i].([]interface{})
+		} else {
+			crtList = list
+		}
 		// Now we need to get the value after the ].
-		list2, err := t.listItem(list, i)
+		list2, err := t.listItem(crtList, i)
 		if err != nil {
 			return list, err
 		}

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -314,16 +314,11 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 			}
 		}
 		// Now we need to get the value after the ].
-<<<<<<< HEAD
-		list2, err := t.listItem(crtList, i)
+		list2, err := t.listItem(crtList, nextI)
 		if err != nil {
 			return list, err
 		}
 		return setIndex(list, i, list2)
-=======
-		list2, err := t.listItem(crtList, nextI)
-		return setIndex(list, i, list2), err
->>>>>>> fix another extreme case
 	case last == '.':
 		// We have a nested object. Send to t.key
 		inner := map[string]interface{}{}

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -301,7 +301,7 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		}
 	case last == '[':
 		// now we have a nested list. Read the index and handle.
-		i, err := t.keyIndex()
+		nextI, err := t.keyIndex()
 		if err != nil {
 			return list, errors.Wrap(err, "error parsing index")
 		}
@@ -309,15 +309,18 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		if len(list) > i {
 			// If nested list already exists, take the value of list to next cycle.
 			crtList = list[i].([]interface{})
-		} else {
-			crtList = list
 		}
 		// Now we need to get the value after the ].
+<<<<<<< HEAD
 		list2, err := t.listItem(crtList, i)
 		if err != nil {
 			return list, err
 		}
 		return setIndex(list, i, list2)
+=======
+		list2, err := t.listItem(crtList, nextI)
+		return setIndex(list, i, list2), err
+>>>>>>> fix another extreme case
 	case last == '.':
 		// We have a nested object. Send to t.key
 		inner := map[string]interface{}{}

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -308,7 +308,10 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		var crtList []interface{}
 		if len(list) > i {
 			// If nested list already exists, take the value of list to next cycle.
-			crtList = list[i].([]interface{})
+			existed := list[i]
+			if existed != nil {
+				crtList = list[i].([]interface{})
+			}
 		}
 		// Now we need to get the value after the ].
 <<<<<<< HEAD

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -427,7 +427,7 @@ func TestParseInto(t *testing.T) {
 			"inner2": "value2",
 		},
 	}
-	input := "outer.inner1=value1,outer.inner3=value3,outer.inner4=4"
+	input := "outer.inner1=value1,outer.inner3=value3,outer.inner4=4,listOuter[0][0].type=listValue"
 	expect := map[string]interface{}{
 		"outer": map[string]interface{}{
 			"inner1": "value1",
@@ -435,9 +435,19 @@ func TestParseInto(t *testing.T) {
 			"inner3": "value3",
 			"inner4": 4,
 		},
+		"listOuter": [][]interface{}{{map[string]string{
+			"type":   "listValue",
+			"status": "alive",
+		}},
+		},
 	}
 
 	if err := ParseInto(input, got); err != nil {
+		t.Fatal(err)
+	}
+
+	input2 := "listOuter[0][0].status=alive"
+	if err := ParseInto(input2, got); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -421,49 +421,118 @@ func TestParseSet(t *testing.T) {
 }
 
 func TestParseInto(t *testing.T) {
-	got := map[string]interface{}{
-		"outer": map[string]interface{}{
-			"inner1": "overwrite",
-			"inner2": "value2",
+	tests := []struct {
+		input  string
+		input2 string
+		got    map[string]interface{}
+		expect map[string]interface{}
+		err    bool
+	}{
+		{
+			input: "outer.inner1=value1,outer.inner3=value3,outer.inner4=4",
+			got: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner1": "overwrite",
+					"inner2": "value2",
+				},
+			},
+			expect: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner1": "value1",
+					"inner2": "value2",
+					"inner3": "value3",
+					"inner4": 4,
+				}},
+			err: false,
+		},
+		{
+			input:  "listOuter[0][0].type=listValue",
+			input2: "listOuter[0][0].status=alive",
+			got:    map[string]interface{}{},
+			expect: map[string]interface{}{
+				"listOuter": [][]interface{}{{map[string]string{
+					"type":   "listValue",
+					"status": "alive",
+				}}},
+			},
+			err: false,
+		},
+		{
+			input:  "listOuter[0][0].type=listValue",
+			input2: "listOuter[1][0].status=alive",
+			got:    map[string]interface{}{},
+			expect: map[string]interface{}{
+				"listOuter": [][]interface{}{
+					{
+						map[string]string{"type": "listValue"},
+					},
+					{
+						map[string]string{"status": "alive"},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			input:  "listOuter[0][1][0].type=listValue",
+			input2: "listOuter[0][0][1].status=alive",
+			got: map[string]interface{}{
+				"listOuter": []interface{}{
+					[]interface{}{
+						[]interface{}{
+							map[string]string{"exited": "old"},
+						},
+					},
+				},
+			},
+			expect: map[string]interface{}{
+				"listOuter": [][][]interface{}{
+					{
+						{
+							map[string]string{"exited": "old"},
+							map[string]string{"status": "alive"},
+						},
+						{
+							map[string]string{"type": "listValue"},
+						},
+					},
+				},
+			},
+			err: false,
 		},
 	}
-	input := "outer.inner1=value1,outer.inner3=value3,outer.inner4=4,listOuter[0][0].type=listValue"
-	expect := map[string]interface{}{
-		"outer": map[string]interface{}{
-			"inner1": "value1",
-			"inner2": "value2",
-			"inner3": "value3",
-			"inner4": 4,
-		},
-		"listOuter": [][]interface{}{{map[string]string{
-			"type":   "listValue",
-			"status": "alive",
-		}},
-		},
-	}
+	for _, tt := range tests {
+		if err := ParseInto(tt.input, tt.got); err != nil {
+			t.Fatal(err)
+		}
+		if tt.err {
+			t.Errorf("%s: Expected error. Got nil", tt.input)
+		}
 
-	if err := ParseInto(input, got); err != nil {
-		t.Fatal(err)
-	}
+		if tt.input2 != "" {
+			if err := ParseInto(tt.input2, tt.got); err != nil {
+				t.Fatal(err)
+			}
+			if tt.err {
+				t.Errorf("%s: Expected error. Got nil", tt.input2)
+			}
+		}
 
-	input2 := "listOuter[0][0].status=alive"
-	if err := ParseInto(input2, got); err != nil {
-		t.Fatal(err)
-	}
+		y1, err := yaml.Marshal(tt.expect)
+		if err != nil {
+			t.Fatal(err)
+		}
+		y2, err := yaml.Marshal(tt.got)
+		if err != nil {
+			t.Fatalf("Error serializing parsed value: %s", err)
+		}
 
-	y1, err := yaml.Marshal(expect)
-	if err != nil {
-		t.Fatal(err)
-	}
-	y2, err := yaml.Marshal(got)
-	if err != nil {
-		t.Fatalf("Error serializing parsed value: %s", err)
-	}
-
-	if string(y1) != string(y2) {
-		t.Errorf("%s: Expected:\n%s\nGot:\n%s", input, y1, y2)
+		if string(y1) != string(y2) {
+			t.Errorf("%s: Expected:\n%s\nGot:\n%s", tt.input, y1, y2)
+		}
 	}
 }
+
 func TestParseIntoString(t *testing.T) {
 	got := map[string]interface{}{
 		"outer": map[string]interface{}{


### PR DESCRIPTION
fix #6116

When value has a nested list in "helm template --set" cmd and the nested list already has a value, it may becomes endless nested list. And it will result in stack overflow.

My solution is to judge the nested list if it already has a value, and if it is yes, take the value of list to next cycle.