### PR TITLE
Auto-completion framework for plugins

### DIFF
--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"helm.sh/helm/v3/pkg/release"
 )
 
 func TestManuallyProcessArgs(t *testing.T) {
@@ -239,6 +241,45 @@ func checkCommand(t *testing.T, plugins []*cobra.Command, tests []staticCompleti
 		}
 		// Check the next level
 		checkCommand(t, pp.Commands(), tt.next)
+	}
+}
+
+func TestPluginDynamicCompletion(t *testing.T) {
+
+	tests := []cmdTestCase{{
+		name:   "completion for plugin",
+		cmd:    "__complete args ''",
+		golden: "output/plugin_args_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin with flag",
+		cmd:    "__complete args --myflag ''",
+		golden: "output/plugin_args_flag_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin with global flag",
+		cmd:    "__complete args --namespace mynamespace ''",
+		golden: "output/plugin_args_ns_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin with multiple args",
+		cmd:    "__complete args --myflag --namespace mynamespace start",
+		golden: "output/plugin_args_many_args_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin no directive",
+		cmd:    "__complete echo -n mynamespace ''",
+		golden: "output/plugin_echo_no_directive.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin bad directive",
+		cmd:    "__complete echo ''",
+		golden: "output/plugin_echo_bad_directive.txt",
+		rels:   []*release.Release{},
+	}}
+	for _, test := range tests {
+		settings.PluginsDirectory = "testdata/helmhome/helm/plugins"
+		runTestCmd(t, []cmdTestCase{test})
 	}
 }
 

--- a/cmd/helm/testdata/helmhome/helm/plugins/args/plugin.complete
+++ b/cmd/helm/testdata/helmhome/helm/plugins/args/plugin.complete
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+echo "plugin.complete was called"
+echo "Namespace: ${HELM_NAMESPACE:-NO_NS}"
+echo "Num args received: ${#}"
+echo "Args received: ${@}"
+
+# Final printout is the optional completion directive of the form :<directive>
+if [ "$HELM_NAMESPACE" = "default" ]; then
+    echo ":4"
+else
+    echo ":2"
+fi

--- a/cmd/helm/testdata/helmhome/helm/plugins/echo/plugin.complete
+++ b/cmd/helm/testdata/helmhome/helm/plugins/echo/plugin.complete
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+echo "echo plugin.complete was called"
+echo "Namespace: ${HELM_NAMESPACE:-NO_NS}"
+echo "Num args received: ${#}"
+echo "Args received: ${@}"
+
+# Final printout is the optional completion directive of the form :<directive>
+if [ "$HELM_NAMESPACE" = "default" ]; then
+    # Output an invalid directive, which should be ignored
+    echo ":2222"
+# else
+    # Don't include the directive, to test it is really optional
+fi

--- a/cmd/helm/testdata/helmhome/helm/plugins/env/completion.yaml
+++ b/cmd/helm/testdata/helmhome/helm/plugins/env/completion.yaml
@@ -1,0 +1,13 @@
+name: env
+commands:
+  - name: list
+    flags:
+    - a
+    - all
+    - log
+  - name: remove
+    validArgs:
+    - all
+    - one
+flags:
+- global

--- a/cmd/helm/testdata/helmhome/helm/plugins/exitwith/completion.yaml
+++ b/cmd/helm/testdata/helmhome/helm/plugins/exitwith/completion.yaml
@@ -1,0 +1,5 @@
+commands:
+  - name: code
+    flags:
+    - a
+    - b

--- a/cmd/helm/testdata/helmhome/helm/plugins/fullenv/completion.yaml
+++ b/cmd/helm/testdata/helmhome/helm/plugins/fullenv/completion.yaml
@@ -1,0 +1,19 @@
+name: wrongname
+commands:
+  - name: empty
+  - name: full
+    commands:
+    - name: more
+      validArgs:
+      - one
+      - two
+      flags:
+      - b
+      - ball
+    - name: less
+      flags:
+      - a
+      - all
+flags:
+- z
+- q

