### PR TITLE
Fix markdown table in helm command doc

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -43,17 +43,15 @@ Common actions for Helm:
 
 Environment variables:
 
-+------------------+--------------------------------------------------------------------------------------------------------+
-| Name                                  | Description                                                                       |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| $XDG_CACHE_HOME                       | set an alternative location for storing cached files.                             |
-| $XDG_CONFIG_HOME                      | set an alternative location for storing Helm configuration.                       |
-| $XDG_DATA_HOME                        | set an alternative location for storing Helm data.                                |
-| $HELM_DRIVER                          | set the backend storage driver. Values are: configmap, secret, memory, postgres   |
-| $HELM_DRIVER_SQL_CONNECTION_STRING    | set the connection string the SQL storage driver should use.                      |
-| $HELM_NO_PLUGINS                      | disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.                        |
-| $KUBECONFIG                           | set an alternative Kubernetes configuration file (default "~/.kube/config")       |
-+------------------+--------------------------------------------------------------------------------------------------------+
+| Name                               | Description                                                                       |
+|------------------------------------|-----------------------------------------------------------------------------------|
+| $XDG_CACHE_HOME                    | set an alternative location for storing cached files.                             |
+| $XDG_CONFIG_HOME                   | set an alternative location for storing Helm configuration.                       |
+| $XDG_DATA_HOME                     | set an alternative location for storing Helm data.                                |
+| $HELM_DRIVER                       | set the backend storage driver. Values are: configmap, secret, memory, postgres   |
+| $HELM_DRIVER_SQL_CONNECTION_STRING | set the connection string the SQL storage driver should use.                      |
+| $HELM_NO_PLUGINS                   | disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.                        |
+| $KUBECONFIG                        | set an alternative Kubernetes configuration file (default "~/.kube/config")       |
 
 Helm stores configuration based on the XDG base directory specification, so
 
@@ -63,13 +61,11 @@ Helm stores configuration based on the XDG base directory specification, so
 
 By default, the default directories depend on the Operating System. The defaults are listed below:
 
-+------------------+---------------------------+--------------------------------+-------------------------+
 | Operating System | Cache Path                | Configuration Path             | Data Path               |
-+------------------+---------------------------+--------------------------------+-------------------------+
+|------------------|---------------------------|--------------------------------|-------------------------|
 | Linux            | $HOME/.cache/helm         | $HOME/.config/helm             | $HOME/.local/share/helm |
 | macOS            | $HOME/Library/Caches/helm | $HOME/Library/Preferences/helm | $HOME/Library/helm      |
 | Windows          | %TEMP%\helm               | %APPDATA%\helm                 | %APPDATA%\helm          |
-+------------------+---------------------------+--------------------------------+-------------------------+
 `
 
 func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) *cobra.Command {


### PR DESCRIPTION
The tables aren't rendered correctly because the syntax was wrong. Fixed it by applying the https://www.markdownguide.org/extended-syntax/#tables table syntax.

See https://helm.sh/docs/helm/helm/#synopsis for the wrong rendering.

![Broken table in html](https://i.imgur.com/bniKxO6.png)

Fix for helm/helm-www#575