### PR TITLE
feat(tests): Allow to provision memory driver

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -19,6 +19,7 @@ package main // import "helm.sh/helm/v3/cmd/helm"
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -26,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
+	"sigs.k8s.io/yaml"
 
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -34,6 +36,9 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/gates"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 // FeatureGateOCI is the feature gate for checking if `helm chart` and `helm registry` commands should work
@@ -78,8 +83,12 @@ func main() {
 		}
 	}
 
-	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+	helmDriver := os.Getenv("HELM_DRIVER")
+	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, debug); err != nil {
 		log.Fatal(err)
+	}
+	if helmDriver == "memory" {
+		loadReleasesInMemory(actionConfig)
 	}
 
 	if err := cmd.Execute(); err != nil {
@@ -105,4 +114,42 @@ func checkOCIFeatureGate() func(_ *cobra.Command, _ []string) error {
 		}
 		return nil
 	}
+}
+
+// This function loads releases into the memory storage if the
+// environment variable is properly set.
+func loadReleasesInMemory(actionConfig *action.Configuration) {
+	filePaths := strings.Split(os.Getenv("HELM_MEMORY_DRIVER_DATA"), ":")
+	if len(filePaths) == 0 {
+		return
+	}
+
+	store := actionConfig.Releases
+	mem, ok := store.Driver.(*driver.Memory)
+	if !ok {
+		// For an unexpected reason we are not dealing with the memory storage driver.
+		return
+	}
+
+	actionConfig.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
+
+	for _, path := range filePaths {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Fatal("Unable to read memory driver data", err)
+		}
+
+		releases := []*release.Release{}
+		if err := yaml.Unmarshal(b, &releases); err != nil {
+			log.Fatal("Unable to unmarshal memory driver data: ", err)
+		}
+
+		for _, rel := range releases {
+			if err := store.Create(rel); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+	// Must reset namespace to the proper one
+	mem.SetNamespace(settings.Namespace())
 }

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -241,7 +241,18 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 		d.Log = log
 		store = storage.Init(d)
 	case "memory":
-		d := driver.NewMemory()
+		var d *driver.Memory
+		if c.Releases != nil {
+			if mem, ok := c.Releases.Driver.(*driver.Memory); ok {
+				// This function can be called more than once (e.g., helm list --all-namespaces).
+				// If a memory driver was already initialized, re-use it but set the possibly new namespace.
+				// We re-use it in case some releases where already created in the existing memory driver.
+				d = mem
+			}
+		}
+		if d == nil {
+			d = driver.NewMemory()
+		}
 		d.SetNamespace(namespace)
 		store = storage.Init(d)
 	default:

--- a/testdata/releases.yaml
+++ b/testdata/releases.yaml
@@ -1,0 +1,43 @@
+# This file can be used as input to create test releases:
+# HELM_MEMORY_DRIVER_DATA=./testdata/releases.yaml HELM_DRIVER=memory helm list --all-namespaces
+- name: athos
+  version: 1
+  namespace: default
+  info:
+    status: deployed
+  chart:
+    metadata:
+      name: athos-chart
+      version: 1.0.0
+      appversion: 1.1.0
+- name: porthos
+  version: 2
+  namespace: default
+  info:
+    status: deployed
+  chart:
+    metadata:
+      name: prothos-chart
+      version: 0.2.0
+      appversion: 0.2.2
+- name: aramis
+  version: 3
+  namespace: default
+  info:
+    status: deployed
+  chart:
+    metadata:
+      name: aramis-chart
+      version: 0.0.3
+      appversion: 3.0.3
+- name: dartagnan
+  version: 4
+  namespace: gascony
+  info:
+    status: deployed
+  chart:
+    metadata:
+      name: dartagnan-chart
+      version: 0.4.4
+      appversion: 4.4.4
+


### PR DESCRIPTION
The memory driver is used for go tests. It can also be used from the
command-line by setting the environment variable HELM_DRIVER=memory.
In the latter case however, there was no way to pre-provision some
releases.

This commit introduces the HELM_MEMORY_DRIVER_DATA variable which
can be used to provide a colon-separated list of yaml files specifying
releases to provision automatically.

An example to try this out:
   HELM_DRIVER=memory \
   HELM_MEMORY_DRIVER_DATA=./testdata/releases.yaml \
   helm list --all-namespaces

Note:

- This is meant to allow writing acceptance tests.  To illustrate new tests have been implemented in the following acceptance-testing PR: https://github.com/helm/acceptance-testing/pull/75

- This PR only allows to *pre-load* releases in the memory driver, it does not persist any changes made by the helm command itself.  It would be possible to simply dump the resulting memory driver content into the same yaml file to create an off-cluster storage mechanism.  However, I purposefully did not do this because it may give users the impression it is a valid way to store releases and since each helm command would parse the entire yaml file of releases and would also dump it, a growing set of releases would cause more and more slowness.  I think the right solution for an off-cluster storage is to use a database (like helm v2 had), not a file (this is beyond the scope of this PR).