### PR TITLE
[helm create] Add hpa boilerplate

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -106,7 +106,7 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 8
+	expectedNumberOfTemplates := 9
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}
@@ -174,7 +174,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 8
+	expectedNumberOfTemplates := 9
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}


### PR DESCRIPTION
Adds hpa boilerplate with following properties which imho are most sane:

* disabled by default
* if enabled:
  * 1 to 100 replicas by default
  * 80% cpu average threshold by default
  * commented out and thus disabled 80% memory average threshold

Fixes #7369 