### PR TITLE
[helm create] Include serviceAccount.annotations value

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -103,6 +103,7 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
@@ -302,6 +303,10 @@ metadata:
   name: {{ include "<CHARTNAME>.serviceAccountName" . }}
   labels:
 {{ include "<CHARTNAME>.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 `
 

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -103,6 +103,7 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
In order to ease the use of features such as [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_workload_identity_on_a_new_cluster), it is beneficial to allow users to annotate service accounts out of the box.