### PR TITLE
Fix golangci-lint errors.

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -24,8 +24,6 @@ import (
 	"regexp"
 	"strings"
 
-	"helm.sh/helm/v3/pkg/releaseutil"
-
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -33,6 +31,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/releaseutil"
 )
 
 const templateDesc = `
@@ -53,7 +52,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "template [NAME] [CHART]",
-		Short: fmt.Sprintf("locally render templates"),
+		Short: "locally render templates",
 		Long:  templateDesc,
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/internal/completion/complete.go
+++ b/internal/completion/complete.go
@@ -259,7 +259,7 @@ func NewCompleteCmd(settings *cli.EnvSettings, out io.Writer) *cobra.Command {
 			// completion script to parse.
 			// The directive integer must be that last character following a single :
 			// The completion script expects :directive
-			fmt.Fprintln(out, fmt.Sprintf(":%d", directive))
+			fmt.Fprintf(out, ":%d\n", directive)
 
 			// Print some helpful info to stderr for the user to understand.
 			// Output from stderr should be ignored from the completion script.


### PR DESCRIPTION
This PR fixes errors found by `golangci-lint`.

Signed-off-by: Pavel Macík <pavel.macik@gmail.com>