### PR TITLE
fix(template): fix the bug when helm template with flag --output-dir

### DIFF
--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -130,7 +130,6 @@ func TestTemplateCmd(t *testing.T) {
 	runTestCmd(t, tests)
 }
 
-
 func TestTemplateOutputDir(t *testing.T) {
 	is := assert.New(t)
 
@@ -140,7 +139,7 @@ func TestTemplateOutputDir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	_, _, err = executeActionCommand(fmt.Sprintf("template --output-dir %s testdata/testcharts/chart-for-template-output",dir))
+	_, _, err = executeActionCommand(fmt.Sprintf("template --output-dir %s testdata/testcharts/chart-for-template-output", dir))
 	if err != nil {
 		t.Fatalf("Failed install: %s", err)
 	}
@@ -158,7 +157,6 @@ func TestTemplateOutputDir(t *testing.T) {
 
 }
 
-
 func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	is := assert.New(t)
 	dir, err := ioutil.TempDir("", "output-dir")
@@ -168,8 +166,8 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	var releaseName = "release"
-	newDir := filepath.Join(dir,releaseName)
-	_, _, err = executeActionCommand(fmt.Sprintf("template --output-dir %s %s testdata/testcharts/chart-for-template-output",newDir,releaseName))
+	newDir := filepath.Join(dir, releaseName)
+	_, _, err = executeActionCommand(fmt.Sprintf("template --output-dir %s %s testdata/testcharts/chart-for-template-output", newDir, releaseName))
 
 	if err != nil {
 		t.Fatalf("Failed install: %s", err)
@@ -185,4 +183,3 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	_, err = os.Stat(filepath.Join(newDir, "chart-for-template-output/templates/tests/test-connection.yaml"))
 	is.NoError(err)
 }
-

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/.helmignore
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: chart-for-template-output
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/NOTES.txt
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart-for-template-output.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart-for-template-output.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart-for-template-output.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chart-for-template-output.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/_helpers.tpl
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart-for-template-output.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart-for-template-output.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart-for-template-output.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart-for-template-output.labels" -}}
+helm.sh/chart: {{ include "chart-for-template-output.chart" . }}
+{{ include "chart-for-template-output.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart-for-template-output.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart-for-template-output.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart-for-template-output.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "chart-for-template-output.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/deployment.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart-for-template-output.fullname" . }}
+  labels:
+    {{- include "chart-for-template-output.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart-for-template-output.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart-for-template-output.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "chart-for-template-output.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/network.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/network.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "chart-for-template-output.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "chart-for-template-output.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart-for-template-output.fullname" . }}
+  labels:
+    {{- include "chart-for-template-output.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chart-for-template-output.selectorLabels" . | nindent 4 }}
+

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/serviceaccount.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart-for-template-output.serviceAccountName" . }}
+  labels:
+{{ include "chart-for-template-output.labels" . | nindent 4 }}
+{{- end -}}

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/templates/tests/test-connection.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "chart-for-template-output.fullname" . }}-test-connection"
+  labels:
+{{ include "chart-for-template-output.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "chart-for-template-output.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/cmd/helm/testdata/testcharts/chart-for-template-output/values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-for-template-output/values.yaml
@@ -1,0 +1,66 @@
+# Default values for chart-for-template-output.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -111,7 +111,6 @@ var manifestWithTestHook = `kind: Pod
 	  cmd: fake-command
   `
 
-
 type chartOptions struct {
 	*chart.Chart
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -111,31 +111,6 @@ var manifestWithTestHook = `kind: Pod
 	  cmd: fake-command
   `
 
-var rbacManifests = `apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: schedule-agents
-rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/exec", "pods/log"]
-  verbs: ["*"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: schedule-agents
-  namespace: {{ default .Release.Namespace}}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: schedule-agents
-subjects:
-- kind: ServiceAccount
-  name: schedule-agents
-  namespace: {{ .Release.Namespace }}
-`
 
 type chartOptions struct {
 	*chart.Chart
@@ -239,15 +214,6 @@ func withSampleIncludingIncorrectTemplates() chartOption {
 			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
 			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
 			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
-		}
-		opts.Templates = append(opts.Templates, sampleTemplates...)
-	}
-}
-
-func withMultipleManifestTemplate() chartOption {
-	return func(opts *chartOptions) {
-		sampleTemplates := []*chart.File{
-			{Name: "templates/rbac", Data: []byte(rbacManifests)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -19,16 +19,12 @@ package action
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
@@ -448,82 +444,6 @@ func TestNameTemplate(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestInstallReleaseOutputDir(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	instAction.OutputDir = dir
-
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(dir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
-}
-
-func TestInstallOutputDirWithReleaseName(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	instAction.OutputDir = dir
-	instAction.UseReleaseName = true
-	instAction.ReleaseName = "madra"
-
-	newDir := filepath.Join(dir, instAction.ReleaseName)
-
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(newDir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
 }
 
 func TestNameAndChart(t *testing.T) {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -170,7 +170,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, u.SubNotes, false, u.PostRenderer)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Issue:helm template with --output-dir doesn't write template with a hook to
file

Code Detail:
1. move the `writeToFile` function from `action/install` to `helm/template`
2. add function `parseManifest` to parse the `Release` field Manifest.

Close #7836

Signed-off-by: Dong Gang <dong.gang@daocloud.io>