### PR TITLE
log.Printf replaced to fix the helm upgrade log issue

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 	"sync"
 	"time"

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -418,7 +418,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		if err != nil {
 			return errors.Wrap(err, "failed to replace object")
 		}
-		log.Printf("Replaced %q with kind %s for kind %s\n", target.Name, currentObj.GetObjectKind().GroupVersionKind().Kind, kind)
+		c.Log("Replaced %q with kind %s for kind %s\n", target.Name, currentObj.GetObjectKind().GroupVersionKind().Kind, kind)
 	} else {
 		// send patch to server
 		obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)


### PR DESCRIPTION
this is to resolve the log issue

related issue which is actually the consequence of this bug was seen here:
https://github.com/microsoft/azure-pipelines-tasks/issues/11414