### PR TITLE
fix(comp): Fix broken completion for --output flag

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -99,8 +99,6 @@ func (o *outputValue) Set(s string) error {
 
 func bindPostRenderFlag(cmd *cobra.Command, varRef *postrender.PostRenderer) {
 	cmd.Flags().Var(&postRenderer{varRef}, postRenderFlag, "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
-	// Setup shell completion for the flag
-	cmd.MarkFlagCustom(outputFlag, "__helm_output_options")
 }
 
 type postRenderer struct {


### PR DESCRIPTION
This was detected because the completion tests in the acceptance-testing repo started to fail. 


For commands using the new post-render flag, the completion for the --output flag was broken.

For example:
```
$   helm install -o <TAB>
__helm_handle_reply:47: command not found: __helm_output_options
```

The bash __helm_output_options function is no longer used but was referred to by mistake.
This commit removes the offending code.
