### PR TITLE
fix(sympath): add option to silence symlink log warning

### DIFF
--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 )
 
 // Walk walks the file tree rooted at root, calling walkFn for each file or directory
@@ -70,6 +71,7 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		if err != nil {
 			return errors.Wrapf(err, "error evaluating symlink %s", path)
 		}
+		klog.V(0).Infof("found symbolic link in path: %s resolves to %s", path, resolved)
 		if info, err = os.Lstat(resolved); err != nil {
 			return err
 		}

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -21,7 +21,6 @@ limitations under the License.
 package sympath
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -71,7 +70,6 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		if err != nil {
 			return errors.Wrapf(err, "error evaluating symlink %s", path)
 		}
-		log.Printf("found symbolic link in path: %s resolves to %s", path, resolved)
 		if info, err = os.Lstat(resolved); err != nil {
 			return err
 		}


### PR DESCRIPTION
~This log line is printed if you have a system link in your chart dir. We have some tooling that sandboxs chart packaging with symlinks, leading to this being printed frequently on engineer's machines. The message isn't clear and is confusing if it is an error or not. Symlinks seem to be supported in helm, so there is no reason to print this debugging message.~

Edit:

Took a look at the work required to support #6844 and seems like to much of a refactor and interface change to take on within a reasonable timeframe. Since the goal seems to be to use the `klog` logging library I switched the logging package in this module using a verbosity of 0, which should line up with the [logging standards](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) for the kubernetes project to always output. If a user wants to disable the logging they can use `helm -v -1`.

Signed-off-by: Griffin Dunn <griffin.dunn@datadoghq.com>