### PR TITLE
fix(test) use newly created index instead of ignoring it

### DIFF
--- a/cmd/helm/repo_index_test.go
+++ b/cmd/helm/repo_index_test.go
@@ -119,7 +119,7 @@ func TestRepoIndexCmd(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = repo.LoadIndexFile(destIndex)
+	index, err = repo.LoadIndexFile(destIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,8 +130,8 @@ func TestRepoIndexCmd(t *testing.T) {
 	}
 
 	vs = index.Entries["compressedchart"]
-	if len(vs) != 3 {
-		t.Errorf("expected 3 versions, got %d: %#v", len(vs), vs)
+	if len(vs) != 1 {
+		t.Errorf("expected 1 versions, got %d: %#v", len(vs), vs)
 	}
 
 	expectedVersion = "0.3.0"


### PR DESCRIPTION
This fixes a possible issue in the test for repo index

I think the test code ignores the index in one place and uses the old index values to do wrong assertions

Please do check and provide comments. Looks like it was intentionally ignored, but I don't get why. So, felt it's an issue