### PR TITLE
Fix a bug in storage/driver/secrets.go Delete()

### DIFF
--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -185,11 +185,7 @@ func (secrets *Secrets) Update(key string, rls *rspb.Release) error {
 func (secrets *Secrets) Delete(key string) (rls *rspb.Release, err error) {
 	// fetch the release to check existence
 	if rls, err = secrets.Get(key); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, ErrReleaseNotFound
-		}
-
-		return nil, errors.Wrapf(err, "delete: failed to get release %q", key)
+		return nil, err
 	}
 	// delete the release
 	err = secrets.impl.Delete(key, &metav1.DeleteOptions{})

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -186,7 +186,7 @@ func (secrets *Secrets) Delete(key string) (rls *rspb.Release, err error) {
 	// fetch the release to check existence
 	if rls, err = secrets.Get(key); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrReleaseExists
+			return nil, ErrReleaseNotFound
 		}
 
 		return nil, errors.Wrapf(err, "delete: failed to get release %q", key)

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -194,6 +194,12 @@ func TestSecretDelete(t *testing.T) {
 
 	secrets := newTestFixtureSecrets(t, []*rspb.Release{rel}...)
 
+	// perform the delete on a non-existing release
+	_, err := secrets.Delete("nonexistent")
+	if err != ErrReleaseNotFound {
+		t.Fatalf("Expected ErrReleaseNotFound, got: {%v}", err)
+	}
+
 	// perform the delete
 	rls, err := secrets.Delete(key)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Dao Cong Tien <tiendc@vn.fujitsu.com>

secrets.Delete calls secrets.Get not secrets.impl.Get, and secrets.Get already processes the error type, we don't need to process again.