### PR TITLE
fix(kube) only add to scheme.Scheme once

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -57,20 +57,23 @@ type Client struct {
 	Log     func(string, ...interface{})
 }
 
+var addToScheme sync.Once
+
 // New creates a new Client.
 func New(getter genericclioptions.RESTClientGetter) *Client {
 	if getter == nil {
 		getter = genericclioptions.NewConfigFlags(true)
 	}
 	// Add CRDs to the scheme. They are missing by default.
-	if err := apiextv1.AddToScheme(scheme.Scheme); err != nil {
-		// This should never happen.
-		panic(err)
-	}
-	if err := apiextv1beta1.AddToScheme(scheme.Scheme); err != nil {
-		// This should never happen.
-		panic(err)
-	}
+	addToScheme.Do(func() {
+		if err := apiextv1.AddToScheme(scheme.Scheme); err != nil {
+			// This should never happen.
+			panic(err)
+		}
+		if err := apiextv1beta1.AddToScheme(scheme.Scheme); err != nil {
+			panic(err)
+		}
+	})
 	return &Client{
 		Factory: cmdutil.NewFactory(getter),
 		Log:     nopLogger,


### PR DESCRIPTION
Multiple call to `AddToScheme` is (1) redundant and (2) destroying concurrency of `New`.

Closes #6566

Signed-off-by: Jakub Bielecki <jakub.bielecki@codilime.com>