### PR TITLE
Improve vague error message when templating

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -159,7 +159,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 				log.Printf("[INFO] Missing required value: %s", warn)
 				return "", nil
 			}
-			return val, errors.Errorf(warnWrap(fmt.Sprintf("missing required value: %v", warn)))
+			return val, errors.Errorf(warnWrap(fmt.Sprintf("%v is required", warn)))
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {
@@ -167,7 +167,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 					log.Printf("[INFO] Missing required value: %s", warn)
 					return "", nil
 				}
-				return val, errors.Errorf(warnWrap(fmt.Sprintf("missing required value: %v", warn)))
+				return val, errors.Errorf(warnWrap(fmt.Sprintf("%v is required", warn)))
 			}
 		}
 		return val, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -159,7 +159,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 				log.Printf("[INFO] Missing required value: %s", warn)
 				return "", nil
 			}
-			return val, errors.Errorf(warnWrap(warn))
+			return val, errors.Errorf(warnWrap(fmt.Sprintf("Missing required value: %v", warn)))
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {
@@ -167,7 +167,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 					log.Printf("[INFO] Missing required value: %s", warn)
 					return "", nil
 				}
-				return val, errors.Errorf(warnWrap(warn))
+				return val, errors.Errorf(warnWrap(fmt.Sprintf("Missing required value: %v", warn)))
 			}
 		}
 		return val, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -159,7 +159,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 				log.Printf("[INFO] Missing required value: %s", warn)
 				return "", nil
 			}
-			return val, errors.Errorf(warnWrap(fmt.Sprintf("Missing required value: %v", warn)))
+			return val, errors.Errorf(warnWrap(fmt.Sprintf("missing required value: %v", warn)))
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {
@@ -167,7 +167,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 					log.Printf("[INFO] Missing required value: %s", warn)
 					return "", nil
 				}
-				return val, errors.Errorf(warnWrap(fmt.Sprintf("Missing required value: %v", warn)))
+				return val, errors.Errorf(warnWrap(fmt.Sprintf("missing required value: %v", warn)))
 			}
 		}
 		return val, nil


### PR DESCRIPTION
The error message when templating and a required value is not set is very vague.
This PR gives a better description.

Before:
```
Error: execution error at (service.yaml:16:14): version
```
After:
```
Error: execution error at (service.yaml:16:14): missing required value: version
```