### PR TITLE
Fix output of list action when it is failed

### DIFF
--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -165,6 +165,10 @@ func (l *List) Run() ([]*release.Release, error) {
 		return true
 	})
 
+	if err != nil {
+		return nil, err
+	}
+
 	if results == nil {
 		return results, nil
 	}


### PR DESCRIPTION
Signed-off-by: Song Shukun <song.shukun@fujitsu.com>

Fix #7616 
When `helm list` failed, user gets none of information because the err did not get returned. 