### PR TITLE
Add support for using OCI references as the dependency repository

### DIFF
--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -71,6 +71,15 @@ the dependency charts stored locally. The path should start with a prefix of
 If the dependency chart is retrieved locally, it is not required to have the
 repository added to helm by "helm add repo". Version matching is also supported
 for this case.
+
+Starting from 3.3.0, if OCI Registry support has been enabled via the HELM_EXPERIMENTAL_OCI
+flag, repository can be defined as an OCI image reference. The path should start with a
+prefix of "oci://". For example,
+
+    # Chart.yaml
+    dependencies:
+    - version: "1.2.3"
+      repository: "oci://localhost:5000/myrepo/mychart:2.7.0"
 `
 
 const dependencyListDesc = `
@@ -82,7 +91,7 @@ the contents of a chart.
 This will produce an error if the chart cannot be loaded.
 `
 
-func newDependencyCmd(out io.Writer) *cobra.Command {
+func newDependencyCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dependency update|build|list",
 		Aliases: []string{"dep", "dependencies"},
@@ -92,8 +101,8 @@ func newDependencyCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(newDependencyListCmd(out))
-	cmd.AddCommand(newDependencyUpdateCmd(out))
-	cmd.AddCommand(newDependencyBuildCmd(out))
+	cmd.AddCommand(newDependencyUpdateCmd(cfg, out))
+	cmd.AddCommand(newDependencyBuildCmd(cfg, out))
 
 	return cmd
 }

--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/internal/experimental/registry"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
@@ -40,7 +41,7 @@ If no lock file is found, 'helm dependency build' will mirror the behavior
 of 'helm dependency update'.
 `
 
