### PR TITLE
Memory driver Query should return ErrReleaseNotFound for zero results

### DIFF
--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -23,7 +23,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func TestRollbackCmd(t *testing.T) {
+func makeTestReleases() []*release.Release {
 	rels := []*release.Release{
 		{
 			Name:    "funny-honey",
@@ -38,32 +38,35 @@ func TestRollbackCmd(t *testing.T) {
 			Version: 2,
 		},
 	}
+	return rels
+}
 
+func TestRollbackCmd(t *testing.T) {
 	tests := []cmdTestCase{{
 		name:   "rollback a release",
 		cmd:    "rollback funny-honey 1",
 		golden: "output/rollback.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release with timeout",
 		cmd:    "rollback funny-honey 1 --timeout 120s",
 		golden: "output/rollback-timeout.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release with wait",
 		cmd:    "rollback funny-honey 1 --wait",
 		golden: "output/rollback-wait.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release without revision",
 		cmd:    "rollback funny-honey",
 		golden: "output/rollback-no-revision.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:      "rollback a release without release name",
 		cmd:       "rollback",
 		golden:    "output/rollback-no-args.txt",
-		rels:      rels,
+		rels:      makeTestReleases(),
 		wantError: true,
 	}}
 	runTestCmd(t, tests)

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -70,9 +70,6 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "uninstall: Release not loaded: %s", name)
 	}
-	if len(rels) < 1 {
-		return nil, errMissingRelease
-	}
 
 	releaseutil.SortByRevision(rels)
 	rel := rels[len(rels)-1]

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -106,6 +106,9 @@ func (mem *Memory) Query(keyvals map[string]string) ([]*rspb.Release, error) {
 			return true
 		})
 	}
+	if len(ls) == 0 {
+		return nil, ErrReleaseNotFound
+	}
 	return ls, nil
 }
 

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -83,22 +83,30 @@ func TestMemoryGet(t *testing.T) {
 
 func TestMemoryQuery(t *testing.T) {
 	var tests = []struct {
-		desc string
-		xlen int
-		lbs  map[string]string
+		desc          string
+		xlen          int
+		lbs           map[string]string
+		expectedError error
 	}{
 		{
 			"should be 2 query results",
 			2,
 			map[string]string{"status": "deployed"},
+			nil,
+		},
+		{
+			"should return ErrReleaseNotFound",
+			0,
+			map[string]string{"status": "pending"},
+			ErrReleaseNotFound,
 		},
 	}
 
 	ts := tsFixtureMemory(t)
 	for _, tt := range tests {
 		l, err := ts.Query(tt.lbs)
-		if err != nil {
-			t.Fatalf("Failed to query: %s\n", err)
+		if got, want := err, tt.expectedError; got != want {
+			t.Fatalf("got: %v, want %v", got, want)
 		}
 
 		if tt.xlen != len(l) {


### PR DESCRIPTION
Alternative to #7368 , see that PR for background.

The [`Storage.History` method](https://github.com/helm/helm/blob/master/pkg/storage/storage.go#L148), which just calls `s.Driver.Query`, claims that it returns `ErrReleaseNotFound` if no such release name exists. This is the case when the driver is the `ConfigMaps` driver, the [`Query` of which explicitly returns `ErrReleaseNotFound`](https://github.com/helm/helm/blob/master/pkg/storage/driver/cfgmaps.go#L115). But the `MemoryDriver` just happily returns an empty list of releases, which is inconsistent.

This PR updates and tests the memory driver to be consistent. As mentioned on #7368, a test error then shows up in `TestRollbackRelease` [1], the cause of which is that all the test cases were using the same (mutable) data, rather than generating test data for each test (which this PR does).

[1] The reason it only shows up with this change is because `TestRollbackRelease` after running the first test successfully (which updated the test data), was then *not* erroring when it failed to find the release.

cc @latiif @SimonAlling

Signed-off-by: Michael Nelson <minelson@vmware.com>