### PR TITLE
feat(getter): add timeout option

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -18,6 +18,7 @@ package getter
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -36,6 +37,7 @@ type options struct {
 	username              string
 	password              string
 	userAgent             string
+	timeout               time.Duration
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -78,6 +80,13 @@ func WithTLSClientConfig(certFile, keyFile, caFile string) Option {
 		opts.certFile = certFile
 		opts.keyFile = keyFile
 		opts.caFile = caFile
+	}
+}
+
+// WithTimeout sets the timeout for requests
+func WithTimeout(timeout time.Duration) Option {
+	return func(opts *options) {
+		opts.timeout = timeout
 	}
 }
 

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -119,6 +119,7 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 
 	client := &http.Client{
 		Transport: transport,
+		Timeout:   g.opts.timeout,
 	}
 
 	return client, nil

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -48,6 +49,7 @@ func TestHTTPGetter(t *testing.T) {
 	join := filepath.Join
 	ca, pub, priv := join(cd, "rootca.crt"), join(cd, "crt.pem"), join(cd, "key.pem")
 	insecure := false
+	timeout := time.Second * 5
 
 	// Test with options
 	g, err = NewHTTPGetter(
@@ -55,6 +57,7 @@ func TestHTTPGetter(t *testing.T) {
 		WithUserAgent("Groot"),
 		WithTLSClientConfig(pub, priv, ca),
 		WithInsecureSkipVerifyTLS(insecure),
+		WithTimeout(timeout),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -91,6 +94,10 @@ func TestHTTPGetter(t *testing.T) {
 
 	if hg.opts.insecureSkipVerifyTLS != insecure {
 		t.Errorf("Expected NewHTTPGetter to contain %t as InsecureSkipVerifyTLs flag, got %t", false, hg.opts.insecureSkipVerifyTLS)
+	}
+
+	if hg.opts.timeout != timeout {
+		t.Errorf("Expected NewHTTPGetter to contain %s as Timeout flag, got %s", timeout, hg.opts.timeout)
 	}
 
 	// Test if setting insecureSkipVerifyTLS is being passed to the ops


### PR DESCRIPTION
To allow finer grain control over the request when utilizing `getter` as a package.

Addresses item 1 of #7958.