### PR TITLE
chore(rootfs): bump alpine image to 3.11

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates socat
 


### PR DESCRIPTION
Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>