### PR TITLE
fix: fixes for Go 1.14

### DIFF
--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -243,7 +243,7 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
 	}
-	if err != nil && !strings.Contains(err.Error(), `Looks like "http://someserver/something" is not a valid chart repository or cannot be reached: Get http://someserver/something/index.yaml`) {
+	if err != nil && !strings.Contains(err.Error(), `Looks like "http://someserver/something" is not a valid chart repository or cannot be reached`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
 	}
 

--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -36,6 +36,7 @@ gometalinter.v1 \
   --tests \
   --vendor \
   --deadline 60s \
+  --skip proto \
   ./... || exit_code=1
 
 echo


### PR DESCRIPTION
This makes a few backward-compatible (works with < Go 1.14) fixes to testing.

Go 1.14 changed some error messages, and this caused some unit tests to break. In addition, the formatting rules changed in Go 1.14, which caused the proto.go files to fail style checks. Since there is not really any reason to check the style of generated files, I removed them from `make test-style`.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>