### PR TITLE
chore(pkg): Update comments for v3 release object storage representation 

### DIFF
--- a/pkg/chartutil/chartfile_test.go
+++ b/pkg/chartutil/chartfile_test.go
@@ -39,7 +39,6 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 		t.Fatal("Failed verifyChartfile because f is nil")
 	}
 
-	// Api instead of API because it was generated via protobuf.
 	if f.APIVersion != chart.APIVersionV1 {
 		t.Errorf("Expected API Version %q, got %q", chart.APIVersionV1, f.APIVersion)
 	}

--- a/pkg/chartutil/doc.go
+++ b/pkg/chartutil/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 /*Package chartutil contains tools for working with charts.
 
-Charts are described in the protocol buffer definition (pkg/proto/charts).
+Charts are described in the chart package (pkg/chart).
 This package provides utilities for serializing and deserializing charts.
 
 A chart can be represented on the file system in one of two ways:
@@ -38,7 +38,7 @@ For accepting raw compressed tar file data from an io.Reader, the
 'loader.LoadArchive()' will read in the data, uncompress it, and unpack it
 into a Chart.
 
-When creating charts in memory, use the 'helm.sh/helm/pkg/proto/chart'
+When creating charts in memory, use the 'helm.sh/helm/pkg/chart'
 package directly.
 */
 package chartutil // import "helm.sh/helm/v3/pkg/chartutil"

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -217,14 +217,14 @@ func (cfgmaps *ConfigMaps) Delete(key string) (rls *rspb.Release, err error) {
 
 // newConfigMapsObject constructs a kubernetes ConfigMap object
 // to store a release. Each configmap data entry is the base64
-// encoded string of a release's binary protobuf encoding.
+// encoded gzipped string of a release.
 //
 // The following labels are used within each configmap:
 //
 //    "modifiedAt"     - timestamp indicating when this configmap was last modified. (set in Update)
 //    "createdAt"      - timestamp indicating when this configmap was created. (set in Create)
 //    "version"        - version of the release.
-//    "status"         - status of the release (see proto/hapi/release.status.pb.go for variants)
+//    "status"         - status of the release (see pkg/release/status.go for variants)
 //    "owner"          - owner of the configmap, currently "helm".
 //    "name"           - name of the release.
 //

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -198,14 +198,14 @@ func (secrets *Secrets) Delete(key string) (rls *rspb.Release, err error) {
 
 // newSecretsObject constructs a kubernetes Secret object
 // to store a release. Each secret data entry is the base64
-// encoded string of a release's binary protobuf encoding.
+// encoded gzipped string of a release.
 //
 // The following labels are used within each secret:
 //
 //    "modifiedAt"    - timestamp indicating when this secret was last modified. (set in Update)
 //    "createdAt"     - timestamp indicating when this secret was created. (set in Create)
 //    "version"        - version of the release.
-//    "status"         - status of the release (see proto/hapi/release.status.pb.go for variants)
+//    "status"         - status of the release (see pkg/release/status.go for variants)
 //    "owner"          - owner of the secret, currently "helm".
 //    "name"           - name of the release.
 //

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -31,7 +31,7 @@ var b64 = base64.StdEncoding
 var magicGzip = []byte{0x1f, 0x8b, 0x08}
 
 // encodeRelease encodes a release returning a base64 encoded
-// gzipped binary protobuf encoding representation, or error.
+// gzipped string representation, or error.
 func encodeRelease(rls *rspb.Release) (string, error) {
 	b, err := json.Marshal(rls)
 	if err != nil {
@@ -50,10 +50,9 @@ func encodeRelease(rls *rspb.Release) (string, error) {
 	return b64.EncodeToString(buf.Bytes()), nil
 }
 
-// decodeRelease decodes the bytes in data into a release
-// type. Data must contain a base64 encoded string of a
-// valid protobuf encoding of a release, otherwise
-// an error is returned.
+// decodeRelease decodes the bytes of data into a release
+// type. Data must contain a base64 encoded gzipped string of a
+// valid release, otherwise an error is returned.
 func decodeRelease(data string) (*rspb.Release, error) {
 	// base64 decode string
 	b, err := b64.DecodeString(data)
@@ -77,7 +76,7 @@ func decodeRelease(data string) (*rspb.Release, error) {
 	}
 
 	var rls rspb.Release
-	// unmarshal protobuf bytes
+	// unmarshal release object bytes
 	if err := json.Unmarshal(b, &rls); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some of comments in code described the stored release object as per v2 representation. This PR updates it for the v3 representation.