### PR TITLE
fix(helm): sort hooks by kind for equal weight

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -38,7 +38,8 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 	}
 
-	sort.Sort(hookByWeight(executingHooks))
+	// hooke are pre-ordered by kind, so keep order stable
+	sort.Stable(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
 		// Set default delete policy to before-hook-creation

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -108,7 +108,7 @@ func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering 
 		}
 	}
 
-	return result.hooks, sortByKind(result.generic, ordering), nil
+	return hooksSortedByKind(result.hooks, ordering), manifestsSortedByKind(result.generic, ordering), nil
 }
 
 // sort takes a manifestFile object which may contain multiple resource definition

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -219,7 +219,7 @@ metadata:
 		}
 	}
 
-	sorted = sortByKind(sorted, InstallOrder)
+	sorted = manifestsSortedByKind(sorted, InstallOrder)
 	for i, m := range generic {
 		if m.Content != sorted[i].Content {
 			t.Errorf("Expected %q, got %q", m.Content, sorted[i].Content)


### PR DESCRIPTION
Use the same install order for hooks as for normal resources (non-hooks) for hooks with equal weight.
This makes resource handling more consistent and helps, when there are hook consisting of several resources like e.g. a service account and a job using this service account.

The sort functions are changed from an in place search to an out of place sort to avoid inout parameters.

Closes #7416.

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>