### PR TITLE
Do not delete templated CRDs

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -197,6 +197,11 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 	}
 
 	for _, info := range original.Difference(target) {
+		if info.Mapping.GroupVersionKind.Kind == "CustomResourceDefinition" {
+			c.Log("Skipping the deletion of CustomResourceDefinition %q", info.Name)
+			continue
+		}
+
 		c.Log("Deleting %q in %s...", info.Name, info.Namespace)
 		res.Deleted = append(res.Deleted, info)
 		if err := deleteResource(info); err != nil {
@@ -219,6 +224,11 @@ func (c *Client) Delete(resources ResourceList) (*Result, []error) {
 	var errs []error
 	res := &Result{}
 	err := perform(resources, func(info *resource.Info) error {
+		if info.Mapping.GroupVersionKind.Kind == "CustomResourceDefinition" {
+			c.Log("Skipping the deletion of CustomResourceDefinition %q", info.Name)
+			return nil
+		}
+
 		c.Log("Starting delete for %q %s", info.Name, info.Mapping.GroupVersionKind.Kind)
 		if err := c.skipIfNotFound(deleteResource(info)); err != nil {
 			// Collect the error and continue on


### PR DESCRIPTION
Fixes issue #7279.

Prevent the deletion of CRDs that were defined in the `templates/`
directory. This makes CRD deletion behaviour consistent with Helm
documentation:

 > CRDs are never deleted. Deleting a CRD automatically deletes all of the
 > CRD’s contents across all namespaces in the cluster. Consequently, Helm
 > will not delete CRDs.

Previous the documentation only applied to CRDs that were defined in the
`crds/` directory. It did not consider that Charts could have CRDs in the
`templates/` directory (for example charts that were written before the
`crds/` directory feature or if the Chart author needed templated CRDs).

Signed-off-by: Phil Grayson <phil@philgrayson.com>