### PR TITLE
fix(comp): tail cannot open +2 for reading

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -69,7 +69,7 @@ __helm_override_flags_to_kubectl_flags()
 
 __helm_get_repos()
 {
-    eval $(__helm_binary_name) repo list 2>/dev/null | \tail +2 | \cut -f1
+    eval $(__helm_binary_name) repo list 2>/dev/null | \tail -n +2 | \cut -f1
 }
 
 __helm_get_contexts()
@@ -236,7 +236,7 @@ __helm_list_plugins()
     __helm_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
     local out
     # Use eval in case helm_binary_name contains a variable (e.g., $HOME/bin/h3)
-    if out=$(eval $(__helm_binary_name) plugin list 2>/dev/null | \tail +2 | \cut -f1); then
+    if out=$(eval $(__helm_binary_name) plugin list 2>/dev/null | \tail -n +2 | \cut -f1); then
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }


### PR DESCRIPTION
Fix issue #7304 :

Using bash completion feature produce this error on RHEL/CentOS 7:

    tail: cannot open ‘+2’ for reading: No such file or directory


Signed-off-by: Frank Lin PIAT <fpiat@klabs.be>