### PR TITLE
Adopt resources into release with correct instance and managed-by labels

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -249,7 +249,8 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
 	}
 
-	err = resources.Visit(setMetadataVisitor(rel.Name, rel.Namespace))
+	// It is safe to use "force" here because these are resources currently rendered by the chart.
+	err = resources.Visit(setMetadataVisitor(rel.Name, rel.Namespace, true))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -249,6 +249,11 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
 	}
 
+	err = resources.Visit(setMetadataVisitor(rel.Name, rel.Namespace))
+	if err != nil {
+		return nil, err
+	}
+
 	// Install requires an extra validation step of checking that resources
 	// don't already exist before we actually create resources. If we continue
 	// forward and create the release object with resources that already exist,
@@ -256,7 +261,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	// deleting the release because the manifest will be pointing at that
 	// resource
 	if !i.ClientOnly && !isUpgrade {
-		toBeUpdated, err := existingResourceConflict(resources, rel.Name)
+		toBeUpdated, err := existingResourceConflict(resources, rel.Name, rel.Namespace)
 		if err != nil {
 			return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with install")
 		}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -203,6 +203,11 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}
 
+	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace))
+	if err != nil {
+		return upgradedRelease, err
+	}
+
 	// Do a basic diff using gvk + name to figure out what new resources are being created so we can validate they don't already exist
 	existingResources := make(map[string]bool)
 	for _, r := range current {
@@ -216,7 +221,7 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 		}
 	}
 
-	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name)
+	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with update")
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -203,7 +203,8 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}
 
-	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace))
+	// It is safe to use force only on target because these are resources currently rendered by the chart.
+	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace, true))
 	if err != nil {
 		return upgradedRelease, err
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"helm.sh/helm/v3/pkg/kube"
@@ -30,12 +31,14 @@ import (
 var accessor = meta.NewAccessor()
 
 const (
+	appManagedByLabel              = "app.kubernetes.io/managed-by"
+	appManagedByHelm               = "Helm"
 	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
 
 func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string) (kube.ResourceList, error) {
-	requireUpdate := kube.ResourceList{}
+	var requireUpdate kube.ResourceList
 
 	err := resources.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -48,39 +51,134 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
-
 			return errors.Wrap(err, "could not get information about the resource")
 		}
 
-		// Allow adoption of the resource if it already has app.kubernetes.io/instance and app.kubernetes.io/managed-by labels.
-		anno, err := accessor.Annotations(existing)
-		if err == nil && anno != nil && anno[helmReleaseNameAnnotation] == releaseName && anno[helmReleaseNamespaceAnnotation] == releaseNamespace {
-			requireUpdate = append(requireUpdate, info)
-			return nil
+		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
+		if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
+			return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
 		}
 
-		return fmt.Errorf(
-			"existing resource conflict: namespace: %s, name: %s, existing_kind: %s, new_kind: %s",
-			info.Namespace, info.Name, existing.GetObjectKind().GroupVersionKind(), info.Mapping.GroupVersionKind)
+		requireUpdate.Append(info)
+		return nil
 	})
 
 	return requireUpdate, err
 }
 
