### PR TITLE
feat(upgrade): introduce --disable-openapi-validation:

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -109,6 +109,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.Namespace = client.Namespace
 					instClient.Atomic = client.Atomic
 					instClient.PostRenderer = client.PostRenderer
+					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 
 					rel, err := runInstall(args, instClient, valueOpts, out)
 					if err != nil {
@@ -165,6 +166,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.MarkDeprecated("recreate-pods", "functionality will no longer be updated. Consult the documentation for other methods to recreate pods")
 	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "disable pre/post upgrade hooks")
+	f.BoolVar(&client.DisableOpenAPIValidation, "disable-openapi-validation", false, "if set, the upgrade process will not validate rendered templates against the Kubernetes OpenAPI Schema")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&client.ResetValues, "reset-values", false, "when upgrading, reset the values to the ones built into the chart")
 	f.BoolVar(&client.ReuseValues, "reuse-values", false, "when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' is specified, this is ignored")

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -55,12 +55,13 @@ type Upgrade struct {
 	// Recreate will (if true) recreate pods after a rollback.
 	Recreate bool
 	// MaxHistory limits the maximum number of revisions saved per release
-	MaxHistory    int
-	Atomic        bool
-	CleanupOnFail bool
-	SubNotes      bool
-	Description   string
-	PostRenderer  postrender.PostRenderer
+	MaxHistory               int
+	Atomic                   bool
+	CleanupOnFail            bool
+	SubNotes                 bool
+	Description              string
+	PostRenderer             postrender.PostRenderer
+	DisableOpenAPIValidation bool
 }
 
 // NewUpgrade creates a new Upgrade object with the given configuration.
@@ -188,7 +189,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	if len(notesTxt) > 0 {
 		upgradedRelease.Info.Notes = notesTxt
 	}
-	err = validateManifest(u.cfg.KubeClient, manifestDoc.Bytes())
+	err = validateManifest(u.cfg.KubeClient, manifestDoc.Bytes(), !u.DisableOpenAPIValidation)
 	return currentRelease, upgradedRelease, err
 }
 
@@ -197,7 +198,7 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 	if err != nil {
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
-	target, err := u.cfg.KubeClient.Build(bytes.NewBufferString(upgradedRelease.Manifest), true)
+	target, err := u.cfg.KubeClient.Build(bytes.NewBufferString(upgradedRelease.Manifest), !u.DisableOpenAPIValidation)
 	if err != nil {
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}
@@ -383,8 +384,8 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release, newV
 	return newVals, nil
 }
 
-func validateManifest(c kube.Interface, manifest []byte) error {
-	_, err := c.Build(bytes.NewReader(manifest), true)
+func validateManifest(c kube.Interface, manifest []byte, openAPIValidation bool) error {
+	_, err := c.Build(bytes.NewReader(manifest), openAPIValidation)
 	return err
 }
 


### PR DESCRIPTION
This is a copy of the --disable-openapi-validation flag from the install command as introduced by Matthew Fisher.
See commit 67e57a5fbb7b210e534157b8f67c15ffc3445453

It allows upgrading releases without the need to validate the Kubernetes OpenAPI Schema.