### PR TITLE
Add verification output to the verify command

### DIFF
--- a/cmd/helm/verify.go
+++ b/cmd/helm/verify.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -44,7 +45,14 @@ func newVerifyCmd(out io.Writer) *cobra.Command {
 		Long:  verifyDesc,
 		Args:  require.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return client.Run(args[0])
+			err := client.Run(args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(out, client.Out)
+
+			return nil
 		},
 	}
 

--- a/cmd/helm/verify_test.go
+++ b/cmd/helm/verify_test.go
@@ -65,7 +65,7 @@ func TestVerifyCmd(t *testing.T) {
 		{
 			name:      "verify validates a properly signed chart",
 			cmd:       "verify testdata/testcharts/signtest-0.1.0.tgz --keyring testdata/helm-test-key.pub",
-			expect:    "",
+			expect:    "Signed by: Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>\nUsing Key With Fingerprint: 5E615389B53CA37F0EE60BD3843BBF981FC18762\nChart Hash Verified: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55\n",
 			wantError: false,
 		},
 	}

--- a/pkg/action/verify.go
+++ b/pkg/action/verify.go
@@ -17,6 +17,9 @@ limitations under the License.
 package action
 
 import (
+	"fmt"
+	"strings"
+
 	"helm.sh/helm/v3/pkg/downloader"
 )
 
@@ -25,6 +28,7 @@ import (
 // It provides the implementation of 'helm verify'.
 type Verify struct {
 	Keyring string
+	Out     string
 }
 
 // NewVerify creates a new Verify object with the given configuration.
@@ -34,6 +38,22 @@ func NewVerify() *Verify {
 
 // Run executes 'helm verify'.
 func (v *Verify) Run(chartfile string) error {
-	_, err := downloader.VerifyChart(chartfile, v.Keyring)
-	return err
+	var out strings.Builder
+	p, err := downloader.VerifyChart(chartfile, v.Keyring)
+	if err != nil {
+		return err
+	}
+
+	for name := range p.SignedBy.Identities {
+		fmt.Fprintf(&out, "Signed by: %v\n", name)
+	}
+	fmt.Fprintf(&out, "Using Key With Fingerprint: %X\n", p.SignedBy.PrimaryKey.Fingerprint)
+	fmt.Fprintf(&out, "Chart Hash Verified: %s\n", p.FileHash)
+
+	// TODO(mattfarina): The output is set as a property rather than returned
+	// to maintain the Go API. In Helm v4 this function should return the out
+	// and the property on the struct can be removed.
+	v.Out = out.String()
+
+	return nil
 }


### PR DESCRIPTION
This complements the verification output fixed in #7706. On verify
there should be some detail about the verification rather than
no information.