### PR TITLE
[create] feat: allow image tag override

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -97,6 +97,8 @@ replicaCount: 1
 image:
   repository: nginx
   pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart version.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -262,7 +264,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
While using the chart's appVersion as image tag is the sanest default, it is not uncommon to want to override this if using a custom image, or using helm to manage  an in-house app running different tags across different environments.

cc @scottrigby @unguiculus @rimusz @mattfarina etc.