### PR TITLE
Added export-values handling to dependencies

### DIFF
--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -45,6 +45,7 @@ type Dependency struct {
 	// ImportValues holds the mapping of source values to parent key to be imported. Each item can be a
 	// string or pair of child/parent sublist items.
 	ImportValues []interface{} `json:"import-values,omitempty"`
+	ExportValues []interface{} `json:"export-values,omitempty"`
 	// Alias usable alias to be used for the chart
 	Alias string `json:"alias,omitempty"`
 }

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -212,6 +212,10 @@ func TestProcessDependencyImportValues(t *testing.T) {
 	e["SCBexported2A"] = "blaster"
 	e["global.SC1exported2.all.SC1exported3"] = "SC1expstr"
 
+	// `imports` style
+	e["subchart1.mytags.back-end"] = "false"
+	e["subchart1.mytags.front-end"] = "true"
+
 	if err := processDependencyImportValues(c); err != nil {
 		t.Fatalf("processing import values dependencies %v", err)
 	}

--- a/pkg/chartutil/testdata/subpop/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/Chart.yaml
@@ -25,6 +25,9 @@ dependencies:
         parent: .
       - SCBexported2
       - SC1exported1
+    export-values:
+      - child: mytags
+        parent: tags
 
   - name: subchart2
     repository: http://localhost:10191


### PR DESCRIPTION
NB: This is a reworked implementation of the functionality found in PR #3243 

---

See issue #3242 

There is a need for an `export-values` method when working with requirements.

The attached PR approaches this by mimicking the `import-values` functionality but in the other direction - allowing you to specify the tree in the parent chart you wish to export into the values of the child chart. It also allows you to _ringfence_ settings to a duplicate (aliased) subchart, as can be seen in the example below:

```
dependencies:
      - name: subchart1
        repository: http://localhost:10191
        version: 0.1.0
        tags:
          - front-end
          - subchart1
        export-values:
          - child: release
            parent: release.old

      - name: subchart1
        repository: http://localhost:10191
        version: 0.1.0
        export-values:
          - child: release
            parent: release.new
        alias: subchart1a
```
Obviously, this simple use case can be achieved through other methods - it's when there are many requirements using a mix & match of various parent values that this change become effective.

NB: We should really rename these methods but not sure what would be a good plan. Should it go from `processDependencyImportValues` to `processDependencyImportExportValues`, something else, or should we just leave them with their existing names?