### PR TITLE
Return dry-run upgrade status

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -242,6 +242,9 @@ func (u *Upgrade) performUpgrade(originalRelease, upgradedRelease *release.Relea
 	})
 
 	if u.DryRun {
+		if len(toBeCreated) > 0 {
+			upgradedRelease.Info.Status = release.StatusRequiresUpgrade
+		}
 		u.cfg.Log("dry run for %s", upgradedRelease.Name)
 		if len(u.Description) > 0 {
 			upgradedRelease.Info.Description = u.Description

--- a/pkg/release/status.go
+++ b/pkg/release/status.go
@@ -39,6 +39,8 @@ const (
 	StatusPendingUpgrade Status = "pending-upgrade"
 	// StatusPendingRollback indicates that an rollback operation is underway.
 	StatusPendingRollback Status = "pending-rollback"
+	// StatusRequiresUpgrade indicates an upgrade is required, for example if resources are missing.
+	StatusRequiresUpgrade Status = "requires-upgrade"
 )
 
 func (x Status) String() string { return string(x) }


### PR DESCRIPTION
The Helm Terraform provider currently cannot determine whether an upgrade of a particular chart is required: https://github.com/terraform-providers/terraform-provider-helm/issues/444

This PR adds a new status type when a dry-run upgrading is performed when  and resources are missing from Kubernetes. This should allow the provider to dry-run an upgrade when reading to decide whether an actual (non dry-run) upgrade is required.

I'm not sure if this would be the best way to do this, or if this breaks other assumptions in Helm about status, but a suggested implementation just for feedback atm.

I assume the note in the code:

```
// NOTE: Make sure to update cmd/helm/status.go when adding or modifying any of these statuses.
```

is outdated - I can't seem to see any references to the status constants in that file.