### PR TITLE
pkg/chart/chart: add Manifests field for untemplated manifests

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -453,6 +453,10 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 		return hs, b, "", err
 	}
 
+	for _, f := range ch.Manifests {
+		files[f.Name] = string(f.Data)
+	}
+
 	// NOTES.txt gets rendered like all the other files, but because it's not a hook nor a resource,
 	// pull it out of here into a separate file so that we can actually use the output of the rendered
 	// text file. We have to spin through this map because the file contains path information, so we

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -37,6 +37,8 @@ type Chart struct {
 	Lock *Lock `json:"lock"`
 	// Templates for this chart.
 	Templates []*File `json:"templates"`
+	// Manifests which won't be passed through the rendering engine.
+	Manifests []*File `json:"manifests"`
 	// Values are default config for this chart.
 	Values map[string]interface{} `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values


### PR DESCRIPTION
This commit adds an ability to skip rendering engine for certain
manfiests, when building the chart object programmatically.

This allows to completely skip templating part of helm, while still be
able to use hooks, versioning, upgrades etc. functionality.

Assembling charts programmatically is useful, for example when user wants
to apply post-templating changes to the chart, like kustomize, to avoid
modifying upstream helm chart, but still be able to use helm for
managing the installation.

While for many charts it is fine to be processed by templating engine
multiple times, for others, it is problematic.
The example here are charts, which use similar templating syntax in ConfigMap
objects, so they have to escape {{ }} templating syntax, which is
already non-trivial with helm. The example of such chart is
prometheus-opereator, which brings alerting rules, which also use {{ }}
syntax.

Given that the implementation is very simple, I decided to create a Pull Request directly rather than creating an issue first, to emphasize, that the actual modification needed is very small.

Please let me know what you think about it.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>