### PR TITLE
ref(environment): use string checking instead

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -135,10 +135,10 @@ func (s *EnvSettings) Namespace() string {
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	s.configOnce.Do(func() {
 		clientConfig := kube.GetConfig(s.KubeConfig, s.KubeContext, s.namespace)
-		if len(s.KubeToken) > 0 {
+		if s.KubeToken != "" {
 			clientConfig.BearerToken = &s.KubeToken
 		}
-		if len(s.KubeAPIServer) > 0 {
+		if s.KubeAPIServer != "" {
 			clientConfig.APIServer = &s.KubeAPIServer
 		}
 


### PR DESCRIPTION
It is more idiomatic to compare the string against the empty string than to check the string's length.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>