### PR TITLE
ref(pkg/storage): Improve error handling

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -112,9 +112,6 @@ func (s *Storage) ListDeployed() ([]*rspb.Release, error) {
 func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 	ls, err := s.DeployedAll(name)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return nil, errors.Errorf("%q has no deployed releases", name)
-		}
 		return nil, err
 	}
 
@@ -122,7 +119,7 @@ func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 		return nil, errors.Errorf("%q has no deployed releases", name)
 	}
 
-	return ls[0], err
+	return ls[0], nil
 }
 
 // DeployedAll returns all deployed releases with the provided name, or


### PR DESCRIPTION
* The error returned from `DeployedAll` [will never contain `"not found"`](https://github.com/helm/helm/blob/f35719a62a35bb0673c5dda2d6c6ba231b685dfe/pkg/storage/storage.go#L141:L143).
* The error returned at the end of `Deployed` is already known to be `nil`, and we never want to return `ls[0]` together with a non-`nil` error anyway.