### PR TITLE
fix(render): Render error not being propagated

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -230,6 +230,20 @@ func withSampleTemplates() chartOption {
 	}
 }
 
+func withSampleIncludingIncorrectTemplates() chartOption {
+	return func(opts *chartOptions) {
+		sampleTemplates := []*chart.File{
+			// This adds basic templates and partials.
+			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
+			{Name: "templates/empty", Data: []byte("")},
+			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
+			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+		}
+		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
 func withMultipleManifestTemplate() chartOption {
 	return func(opts *chartOptions) {
 		sampleTemplates := []*chart.File{

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -460,7 +460,7 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 	}
 
 	if err2 != nil {
-		return hs, b, "", err
+		return hs, b, "", err2
 	}
 
 	// NOTES.txt gets rendered like all the other files, but because it's not a hook nor a resource,

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -240,6 +240,21 @@ func TestInstallRelease_DryRun(t *testing.T) {
 	is.Equal(res.Info.Description, "Dry run complete")
 }
 
+func TestInstallReleaseIncorrectTemplate_DryRun(t *testing.T) {
+	is := assert.New(t)
+	instAction := installAction(t)
+	instAction.DryRun = true
+	vals := map[string]interface{}{}
+	_, err := instAction.Run(buildChart(withSampleIncludingIncorrectTemplates()), vals)
+	expectedErr := "\"hello/templates/incorrect\" at <.Values.bad.doh>: nil pointer evaluating interface {}.doh"
+	if err == nil {
+		t.Fatalf("Install should fail containing error: %s", expectedErr)
+	}
+	if err != nil {
+		is.Contains(err.Error(), expectedErr)
+	}
+}
+
 func TestInstallRelease_NoHooks(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)


### PR DESCRIPTION
Errors when rendering templates are not being propagated up the stack. This means that any template issues like in #7593 would not return an error to the user and just fail silently and without any output. This PR fixes this.

Fixes #7593 