### PR TITLE
fix: Change early exit condition to accommodate charts with sub dependencies

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -116,7 +116,7 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 
 // processDependencyEnabled removes disabled charts from dependencies
 func processDependencyEnabled(c *chart.Chart, v map[string]interface{}, path string) error {
-	if c.Metadata.Dependencies == nil {
+	if c.Metadata.Dependencies == nil && len(c.Dependencies()) == 0 {
 		return nil
 	}
 

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -269,6 +269,63 @@ func TestProcessDependencyImportValuesForEnabledCharts(t *testing.T) {
 	}
 }
 
+func TestProcessDependencyEnabledRespectsChildConditionsWhenParentLacksDependenciesBlock(t *testing.T) {
+	c := loadChart(t, "testdata/respect-conditions-without-dependencies-block/parent-chart")
+
+	if err := processDependencyImportValues(c); err != nil {
+		t.Fatalf("processing import values dependencies %v", err)
+	}
+
+	if len(c.Dependencies()) != 1 {
+		t.Fatalf("expected 1 dependency for this chart, but got %d", len(c.Dependencies()))
+	}
+
+	if len(c.Metadata.Dependencies) != 0 {
+		t.Fatalf("expected 0 dependencies specified in parent chart's Chart.yaml, got %d", len(c.Metadata.Dependencies))
+	}
+
+	if len(c.Dependencies()[0].Dependencies()) != 3 {
+		t.Fatalf("expected 3 dependencies for the subchart, but got %d", len(c.Dependencies()))
+	}
+
+	if len(c.Dependencies()[0].Metadata.Dependencies) != 3 {
+		t.Fatalf("expected 3 dependencies specified in subchart's Chart.yaml, got %d", len(c.Dependencies()[0].Metadata.Dependencies))
+	}
+
+	if err := processDependencyEnabled(c, c.Values, ""); err != nil {
+		t.Fatalf("expected no errors but got %q", err)
+	}
+
+	if len(c.Dependencies()) != 1 {
+		t.Fatalf("expected 1 dependency for this chart, but got %d", len(c.Dependencies()))
+	}
+
+	if len(c.Dependencies()[0].Dependencies()) != 2 {
+		t.Fatalf("expected 2 dependencies for this chart, but got %d", len(c.Dependencies()[0].Dependencies()))
+	}
+
+	if len(c.Metadata.Dependencies) != 0 {
+		t.Fatalf("expected 0 dependencies specified in Chart.yaml, got %d", len(c.Metadata.Dependencies))
+	}
+
+	if len(c.Dependencies()[0].Metadata.Dependencies) != 2 {
+		t.Fatalf("expected 2 dependencies specified in subchart's Chart.yaml, got %d", len(c.Dependencies()[0].Metadata.Dependencies))
+	}
+
+	subChartDependencyChart0Name := c.Dependencies()[0].Dependencies()[0].Name()
+	subChartDependencyChart1Name := c.Dependencies()[0].Dependencies()[1].Name()
+	devChartName := "dev"
+	prodChartName := "prod"
+
+	if subChartDependencyChart0Name != devChartName {
+		t.Fatalf("subchart's dependency chart name should be %s but got %s", devChartName, subChartDependencyChart1Name)
+	}
+
+	if subChartDependencyChart1Name != prodChartName {
+		t.Fatalf("subchart's dependency chart name should be %s but got %s", prodChartName, subChartDependencyChart1Name)
+	}
+}
+
 func TestGetAliasDependency(t *testing.T) {
 	c := loadChart(t, "testdata/frobnitz")
 	req := c.Metadata.Dependencies

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/Chart.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: parent-chart
+version: v0.1.0
+appVersion: v0.1.0

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/Chart.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: daughter-chart
+version: v0.1.0
+appVersion: v0.1.0
+dependencies:
+  - name: dev
+    repository: "file://charts/dev"
+    version: ">= 0.0.1"
+    condition: global.dev.enabled,dev.enabled
+  - name: staging
+    repository: "file://charts/staging"
+    version: ">= 0.0.1"
+    condition: staging.enabled,global.staging.enabled
+  - name: prod
+    repository: "file://charts/prod"
+    version: ">= 0.0.1"
+    condition: global.prod.enabled,prod.enabled

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/dev/Chart.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/dev/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: dev
+version: v0.1.0
+appVersion: v0.1.0

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/dev/templates/secret.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/dev/templates/secret.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dev-test
+stringData:
+  key: value

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/prod/Chart.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/prod/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: prod
+version: v0.1.0
+appVersion: v0.1.0

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/prod/templates/secret.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/prod/templates/secret.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-test
+stringData:
+  key: value

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/staging/Chart.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/staging/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: staging
+version: v0.1.0
+appVersion: v0.1.0

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/staging/templates/secret.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/charts/staging/templates/secret.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: staging-test
+stringData:
+  key: value

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/values.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/charts/daughter-chart/values.yaml
@@ -1,0 +1,7 @@
+# Default values for daughter-chart.
+dev:
+  enabled: false
+staging:
+  enabled: false
+prod:
+  enabled: true

--- a/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/values.yaml
+++ b/pkg/chartutil/testdata/respect-conditions-without-dependencies-block/parent-chart/values.yaml
@@ -1,0 +1,6 @@
+# Default values for parent-chart.
+global:
+  dev:
+    enabled: true
+  staging:
+    enabled: true


### PR DESCRIPTION
My team has been having trouble using an umbrella chart type structure with Helm 3.

One of our sub charts has a dependency that Helm no longer honours so I decided to take a look into it. Turns out that the early exit condition in the `processDependencyEnabled` function seemed to be causing the problems.

I didn't want to remove the early exit check completely so I just added a small check to see whether the chart has any dependencies, as well, which might also have dependency metadata. I didn't think it was worth looping through all the potential dependencies looking for chart metadata. 

This solution is from someone who only just looked at the codebase today so I'm open to feedback and suggestions. Let me know.

Seems to cover #7389 and #5780.

Signed-off-by: Sam McKendrick <sam.macca9@gmail.com>