### PR TITLE
Add TLS renegotiation support 

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -47,6 +47,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 	f.StringVar(&c.CertFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&c.KeyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&c.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.StringVar(&c.Renegotiate, "renegotiate", "never", "TLS renegotiation strategy, valid options include 'never', 'once' and 'freely'")
 }
 
 // bindOutputFlag will add the output flag to the given command and bind the

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -49,6 +49,8 @@ type repoAddOptions struct {
 
 	repoFile  string
 	repoCache string
+
+	renegotiate string
 }
 
 func newRepoAddCmd(out io.Writer) *cobra.Command {
@@ -75,6 +77,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&o.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&o.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&o.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.StringVar(&o.renegotiate, "renegotiate", "never", "TLS renegotiation strategy, valid options include 'never', 'once' and 'freely'")
 
 	return cmd
 }
@@ -113,13 +116,14 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	c := repo.Entry{
-		Name:     o.name,
-		URL:      o.url,
-		Username: o.username,
-		Password: o.password,
-		CertFile: o.certFile,
-		KeyFile:  o.keyFile,
-		CAFile:   o.caFile,
+		Name:        o.name,
+		URL:         o.url,
+		Username:    o.username,
+		Password:    o.password,
+		CertFile:    o.certFile,
+		KeyFile:     o.keyFile,
+		CAFile:      o.caFile,
+		Renegotiate: o.renegotiate,
 	}
 
 	r, err := repo.NewChartRepository(&c, getter.All(settings))

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -61,12 +61,12 @@ func testfile(t *testing.T, file string) (path string) {
 	return path
 }
 
-func TestNewClientTLS(t *testing.T) {
+func TestNewClientTLSWithRenegotiate(t *testing.T) {
 	certFile := testfile(t, testCertFile)
 	keyFile := testfile(t, testKeyFile)
 	caCertFile := testfile(t, testCaCertFile)
 
-	cfg, err := NewClientTLS(certFile, keyFile, caCertFile)
+	cfg, err := NewClientTLSWithRenegotiate(certFile, keyFile, caCertFile, RenegotiateNever)
 	if err != nil {
 		t.Error(err)
 	}
@@ -81,7 +81,7 @@ func TestNewClientTLS(t *testing.T) {
 		t.Fatalf("mismatch tls RootCAs, expecting non-nil")
 	}
 
-	cfg, err = NewClientTLS("", "", caCertFile)
+	cfg, err = NewClientTLSWithRenegotiate("", "", caCertFile, RenegotiateNever)
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +96,7 @@ func TestNewClientTLS(t *testing.T) {
 		t.Fatalf("mismatch tls RootCAs, expecting non-nil")
 	}
 
-	cfg, err = NewClientTLS(certFile, keyFile, "")
+	cfg, err = NewClientTLSWithRenegotiate(certFile, keyFile, "", RenegotiateNever)
 	if err != nil {
 		t.Error(err)
 	}
@@ -109,5 +109,13 @@ func TestNewClientTLS(t *testing.T) {
 	}
 	if cfg.RootCAs != nil {
 		t.Fatalf("mismatch tls RootCAs, expecting nil")
+	}
+
+	cfgNoRenegotiate, err = NewClientTLS(certFile, keyFile, "")
+	if err != nil {
+		t.Error(err)
+	}
+	if cfg != cfgNoRenegotiate {
+		t.Fatalf("config mismatch, configs from NewClientTLS and NewClientTLSWithRenegotiate don't match")
 	}
 }

--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -71,3 +71,12 @@ func ExtractHostname(addr string) (string, error) {
 	}
 	return u.Hostname(), nil
 }
