### PR TITLE
feat(helm): reintroduce name flag

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -142,6 +142,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.StringVarP(&client.ReleaseName, "name", "", "", "The release name (and omit NAME parameter)")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -142,7 +142,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
-	f.StringVarP(&client.ReleaseName, "name", "", "", "The release name (and omit NAME parameter)")
+	f.StringVarP(&client.ReleaseName, "name", "", "", "the release name (and omit NAME parameter)")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -189,7 +189,17 @@ func TestInstall(t *testing.T) {
 			cmd:    "install aeneas testdata/testcharts/deprecated --namespace default",
 			golden: "output/deprecated-chart.txt",
 		},
+		// Install using v2 name flags (--name)
+		{
+			name:   "basic install using name flag no arguments",
+			cmd:    "install --name aeneas --namespace default testdata/testcharts/empty",
+			golden: "output/install.txt",
+		},
+		{
+			name:      "basic install using name flag and name argument no arguments",
+			cmd:       "install --name aeneas --namespace default aeneas testdata/testcharts/empty",
+			wantError: true,
+		},
 	}
-
 	runTestActionCmd(t, tests)
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -553,7 +553,7 @@ func (i *Install) NameAndChart(args []string) (string, string, error) {
 			return errors.New("cannot set --name-template and also specify a name")
 		}
 		if i.ReleaseName != "" {
-			return errors.New("cannot set --name and also specify specify a name argument")
+			return errors.New("cannot set --name and also specify a name argument")
 		}
 		return nil
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -552,6 +552,9 @@ func (i *Install) NameAndChart(args []string) (string, string, error) {
 		if i.NameTemplate != "" {
 			return errors.New("cannot set --name-template and also specify a name")
 		}
+		if i.ReleaseName != "" {
+			return errors.New("cannot set --name and also specify specify a name argument")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
These changes reintroduce `--name` as an accepted long flag. 

Fixes https://github.com/helm/helm/issues/7345