### PR TITLE
feat(cmd) Add flag for InMemory Cache for downloading charts

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -195,6 +195,12 @@ func TestInstall(t *testing.T) {
 			cmd:    "install aeneas testdata/testcharts/deprecated --namespace default",
 			golden: "output/deprecated-chart.txt",
 		},
+		// Install with non url and in-memory-cache enabled
+		{
+			name:      "install with inMemory cache enabled ",
+			cmd:       "install cached testdata/testcharts/empty --namespace default --use-inmemory-cache",
+			wantError: true,
+		},
 	}
 
 	runTestActionCmd(t, tests)


### PR DESCRIPTION
This feature allows us to use the --use-inmemory-cache flag to
use a chart without downloading it to the helm repository cache,
instead which is downloaded to InMemoryCache

augments and dependent on
 https://github.com/helm/helm/pull/7601

Signed-off-by: Vibhav Bobade <vibhav.bobde@gmail.com>