### PR TITLE
[WIP] Configuration settings

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -43,7 +43,7 @@ import (
 // FeatureGateOCI is the feature gate for checking if `helm chart` and `helm registry` commands should work
 const FeatureGateOCI = gates.Gate("HELM_EXPERIMENTAL_OCI")
 
-var settings = cli.New()
+var settings = cli.SettingsFromEnv()
 
 func init() {
 	log.SetFlags(log.Lshortfile)
@@ -72,8 +72,10 @@ func main() {
 
 	// run when each command's execute method is called
 	cobra.OnInitialize(func() {
-		helmDriver := os.Getenv("HELM_DRIVER")
-		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, debug); err != nil {
+		namespace := settings.GetNamespace()
+		helmDriver := settings.HelmDriver
+
+		if err := actionConfig.Init(settings.RESTClientGetter(), namespace, helmDriver, debug); err != nil {
 			log.Fatal(err)
 		}
 		if helmDriver == "memory" {
@@ -141,5 +143,5 @@ func loadReleasesInMemory(actionConfig *action.Configuration) {
 		}
 	}
 	// Must reset namespace to the proper one
-	mem.SetNamespace(settings.Namespace())
+	mem.SetNamespace(settings.GetNamespace())
 }

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -127,7 +127,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	}
 
 	if mem, ok := store.Driver.(*driver.Memory); ok {
-		mem.SetNamespace(settings.Namespace())
+		mem.SetNamespace(settings.GetNamespace())
 	}
 	c, err := root.ExecuteC()
 
@@ -163,7 +163,7 @@ func resetEnv() func() {
 			kv := strings.SplitN(pair, "=", 2)
 			os.Setenv(kv[0], kv[1])
 		}
-		settings = cli.New()
+		settings = cli.SettingsFromEnv()
 	}
 }
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -225,7 +225,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	client.Namespace = settings.Namespace()
+	client.Namespace = settings.GetNamespace()
 	return client.Run(chartRequested, vals)
 }
 

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -68,7 +68,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 				}
 			}
 
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.GetNamespace()
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -47,7 +47,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Long:  releaseTestHelp,
 		Args:  require.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.GetNamespace()
 			rel, runErr := client.Run(args[0])
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -73,7 +73,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client.Namespace = settings.Namespace()
+			client.Namespace = settings.GetNamespace()
 
 			// Fixes #7002 - Support reading values from STDIN for `upgrade` command
 			// Must load values AFTER determining if we have to call install so that values loaded from stdin are are not read twice

--- a/internal/completion/complete.go
+++ b/internal/completion/complete.go
@@ -174,7 +174,7 @@ func (d BashCompDirective) string() string {
 }
 
 // NewCompleteCmd add a special hidden command that an be used to request completions
