### PR TITLE
Fixes issue where <CHARTNAME> is left in starter values file

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -445,6 +445,15 @@ func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
 	}
 	schart.Values = m
 
+	// SaveDir looks for the file values.yaml when saving rather than the values
+	// key in order to preserve the comments in the YAML. The name placeholder
+	// needs to be replaced on that file.
+	for _, f := range schart.Raw {
+		if f.Name == ValuesfileName {
+			f.Data = transform(string(f.Data), schart.Name())
+		}
+	}
+
 	return SaveDir(schart, dest)
 }
 

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chartutil
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -104,6 +105,15 @@ func TestCreateFrom(t *testing.T) {
 	} {
 		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
 			t.Errorf("Expected %s file: %s", f, err)
+		}
+
+		// Check each file to make sure <CHARTNAME> has been replaced
+		b, err := ioutil.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			t.Errorf("Unable to read file %s: %s", f, err)
+		}
+		if bytes.Contains(b, []byte("<CHARTNAME>")) {
+			t.Errorf("File %s contains <CHARTNAME>", f)
 		}
 	}
 }


### PR DESCRIPTION
This is a leftover bug from #7201.

Closes #7532