### PR TITLE
fix(storage): Deployed, DeployedAll, and History methods should return correct errors.

### DIFF
--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -23,7 +23,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func TestRollbackCmd(t *testing.T) {
+func makeTestReleases() []*release.Release {
 	rels := []*release.Release{
 		{
 			Name:    "funny-honey",
@@ -38,32 +38,35 @@ func TestRollbackCmd(t *testing.T) {
 			Version: 2,
 		},
 	}
+	return rels
+}
 
+func TestRollbackCmd(t *testing.T) {
 	tests := []cmdTestCase{{
 		name:   "rollback a release",
 		cmd:    "rollback funny-honey 1",
 		golden: "output/rollback.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release with timeout",
 		cmd:    "rollback funny-honey 1 --timeout 120s",
 		golden: "output/rollback-timeout.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release with wait",
 		cmd:    "rollback funny-honey 1 --wait",
 		golden: "output/rollback-wait.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:   "rollback a release without revision",
 		cmd:    "rollback funny-honey",
 		golden: "output/rollback-no-revision.txt",
-		rels:   rels,
+		rels:   makeTestReleases(),
 	}, {
 		name:      "rollback a release without release name",
 		cmd:       "rollback",
 		golden:    "output/rollback-no-args.txt",
-		rels:      rels,
+		rels:      makeTestReleases(),
 		wantError: true,
 	}}
 	runTestCmd(t, tests)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -18,7 +18,6 @@ package storage // import "helm.sh/helm/v3/pkg/storage"
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -115,10 +114,6 @@ func (s *Storage) Deployed(name string) (*rspb.Release, error) {
 		return nil, err
 	}
 
-	if len(ls) == 0 {
-		return nil, errors.Errorf("%q has no deployed releases", name)
-	}
-
 	// If executed concurrently, Helm's database gets corrupted
 	// and multiple releases are DEPLOYED. Take the latest.
 	relutil.Reverse(ls, relutil.SortByRevision)
@@ -136,13 +131,13 @@ func (s *Storage) DeployedAll(name string) ([]*rspb.Release, error) {
 		"owner":  "helm",
 		"status": "deployed",
 	})
-	if err == nil {
-		return ls, nil
+	if err != nil {
+		return nil, err
 	}
-	if strings.Contains(err.Error(), "not found") {
-		return nil, errors.Errorf("%q has no deployed releases", name)
+	if len(ls) == 0 {
+		return nil, driver.ErrReleaseNotFound
 	}
-	return nil, err
+	return ls, nil
 }
 
 // History returns the revision history for the release with the provided name, or
@@ -150,7 +145,17 @@ func (s *Storage) DeployedAll(name string) ([]*rspb.Release, error) {
 func (s *Storage) History(name string) ([]*rspb.Release, error) {
 	s.Log("getting release history for %q", name)
 
-	return s.Driver.Query(map[string]string{"name": name, "owner": "helm"})
+	ls, err := s.Driver.Query(map[string]string{
+		"name":  name,
+		"owner": "helm",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(ls) == 0 {
+		return nil, driver.ErrReleaseNotFound
+	}
+	return ls, nil
 }
 
 // removeLeastRecent removes items from history until the lengh number of releases
@@ -204,9 +209,6 @@ func (s *Storage) Last(name string) (*rspb.Release, error) {
 	h, err := s.History(name)
 	if err != nil {
 		return nil, err
-	}
-	if len(h) == 0 {
-		return nil, errors.Errorf("no revision for release %q", name)
 	}
 
 	relutil.Reverse(h, relutil.SortByRevision)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -188,7 +188,7 @@ func TestStorageDeployed(t *testing.T) {
 
 	setup()
 
-	rls, err := storage.Last(name)
+	rls, err := storage.Deployed(name)
 	if err != nil {
 		t.Fatalf("Failed to query for deployed release: %s\n", err)
 	}
@@ -202,6 +202,17 @@ func TestStorageDeployed(t *testing.T) {
 		t.Fatalf("Expected release version %d, actual %d\n", vers, rls.Version)
 	case rls.Info.Status != rspb.StatusDeployed:
 		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rls.Info.Status.String())
+	}
+}
+
+func TestStorageDeployedError(t *testing.T) {
+	storage := Init(driver.NewMemory())
+
+	const name = "angry-bird"
+
+	_, err := storage.Deployed(name)
+	if err != driver.ErrReleaseNotFound {
+		t.Fatalf("Expected ErrReleaseNotFound, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
The `Deployed`, `DeployedAll`, and `History` methods all claim in their docstrings to return `ErrReleaseNotFound` when there are no matching releases, but their actual behavior is not correct:

1. `History` is dependent on the underlying implementation, which as #7372 points out below, is inconsistent between `ConfigMap` / `Secret` vs. `Memory`.
2. `Deployed` and `DeployedAll` return entirely custom errors.

This PR makes the `Storage` client consistent in behavior, regardless of the underlying `Driver` implementations:

1. All three methods now return `ErrReleaseNotFound` when `len(ls) == 0`. 
2. The test `TestStorageDeployed` in `storage_test.go` was calling `Last`, not `Deployed`. That's fixed.

I also added a tiny error test. I'd love to move these storage tests to table tests in a subsequent PR.

This is a breaking change for anyone who uses the `Storage` client with any driver, but it's breaking in that now at least the code and docstrings match.

I searched and found that this is adjacent to https://github.com/helm/helm/pull/7372, but gets at the problem at the client level, rather than the implementations. I also took the testing fix from that, so that change should be changed first, in my opinion.

cc @absoludity @latiff @SimonAlling 