### PR TITLE
fix(tests): Make tests pass on MacOS

### DIFF
--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -227,8 +227,8 @@ func TestGetLocalPath(t *testing.T) {
 	}{
 		{
 			name:   "absolute path",
-			repo:   "file:////proc",
-			expect: "/proc",
+			repo:   "file:////tmp",
+			expect: "/tmp",
 		},
 		{
 			name:      "relative path",


### PR DESCRIPTION
This newly added tests was failing on MacOS because /proc does not
exist.  This commit replaces /proc with /tmp to achieve the same result.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>