### PR TITLE
Workaround obsolete API versions

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -427,5 +427,5 @@ func recreate(cfg *Configuration, resources kube.ResourceList) error {
 
 func objectKey(r *resource.Info) string {
 	gvk := r.Object.GetObjectKind().GroupVersionKind()
-	return fmt.Sprintf("%s/%s/%s/%s", gvk.GroupVersion().String(), gvk.Kind, r.Namespace, r.Name)
+	return fmt.Sprintf("%s/%s/%s", gvk.Kind, r.Namespace, r.Name)
 }


### PR DESCRIPTION
This is a workaround for changes in API versions like
extensions/v1beta1 => apps/v1

Ignore group and version.

Signed-off-by: Sebastian Poehn <sebastian.poehn@gmail.com>