### PR TITLE
Fix: helm3 - kind sorter incorrectly compares unknown and namespace

### DIFF
--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -134,11 +134,13 @@ func (k *kindSorter) Less(i, j int) bool {
 	b := k.manifests[j]
 	first, aok := k.ordering[a.Head.Kind]
 	second, bok := k.ordering[b.Head.Kind]
-	if first == second {
-		// if both are unknown and of different kind sort by kind alphabetically
-		if !aok && !bok && a.Head.Kind != b.Head.Kind {
+
+	if !aok && !bok {
+		// if both are unknown then sort alphabetically by kind, keep original order if same kind
+		if a.Head.Kind != b.Head.Kind {
 			return a.Head.Kind < b.Head.Kind
 		}
+		return first < second
 	}
 	// unknown kind is last
 	if !aok {

--- a/pkg/releaseutil/kind_sorter_test.go
+++ b/pkg/releaseutil/kind_sorter_test.go
@@ -245,3 +245,24 @@ func TestKindSorterKeepOriginalOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestKindSorterNamespaceAgainstUnknown(t *testing.T) {
+	unknown := Manifest{
+		Name: "a",
+		Head: &SimpleHead{Kind: "Unknown"},
+	}
+	namespace := Manifest{
+		Name: "b",
+		Head: &SimpleHead{Kind: "Namespace"},
+	}
+
+	manifests := []Manifest{unknown, namespace}
+	sortByKind(manifests, InstallOrder)
+
+	expectedOrder := []Manifest{namespace, unknown}
+	for i, manifest := range manifests {
+		if expectedOrder[i].Name != manifest.Name {
+			t.Errorf("Expected %s, got %s", expectedOrder[i].Name, manifest.Name)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

The kind_sorter incorrectly compares Namespace and unknown type. This PR fixes comparison logic in Less method.

This is to fix a previous issue in helm2 -> https://github.com/helm/helm/issues/4728

I have ported the changes from PR -> https://github.com/helm/helm/pull/5186 

Signed-off-by: Bradley Skuse <bradleyskuse@me.com>

