### PR TITLE
feat(pkg): Install / Template Charts without downloading to filesystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gosuri/uitable v0.0.4
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.3.0
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/mattn/go-shellwords v1.0.10
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/opencontainers/go-digest v1.0.0-rc1


### PR DESCRIPTION
fixes https://github.com/helm/helm/issues/7545

- This will allow users to use the charts without them being downloaded to the HELM_REPOSITORY_CACHE by setting the value for the same to "off"