--- a/cmd/helm/testdata/output/plugin_args_comp.txt
+++ b/cmd/helm/testdata/output/plugin_args_comp.txt
@@ -1,0 +1,5 @@
+plugin.complete was called
+Namespace: default
+Num args received: 1
+Args received: 
+:4

--- a/cmd/helm/testdata/output/plugin_args_flag_comp.txt
+++ b/cmd/helm/testdata/output/plugin_args_flag_comp.txt
@@ -1,0 +1,5 @@
+plugin.complete was called
+Namespace: default
+Num args received: 2
+Args received: --myflag 
+:4

--- a/cmd/helm/testdata/output/plugin_args_many_args_comp.txt
+++ b/cmd/helm/testdata/output/plugin_args_many_args_comp.txt
@@ -1,0 +1,5 @@
+plugin.complete was called
+Namespace: mynamespace
+Num args received: 2
+Args received: --myflag start
+:2

--- a/cmd/helm/testdata/output/plugin_args_ns_comp.txt
+++ b/cmd/helm/testdata/output/plugin_args_ns_comp.txt
@@ -1,0 +1,5 @@
+plugin.complete was called
+Namespace: mynamespace
+Num args received: 1
+Args received: 
+:2

--- a/cmd/helm/testdata/output/plugin_echo_bad_directive.txt
+++ b/cmd/helm/testdata/output/plugin_echo_bad_directive.txt
@@ -1,0 +1,5 @@
+echo plugin.complete was called
+Namespace: default
+Num args received: 1
+Args received: 
+:0

--- a/cmd/helm/testdata/output/plugin_echo_no_directive.txt
+++ b/cmd/helm/testdata/output/plugin_echo_no_directive.txt
@@ -1,0 +1,5 @@
+echo plugin.complete was called
+Namespace: mynamespace
+Num args received: 1
+Args received: 
+:0


### PR DESCRIPTION
Closes #7043

This PR adds a framework allowing plugins to provide both static auto-completion and dynamic auto-completion, as described in #7043

In summary, with this PR plugins could optionally provide:
1. a `completion.yaml` file to specify all flags and sub-commands to be completed
1. a `plugin.complete` executable to be called when dynamic completions are required (i.e., when the list of flags and sub-commands does not provide the required completion)

I've prepared examples of how to use this framework in the `fullstatus` plugin and the `2to3` plugin.
The new `completion.yaml` file providing static completion can be seen at
https://github.com/marckhouzam/helm-fullstatus/blob/master/completion.yaml and https://github.com/marckhouzam/helm-2to3/blob/master/completion.yaml

For the `fullstatus` plugin, the new `plugin.complete` file providing dynamic completion can be seen at
https://github.com/marckhouzam/helm-fullstatus/blob/master/plugin.complete

For the `2to3` plugin, I've used the actual go binary to provide simple dynamic completion, as can be seen in the following commit: https://github.com/marckhouzam/helm-2to3/commit/0e22f706d87ee67fce7ab6767857ad0d765feae4

To test:
```
cd helm; make
bin/helm plugin install https://github.com/marckhouzam/helm-fullstatus
bin/helm plugin install https://github.com/marckhouzam/helm-2to3

source <(bin/helm completion bash)

bin/helm fullstatus --ou<TAB>
bin/helm fullstatus --output <TAB>
bin/helm fullstatus <TAB>

bin/helm 2to3 <TAB>
bin/helm 2to3 con<TAB>
bin/helm 2to3 convert <TAB>
# etc
```

This PR includes go tests for the new feature.
A first pass at some user documentation can be see in the description of #7043 

**Of note:**
* This PR provides a contract between plugin developers and Helm, which will require backwards-compatibility support.

**Questions for maintainers**:
* Should the existing `plugin.yaml` file be enhanced to allow plugin developers to specify which files should be used to provide completions?  I've gone an easier route and hard-coded the files to be `<pluginRootDir>/completion.yaml` and `<pluginRootDir>/plugin.complete` for every plugin.
