### PR TITLE
fix(helm): stdin values for helm upgrade --install

### DIFF
--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -211,7 +211,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	}
 
 	deployed, err := r.cfg.Releases.DeployedAll(currentRelease.Name)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "has no deployed releases") {
 		return nil, err
 	}
 	// Supersede all previous deployments, see issue #2941.

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -141,6 +141,11 @@ func (mem *Memory) Query(keyvals map[string]string) ([]*rspb.Release, error) {
 			break
 		}
 	}
+
+	if len(ls) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
 	return ls, nil
 }
 


### PR DESCRIPTION
Fixes #7002

The cause of this issue is the helm upgrade cmd parses the command line options (which reads from std in) before determining if it needs to call the helm install command (because of the missing release).  Then when helm install is called, it rereads the command line args and this time reads nothing from stdin.

There were never any test cases that tested using the "--values -"/"-f -" syntax to pass values via stdin. Because of this there was no test harness or way to achieve this. I updated helm_test.go to support passing stdin as a *os.File.

The actual fix was in cmd/helm/upgrade.go and involved changing the order of operations of the parsing of arguments and calling install if necessary.

I added test cases to actually test "helm upgrade --install" (there were none) in combination with using the stdin values and another for just "helm upgrade" with stdin values.

Signed-off-by: Matt Morrissette <yinzara@gmail.com>