### PR TITLE
Workaround obsolete API versions

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -452,12 +452,11 @@ func isCRD(groupVersion string) bool {
 		return false
 	}
 	group := s[0]
-	s = strings.Split(group, ".")
-	if len(s) == 1 {
+	if strings.Count(group, ".") == 0 {
 		// "apps/v1"
 		return false
 	}
-	if s[len(s)-2] == "k8s" && s[len(s)-1] == "io" {
+	if strings.HasSuffix(group, "k8s.io") {
 		// "networking.k8s.io/v1"
 		return false
 	}


### PR DESCRIPTION
This is a workaround for changes in API versions like
extensions/v1beta1 => apps/v1

From Helm's perspective those are new Resources as the API version
cannot be changed. However there is a compat layer in k8s that will
return the old resources for the new API version. Helm will reject the
resource 'creation' as there is already a resource of the same kind and
version.

Do we want to maintain compat code in this place? Probably not.