### PR TITLE
test: forward-port regression test from Helm 2

### DIFF
--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package lint
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/lint/support"
 )
 
@@ -102,5 +105,32 @@ func TestGoodChart(t *testing.T) {
 	m := All(goodChartDir, values, namespace, strict).Messages
 	if len(m) != 0 {
 		t.Errorf("All failed but shouldn't have: %#v", m)
+	}
+}
+
+// TestHelmCreateChart tests that a `helm create` always passes a `helm lint` test.
+//
+// See https://github.com/helm/helm/issues/7923
+func TestHelmCreateChart(t *testing.T) {
+	dir, err := ioutil.TempDir("", "-helm-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	createdChart, err := chartutil.Create("testhelmcreatepasseslint", dir)
+	if err != nil {
+		t.Error(err)
+		// Fatal is bad because of the defer.
+		return
+	}
+
+	// Note: we test with strict=true here, even though others have
+	// strict = false.
+	m := All(createdChart, values, namespace, true).Messages
+	if ll := len(m); ll != 1 {
+		t.Errorf("All should have had exactly 1 error. Got %d", ll)
+	} else if msg := m[0].Err.Error(); !strings.Contains(msg, "icon is recommended") {
+		t.Errorf("Unexpected lint error: %s", msg)
 	}
 }


### PR DESCRIPTION
Add a regression test from #7926 (Helm v2) that makes sure `helm create` produces charts that will pass `helm lint --strict`.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>