### PR TITLE
fix(helm): Don't wait for service to be ready when external IP are set

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -188,12 +188,24 @@ func (w *waiter) serviceReady(s *corev1.Service) bool {
 	}
 
 	// Make sure the service is not explicitly set to "None" before checking the IP
-	if (s.Spec.ClusterIP != corev1.ClusterIPNone && s.Spec.ClusterIP == "") ||
-		// This checks if the service has a LoadBalancer and that balancer has an Ingress defined
-		(s.Spec.Type == corev1.ServiceTypeLoadBalancer && s.Status.LoadBalancer.Ingress == nil) {
-		w.log("Service does not have IP address: %s/%s", s.GetNamespace(), s.GetName())
+	if s.Spec.ClusterIP != corev1.ClusterIPNone && s.Spec.ClusterIP == "" {
 		return false
 	}
+
+	// This checks if the service has a LoadBalancer and that balancer has an Ingress defined
+	if s.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		// do not wait when at least 1 external IP is set
+		if len(s.Spec.ExternalIPs) > 0 {
+			w.log("Service has externaIPs addresses: %s/%s (%v)", s.GetNamespace(), s.GetName(), s.Spec.ExternalIPs)
+			return true
+		}
+
+		if s.Status.LoadBalancer.Ingress == nil {
+			w.log("Service does not have IP address: %s/%s", s.GetNamespace(), s.GetName())
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -189,6 +189,7 @@ func (w *waiter) serviceReady(s *corev1.Service) bool {
 
 	// Make sure the service is not explicitly set to "None" before checking the IP
 	if s.Spec.ClusterIP != corev1.ClusterIPNone && s.Spec.ClusterIP == "" {
+		w.log("Service does not have IP address: %s/%s", s.GetNamespace(), s.GetName())
 		return false
 	}
 
@@ -196,7 +197,7 @@ func (w *waiter) serviceReady(s *corev1.Service) bool {
 	if s.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		// do not wait when at least 1 external IP is set
 		if len(s.Spec.ExternalIPs) > 0 {
-			w.log("Service has externaIPs addresses: %s/%s (%v)", s.GetNamespace(), s.GetName(), s.Spec.ExternalIPs)
+			w.log("Service %s/%s has external IP addresses (%v), marking as ready", s.GetNamespace(), s.GetName(), s.Spec.ExternalIPs)
 			return true
 		}
 

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -189,7 +189,7 @@ func (w *waiter) serviceReady(s *corev1.Service) bool {
 
 	// Make sure the service is not explicitly set to "None" before checking the IP
 	if s.Spec.ClusterIP != corev1.ClusterIPNone && s.Spec.ClusterIP == "" {
-		w.log("Service does not have IP address: %s/%s", s.GetNamespace(), s.GetName())
+		w.log("Service does not have cluster IP address: %s/%s", s.GetNamespace(), s.GetName())
 		return false
 	}
 
@@ -202,7 +202,7 @@ func (w *waiter) serviceReady(s *corev1.Service) bool {
 		}
 
 		if s.Status.LoadBalancer.Ingress == nil {
-			w.log("Service does not have IP address: %s/%s", s.GetNamespace(), s.GetName())
+			w.log("Service does not have load balancer ingress IP address: %s/%s", s.GetNamespace(), s.GetName())
 			return false
 		}
 	}


### PR DESCRIPTION
Resolves #7513
As, [according to the doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#servicespec-v1-core), the externalIPs are not managed by k8s; helm should not wait for services  which set at least one externalIPs.