### PR TITLE
IsReachable() needs to give detailed error message.

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -86,7 +86,7 @@ func (c *Client) IsReachable() error {
 	client, _ := c.Factory.KubernetesClientSet()
 	_, err := client.ServerVersion()
 	if err != nil {
-		return errors.New("Kubernetes cluster unreachable")
+		return fmt.Errorf("Kubernetes cluster unreachable: %s", err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
The IsReachable() function in pkg/kube/client.go should give detailed error message, since the users need to know what the error is when the cluster is unreachable.