### PR TITLE
Fix shasums to be usable by shasum and sha256sum applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,15 +157,22 @@ fetch-dist:
 
 .PHONY: sign
 sign:
-	for f in _dist/*.{gz,zip,sha256} ; do \
+	for f in _dist/*.{gz,zip,sha256,sha256sum} ; do \
 		gpg --armor --detach-sign $${f} ; \
 	done
 
+# The contents of the .sha256sum file are compatible with tools like
+# shasum. For example, using the following command will verify
+# the file helm-3.1.0-rc.1-darwin-amd64.tar.gz:
+#   shasum -a 256 -c helm-3.1.0-rc.1-darwin-amd64.tar.gz.sha256sum
+# The .sha256 files hold only the hash and are not compatible with
+# verification tools like shasum or sha256sum. This method and file can be
+# removed in Helm v4.
 .PHONY: checksum
 checksum:
-	@if [ -f "_dist/shasums.txt" ]; then >_dist/shasums.txt; fi
 	for f in _dist/*.{gz,zip} ; do \
-		shasum -a 256 "$${f}"  | sed 's/_dist\///' | tee -a "_dist/shasums.txt" | awk '{print $$1}' > "$${f}.sha256" ; \
+		shasum -a 256 "$${f}" | sed 's/_dist\///' > "$${f}.sha256sum" ; \
+		shasum -a 256 "$${f}" | awk '{print $$1}' > "$${f}.sha256" ; \
 	done
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
When #7277 was merged is was intended to create shasums accessible
in a way shasum -c or sha256sum could use to verify the files the
Helm project ships. The solution created a new file named
shasums.txt. This setup contained a few problems:

1. The new file file was not uploaded to get.helm.sh for someone
   to download and use.
2. The file had not version in the naming or path. This means that
   each new release of Helm will overwrite it. Downloading and
   validating an old file is impossible.
3. If one downloads a single file, the shasums.txt file, and uses
   shasum -c it will return an exit code that is 1. This is because
   of missing files as it is looking for all the files from the
   release.
4. The shasums.txt file is not signed for verification like the
   other files.

This change fixes these problems with the following changes:

* Instead of a shasums.txt file there is a .sha256sum file for
  each package. For example, helm-3.1.0-linux-amd64.zip.sha256sum.
  This file will can be used with `shasum -a 256 -c` to verify
  the single file helm-3.1.0-linux-amd64.zip. The exit code of
  checking a single file is 0 if the file passes.
* This new .sha256sum file is signed just like the .tar.gz, .zip,
  and .sha256 files. The provenance can be verified.
* The file name starts with `helm-` meaning the existing upload
  script in the deploy.sh file will move it to get.helm.sh.

Note, the existing .sha256 file can be deprecated and removed
in Helm v4 with the new .sha256sum file taking over. But,
for backwards compatibility with scripts it needs to be kept
during v3.

Closes #7567