### PR TITLE
stop with an error immediately if a file or directory with that name already exists

### DIFF
--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/repo/repotest"
@@ -96,14 +95,14 @@ func TestPullCmd(t *testing.T) {
 			args:         "test/test1 --untar --untardir test1",
 			existFile:    "test1",
 			wantError:    true,
-			wantErrorMsg: "failed to untar",
+			wantErrorMsg: fmt.Sprintf("failed to untar: a file or directory with the name %s already exists", filepath.Join(srv.Root(), "test1")),
 		},
 		{
 			name:         "Fetch untar when dir with same name existed",
 			args:         "test/test2 --untar --untardir test2",
 			existDir:     "test2",
 			wantError:    true,
-			wantErrorMsg: "failed to untar",
+			wantErrorMsg: fmt.Sprintf("failed to untar: a file or directory with the name %s already exists", filepath.Join(srv.Root(), "test2")),
 		},
 		{
 			name:         "Fetch, verify, untar",
@@ -163,7 +162,7 @@ func TestPullCmd(t *testing.T) {
 			_, out, err := executeActionCommand(cmd)
 			if err != nil {
 				if tt.wantError {
-					if tt.wantErrorMsg != "" && strings.Contains(tt.wantErrorMsg, err.Error()) {
+					if tt.wantErrorMsg != "" && tt.wantErrorMsg == err.Error() {
 						t.Fatalf("%q reported error not equel wantErr, reported: %s, wanted: %s", tt.name, err, tt.wantErrorMsg)
 					}
 					return

--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -93,6 +93,8 @@ func TestPullCmd(t *testing.T) {
 			expectFile:   "./signtest",
 			expectDir:    true,
 			expectVerify: true,
+			failExpect:   "Failed to untar signtest",
+			wantError:    true,
 		},
 		{
 			name:       "Chart fetch using repo URL",

--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -163,7 +163,7 @@ func TestPullCmd(t *testing.T) {
 			if err != nil {
 				if tt.wantError {
 					if tt.wantErrorMsg != "" && tt.wantErrorMsg == err.Error() {
-						t.Fatalf("%q reported error not equel wantErr, reported: %s, wanted: %s", tt.name, err, tt.wantErrorMsg)
+						t.Fatalf("Actual error %s, not equal to expected error %s", err, tt.wantErrorMsg)
 					}
 					return
 				}

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -109,13 +109,13 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		if !filepath.IsAbs(ud) {
 			ud = filepath.Join(p.DestDir, ud)
 		}
-		if fi, err := os.Stat(ud); err != nil {
+		if _, err := os.Stat(ud); err != nil {
 			if err := os.MkdirAll(ud, 0755); err != nil {
 				return out.String(), errors.Wrap(err, "failed to untar (mkdir)")
 			}
 
-		} else if !fi.IsDir() {
-			return out.String(), errors.Errorf("failed to untar: %s is not a directory", ud)
+		} else {
+			return out.String(), errors.Errorf("failed to untar: %s already exited", ud)
 		}
 
 		return out.String(), chartutil.ExpandFile(ud, saved)

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -114,7 +114,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 				return out.String(), errors.Wrap(err, "failed to untar (mkdir)")
 			}
 
-		} else {
+		} else if ud != "." {
 			return out.String(), errors.Errorf("failed to untar: a file or directory with the name %s already exists", ud)
 		}
 

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -115,7 +115,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 			}
 
 		} else {
-			return out.String(), errors.Errorf("failed to untar: %s already exited", ud)
+			return out.String(), errors.Errorf("failed to untar: a file or directory with the name %s already exists", ud)
 		}
 
 		return out.String(), chartutil.ExpandFile(ud, saved)

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -109,13 +109,18 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		if !filepath.IsAbs(ud) {
 			ud = filepath.Join(p.DestDir, ud)
 		}
-		if _, err := os.Stat(ud); err != nil {
-			if err := os.MkdirAll(ud, 0755); err != nil {
+		// Let udCheck to check conflict file/dir without replacing ud when untarDir is .
+		udCheck := ud
+		if udCheck == "." {
+			_, udCheck = filepath.Split(chartRef)
+		}
+		if _, err := os.Stat(udCheck); err != nil {
+			if err := os.MkdirAll(udCheck, 0755); err != nil {
 				return out.String(), errors.Wrap(err, "failed to untar (mkdir)")
 			}
 
-		} else if ud != "." {
-			return out.String(), errors.Errorf("failed to untar: a file or directory with the name %s already exists", ud)
+		} else {
+			return out.String(), errors.Errorf("failed to untar: a file or directory with the name %s already exists", udCheck)
 		}
 
 		return out.String(), chartutil.ExpandFile(ud, saved)

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -113,6 +113,9 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		udCheck := ud
 		if udCheck == "." {
 			_, udCheck = filepath.Split(chartRef)
+		} else {
+			_, chartName := filepath.Split(chartRef)
+			udCheck = filepath.Join(udCheck, chartName)
 		}
 		if _, err := os.Stat(udCheck); err != nil {
 			if err := os.MkdirAll(udCheck, 0755); err != nil {

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -109,7 +109,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		if !filepath.IsAbs(ud) {
 			ud = filepath.Join(p.DestDir, ud)
 		}
-		// Let udCheck to check conflict file/dir without replacing ud when untarDir is .
+		// Let udCheck to check conflict file/dir without replacing ud when untarDir is the current directory(.).
 		udCheck := ud
 		if udCheck == "." {
 			_, udCheck = filepath.Split(chartRef)


### PR DESCRIPTION
fix #7182

If the path already exited, no matter it is a file or directory, stop with an error immediately.