### PR TITLE
fix(comp): Allow zsh completion to handle -n flag

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -139,7 +139,10 @@ __helm_compgen() {
 	fi
 	for w in "${completions[@]}"; do
 		if [[ "${w}" = "$1"* ]]; then
-			echo "${w}"
+			# Use printf instead of echo beause it is possible that
+			# the value to print is -n, which would be interpreted
+			# as a flag to echo
+			printf "%s\n" "${w}"
 		fi
 	done
 }


### PR DESCRIPTION
I ran into this while adding more tests to the acceptance-testing repo.

When doing zsh completion, the `-n` flag would not be handled properly.
Doing
```
helm -n<TAB>
```
would not add the space after the `-n`.
This was caused by the fact that the `-n` flag was being swallowed by the `echo` command.

To fix this, we use `printf` instead.

This has been regression-tested with the acceptance-testing repo