### PR TITLE
fix(helm): Validate number of arguments in install client

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -555,6 +555,10 @@ func (i *Install) NameAndChart(args []string) (string, string, error) {
 		return nil
 	}
 
+	if len(args) > 2 {
+		return args[0], args[1], errors.Errorf("expected at most two arguments, unexpected arguments: %v", strings.Join(args[2:], ", "))
+	}
+
 	if len(args) == 2 {
 		return args[0], args[1], flagsNotSet()
 	}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -505,6 +505,14 @@ func TestNameAndChart(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 	is.Equal("must either provide a name or specify --generate-name", err.Error())
+
+	instAction.NameTemplate = ""
+	instAction.ReleaseName = ""
+	_, _, err = instAction.NameAndChart([]string{"foo", chartName, "bar"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	is.Equal("expected at most two arguments, unexpected arguments: bar", err.Error())
 }
 
 func TestNameAndChartGenerateName(t *testing.T) {


### PR DESCRIPTION
When passing more then two arguments (e.g. due to a mistake in a flag) the following error was returned `must either provide a name or specify --generate-name`, which can be confusing. Now the following error message will be returned `expected at most two arguments, unexpected arguments: bar`, which would at least point the user towards the issue.