+
+// ExtractScheme returns scheme from URL
+func ExtractScheme(addr string) (string, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", err
+	}
+	return u.Scheme, nil
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -93,15 +93,16 @@ type Install struct {
 
 // ChartPathOptions captures common options used for controlling chart paths
 type ChartPathOptions struct {
-	CaFile   string // --ca-file
-	CertFile string // --cert-file
-	KeyFile  string // --key-file
-	Keyring  string // --keyring
-	Password string // --password
-	RepoURL  string // --repo
-	Username string // --username
-	Verify   bool   // --verify
-	Version  string // --version
+	CaFile      string // --ca-file
+	CertFile    string // --cert-file
+	KeyFile     string // --key-file
+	Keyring     string // --keyring
+	Password    string // --password
+	RepoURL     string // --repo
+	Username    string // --username
+	Verify      bool   // --verify
+	Version     string // --version
+	Renegotiate string // --renegotiate
 }
 
 // NewInstall creates a new Install object with the given configuration.
@@ -670,8 +671,12 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		dl.Verify = downloader.VerifyAlways
 	}
 	if c.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthRepoURL(c.RepoURL, c.Username, c.Password, name, version,
-			c.CertFile, c.KeyFile, c.CaFile, getter.All(settings))
+		finder := repo.NewChartFinder(c.RepoURL, name, version)
+		finder.SetCredentials(c.Username, c.Password)
+		finder.SetTLSFiles(c.CertFile, c.KeyFile, c.CaFile)
+		finder.SetTLSRenegotiation(c.Renegotiate)
+		finder.SetProvider(getter.All(settings))
+		chartURL, err := finder.GetURL()
 		if err != nil {
 			return "", err
 		}

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -64,6 +64,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		Options: []getter.Option{
 			getter.WithBasicAuth(p.Username, p.Password),
 			getter.WithTLSClientConfig(p.CertFile, p.KeyFile, p.CaFile),
+			getter.WithTLSRenegotiate(p.Renegotiate),
 		},
 		RepositoryConfig: p.Settings.RepositoryConfig,
 		RepositoryCache:  p.Settings.RepositoryCache,
@@ -88,7 +89,12 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, getter.All(p.Settings))
+		finder := repo.NewChartFinder(p.RepoURL, chartRef, p.Version)
+		finder.SetCredentials(p.Username, p.Password)
+		finder.SetTLSFiles(p.CertFile, p.KeyFile, p.CaFile)
+		finder.SetProvider(getter.All(p.Settings))
+		finder.SetTLSRenegotiation(p.Renegotiate)
+		chartURL, err := finder.GetURL()
 		if err != nil {
 			return out.String(), err
 		}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -182,6 +182,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 			c.Options,
 			getter.WithURL(rc.URL),
 			getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile),
