### PR TITLE
Fixing docs from version to appVersion

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -99,7 +99,7 @@ replicaCount: 1
 image:
   repository: nginx
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart version.
+  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
In the created chart from `helm create` is notes a tag overrides
version. It actually overrides appVersion. Updating the docs
to reflect reality.

I totally didn't write this while @adamreese was talking during a Helm dev call.