### PR TITLE
fix(helm): add .orig as typical backup file in .helmignore

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -170,6 +170,7 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project


### PR DESCRIPTION
Mercurial VCS (hg) backout's can generate '.orig' files
to avoid these being picked, generate a .helmignore where
also the .orig files are ignored.

Signed-off-by: Jan Heylen <jan.heylen@nokia.com>