### PR TITLE
Updating CONTRIBUTING to match current practice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,9 +184,9 @@ contributing to Helm. All issue types follow the same general lifecycle. Differe
 
 ## How to Contribute a Patch
 
-1. If you haven't already done so, sign a Contributor License Agreement (see details above).
-2. Fork the desired repo, develop and test your code changes.
-3. Submit a pull request.
+1. Identify or create the related issue.
+2. Fork the desired repo; develop and test your code changes.
+3. Submit a pull request, making sure to sign your work and link the related issue.
 
 Coding conventions and standards are explained in the [official developer docs](https://helm.sh/docs/developers/).
 


### PR DESCRIPTION
This PR is intended to clarify and reword the contributing guidelines to match current practice.

- When we entered the CNCF we switched from CLA to DCO, but there is an orphan reference to "Contributor License Agreement" which no longer has further explanation.
- We want to encourage the opening of issues instead of just stand-alone pull requests.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>