### PR TITLE
fix: add new static linter and fix issues it found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - structcheck
     - unused
     - varcheck
+    - staticcheck
 
 linters-settings:
   gofmt:

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -106,7 +106,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 				fmt.Fprint(&message, "\n")
 			}
 
-			fmt.Fprintf(out, message.String())
+			fmt.Fprint(out, message.String())
 
 			summary := fmt.Sprintf("%d chart(s) linted, %d chart(s) failed", len(paths), failed)
 			if failed > 0 {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/xeipuuv/gojsonschema v1.1.0
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery v0.17.3

--- a/internal/completion/complete.go
+++ b/internal/completion/complete.go
@@ -368,7 +368,7 @@ func CompDebug(msg string) {
 
 	if debug {
 		// Must print to stderr for this not to be read by the completion script.
-		fmt.Fprintf(os.Stderr, msg)
+		fmt.Fprintln(os.Stderr, msg)
 	}
 }
 
@@ -389,7 +389,7 @@ func CompError(msg string) {
 	// If not already printed by the call to CompDebug().
 	if !debug {
 		// Must print to stderr for this not to be read by the completion script.
-		fmt.Fprintf(os.Stderr, msg)
+		fmt.Fprintln(os.Stderr, msg)
 	}
 }
 

--- a/internal/experimental/registry/client_test.go
+++ b/internal/experimental/registry/client_test.go
@@ -162,13 +162,13 @@ func (suite *RegistryClientTestSuite) Test_2_LoadChart() {
 	// non-existent ref
 	ref, err := ParseReference(fmt.Sprintf("%s/testrepo/whodis:9.9.9", suite.DockerRegistryHost))
 	suite.Nil(err)
-	ch, err := suite.RegistryClient.LoadChart(ref)
+	_, err = suite.RegistryClient.LoadChart(ref)
 	suite.NotNil(err)
 
 	// existing ref
 	ref, err = ParseReference(fmt.Sprintf("%s/testrepo/testchart:1.2.3", suite.DockerRegistryHost))
 	suite.Nil(err)
-	ch, err = suite.RegistryClient.LoadChart(ref)
+	ch, err := suite.RegistryClient.LoadChart(ref)
 	suite.Nil(err)
 	suite.Equal("testchart", ch.Metadata.Name)
 	suite.Equal("1.2.3", ch.Metadata.Version)

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -116,11 +116,9 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		// key will be raised as well
 		err := yaml.Unmarshal([]byte(renderedContent), &yamlStruct)
 
-		validYaml := linter.RunLinterRule(support.ErrorSev, path, validateYamlContent(err))
-
-		if !validYaml {
-			continue
-		}
+		// If YAML linting fails, we sill progress. So we don't capture the returned state
+		// on this linter run.
+		linter.RunLinterRule(support.ErrorSev, path, validateYamlContent(err))
 	}
 }
 


### PR DESCRIPTION
This PR adds a new static analyzer to the testing target.

In the course of adding, the analyzer found two cases where code was incorrect. While neither case imposes any risk, I have fixed them both.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>