### PR TITLE
fix(pkg/kube): continue deleting objects when one fails

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -223,6 +223,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 
 		if err := info.Get(); err != nil {
 			c.Log("Unable to get obj %q, err: %s", info.Name, err)
+			continue
 		}
 		annotations, err := metadataAccessor.Annotations(info.Object)
 		if err != nil {
@@ -232,16 +233,11 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 			c.Log("Skipping delete of %q due to annotation [%s=%s]", info.Name, ResourcePolicyAnno, KeepPolicy)
 			continue
 		}
-
-		res.Deleted = append(res.Deleted, info)
 		if err := deleteResource(info); err != nil {
-			if apierrors.IsNotFound(err) {
-				c.Log("Attempted to delete %q, but the resource was missing", info.Name)
-			} else {
-				c.Log("Failed to delete %q, err: %s", info.Name, err)
-				return res, errors.Wrapf(err, "Failed to delete %q", info.Name)
-			}
+			c.Log("Failed to delete %q, err: %s", info.ObjectName(), err)
+			continue
 		}
+		res.Deleted = append(res.Deleted, info)
 	}
 	return res, nil
 }

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -164,9 +164,21 @@ func TestUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := c.Update(first, second, false); err != nil {
+	result, err := c.Update(first, second, false)
+	if err != nil {
 		t.Fatal(err)
 	}
+
+	if len(result.Created) != 1 {
+		t.Errorf("expected 1 resource created, got %d", len(result.Created))
+	}
+	if len(result.Updated) != 2 {
+		t.Errorf("expected 2 resource updated, got %d", len(result.Updated))
+	}
+	if len(result.Deleted) != 1 {
+		t.Errorf("expected 1 resource deleted, got %d", len(result.Deleted))
+	}
+
 	// TODO: Find a way to test methods that use Client Set
 	// Test with a wait
 	// if err := c.Update("test", objBody(codec, &listB), objBody(codec, &listC), false, 300, true); err != nil {
@@ -190,8 +202,7 @@ func TestUpdate(t *testing.T) {
 		"/namespaces/default/pods/squid:DELETE",
 	}
 	if len(expectedActions) != len(actions) {
-		t.Errorf("unexpected number of requests, expected %d, got %d", len(expectedActions), len(actions))
-		return
+		t.Fatalf("unexpected number of requests, expected %d, got %d", len(expectedActions), len(actions))
 	}
 	for k, v := range expectedActions {
 		if actions[k] != v {


### PR DESCRIPTION
* Continue deleting objects when one fails to minimize the risk of an
  upgrade ending in an unrecoverable state
* Exclude failed deleted object from the returned result set