-func NewCompleteCmd(settings *cli.EnvSettings, out io.Writer) *cobra.Command {
+func NewCompleteCmd(settings *cli.Settings, out io.Writer) *cobra.Command {
 	debug = settings.Debug
 	return &cobra.Command{
 		Use:                   fmt.Sprintf("%s [command-line]", CompRequestCmd),

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -613,7 +613,7 @@ OUTER:
 // - URL
 //
 // If 'verify' was set on ChartPathOptions, this will attempt to also verify the chart.
-func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (string, error) {
+func (c *ChartPathOptions) LocateChart(name string, settings *cli.Settings) (string, error) {
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -38,7 +38,7 @@ import (
 type Pull struct {
 	ChartPathOptions
 
-	Settings *cli.EnvSettings // TODO: refactor this out of pkg/action
+	Settings *cli.Settings // TODO: refactor this out of pkg/action
 
 	Devel       bool
 	Untar       bool

--- a/pkg/cli/settings.go
+++ b/pkg/cli/settings.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cli
 
 import (
@@ -9,9 +25,11 @@ import (
 	"strconv"
 )
 
-// Settings describes all of the settings required by the Helm client.
+// Settings describes all of the configuration options required by the Helm client.
 type Settings struct {
-	Namespace  string
+	// The Kubernetes namespace
+	Namespace string
+	// The Helm driver ("memory", "secret", or "configmap")
 	HelmDriver string
 	// KubeConfig is the path to the kubeconfig file
 	KubeConfig string
@@ -32,6 +50,7 @@ type Settings struct {
 	// PluginsDirectory is the path to the plugins directory.
 	PluginsDirectory string
 
+	// Kubernetes configuration flags
 	config *genericclioptions.ConfigFlags
 }
 
@@ -113,8 +132,4 @@ func (s *Settings) EnvVars() map[string]string {
 		envvars["KUBECONFIG"] = s.KubeConfig
 	}
 	return envvars
-}
-
-func (s *Settings) validate() error {
-	return nil
 }

--- a/pkg/cli/settings_test.go
+++ b/pkg/cli/settings_test.go
@@ -71,15 +71,15 @@ func TestEnvSettings(t *testing.T) {
 
 			flags := pflag.NewFlagSet("testing", pflag.ContinueOnError)
 
-			settings := New()
+			settings := SettingsFromEnv()
 			settings.AddFlags(flags)
 			flags.Parse(strings.Split(tt.args, " "))
 
 			if settings.Debug != tt.debug {
 				t.Errorf("expected debug %t, got %t", tt.debug, settings.Debug)
 			}
-			if settings.Namespace() != tt.ns {
-				t.Errorf("expected namespace %q, got %q", tt.ns, settings.Namespace())
+			if settings.GetNamespace() != tt.ns {
+				t.Errorf("expected namespace %q, got %q", tt.ns, settings.GetNamespace())
 			}
 			if settings.KubeContext != tt.kcontext {
 				t.Errorf("expected kube-context %q, got %q", tt.kcontext, settings.KubeContext)
@@ -92,7 +92,7 @@ func resetEnv() func() {
 	origEnv := os.Environ()
 
 	// ensure any local envvars do not hose us
-	for e := range New().EnvVars() {
+	for e := range SettingsFromEnv().EnvVars() {
 		os.Unsetenv(e)
 	}
 

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -1,0 +1,75 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import "fmt"
+
+type MissingConfigError struct {
+	string
+}
+
+func (e MissingConfigError) Error() string {
+	return fmt.Sprintf("missing config error: %s param missing from client configuration", e.string)
+}
+
+// Checks whether the error yielded by the Validate function contains MissingConfigErrors.
+func HasMissingConfigErrors(errs []error) bool {
+	return len(errs) > 0
+}
+
+// Ensures that the required fields are set on the Settings struct and returns a list of MissingConfigError
+// for all missing fields.
+func (s *Settings) Validate() []error {
+	errs := make([]error, 0)
+
+	if s.Namespace == "" {
+		appendError(&errs, "Namespace")
+	}
+	if s.HelmDriver == "" {
+		appendError(&errs, "HelmDriver")
+	}
+	if s.KubeConfig == "" {
+		appendError(&errs, "KubeConfig")
+	}
+	if s.KubeContext == "" {
+		appendError(&errs, "KubeContext")
+	}
+	if s.KubeToken == "" {
+		appendError(&errs, "KubeToken")
+	}
+	if s.KubeAPIServer == "" {
+		appendError(&errs, "KubeAPIServer")
+	}
+	if s.RegistryConfig == "" {
+		appendError(&errs, "RegistryConfig")
+	}
+	if s.RepositoryConfig == "" {
+		appendError(&errs, "RepositoryConfig")
+	}
+	if s.RepositoryCache == "" {
+		appendError(&errs, "RepositoryCache")
+	}
+	if s.PluginsDirectory == "" {
+		appendError(&errs, "RepositoryCache")
+	}
+
+	return errs
+}
+
+func appendError(errs *[]error, field string) {
+	*errs = append(*errs, MissingConfigError{field})
+}

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import "testing"
+
+func TestSettingsValidation(t *testing.T) {
+	tests := []struct {
+		name string
+
+		// input
+		settings Settings
+
+		// expected
+		expectedErrs []error
+	}{
+		{settings: *SettingsFromEnv(), expectedErrs: []error{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var errsEqual = func(es1, es2 []error) bool {
+				return true
+			}
+
+			errs := tt.settings.Validate()
+			if !errsEqual(errs, tt.expectedErrs) {
+				t.Errorf("expected errors %v, got %v", tt.expectedErrs, errs)
+			}
+		})
+	}
+}

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -59,7 +59,7 @@ func TestResolveChartRef(t *testing.T) {
 		Out:              os.Stderr,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
@@ -99,7 +99,7 @@ func TestResolveChartOpts(t *testing.T) {
 		Out:              os.Stderr,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
@@ -199,7 +199,7 @@ func TestDownloadTo(t *testing.T) {
 		Keyring:          "testdata/helm-test-key.pub",
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
@@ -252,7 +252,7 @@ func TestDownloadTo_TLS(t *testing.T) {
 		Keyring:          "testdata/helm-test-key.pub",
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
@@ -299,7 +299,7 @@ func TestDownloadTo_VerifyLater(t *testing.T) {
 		Verify:           VerifyLater,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
@@ -328,7 +328,7 @@ func TestScanReposForURL(t *testing.T) {
 		Verify:           VerifyLater,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		Getters: getter.All(&cli.EnvSettings{
+		Getters: getter.All(&cli.Settings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -133,7 +133,7 @@ var httpProvider = Provider{
 // All finds all of the registered getters as a list of Provider instances.
 // Currently, the built-in getters and the discovered plugins with downloader
 // notations are collected.
-func All(settings *cli.EnvSettings) Providers {
+func All(settings *cli.Settings) Providers {
 	result := Providers{httpProvider}
 	pluginDownloaders, _ := collectPlugins(settings)
 	result = append(result, pluginDownloaders...)

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -53,7 +53,7 @@ func TestProviders(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	env := cli.New()
+	env := cli.SettingsFromEnv()
 	env.PluginsDirectory = pluginDir
 
 	all := All(env)
@@ -67,7 +67,7 @@ func TestAll(t *testing.T) {
 }
 
 func TestByScheme(t *testing.T) {
-	env := cli.New()
+	env := cli.SettingsFromEnv()
 	env.PluginsDirectory = pluginDir
 
 	g := All(env)

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -122,7 +122,7 @@ func TestDownload(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	g, err := All(cli.New()).ByScheme("http")
+	g, err := All(cli.SettingsFromEnv()).ByScheme("http")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -30,7 +30,7 @@ import (
 
 // collectPlugins scans for getter plugins.
 // This will load plugins according to the cli.
-func collectPlugins(settings *cli.EnvSettings) (Providers, error) {
+func collectPlugins(settings *cli.Settings) (Providers, error) {
 	plugins, err := plugin.FindPlugins(settings.PluginsDirectory)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func collectPlugins(settings *cli.EnvSettings) (Providers, error) {
 // implemented in plugins.
 type pluginGetter struct {
 	command  string
-	settings *cli.EnvSettings
+	settings *cli.Settings
 	name     string
 	base     string
 	opts     options
@@ -86,7 +86,7 @@ func (p *pluginGetter) Get(href string, options ...Option) (*bytes.Buffer, error
 }
 
 // NewPluginGetter constructs a valid plugin getter
-func NewPluginGetter(command string, settings *cli.EnvSettings, name, base string) Constructor {
+func NewPluginGetter(command string, settings *cli.Settings, name, base string) Constructor {
 	return func(options ...Option) (Getter, error) {
 		result := &pluginGetter{
 			command:  command,

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestCollectPlugins(t *testing.T) {
-	env := cli.New()
-	env.PluginsDirectory = pluginDir
+	settings := cli.SettingsFromEnv()
+	settings.PluginsDirectory = pluginDir
 
-	p, err := collectPlugins(env)
+	p, err := collectPlugins(settings)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,9 +54,9 @@ func TestPluginGetter(t *testing.T) {
 		t.Skip("TODO: refactor this test to work on windows")
 	}
 
-	env := cli.New()
-	env.PluginsDirectory = pluginDir
-	pg := NewPluginGetter("echo", env, "test", ".")
+	settings := cli.SettingsFromEnv()
+	settings.PluginsDirectory = pluginDir
+	pg := NewPluginGetter("echo", settings, "test", ".")
 	g, err := pg()
 	if err != nil {
 		t.Fatal(err)
@@ -79,10 +79,10 @@ func TestPluginSubCommands(t *testing.T) {
 		t.Skip("TODO: refactor this test to work on windows")
 	}
 
-	env := cli.New()
-	env.PluginsDirectory = pluginDir
+	settings := cli.SettingsFromEnv()
+	settings.PluginsDirectory = pluginDir
 
-	pg := NewPluginGetter("echo -n", env, "test", ".")
+	pg := NewPluginGetter("echo -n", settings, "test", ".")
 	g, err := pg()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -79,7 +79,7 @@ func NewHTTPInstaller(source string) (*HTTPInstaller, error) {
 		return nil, err
 	}
 
-	get, err := getter.All(new(cli.EnvSettings)).ByScheme("http")
+	get, err := getter.All(new(cli.Settings)).ByScheme("http")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -215,7 +215,7 @@ func FindPlugins(plugdirs string) ([]*Plugin, error) {
 // SetupPluginEnv prepares os.Env for plugins. It operates on os.Env because
 // the plugin subsystem itself needs access to the environment variables
 // created here.
-func SetupPluginEnv(settings *cli.EnvSettings, name, base string) {
+func SetupPluginEnv(settings *cli.Settings, name, base string) {
 	env := settings.EnvVars()
 	env["HELM_PLUGIN_NAME"] = name
 	env["HELM_PLUGIN_DIR"] = base

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -305,7 +305,7 @@ func TestSetupEnv(t *testing.T) {
 	name := "pequod"
 	base := filepath.Join("testdata/helmhome/helm/plugins", name)
 
-	s := cli.New()
+	s := cli.SettingsFromEnv()
 	s.PluginsDirectory = "testdata/helmhome/helm/plugins"
 
 	SetupPluginEnv(s, name, base)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -45,7 +45,7 @@ func TestLoadChartRepository(t *testing.T) {
 	r, err := NewChartRepository(&Entry{
 		Name: testRepository,
 		URL:  testURL,
-	}, getter.All(&cli.EnvSettings{}))
+	}, getter.All(&cli.Settings{}))
 	if err != nil {
 		t.Errorf("Problem creating chart repository from %s: %v", testRepository, err)
 	}
@@ -78,7 +78,7 @@ func TestIndex(t *testing.T) {
 	r, err := NewChartRepository(&Entry{
 		Name: testRepository,
 		URL:  testURL,
-	}, getter.All(&cli.EnvSettings{}))
+	}, getter.All(&cli.Settings{}))
 	if err != nil {
 		t.Errorf("Problem creating chart repository from %s: %v", testRepository, err)
 	}
@@ -283,7 +283,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.Settings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -291,7 +291,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 		t.Errorf("%s is not the valid URL", chartURL)
 	}
 
-	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{}))
+	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.1.0", "", "", "", getter.All(&cli.Settings{}))
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -302,7 +302,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 
 func TestErrorFindChartInRepoURL(t *testing.T) {
 
-	g := getter.All(&cli.EnvSettings{
+	g := getter.All(&cli.Settings{
 		RepositoryCache: ensure.TempDir(t),
 	})
 

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -159,7 +159,7 @@ func TestDownloadIndexFile(t *testing.T) {
 		r, err := NewChartRepository(&Entry{
 			Name: testRepo,
 			URL:  srv.URL,
-		}, getter.All(&cli.EnvSettings{}))
+		}, getter.All(&cli.Settings{}))
 		if err != nil {
 			t.Errorf("Problem creating chart repository from %s: %v", testRepo, err)
 		}
@@ -217,7 +217,7 @@ func TestDownloadIndexFile(t *testing.T) {
 		r, err := NewChartRepository(&Entry{
 			Name: testRepo,
 			URL:  srv.URL + chartRepoURLPath,
-		}, getter.All(&cli.EnvSettings{}))
+		}, getter.All(&cli.Settings{}))
 		if err != nil {
 			t.Errorf("Problem creating chart repository from %s: %v", testRepo, err)
 		}


### PR DESCRIPTION
Fixes #8030

The (tentative) approach that I'm adopting here renames the CLI settings struct `Settings`, thus de-emphasizing the `Env` part, and makes it more friendly for use in libraries, including the addition of a `Validate` function that ensures that the provided settings are present.