### PR TITLE
Adds script to help craft release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,21 @@ checksum:
 clean:
 	@rm -rf $(BINDIR) ./_dist
 
+.PHONY: release-notes
+release-notes:
+		@if [ ! -d "./_dist" ]; then \
+			echo "please run 'make fetch-release' first" && \
+			exit 1; \
+		fi
+		@if [ -z "${PREVIOUS_RELEASE}" ]; then \
+			echo "please set PREVIOUS_RELEASE environment variable" \
+			&& exit 1; \
+		fi
+
+		@./scripts/release-notes.sh ${PREVIOUS_RELEASE} ${VERSION}
+
+
+
 .PHONY: info
 info:
 	 @echo "Version:           ${VERSION}"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 RELEASE=${RELEASE:-$2}
 PREVIOUS_RELEASE=${PREVIOUS_RELEASE:-$1}

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+RELEASE=${RELEASE:-$2}
+PREVIOUS_RELEASE=${PREVIOUS_RELEASE:-$1}
+
+## Ensure Correct Usage
+if [[ -z "${PREVIOUS_RELEASE}" || -z "${RELEASE}" ]]; then
+  echo Usage:
+  echo ./scripts/release-notes.sh v3.0.0 v3.1.0
+  echo or
+  echo PREVIOUS_RELEASE=v3.0.0
+  echo RELEASE=v3.1.0
+  echo ./scripts/release-notes.sh
+  exit 1
+fi
+
+## validate git tags
+for tag in $RELEASE $PREVIOUS_RELEASE; do
+  OK=$(git tag -l ${tag} | wc -l)
+  if [[ "$OK" == "0" ]]; then
+    echo ${tag} is not a valid release version
+    exit 1
+  fi
+done
+
+## Check for hints that checksum files were downloaded
+## from `make fetch-dist`
+if [[ ! -e "./_dist/helm-${RELEASE}-darwin-amd64.tar.gz.sha256" ]]; then
+  echo "checksum file ./_dist/helm-${RELEASE}-darwin-amd64.tar.gz.sha256 not found in ./_dist/"
+  echo "Did you forget to run \`make fetch-dist\` first ?"
+  exit 1
+fi
+
+## Generate CHANGELOG from git log
+CHANGELOG=$(git log --no-merges --pretty=format:'- %s %H (%aN)' ${PREVIOUS_RELEASE}..${RELEASE})
+if [[ ! $? -eq 0 ]]; then
+  echo "Error creating changelog"
+  echo "try running \`git log --no-merges --pretty=format:'- %s %H (%aN)' ${PREVIOUS_RELEASE}..${RELEASE}\`"
+  exit 1
+fi
+
+## guess at MAJOR / MINOR / PATCH versions
+MAJOR=$(echo ${RELEASE} | sed 's/^v//' | cut -f1 -d.)
+MINOR=$(echo ${RELEASE} | sed 's/^v//' | cut -f2 -d.)
+PATCH=$(echo ${RELEASE} | sed 's/^v//' | cut -f3 -d.)
+
+## Print release notes to stdout
+cat <<EOF
+## ${RELEASE}
+
+Helm ${RELEASE} is a feature release. This release, we focused on <insert focal point>. Users are encouraged to upgrade for the best experience.
+
+The community keeps growing, and we'd love to see you there!
+
+- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
+  - `#helm-users` for questions and just to hang out
+  - `#helm-dev` for discussing PRs, code, and bugs
+- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
+- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)
+
+## Notable Changes
+
+- Add list of
+- notable changes here
+
+## Installation and Upgrading
+
+Download Helm ${RELEASE}. The common platform binaries are here:
+
+- [MacOS amd64](https://get.helm.sh/helm-${RELEASE}-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-darwin-amd64.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-darwin-amd64.tar.gz.sha256))
+- [Linux amd64](https://get.helm.sh/helm-${RELEASE}-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-amd64.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-linux-amd64.tar.gz.sha256))
+- [Linux arm](https://get.helm.sh/helm-${RELEASE}-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-arm.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-linux-arm.tar.gz.sha256))
+- [Linux arm64](https://get.helm.sh/helm-${RELEASE}-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-arm64.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-linux-arm64.tar.gz.sha256))
+- [Linux i386](https://get.helm.sh/helm-${RELEASE}-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-386.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-linux-386.tar.gz.sha256))
+- [Linux ppc64le](https://get.helm.sh/helm-${RELEASE}-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-ppc64le.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-linux-ppc64le.tar.gz.sha256))
+- [Linux s390x](https://get.helm.sh/helm-${RELEASE}-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-${RELEASE}-linux-s390x.tar.gz.sha256) / $(cat _dist/helm-${RELEASE}-darwin-amd64.tar.gz.sha256))
+- [Windows amd64](https://get.helm.sh/helm-${RELEASE}-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-${RELEASE}-windows-amd64.zip.sha256) / $(cat _dist/helm-${RELEASE}-windows-amd64.zip.sha256))
+
+The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with \`bash\`.
+
+## What's Next
+
+- ${MAJOR}.${MINOR}.$(expr ${PATCH} + 1) will contain only bug fixes.
+- ${MAJOR}.$(expr ${MINOR} + 1).${PATCH} is the next feature release. This release will focus on ...
+
+## Changelog
+
+${CHANGELOG}
+EOF


### PR DESCRIPTION
Implements #7581

Example Usage:
```
$ PREVIOUS_RELEASE=v3.0.0 make release-notes
## v3.1.0

Helm v3.1.0 is a feature release. This release, we focused on <insert focal point>. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Notable Changes

- Add list of
- notable changes here

## Installation and Upgrading

Download Helm v3.1.0. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.1.0-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-darwin-amd64.tar.gz.sha256) / aacb6ce8ffa08eebc4e4a570226675f53963c86feb8386d46abf4b8871066c92)
- [Linux amd64](https://get.helm.sh/helm-v3.1.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-amd64.tar.gz.sha256) / f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de)
- [Linux arm](https://get.helm.sh/helm-v3.1.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-arm.tar.gz.sha256) / cb2824c01860196fab8cd6ececd04ff78e9c6606d175e6cd5f41e7d99881795b)
- [Linux arm64](https://get.helm.sh/helm-v3.1.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-arm64.tar.gz.sha256) / 1ba32db0600db61d8ace7a3afbaf7b045e16c0aab2a054dd9ec8e02755c07674)
- [Linux i386](https://get.helm.sh/helm-v3.1.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-386.tar.gz.sha256) / 9bb03099968f16c20298773fe5e466fa66206bf0f125ea656e1722cd86f32439)
- [Linux ppc64le](https://get.helm.sh/helm-v3.1.0-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-ppc64le.tar.gz.sha256) / 6ba4a2a6690c0224ab513971e6c56243c60ffbcc3ba4f68960a693b070bd5f71)
- [Linux s390x](https://get.helm.sh/helm-v3.1.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.1.0-linux-s390x.tar.gz.sha256) / aacb6ce8ffa08eebc4e4a570226675f53963c86feb8386d46abf4b8871066c92)
- [Windows amd64](https://get.helm.sh/helm-v3.1.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.1.0-windows-amd64.zip.sha256) / f6a6ee20bd216beb2f0195f083b03d43b8801e885a483011807824bd0915b835)

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.1.1 will contain only bug fixes.
- 3.2.0 is the next feature release. This release will focus on ...

## Changelog

- add test for template recursion b29d20baf09943e134c2fa5e1e1cab3bf93315fa (Daniel Cheng)
- fix recursion count in templates 805a591b5057845be0e872a3f667e81d07203367 (Daniel Cheng)
- Fix shasums to be usable by shasum and sha256sum applications 9887a3e4ca4ef473a4ddd419573edbd5c82bb231 (Matt Farina)
...
...
- Porting fix from commit f5986db184cf6d16dcd48760ac749a20236fb845 afda6b49408bad8f7a7a5faa9eeda016c8763400 (Lam Le)
- Fix import 41e70306b3464b99cf3afe4e23e85948fede3483 (Yagnesh Mistry)
- fix rename for helm dependency upgrade ceb6bcb318fa1f93ad2f67e3ba1cbbf1600fc154 (Yagnesh Mistry)
```

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>