### PR TITLE
chartutil: apply all labels to pods in default deployment template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -238,7 +238,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+        {{- include "<CHARTNAME>.labels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Pods created from deployment template generated with `helm create`
currently only have the selector labels applied (i.e.
`app.kubernetes.io/name` and `app.kubernetes.io/instance`). This
changes the template so that all labels are applied to pods, just like
any other object the app consists of.

Signed-off-by: mig4 <42650719@auril.club>