### PR TITLE
Update values.yaml linting to respect value options flags

### DIFF
--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -14,23 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lint // import "helm.sh/helm/v3/pkg/lint"
+package main
 
 import (
-	"path/filepath"
-
-	"helm.sh/helm/v3/pkg/lint/rules"
-	"helm.sh/helm/v3/pkg/lint/support"
+	"fmt"
+	"testing"
 )
 
-// All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, strict bool) support.Linter {
-	// Using abs path to get directory context
-	chartDir, _ := filepath.Abs(basedir)
-
-	linter := support.Linter{ChartDir: chartDir}
-	rules.Chartfile(&linter)
-	rules.Values(&linter, values)
-	rules.Templates(&linter, values, namespace, strict)
-	return linter
+func TestLintCmd(t *testing.T) {
+	chart := "testdata/testcharts/chart-with-schema-negative"
+	tests := []cmdTestCase{
+		{
+			name:      "check fails without value option flags",
+			cmd:       fmt.Sprintf("lint %s", chart),
+			wantError: true,
+		},
+		{
+			name: "check passes with value option flags",
+			cmd:  fmt.Sprintf("lint %s --set age=25,employmentInfo.salary=100000", chart),
+		},
+	}
+	runTestCmd(t, tests)
 }

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Values lints a chart's values.yaml file.
-func Values(linter *support.Linter) {
+func Values(linter *support.Linter, values map[string]interface{}) {
 	file := "values.yaml"
 	vf := filepath.Join(linter.ChartDir, file)
 	fileExists := linter.RunLinterRule(support.InfoSev, file, validateValuesFileExistence(vf))
@@ -37,7 +37,7 @@ func Values(linter *support.Linter) {
 		return
 	}
 
-	linter.RunLinterRule(support.ErrorSev, file, validateValuesFile(vf))
+	linter.RunLinterRule(support.ErrorSev, file, validateValues(vf, values))
 }
 
 func validateValuesFileExistence(valuesPath string) error {
@@ -48,8 +48,8 @@ func validateValuesFileExistence(valuesPath string) error {
 	return nil
 }
 
-func validateValuesFile(valuesPath string) error {
-	values, err := chartutil.ReadValuesFile(valuesPath)
+func validateValues(valuesPath string, values map[string]interface{}) error {
+	fv, err := chartutil.ReadValuesFile(valuesPath)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse YAML")
 	}
@@ -63,5 +63,5 @@ func validateValuesFile(valuesPath string) error {
 	if err != nil {
 		return err
 	}
-	return chartutil.ValidateAgainstSingleSchema(values, schema)
+	return chartutil.ValidateAgainstSingleSchema(chartutil.CoalesceTables(values, fv), schema)
 }


### PR DESCRIPTION
Previously, the lint command ignored values passed via value options
flags when linting a chart's `values.yaml` file. This was problematic
because such values are often required when validating against JSON
schema

Closes #7273

Signed-off-by: Robbie deMuth <robbie.demuth@appian.com>