### PR TITLE
fix: lint with strict passes for helm create

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -74,7 +74,7 @@ serviceAccount:
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
A change in the YAML parser between Helm 2 and Helm 3 led to a subtle bug in `helm lint`

Closes #7923 
