### PR TITLE
Fixing issue where archives created on windows have broken paths

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -223,7 +223,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 func writeToTar(out *tar.Writer, name string, body []byte) error {
 	// TODO: Do we need to create dummy parent directory names if none exist?
 	h := &tar.Header{
-		Name:    name,
+		Name:    filepath.ToSlash(name),
 		Mode:    0644,
 		Size:    int64(len(body)),
 		ModTime: time.Now(),


### PR DESCRIPTION
When archives are created on windows the path spearator in the
archive file is \\. This causes issues when the file is unpacked.
For example, on Linux the files are unpacked in a flat structure
and \ is part of the file name. This causes comp issues. In Helm
v2 the path was set as / when the archive was written. This works
on both Windows and POSIX systems.

The fix being implemented is to use the ToSlash function to ensure
/ is used as the separator.

Fixes #7748