### PR TITLE
/pkg/repo/chartrepo_test.go: fix failed unit test

### DIFF
--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -308,7 +308,7 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 
 	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", g); err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
-	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached: Get http://someserver/something/index.yaml`) {
+	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached: failed to fetch http://someserver/something/index.yaml : 503 Service Unavailable`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Song Shukun <song.shukun@fujitsu.com>

The test failed just because the expected error message is a little wrong.