### PR TITLE
fix(helm): allow a previously failed release to be upgraded

### DIFF
--- a/cmd/helm/testdata/output/upgrade-with-bad-or-missing-existing-release.txt
+++ b/cmd/helm/testdata/output/upgrade-with-bad-or-missing-existing-release.txt
@@ -1,0 +1,1 @@
+Error: UPGRADE FAILED: "funny-bunny" has no deployed releases

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	rspb "helm.sh/helm/v3/pkg/release"
@@ -28,8 +30,29 @@ var (
 	// ErrReleaseExists indicates that a release already exists.
 	ErrReleaseExists = errors.New("release: already exists")
 	// ErrInvalidKey indicates that a release key could not be parsed.
-	ErrInvalidKey = errors.Errorf("release: invalid key")
+	ErrInvalidKey = errors.New("release: invalid key")
+	// ErrNoDeployedReleases indicates that there are no releases with the given key in the deployed state
+	ErrNoDeployedReleases = errors.New("has no deployed releases")
 )
+
+// StorageDriverError records an error and the release name that caused it
+type StorageDriverError struct {
+	ReleaseName string
+	Err         error
+}
+
+func (e *StorageDriverError) Error() string {
+	return fmt.Sprintf("%q %s", e.ReleaseName, e.Err.Error())
+}
+
+func (e *StorageDriverError) Unwrap() error { return e.Err }
+
+func NewErrNoDeployedReleases(releaseName string) error {
+	return &StorageDriverError{
+		ReleaseName: releaseName,
+		Err:         ErrNoDeployedReleases,
+	}
+}
 
 // Creator is the interface that wraps the Create method.
 //

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -116,7 +116,7 @@ func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 	}
 
 	if len(ls) == 0 {
-		return nil, errors.Errorf("%q has no deployed releases", name)
+		return nil, driver.NewErrNoDeployedReleases(name)
 	}
 
 	// If executed concurrently, Helm's database gets corrupted
@@ -140,7 +140,7 @@ func (s *Storage) DeployedAll(name string) ([]*rspb.Release, error) {
 		return ls, nil
 	}
 	if strings.Contains(err.Error(), "not found") {
-		return nil, errors.Errorf("%q has no deployed releases", name)
+		return nil, driver.NewErrNoDeployedReleases(name)
 	}
 	return nil, err
 }


### PR DESCRIPTION
This PR changes the behavior of "helm upgrade" command when there have been no successful and at least one failed release.  This allows the user to recover from a failed install (or a partially failed install) without uninstalling the release.   The user can now decide to decide to ignore the "no deployed releases" errors and allow it to upgrade a failed release.

There were no test cases that tested the failure scenarios of upgrading a failed/missing release so I added them and also added additional test cases that test the new functionality.

Fixes issue #5595

Signed-off-by: Matt Morrissete <yinzara@gmail.com>