-func newDependencyBuildCmd(out io.Writer) *cobra.Command {
+func newDependencyBuildCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	client := action.NewDependency()
 
 	cmd := &cobra.Command{
@@ -53,11 +54,15 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				chartpath = filepath.Clean(args[0])
 			}
+			getters := getter.All(settings)
+			if FeatureGateOCI.IsEnabled() {
+				getters = append(getters, registry.NewRegistryGetterProvider(cfg.RegistryClient))
+			}
 			man := &downloader.Manager{
 				Out:              out,
 				ChartPath:        chartpath,
 				Keyring:          client.Keyring,
-				Getters:          getter.All(settings),
+				Getters:          getters,
 				RepositoryConfig: settings.RepositoryConfig,
 				RepositoryCache:  settings.RepositoryCache,
 				Debug:            settings.Debug,

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -141,7 +141,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	cmd.AddCommand(
 		// chart commands
 		newCreateCmd(out),
-		newDependencyCmd(out),
+		newDependencyCmd(actionConfig, out),
 		newPullCmd(out),
 		newShowCmd(out),
 		newLintCmd(out),

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3
 	github.com/sirupsen/logrus v1.4.2

--- a/internal/experimental/registry/client_test.go
+++ b/internal/experimental/registry/client_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -33,12 +32,12 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
-
 	auth "github.com/deislabs/oras/pkg/auth/docker"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/registry"
 	_ "github.com/docker/distribution/registry/auth/htpasswd"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/bcrypt"
 
@@ -107,7 +106,7 @@ func (suite *RegistryClientTestSuite) SetupSuite() {
 
 	// Registry config
 	config := &configuration.Configuration{}
-	port, err := getFreePort()
+	port, err := freeport.GetFreePort()
 	suite.Nil(err, "no error finding free port for test registry")
 	suite.DockerRegistryHost = fmt.Sprintf("localhost:%d", port)
 	config.HTTP.Addr = fmt.Sprintf(":%d", port)
@@ -252,21 +251,6 @@ func (suite *RegistryClientTestSuite) Test_8_ManInTheMiddle() {
 
 func TestRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(RegistryClientTestSuite))
-}
-
-// borrowed from https://github.com/phayes/freeport
-func getFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 func initCompromisedRegistryTestServer() string {

--- a/internal/experimental/registry/constants.go
+++ b/internal/experimental/registry/constants.go
@@ -22,6 +22,9 @@ const (
 
 	// HelmChartContentLayerMediaType is the reserved media type for Helm chart package content
 	HelmChartContentLayerMediaType = "application/tar+gzip"
+
+	// OCIProtocol is the protocol used for OCI registry URLs
+	OCIProtocol = "oci"
 )
 
 // KnownMediaTypes returns a list of layer mediaTypes that the Helm client knows about

--- a/internal/experimental/registry/getter.go
+++ b/internal/experimental/registry/getter.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry // import "helm.sh/helm/v3/internal/experimental/registry"
+
+import (
+	"bytes"
+	"net/url"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/getter"
+)
+
+// Getter is the HTTP(/S) backend handler for OCI image registries.
+type Getter struct {
+	Client *Client
+}
+
+func NewRegistryGetter(c *Client) *Getter {
+	return &Getter{Client: c}
+}
+
+func NewRegistryGetterProvider(c *Client) getter.Provider {
+	return getter.Provider{
+		Schemes: []string{OCIProtocol},
+		New: func(options ...getter.Option) (g getter.Getter, e error) {
+			return NewRegistryGetter(c), nil
+		},
+	}
+}
+
+func (g *Getter) Get(href string, options ...getter.Option) (*bytes.Buffer, error) {
+	u, err := url.Parse(href)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := ParseReference(u.Host + u.Path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// first we'll pull the chart
+	err = g.Client.PullChart(ref)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// once we know we have the chart, we'll load up the chart
+	c, err := g.Client.LoadChart(ref)
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	// lastly, we'll write the tarred and gzipped contents of the chart to our output buffer
+	err = chartutil.Write(c, buf)
+
+	return buf, err
+}

--- a/internal/experimental/registry/getter_test.go
+++ b/internal/experimental/registry/getter_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	auth "github.com/deislabs/oras/pkg/auth/docker"
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/registry"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+func TestValidRegistryUrlWithImageTag(t *testing.T) {
+	os.RemoveAll(testCacheRootDir)
+	os.Mkdir(testCacheRootDir, 0700)
+
+	var out bytes.Buffer
+	credentialsFile := filepath.Join(testCacheRootDir, CredentialsFileBasename)
+
+	client, err := auth.NewClient(credentialsFile)
+	assert.Nil(t, err, "no error creating auth client")
+
+	resolver, err := client.Resolver(context.Background(), http.DefaultClient, false)
+	assert.Nil(t, err, "no error creating resolver")
+
+	// create cache
+	cache, err := NewCache(
+		CacheOptDebug(true),
+		CacheOptWriter(&out),
+		CacheOptRoot(filepath.Join(testCacheRootDir, CacheRootDir)),
+	)
+	assert.Nil(t, err, "no error creating cache")
+
+	// init test client
+	registryClient, err := NewClient(
+		ClientOptDebug(true),
+		ClientOptWriter(&out),
+		ClientOptAuthorizer(&Authorizer{
+			Client: client,
+		}),
+		ClientOptResolver(&Resolver{
+			Resolver: resolver,
+		}),
+		ClientOptCache(cache),
+	)
+	assert.Nil(t, err, "no error creating registry client")
+
+	// create htpasswd file (w BCrypt, which is required)
+	pwBytes, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
+	assert.Nil(t, err, "no error generating bcrypt password for test htpasswd file")
+	htpasswdPath := filepath.Join(testCacheRootDir, testHtpasswdFileBasename)
+	err = ioutil.WriteFile(htpasswdPath, []byte(fmt.Sprintf("%s:%s\n", testUsername, string(pwBytes))), 0644)
+	assert.Nil(t, err, "no error creating test htpasswd file")
+
+	// Registry config
+	config := &configuration.Configuration{}
+	port, err := freeport.GetFreePort()
+	assert.Nil(t, err, "failed to find free port for test registry")
+	dockerRegistryHost := fmt.Sprintf("localhost:%d", port)
+	config.HTTP.Addr = fmt.Sprintf(":%d", port)
+	config.HTTP.DrainTimeout = time.Duration(10) * time.Second
+	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
+	config.Auth = configuration.Auth{
+		"htpasswd": configuration.Parameters{
+			"realm": "localhost",
+			"path":  htpasswdPath,
+		},
+	}
+	dockerRegistry, err := registry.NewRegistry(context.Background(), config)
+	assert.Nil(t, err, "failed to create test registry")
+
+	// Start Docker registry
+	go dockerRegistry.ListenAndServe()
+	registryClient.Login(dockerRegistryHost, testUsername, testPassword, false)
+
+	ref, _ := ParseReference(fmt.Sprintf("%s/testrepo/testchart:1.2.3", dockerRegistryHost))
+
+	ch := &chart.Chart{}
+	ch.Metadata = &chart.Metadata{
+		APIVersion: "v1",
+		Name:       "testchart",
+		Version:    "1.2.3",
+	}
+
+	err = registryClient.SaveChart(ch, ref)
+	assert.NoError(t, err)
+	err = registryClient.PushChart(ref)
+	assert.NoError(t, err)
+
+	g := NewRegistryGetter(registryClient)
+	res, err := g.Get(fmt.Sprintf("oci://%s/testrepo/testchart:1.2.3", dockerRegistryHost))
+	assert.NoError(t, err, "failed to retrieve chart")
+
+	downloadedChart, err := loader.LoadArchive(res)
+	assert.NoError(t, err, "failed to load archive")
+	assert.Equal(t, "testchart", downloadedChart.Name())
+	assert.Equal(t, "1.2.3", downloadedChart.Metadata.Version)
+
+	registryClient.Logout(dockerRegistryHost)
+	os.RemoveAll(testCacheRootDir)
+}

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -96,6 +96,37 @@ func TestFindChartURL(t *testing.T) {
 	}
 }
 
+func TestFindChartUrlForOCIRepository(t *testing.T) {
+	var b bytes.Buffer
+	m := &Manager{
+		Out:              &b,
+		RepositoryConfig: repoConfig,
+		RepositoryCache:  repoCache,
+	}
+	repos, err := m.loadChartRepositories()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := "alpine"
+	version := "0.1.0"
+	repoURL := "oci://example.com/charts/alpine"
+
+	churl, username, password, err := m.findChartURL(name, version, repoURL, repos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if churl != "oci://example.com/charts/alpine" {
+		t.Errorf("Unexpected URL %q", churl)
+	}
+	if username != "" {
+		t.Errorf("Unexpected username %q", username)
+	}
+	if password != "" {
+		t.Errorf("Unexpected password %q", password)
+	}
+}
+
 func TestGetRepoNames(t *testing.T) {
 	b := bytes.NewBuffer(nil)
 	m := &Manager{

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -205,7 +205,6 @@ func FindChartInRepoURL(repoURL, chartName, chartVersion, certFile, keyFile, caF
 // without adding repo to repositories, like FindChartInRepoURL,
 // but it also receives credentials for the chart repository.
 func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers) (string, error) {
-
 	// Download and write the index file to a temporary location
 	buf := make([]byte, 20)
 	rand.Read(buf)


### PR DESCRIPTION
## Summary

This PR introduces the ability to specify OCI references as the `repository` for chart dependencies. This means it will be possible to specify:
```yaml
# Chart.yaml
dependencies:
- name: nginx
  version: "1.2.3"
  repository: "oci://nginx:latest"
```

This MR *does not* (yet anyway) add support for directly installing OCI-compatible images via `helm install`, i.e `helm install --name nginx oci://nginx`, although that addition _should_ be fairly easy.

## Points of discussion

### Versions

Currently, the helm versioning system relies on SemVer. This is great, and something I think should definitely be kept. *However*, with OCI registries, we have no way of determining a version or any way of indexing. Thus, we have some options:

1. Ignore the version: this is what the current code does, and I don't like it. This will rely solely on the image name and tag for the download.
2. Enforce SemVer tagging and disallow image tags in the image reference. This would mean that the download would just use the version as the image tag. e.g `version: 1.10` and `repository: oci://nginx` would download `nginx:1.10`. I'm not a fan of enforcing this SemVer tagging, as it makes Helm's system less flexible than what image tags allow, and may disrupt workflows for application charts that developers might be used to (e.g using the commit ref and `latest` as tags)
3. Require _either_ version _or_ a tag. This would mean that if no tag is specified, users are required to specify the `version`, which will then be used as the image tag. If a tag is provided, we'll use that, and not require the version to be specified (as it will be whatever image was specified). This is my personal favourite. One downside to this is that the "either or" might be confusing, and I can see it confusing developers if using both version and tag. Or if a tag is not specified, knowing that the version is what's being used.

I'd love to see some discussion around the versioning, as that's currently the main problem I can see with an OCI implementation. As mentioned, my preferred option is _some variation_ of the third option. Most importantly, I'd like to allow Helm users to use specific image tags shall they wish to do so.

## Limitations

It is not possible to do provenance verification at download-time (meaning this would be incompatible with `install --verify`) as no provenance file is present in the image.

## Notes

Resolves #6593 