+			getter.WithTLSRenegotiate(rc.Renegotiate),
 		)
 		if rc.Username != "" && rc.Password != "" {
 			c.Options = append(
@@ -216,6 +217,10 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 
 	if r.Config.CertFile != "" || r.Config.KeyFile != "" || r.Config.CAFile != "" {
 		c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
+	}
+
+	if r.Config.Renegotiate != "" {
+		c.Options = append(c.Options, getter.WithTLSRenegotiate(r.Config.Renegotiate))
 	}
 
 	// Next, we need to load the index, and actually look up the chart.

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -91,6 +91,7 @@ func TestResolveChartOpts(t *testing.T) {
 			expect: []getter.Option{
 				getter.WithURL("https://example.com/foo-1.2.3.tgz"),
 				getter.WithTLSClientConfig("cert", "key", "ca"),
+				getter.WithTLSRenegotiate("never"),
 			},
 		},
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -535,7 +535,9 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
-	url, err = repo.FindChartInRepoURL(repoURL, name, version, "", "", "", m.Getters)
+	finder := repo.NewChartFinder(repoURL, name, version)
+	finder.SetProvider(m.Getters)
+	url, err = finder.GetURL()
 	if err == nil {
 		return
 	}

--- a/pkg/downloader/testdata/repositories.yaml
+++ b/pkg/downloader/testdata/repositories.yaml
@@ -21,3 +21,4 @@ repositories:
     certFile: "cert"
     keyFile: "key"
     caFile: "ca"
+    renegotiate: "never"

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -28,13 +28,14 @@ import (
 //
 // Getters may or may not ignore these parameters as they are passed in.
 type options struct {
-	url       string
-	certFile  string
-	keyFile   string
-	caFile    string
-	username  string
-	password  string
-	userAgent string
+	url         string
+	certFile    string
+	keyFile     string
+	caFile      string
+	username    string
+	password    string
+	userAgent   string
+	renegotiate string
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -70,6 +71,13 @@ func WithTLSClientConfig(certFile, keyFile, caFile string) Option {
 		opts.certFile = certFile
 		opts.keyFile = keyFile
 		opts.caFile = caFile
+	}
+}
+
+// WithTLSRenegotiate sets the TLS renegotiation support
+func WithTLSRenegotiate(option string) Option {
+	return func(opts *options) {
+		opts.renegotiate = option
 	}
 }
 

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -148,7 +148,7 @@ func TestDownloadTLS(t *testing.T) {
 	ca, pub, priv := filepath.Join(cd, "rootca.crt"), filepath.Join(cd, "crt.pem"), filepath.Join(cd, "key.pem")
 
 	tlsSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	tlsConf, err := tlsutil.NewClientTLS(pub, priv, ca)
+	tlsConf, err := tlsutil.NewClientTLSWithRenegotiate(pub, priv, ca, tlsutil.RenegotiateNever)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "can't create TLS config for client"))
 	}
@@ -162,6 +162,7 @@ func TestDownloadTLS(t *testing.T) {
 	g, err := NewHTTPGetter(
 		WithURL(u.String()),
 		WithTLSClientConfig(pub, priv, ca),
+		WithTLSRenegotiate(tlsutil.RenegotiateNever),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -177,7 +178,7 @@ func TestDownloadTLS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig(pub, priv, ca)); err != nil {
+	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig(pub, priv, ca), WithTLSRenegotiate(tlsutil.RenegotiateNever)); err != nil {
 		t.Error(err)
 	}
 
@@ -187,7 +188,18 @@ func TestDownloadTLS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig("", "", ca)); err != nil {
+	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig("", "", ca), WithTLSRenegotiate(tlsutil.RenegotiateNever)); err != nil {
 		t.Error(err)
 	}
+
+	// test with OnceAsClient TLS renegotiation
+	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig(pub, priv, ca), WithTLSRenegotiate(tlsutil.RenegotiateOnceAsClient)); err != nil {
+		t.Error(err)
+	}
+
+	// test with FreelyAsClient TLS renegotiation
+	if _, err := g.Get(u.String(), WithURL(u.String()), WithTLSClientConfig(pub, priv, ca), WithTLSRenegotiate(tlsutil.RenegotiateFreelyAsClient)); err != nil {
+		t.Error(err)
+	}
+
 }

--- a/pkg/getter/testdata/repository/repositories.yaml
+++ b/pkg/getter/testdata/repository/repositories.yaml
@@ -7,9 +7,11 @@ repositories:
   keyFile: ""
   name: stable
   url: https://kubernetes-charts.storage.googleapis.com
+  renegotiate: never
 - caFile: ""
   cache: repository/cache/local-index.yaml
   certFile: ""
   keyFile: ""
   name: local
   url: http://127.0.0.1:8879/charts
+  renegotiate: never

--- a/pkg/repo/testdata/repositories.yaml
+++ b/pkg/repo/testdata/repositories.yaml
@@ -3,6 +3,8 @@ repositories:
   - name: stable
     url: https://example.com/stable/charts
     cache: stable-index.yaml
+    renegotiate: never
   - name: incubator
     url: https://example.com/incubator
     cache: incubator-index.yaml
+    renegotiate: never


### PR DESCRIPTION
Add flag to support TLS renegotiation for chart repos and refactor chartrepo find code.

Fixes https://github.com/helm/helm/issues/7344


add a chart repository

Usage:
  helm repo add [NAME] [URL] [flags]

Flags:
      --ca-file string       verify certificates of HTTPS-enabled servers using this CA bundle
      --cert-file string     identify HTTPS client using this SSL certificate file
  -h, --help                 help for add
      --key-file string      identify HTTPS client using this SSL key file
      --no-update            raise error if repo is already registered
      --password string      chart repository password
      --renegotiate string   TLS renegotiation strategy, valid options include Never, OnceAsClient and FreelyAsClient (default "Never")
      --username string      chart repository username

