### PR TITLE
Adding notes on semver to create Chart.yaml

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -81,10 +81,12 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.16.0
 `
 


### PR DESCRIPTION
The version field in the Chart.yaml has a comment describing it
but it did not note the version needs to follow SemVer. There
have been numerous questions, over time, about this format. Add
note here so it's exposed in more places.