### PR TITLE
refactor(pkg/lint/test): Improve the checking error message in unit test

### DIFF
--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -93,7 +93,7 @@ func TestBadValues(t *testing.T) {
 	if len(m) < 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
-	if !strings.Contains(m[0].Err.Error(), "cannot unmarshal") {
+	if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
 		t.Errorf("All didn't have the error for invalid key format: %s", m[0].Err)
 	}
 }


### PR DESCRIPTION
Suggested by @mattfarina to improve for usability the error message being checked in unit test `TestBadValues`: https://github.com/helm/helm/pull/7691#issuecomment-597142837