### PR TITLE
fixed capitalization in a few help messages.

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -52,7 +52,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "completion SHELL",
-		Short: "Generate autocompletions script for the specified shell (bash or zsh)",
+		Short: "generate autocompletions script for the specified shell (bash or zsh)",
 		Long:  completionDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletion(out, cmd, args)

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -71,7 +71,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "The name or absolute path to Helm starter scaffold")
+	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
 	return cmd
 }
 

--- a/cmd/helm/env.go
+++ b/cmd/helm/env.go
@@ -40,7 +40,7 @@ func newEnvCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "env",
-		Short: "Helm client environment information",
+		Short: "helm client environment information",
 		Long:  envHelp,
 		Args:  require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -82,7 +82,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 
 	f := cmd.Flags()
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
-	f.BoolVar(&outputLogs, "logs", false, "Dump the logs from test pods (this runs after all tests are complete, but before any cleanup)")
+	f.BoolVar(&outputLogs, "logs", false, "dump the logs from test pods (this runs after all tests are complete, but before any cleanup)")
 
 	return cmd
 }


### PR DESCRIPTION
Our convention is that all help strings for commands and options begin with a lowercase letter (unless the word is a proper noun). I brought a few help text messages into alignment.

Note that in one case, I changed `Helm` to `helm` because our guidelines state that when we mean the tool, casing is `helm`, whereas the project is `Helm`.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>