### PR TITLE
fix: Fixed a regression that was introduced with changed nil handling

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -113,7 +113,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
 
 podAnnotations: {}
 


### PR DESCRIPTION
This fixes a test case that is causing `master` to fail.

The issue is caused by the changed handling of empty field values:

```yaml
name:
```

This used to be interpreted as `name: ""`, but with a fix to some removal code is now treated as `name: null`, which in turn is treated as `delete the field name`.

The fix was to make the `values.yaml` file read:

```yaml
name: ""
```

This is the same as the fix in Helm 2. Hooray for regression tests!

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>