### PR TITLE
fix(cmd/helm): upgrade go-shellwords

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -97,39 +96,11 @@ func storageFixture() *storage.Storage {
 	return storage.Init(driver.NewMemory())
 }
 
-// go-shellwords does not handle empty arguments properly
-// https://github.com/mattn/go-shellwords/issues/5#issuecomment-573431458
-//
-// This method checks if the last argument was an empty one,
-// and if go-shellwords missed it, we add it ourselves.
-//
-// This is important for completion tests as completion often
-// uses an empty last parameter.
-func checkLastEmpty(in string, out []string) []string {
-	lastIndex := len(in) - 1
-
-	if lastIndex >= 1 && (in[lastIndex] == '"' && in[lastIndex-1] == '"' ||
-		in[lastIndex] == '\'' && in[lastIndex-1] == '\'') {
-		// The last parameter of 'in' was empty ("" or ''), let's make sure it was detected.
-		if len(out) > 0 && out[len(out)-1] != "" {
-			// Bug from go-shellwords:
-			// 'out' does not have the empty parameter.  We add it ourselves as a workaround.
-			out = append(out, "")
-		} else {
-			fmt.Println("WARNING: go-shellwords seems to have been fixed.  This workaround can be removed.")
-		}
-	}
-	return out
-}
-
 func executeActionCommandC(store *storage.Storage, cmd string) (*cobra.Command, string, error) {
 	args, err := shellwords.Parse(cmd)
 	if err != nil {
 		return nil, "", err
 	}
-	// Workaround the bug in shellwords
-	args = checkLastEmpty(cmd, args)
-
 	buf := new(bytes.Buffer)
 
 	actionConfig := &action.Configuration{

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.7.1
 	github.com/gosuri/uitable v0.0.4
-	github.com/mattn/go-shellwords v1.0.9
+	github.com/mattn/go-shellwords v1.0.10
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,8 @@ github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.9 h1:eaB5JspOwiKKcHdqcjbfe5lA9cNn/4NRRtddXJCimqk=
 github.com/mattn/go-shellwords v1.0.9/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-shellwords v1.0.10 h1:Y7Xqm8piKOO3v10Thp7Z36h4FYFjt5xB//6XvOrs2Gw=
+github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=


### PR DESCRIPTION
Removes workaround introduced in #7323