### PR TITLE
Fix : Prints empty list in json/yaml is no repositories are present

### DIFF
--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -38,7 +38,7 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			f, err := repo.LoadFile(settings.RepositoryConfig)
-			if isNotExist(err) || (len(f.Repositories) == 0 && !(outfmt.String() == "json" || outfmt.String() == "yaml")) {
+			if isNotExist(err) || (len(f.Repositories) == 0 && !(outfmt == output.JSON || outfmt == output.YAML)) {
 				return errors.New("no repositories to show")
 			}
 

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -38,7 +38,7 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			f, err := repo.LoadFile(settings.RepositoryConfig)
-			if isNotExist(err) || len(f.Repositories) == 0 {
+			if isNotExist(err) || (len(f.Repositories) == 0 && !(outfmt.String() == "json" || outfmt.String() == "yaml")) {
 				return errors.New("no repositories to show")
 			}
 


### PR DESCRIPTION
Prints empty repolist in json/yaml if there are no repositories and output format is given as json/yaml rather that printing the error msg "no repositories to show"
~~~
$ ./helm repo list -oyaml  
[]
$ ./helm repo list -ojson
[]
$ ./helm repo list       
Error: no repositories to show
~~~
Fixes [#7939](https://github.com/helm/helm/issues/7939)