### PR TITLE
fix: update unit test for go 1.14 error string change

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -18,7 +18,6 @@ package getter
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -68,10 +67,7 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		// In Go 1.14, the error returned from client.Do changed.
-		// This is for backward compatibility, so that tests will pass
-		// for Go 1.13 and before as well as 1.14 and beyond.
-		return buf, fmt.Errorf("Get %s: %s", href, err)
+		return buf, err
 	}
 	if resp.StatusCode != 200 {
 		return buf, errors.Errorf("failed to fetch %s : %s", href, resp.Status)

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -18,6 +18,7 @@ package getter
 import (
 	"bytes"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -67,7 +68,10 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return buf, err
+		// In Go 1.14, the error returned from client.Do changed.
+		// This is for backward compatibility, so that tests will pass
+		// for Go 1.13 and before as well as 1.14 and beyond.
+		return buf, fmt.Errorf("Get %s: %s", href, err)
 	}
 	if resp.StatusCode != 200 {
 		return buf, errors.Errorf("failed to fetch %s : %s", href, resp.Status)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -308,7 +308,7 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 
 	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", g); err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
-	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached: Get http://someserver/something/index.yaml`) {
+	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
 	}
 


### PR DESCRIPTION
I accidentally updated to Go 1.14, and upon doing so my unit tests started failing. I traced this down to a change in the error coming back from the `http.Client`'s `Do()` method. I updated the error message in a way that is backward compatible to previous Go versions, but also works with Go 1.14 and beyond.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>