### PR TITLE
fix(tests): Use relative path to acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEP           = $(GOPATH)/bin/dep
 GOX           = $(GOPATH)/bin/gox
 GOIMPORTS     = $(GOPATH)/bin/goimports
 
-ACCEPTANCE_DIR:=$(GOPATH)/src/helm.sh/acceptance-testing
+ACCEPTANCE_DIR:=../acceptance-testing
 # To specify the subset of acceptance tests to run. '.' means all tests
 ACCEPTANCE_RUN_TESTS=.
 


### PR DESCRIPTION
With Helm using go modules, its git repo need not reside under $GOPATH/src/helm.sh anymore.  In fact it may be desirable for a user to move it to another location (e.g., to get the debugger to work).

In the same train of thought, the acceptance-testing repo, which is not even a go program, need not be in the GOPATH.

This commit reduces the requirement on the location of the acceptance-testing repo to a relative path to the helm repo, instead of an absolute path within GOPATH.

This change is backwards-compatible (i.e., if helm and acceptance-testing are still under $GOPATH/src/helm.sh, the command `make test-acceptance-testing` will continue to work)