### PR TITLE
fix(test): Remove invalid subcommand in test

### DIFF
--- a/cmd/helm/root_test.go
+++ b/cmd/helm/root_test.go
@@ -35,23 +35,23 @@ func TestRootCmd(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			args: "home",
+			args: "env",
 		},
 		{
 			name:      "with $XDG_CACHE_HOME set",
-			args:      "home",
+			args:      "env",
 			envvars:   map[string]string{xdg.CacheHomeEnvVar: "/bar"},
 			cachePath: "/bar/helm",
 		},
 		{
 			name:       "with $XDG_CONFIG_HOME set",
-			args:       "home",
+			args:       "env",
 			envvars:    map[string]string{xdg.ConfigHomeEnvVar: "/bar"},
 			configPath: "/bar/helm",
 		},
 		{
 			name:     "with $XDG_DATA_HOME set",
-			args:     "home",
+			args:     "env",
 			envvars:  map[string]string{xdg.DataHomeEnvVar: "/bar"},
 			dataPath: "/bar/helm",
 		},


### PR DESCRIPTION
The 'home' command was removed for v3, so this commit adapts the tests.
Having an invalid subcommand does not cause problems currently, but
will start causing failures on newer versions of Cobra, which complain
on invalid subcommands.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>