### PR TITLE
add option to bypass kubeconfig namespace

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -55,6 +55,8 @@ var ErrNoObjectsVisited = errors.New("no objects visited")
 type Client struct {
 	Factory Factory
 	Log     func(string, ...interface{})
+	// Namespace allows to bypass the kubeconfig file for the choice of the namespace
+	Namespace string
 }
 
 // New creates a new Client.
@@ -113,6 +115,9 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 }
 
 func (c *Client) namespace() string {
+	if c.Namespace != "" {
+		return c.Namespace
+	}
 	if ns, _, err := c.Factory.ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}


### PR DESCRIPTION
Fixes #7377  (kind of)
This PR allows to bypass the kubeconfig namespace (or even not implement some RESTClientGetter methods)

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

cc @hickeyma @bacongobbler 