-func setMetadataVisitor(releaseName, releaseNamespace string) resource.VisitorFunc {
+func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) error {
+	lbls, err := accessor.Labels(obj)
+	if err != nil {
+		return err
+	}
+	annos, err := accessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	if err := requireValue(lbls, appManagedByLabel, appManagedByHelm); err != nil {
+		errs = append(errs, fmt.Errorf("label validation error: %s", err))
+	}
+	if err := requireValue(annos, helmReleaseNameAnnotation, releaseName); err != nil {
+		errs = append(errs, fmt.Errorf("annotation validation error: %s", err))
+	}
+	if err := requireValue(annos, helmReleaseNamespaceAnnotation, releaseNamespace); err != nil {
+		errs = append(errs, fmt.Errorf("annotation validation error: %s", err))
+	}
+
+	if len(errs) > 0 {
+		err := errors.New("invalid ownership metadata")
+		for _, e := range errs {
+			err = fmt.Errorf("%w; %s", err, e)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func requireValue(meta map[string]string, k, v string) error {
+	actual, ok := meta[k]
+	if !ok {
+		return fmt.Errorf("missing key %q: must be set to %q", k, v)
+	}
+	if actual != v {
+		return fmt.Errorf("key %q must equal %q: current value is %q", k, v, actual)
+	}
+	return nil
+}
+
+// setMetadataVisitor adds release tracking metadata to all resources. If force is enabled, existing
+// ownership metadata will be overwritten. Otherwise an error will be returned if any resource has an
+// existing and conflicting value for the managed by label or Helm release/namespace annotations.
+func setMetadataVisitor(releaseName, releaseNamespace string, force bool) resource.VisitorFunc {
 	return func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
 		}
-		anno, err := accessor.Annotations(info.Object)
-		if err != nil {
-			return err
+
+		if !force {
+			if err := checkOwnership(info.Object, releaseName, releaseNamespace); err != nil {
+				return fmt.Errorf("%s cannot be owned: %s", resourceString(info), err)
+			}
 		}
-		if anno == nil {
-			anno = make(map[string]string)
+
+		if err := mergeLabels(info.Object, map[string]string{
+			appManagedByLabel: appManagedByHelm,
+		}); err != nil {
+			return fmt.Errorf(
+				"%s labels could not be updated: %s",
+				resourceString(info), err,
+			)
 		}
-		anno[helmReleaseNameAnnotation] = releaseName
-		anno[helmReleaseNamespaceAnnotation] = releaseNamespace
-		return accessor.SetAnnotations(info.Object, anno)
+
+		if err := mergeAnnotations(info.Object, map[string]string{
+			helmReleaseNameAnnotation:      releaseName,
+			helmReleaseNamespaceAnnotation: releaseNamespace,
+		}); err != nil {
+			return fmt.Errorf(
+				"%s annotations could not be updated: %s",
+				resourceString(info), err,
+			)
+		}
+
+		return nil
 	}
+}
+
+func resourceString(info *resource.Info) string {
+	_, k := info.Mapping.GroupVersionKind.ToAPIVersionAndKind()
+	return fmt.Sprintf(
+		"%s %q in namespace %q",
+		k, info.Name, info.Namespace,
+	)
+}
+
+func mergeLabels(obj runtime.Object, labels map[string]string) error {
+	current, err := accessor.Labels(obj)
+	if err != nil {
+		return err
+	}
+	return accessor.SetLabels(obj, mergeStrStrMaps(current, labels))
+}
+
+func mergeAnnotations(obj runtime.Object, annotations map[string]string) error {
+	current, err := accessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+	return accessor.SetAnnotations(obj, mergeStrStrMaps(current, annotations))
+}
+
+// merge two maps, always taking the value on the right
+func mergeStrStrMaps(current, desired map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range current {
+		result[k] = v
+	}
+	for k, desiredVal := range desired {
+		result[k] = desiredVal
+	}
+	return result
 }

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/kube"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+func newDeploymentResource(name, namespace string) *resource.Info {
+	return &resource.Info{
+		Name: name,
+		Mapping: &meta.RESTMapping{
+			Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"},
+			GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		},
+		Object: &appsv1.Deployment{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+func TestCheckOwnership(t *testing.T) {
+	deployFoo := newDeploymentResource("foo", "ns-a")
+
+	// Verify that a resource that lacks labels/annotations is not owned
+	err := checkOwnership(deployFoo.Object, "rel-a", "ns-a")
+	assert.EqualError(t, err, `invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "rel-a"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "ns-a"`)
+
+	// Set managed by label and verify annotation error message
+	_ = accessor.SetLabels(deployFoo.Object, map[string]string{
+		appManagedByLabel: appManagedByHelm,
+	})
+	err = checkOwnership(deployFoo.Object, "rel-a", "ns-a")
+	assert.EqualError(t, err, `invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "rel-a"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "ns-a"`)
+
+	// Set only the release name annotation and verify missing release namespace error message
+	_ = accessor.SetAnnotations(deployFoo.Object, map[string]string{
+		helmReleaseNameAnnotation: "rel-a",
+	})
+	err = checkOwnership(deployFoo.Object, "rel-a", "ns-a")
+	assert.EqualError(t, err, `invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "ns-a"`)
+
+	// Set both release name and namespace annotations and verify no ownership errors
+	_ = accessor.SetAnnotations(deployFoo.Object, map[string]string{
+		helmReleaseNameAnnotation:      "rel-a",
+		helmReleaseNamespaceAnnotation: "ns-a",
+	})
+	err = checkOwnership(deployFoo.Object, "rel-a", "ns-a")
+	assert.NoError(t, err)
+
+	// Verify ownership error for wrong release name
+	err = checkOwnership(deployFoo.Object, "rel-b", "ns-a")
+	assert.EqualError(t, err, `invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "rel-b": current value is "rel-a"`)
+
+	// Verify ownership error for wrong release namespace
+	err = checkOwnership(deployFoo.Object, "rel-a", "ns-b")
+	assert.EqualError(t, err, `invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "ns-b": current value is "ns-a"`)
+
+	// Verify ownership error for wrong manager label
+	_ = accessor.SetLabels(deployFoo.Object, map[string]string{
+		appManagedByLabel: "helm",
+	})
+	err = checkOwnership(deployFoo.Object, "rel-a", "ns-a")
+	assert.EqualError(t, err, `invalid ownership metadata; label validation error: key "app.kubernetes.io/managed-by" must equal "Helm": current value is "helm"`)
+}
+
+func TestSetMetadataVisitor(t *testing.T) {
+	var (
+		err       error
+		deployFoo = newDeploymentResource("foo", "ns-a")
+		deployBar = newDeploymentResource("bar", "ns-a-system")
+		resources = kube.ResourceList{deployFoo, deployBar}
+	)
+
+	// Set release tracking metadata and verify no error
+	err = resources.Visit(setMetadataVisitor("rel-a", "ns-a", true))
+	assert.NoError(t, err)
+
+	// Verify that release "b" cannot take ownership of "a"
+	err = resources.Visit(setMetadataVisitor("rel-b", "ns-a", false))
+	assert.Error(t, err)
+
+	// Force release "b" to take ownership
+	err = resources.Visit(setMetadataVisitor("rel-b", "ns-a", true))
+	assert.NoError(t, err)
+
+	// Check that there is now no ownership error when setting metadata without force
+	err = resources.Visit(setMetadataVisitor("rel-b", "ns-a", false))
+	assert.NoError(t, err)
+
+	// Add a new resource that is missing ownership metadata and verify error
+	resources.Append(newDeploymentResource("baz", "default"))
+	err = resources.Visit(setMetadataVisitor("rel-b", "ns-a", false))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `Deployment "baz" in namespace "" cannot be owned`)
+}


### PR DESCRIPTION
Alternative implementation to https://github.com/helm/helm/pull/7627, https://github.com/helm/helm/pull/7625, and https://github.com/helm/helm/pull/7575.

Help with validation would be appreciated, but in theory this closes https://github.com/helm/helm/issues/6850, closes https://github.com/helm/helm/issues/4824, closes https://github.com/helm/helm/issues/2947, and closes https://github.com/helm/helm/issues/7418. This implementation would also help make https://github.com/helm/helm/issues/2730 very approachable.

## How it Works

### ~Option A: Standard Labels~ https://github.com/helm/helm/pull/7649/commits/a29365b3c663f1c182ea78461825ae28b8573915

Helm will assume that it has the right to "adopt" any existing Kubernetes resource containing the following labels:

* `app.kubernetes.io/managed-by: Helm`
* `app.kubernetes.io/instance: <RELEASE_NAME>`

The major downside is that in order to get this functionality, setting these labels is required. Despite this having been a [documented best practice](https://helm.sh/docs/topics/chart_best_practices/labels/#standard-labels) since well before Helm 3, that might be hard to accomplish for chart authors who have historically been using non-standard values for these labels. A workaround for this would be to enable the same behavior via custom annotations.

### Option B: New Helm Annotations https://github.com/helm/helm/pull/7649/commits/271cb2268bfd94012639f4866e8d52189e12a97b

Helm will assume that it has the right to "adopt" any existing Kubernetes resource containing the following annotations:

* `meta.helm.sh/release-name: <RELEASE_NAME>`
* `meta.helm.sh/release-namespace: <RELEASE_NAMESPACE>`

For consistency and to make things easier for chart authors, we will automatically inject or override existing values for these annotations. I think this ends up being the simplest solution, and probably something we can safely expose without a feature flag.

## To Do

1. Validate that 3-way diffs work correctly. See PR comment below.
1. Decide if this should be opt-in/behind an experimental feature flag
1. Error out if annotations list a different release as owner of resource (fix for https://github.com/helm/helm/issues/7699 / #2388)
    - This will be enabled in a followup PR, but is implemented in https://github.com/helm/helm/pull/7649/commits/8d1de39fe3234c8925dac6d3efca6aba687ebf87
1. ~Add tests~

## Release Note

Helm will no longer error when attempting to create a resource that already exists in the target cluster if the existing resource has the correct `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations, and matches the label selector `app.kubernetes.io/managed-by=Helm`. This facilitates zero-downtime migrations to Helm 3 for managing existing deployments, and allows Helm to "adopt" existing resources that it previously created.

In order to allow an existing resource to be adopted by Helm, add release metadata and the managed-by label:

```
KIND=deployment
NAME=my-app-staging
RELEASE=staging
NAMESPACE=default
kubectl annotate $KIND $NAME meta.helm.sh/release-name=$RELEASE
kubectl annotate $KIND $NAME meta.helm.sh/release-namespace=$NAMESPACE
kubectl label $KIND $NAME app.kubernetes.io/managed-by=Helm
```