### PR TITLE
Helm upgrades with --reuse-values and nil user values -- with tests

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -175,8 +175,14 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}) {
 //
 // dest is considered authoritative.
 func CoalesceTables(dst, src map[string]interface{}) map[string]interface{} {
+	// When --reuse-values is set but there are no modifications yet, return new values
 	if dst == nil || src == nil {
-		return src
+		if src == nil {
+			return dst
+		}
+		if dst == nil {
+			return src
+		}
 	}
 	// Because dest has higher precedence than src, dest values override src
 	// values.

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -176,13 +176,11 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}) {
 // dest is considered authoritative.
 func CoalesceTables(dst, src map[string]interface{}) map[string]interface{} {
 	// When --reuse-values is set but there are no modifications yet, return new values
-	if dst == nil || src == nil {
-		if src == nil {
-			return dst
-		}
-		if dst == nil {
-			return src
-		}
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		return src
 	}
 	// Because dest has higher precedence than src, dest values override src
 	// values.

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -211,4 +211,57 @@ func TestCoalesceTables(t *testing.T) {
 	if _, ok = dst["hole"]; ok {
 		t.Error("The hole still exists.")
 	}
+
+	dst2 := map[string]interface{}{
+		"name": "Ishmael",
+		"address": map[string]interface{}{
+			"street":  "123 Spouter Inn Ct.",
+			"city":    "Nantucket",
+			"country": nil,
+		},
+		"details": map[string]interface{}{
+			"friends": []string{"Tashtego"},
+		},
+		"boat": "pequod",
+		"hole": nil,
+	}
+
+	// What we expect is that anything in dst should have all values set,
+	// this happens when the --reuse-values flag is set but the chart has no modifications yet
+	CoalesceTables(dst2, nil)
+
+	if dst2["name"] != "Ishmael" {
+		t.Errorf("Unexpected name: %s", dst["name"])
+	}
+
+	addr2, ok := dst2["address"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Address went away.")
+	}
+
+	if addr2["street"].(string) != "123 Spouter Inn Ct." {
+		t.Errorf("Unexpected address: %v", addr2["street"])
+	}
+
+	if addr2["city"].(string) != "Nantucket" {
+		t.Errorf("Unexpected city: %v", addr2["city"])
+	}
+
+	if _, ok = addr2["country"]; ok {
+		t.Error("The country is not left out.")
+	}
+
+	if det2, ok := dst2["details"].(map[string]interface{}); !ok {
+		t.Fatalf("Details is the wrong type: %v", dst["details"])
+	} else if _, ok := det2["friends"]; !ok {
+		t.Error("Could not find your friends. Maybe you don't have any. :-(")
+	}
+
+	if dst2["boat"].(string) != "pequod" {
+		t.Errorf("Expected boat string, got %v", dst["boat"])
+	}
+
+	if _, ok = dst["hole"]; ok {
+		t.Error("The hole still exists.")
+	}
 }

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -217,13 +217,13 @@ func TestCoalesceTables(t *testing.T) {
 		"address": map[string]interface{}{
 			"street":  "123 Spouter Inn Ct.",
 			"city":    "Nantucket",
-			"country": nil,
+			"country": "US",
 		},
 		"details": map[string]interface{}{
 			"friends": []string{"Tashtego"},
 		},
 		"boat": "pequod",
-		"hole": nil,
+		"hole": "black",
 	}
 
 	// What we expect is that anything in dst should have all values set,
@@ -231,7 +231,7 @@ func TestCoalesceTables(t *testing.T) {
 	CoalesceTables(dst2, nil)
 
 	if dst2["name"] != "Ishmael" {
-		t.Errorf("Unexpected name: %s", dst["name"])
+		t.Errorf("Unexpected name: %s", dst2["name"])
 	}
 
 	addr2, ok := dst2["address"].(map[string]interface{})
@@ -247,21 +247,21 @@ func TestCoalesceTables(t *testing.T) {
 		t.Errorf("Unexpected city: %v", addr2["city"])
 	}
 
-	if _, ok = addr2["country"]; ok {
-		t.Error("The country is not left out.")
+	if addr2["country"].(string) != "US" {
+		t.Errorf("Unexpected Country: %v", addr2["country"])
 	}
 
 	if det2, ok := dst2["details"].(map[string]interface{}); !ok {
-		t.Fatalf("Details is the wrong type: %v", dst["details"])
+		t.Fatalf("Details is the wrong type: %v", dst2["details"])
 	} else if _, ok := det2["friends"]; !ok {
 		t.Error("Could not find your friends. Maybe you don't have any. :-(")
 	}
 
 	if dst2["boat"].(string) != "pequod" {
-		t.Errorf("Expected boat string, got %v", dst["boat"])
+		t.Errorf("Expected boat string, got %v", dst2["boat"])
 	}
 
-	if _, ok = dst["hole"]; ok {
-		t.Error("The hole still exists.")
+	if dst2["hole"].(string) != "black" {
+		t.Errorf("Expected hole string, got %v", dst2["boat"])
 	}
 }


### PR DESCRIPTION
Duplicate of [pr](https://github.com/helm/helm/pull/6917) but with tests added

This PR allows helm charts to have an upgrade with --reuse-values when the chart has no modifications already.

Gives priority to dst when the src parameter is nil.

Resolves #6899