### PR TITLE
Fixes issue where non-CRDs are read in from the crd directory

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -135,7 +135,7 @@ func (ch *Chart) CRDs() []*File {
 	files := []*File{}
 	// Find all resources in the crds/ directory
 	for _, f := range ch.Files {
-		if strings.HasPrefix(f.Name, "crds/") {
+		if strings.HasPrefix(f.Name, "crds/") && hasManifestExtension(f.Name) {
 			files = append(files, f)
 		}
 	}
@@ -151,7 +151,7 @@ func (ch *Chart) CRDObjects() []CRD {
 	crds := []CRD{}
 	// Find all resources in the crds/ directory
 	for _, f := range ch.Files {
-		if strings.HasPrefix(f.Name, "crds/") {
+		if strings.HasPrefix(f.Name, "crds/") && hasManifestExtension(f.Name) {
 			mycrd := CRD{Name: f.Name, Filename: filepath.Join(ch.ChartFullPath(), f.Name), File: f}
 			crds = append(crds, mycrd)
 		}
@@ -161,4 +161,9 @@ func (ch *Chart) CRDObjects() []CRD {
 		crds = append(crds, dep.CRDObjects()...)
 	}
 	return crds
+}
+
+func hasManifestExtension(fname string) bool {
+	ext := filepath.Ext(fname)
+	return strings.EqualFold(ext, ".yaml") || strings.EqualFold(ext, ".yml") || strings.EqualFold(ext, ".json")
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -41,6 +41,10 @@ func TestCRDs(t *testing.T) {
 				Name: "crdsfoo/bar/baz.yaml",
 				Data: []byte("hello"),
 			},
+			{
+				Name: "crds/README.md",
+				Data: []byte("# hello"),
+			},
 		},
 	}
 


### PR DESCRIPTION
For example, a readme markdown is read in and parsed

Closes #7536