### PR TITLE
Fix a bug in Delete() in storage/driver/cfgmaps.go

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -201,11 +201,6 @@ func (cfgmaps *ConfigMaps) Update(key string, rls *rspb.Release) error {
 func (cfgmaps *ConfigMaps) Delete(key string) (rls *rspb.Release, err error) {
 	// fetch the release to check existence
 	if rls, err = cfgmaps.Get(key); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, ErrReleaseExists
-		}
-
-		cfgmaps.Log("delete: failed to get release %q: %s", key, err)
 		return nil, err
 	}
 	// delete the release

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -194,6 +194,12 @@ func TestConfigMapDelete(t *testing.T) {
 
 	cfgmaps := newTestFixtureCfgMaps(t, []*rspb.Release{rel}...)
 
+	// perform the delete on a non-existent release
+	_, err := cfgmaps.Delete("nonexistent")
+	if err != ErrReleaseNotFound {
+		t.Fatalf("Expected ErrReleaseNotFound: got {%v}", err)
+	}
+
 	// perform the delete
 	rls, err := cfgmaps.Delete(key)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Dao Cong Tien <tiendc@vn.fujitsu.com>

cfgmaps.Delete calls cfgmaps.Get not cfgmaps.impl.Get, and cfgmaps.Get already processes the error type, we don't need to process again.