### PR TITLE
Add fromYamlArray and fromJsonArray template helpers

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -48,11 +48,13 @@ func funcMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
-		"toToml":   toTOML,
-		"toYaml":   toYAML,
-		"fromYaml": fromYAML,
-		"toJson":   toJSON,
-		"fromJson": fromJSON,
+		"toToml":        toTOML,
+		"toYaml":        toYAML,
+		"fromYaml":      fromYAML,
+		"fromYamlArray": fromYAMLArray,
+		"toJson":        toJSON,
+		"fromJson":      fromJSON,
+		"fromJsonArray": fromJSONArray,
 
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the
@@ -97,6 +99,21 @@ func fromYAML(str string) map[string]interface{} {
 	return m
 }
 
+// fromYAMLArray converts a YAML array into a []interface{}.
+//
+// This is not a general-purpose YAML parser, and will not parse all valid
+// YAML documents. Additionally, because its intended use is within templates
+// it tolerates errors. It will insert the returned error message string as
+// the first and only item in the returned array.
+func fromYAMLArray(str string) []interface{} {
+	a := []interface{}{}
+
+	if err := yaml.Unmarshal([]byte(str), &a); err != nil {
+		a = []interface{}{err.Error()}
+	}
+	return a
+}
+
 // toTOML takes an interface, marshals it to toml, and returns a string. It will
 // always return a string, even on marshal error (empty string).
 //
@@ -137,4 +154,19 @@ func fromJSON(str string) map[string]interface{} {
 		m["Error"] = err.Error()
 	}
 	return m
+}
+
+// fromJSONArray converts a JSON array into a []interface{}.
+//
+// This is not a general-purpose JSON parser, and will not parse all valid
+// JSON documents. Additionally, because its intended use is within templates
+// it tolerates errors. It will insert the returned error message string as
+// the first and only item in the returned array.
+func fromJSONArray(str string) []interface{} {
+	a := []interface{}{}
+
+	if err := json.Unmarshal([]byte(str), &a); err != nil {
+		a = []interface{}{err.Error()}
+	}
+	return a
 }

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -46,6 +46,14 @@ func TestFuncs(t *testing.T) {
 		expect: "map[hello:world]",
 		vars:   `hello: world`,
 	}, {
+		tpl:    `{{ fromYamlArray . }}`,
+		expect: "[one 2 map[name:helm]]",
+		vars:   "- one\n- 2\n- name: helm\n",
+	}, {
+		tpl:    `{{ fromYamlArray . }}`,
+		expect: "[one 2 map[name:helm]]",
+		vars:   `["one", 2, { "name": "helm" }]`,
+	}, {
 		// Regression for https://github.com/helm/helm/issues/2271
 		tpl:    `{{ toToml . }}`,
 		expect: "[mast]\n  sail = \"white\"\n",
@@ -63,6 +71,14 @@ func TestFuncs(t *testing.T) {
 		expect: `map[Error:json: cannot unmarshal array into Go value of type map[string]interface {}]`,
 		vars:   `["one", "two"]`,
 	}, {
+		tpl:    `{{ fromJsonArray . }}`,
+		expect: `[one 2 map[name:helm]]`,
+		vars:   `["one", 2, { "name": "helm" }]`,
+	}, {
+		tpl:    `{{ fromJsonArray . }}`,
+		expect: `[json: cannot unmarshal object into Go value of type []interface {}]`,
+		vars:   `{"hello": "world"}`,
+	}, {
 		tpl:    `{{ merge .dict (fromYaml .yaml) }}`,
 		expect: `map[a:map[b:c]]`,
 		vars:   map[string]interface{}{"dict": map[string]interface{}{"a": map[string]interface{}{"b": "c"}}, "yaml": `{"a":{"b":"d"}}`},
@@ -74,6 +90,10 @@ func TestFuncs(t *testing.T) {
 		tpl:    `{{ fromYaml . }}`,
 		expect: `map[Error:error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}]`,
 		vars:   `["one", "two"]`,
+	}, {
+		tpl:    `{{ fromYamlArray . }}`,
+		expect: `[error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go value of type []interface {}]`,
+		vars:   `hello: world`,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Changes

Add 2 template helpers

- **fromYamlArray**: parses a YAML array and returns **[]interface{}**
- **fromJsonArray**:  parses a JSON array and returns **[]interface{}**

### Use case

I have a sub-chart which parse all content of a value block as **ConfigMap** data, of which all values are string-like YAML objects/array.

```yaml
# values.yaml
argocd:
  server:
    config:
      repositories: |
        - name: rocketspacer-hello-world
          sshPrivateKeySecret:
               key: sshPrivateKey
               name: repo-argocd-rocketspacer-hello-world
          type: git
          url: git@github.com:rocketspacer/hello-world.git
        - name: rocketspacer-hello-helm
          sshPrivateKeySecret:
               key: sshPrivateKey
               name: repo-argocd-rocketspacer-hello-helm
          type: git
          url: git@github.com:rocketspacer/hello-helm.git

# charts/argocd/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
data:
{{- toYaml .Values.server.config | nindent 4 }}
```

I need to parse the content of **.Values.argocd.server.config.repositories** as an array so I can loop through and generate corresponding secrets, like:

```yaml
# templates/secrets.yaml
{{- range $repo := .Values.argocd.server.config.repositories | fromYamlArray }}
---
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: repo-argocd-{{ $repo.name }}
  namespace: {{ $.Release.Namespace }}
data:
  {{ $repo.sshPrivateKeySecret.key }}: | {{- index $.Values.sshKeys $repo.sshPrivateKeySecret.name | toString | nindent 4 }}
{{- end }}
```