### PR TITLE
Snapcraft installation instructions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you want to use a package manager:
 - [Chocolatey](https://chocolatey.org/) users can use `choco install kubernetes-helm`.
 - [Scoop](https://scoop.sh/) users can use `scoop install helm`.
 - [GoFish](https://gofi.sh/) users can use `gofish install helm`.
+- [Snapcraft](https://snapcraft.io/) users can use `snap install helm --classic`
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
 


### PR DESCRIPTION
Helm is available as a snap - https://snapcraft.io/helm; added this to the installation options.

Signed-off-by: Ihor Dvoretskyi <ihor@linux.com>