### PR TITLE
Fixes verification output on pull command

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -101,7 +101,11 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.Verify {
-		fmt.Fprintf(&out, "Verification: %v\n", v)
+		for name := range v.SignedBy.Identities {
+			fmt.Fprintf(&out, "Signed by: %v\n", name)
+		}
+		fmt.Fprintf(&out, "Using Key With Fingerprint: %X\n", v.SignedBy.PrimaryKey.Fingerprint)
+		fmt.Fprintf(&out, "Chart Hash Verified: %s\n", v.FileHash)
 	}
 
 	// After verification, untar the chart into the requested directory.


### PR DESCRIPTION
When using the --verify flag on the pull command the output was
an internal Go object rather than useful detail. This is a bug.
The output new displays who signed the chart along with the
hash.

Fixes #7624