### PR TITLE
Add EnvSettings.SetNamespace method

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -121,6 +121,11 @@ func (s *EnvSettings) Namespace() string {
 	return "default"
 }
 
+//SetNamespace sets the namespace
+func (s *EnvSettings) SetNamespace(ns string) {
+	s.namespace = ns
+}
+
 //RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -86,6 +86,13 @@ func TestEnvSettings(t *testing.T) {
 			}
 		})
 	}
+
+	settings := New()
+	settings.SetNamespace("custom-namespace")
+
+	if settings.Namespace() != "custom-namespace" {
+		t.Errorf("expected namespace %s, got %s", "custom-namespace", settings.Namespace())
+	}
 }
 
 func resetEnv() func() {


### PR DESCRIPTION
I would like to be able to set the namespace for install/upgrade/etc actions programmatically (that is, not via CLI options) in my code that uses Helm's Go API (including the `cli` package for some CLI options and for action configuration).

At the moment, the workaround I found is to pass the desired namespace to `action.Configuration.Init` [like so](https://github.com/helm/helm/blob/a6b2c9e2126753f6f94df231e89b2153c2862764/cmd/helm/list.go#L74), but I believe being able to set namespace on `EnvSettings` would be the proper way.