### PR TITLE
Fixing validation issue

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -208,7 +208,6 @@ func (c *Client) Validate(namespace string, reader io.Reader) error {
 		DefaultNamespace().
 		// Schema(c.validator()). // No schema validation
 		Stream(reader, "").
-		Latest().
 		Flatten().
 		Do().Infos()
 	return scrubValidationError(err)


### PR DESCRIPTION
Latest() should not have been added Validate

This was accidentally added while trying to figure out listing manifests for status.

Closes #7797 
