### PR TITLE
fix: removed strict template errors in linter

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -81,7 +81,6 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		return
 	}
 	var e engine.Engine
-	e.Strict = strict
 	e.LintMode = true
 	renderedContentMap, err := e.Render(chart, valuesToRender)
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR closes #7483 by no longer setting the `Engine.Strict` flag on the template engine when `helm lint --strict` is executed.

According to the documentation for `--strict`, when it is specified, it converts warnings to errors. However, in the code, `--strict=true` also sets the template engine into `Strict`. When the template engine is in strict mode, if any value is missing from the `.Values` object, it produces an error. However, templates frequently use things like `{{ default "foo" .Values.optionalThing }}` to allow users to override a default. In this case, it is likely that a value will not be present in the `Values.yaml`.

Issue #7483 reports this as a bug. I think it is open to interpretation. So I have opened a PR that changes the behavior, but we could certainly decide not to change this particular behavior. 

**Special notes for your reviewer**:

If we merge this PR, some charts that did _not_ pass `helm lint --strict` will now pass.

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility

Closes #7483 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>