### PR TITLE
feat(comp): Move kube-context completion to Go

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -30,6 +30,7 @@ import (
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"helm.sh/helm/v3/internal/completion"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/gates"
@@ -66,6 +67,16 @@ func main() {
 
 	actionConfig := new(action.Configuration)
 	cmd := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
+
+	if calledCmd, _, err := cmd.Find(os.Args[1:]); err == nil && calledCmd.Name() == completion.CompRequestCmd {
+		// If completion is being called, we have to check if the completion is for the "--kube-context"
+		// value; if it is, we cannot call the action.Init() method with an incomplete kube-context value
+		// or else it will fail immediately.  So, we simply unset the invalid kube-context value.
+		if args := os.Args[1:]; len(args) > 2 && args[len(args)-2] == "--kube-context" {
+			// We are completing the kube-context value!  Reset it as the current value is not valid.
+			settings.KubeContext = ""
+		}
+	}
 
 	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
 		log.Fatal(err)

--- a/internal/completion/complete.go
+++ b/internal/completion/complete.go
@@ -35,9 +35,9 @@ import (
 // This should ultimately be pushed down into Cobra.
 // ==================================================================================
 
-// compRequestCmd Hidden command to request completion results from the program.
+// CompRequestCmd Hidden command to request completion results from the program.
 // Used by the shell completion script.
-const compRequestCmd = "__complete"
+const CompRequestCmd = "__complete"
 
 // Global map allowing to find completion functions for commands or flags.
 var validArgsFunctions = map[interface{}]func(cmd *cobra.Command, args []string, toComplete string) ([]string, BashCompDirective){}
@@ -123,7 +123,7 @@ __helm_custom_func()
         done < <(compgen -W "${out[*]}" -- "$cur")
     fi
 }
-`, compRequestCmd, BashCompDirectiveError, BashCompDirectiveNoSpace, BashCompDirectiveNoFileComp)
+`, CompRequestCmd, BashCompDirectiveError, BashCompDirectiveNoSpace, BashCompDirectiveNoFileComp)
 }
 
 // RegisterValidArgsFunc should be called to register a function to provide argument completion for a command
@@ -177,14 +177,14 @@ func (d BashCompDirective) string() string {
 func NewCompleteCmd(settings *cli.EnvSettings, out io.Writer) *cobra.Command {
 	debug = settings.Debug
 	return &cobra.Command{
-		Use:                   fmt.Sprintf("%s [command-line]", compRequestCmd),
+		Use:                   fmt.Sprintf("%s [command-line]", CompRequestCmd),
 		DisableFlagsInUseLine: true,
 		Hidden:                true,
 		DisableFlagParsing:    true,
 		Args:                  require.MinimumNArgs(1),
 		Short:                 "Request shell completion choices for the specified command-line",
 		Long: fmt.Sprintf("%s is a special command that is used by the shell completion logic\n%s",
-			compRequestCmd, "to request completion choices for the specified command-line."),
+			CompRequestCmd, "to request completion choices for the specified command-line."),
 		Run: func(cmd *cobra.Command, args []string) {
 			CompDebugln(fmt.Sprintf("%s was called with args %v", cmd.Name(), args))
 


### PR DESCRIPTION
This moves that last custom completion done in Bash to Go.
This actually removes the last dependency to `kubectl`.  

I hadn't done that before because the call to `action.Init()` would fail before doing the completion, when the `--kube-context` value was partial (because it was being completed).  But I found a way around that by looking for that specific scenario, as implemented in this PR.