### PR TITLE
Add back fix for CRD patch creation

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -355,7 +355,12 @@ func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.P
 	// returned from ConvertToVersion. Anything that's unstructured should
 	// use the jsonpatch.CreateMergePatch. Strategic Merge Patch is not supported
 	// on objects like CRDs.
-	if _, ok := versionedObject.(runtime.Unstructured); ok {
+	_, isUnstructured := versionedObject.(runtime.Unstructured)
+
+	// On newer K8s versions, CRDs aren't unstructured but has this dedicated type
+	_, isCRD := versionedObject.(*apiextv1beta1.CustomResourceDefinition)
+
+	if isUnstructured || isCRD {
 		// fall back to generic JSON merge patch
 		patch, err := jsonpatch.CreateMergePatch(oldData, newData)
 		return patch, types.MergePatchType, err


### PR DESCRIPTION
It seems that #5853 was re-introduced with the work for the `v3.x` release. This PR adds back the fix submitted by @mumoshu on #6092 for `v2.x`.