### PR TITLE
feat: lint info on template spacing failure

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -377,7 +377,7 @@ const defaultNotes = `1. Get the application URL by running these commands:
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "<CHARTNAME>.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "<CHARTNAME>.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "<CHARTNAME>.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "<CHARTNAME>.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -188,10 +188,16 @@ func validateNoReleaseTime(manifest []byte) error {
 
 // TODO: I strongly suspect that there are better regexps than these two.
 var (
-	badTplStart = regexp.MustCompile(`{{-?[^-\s]+`)
-	badTplEnd   = regexp.MustCompile(`[^\s-]+-?}}`)
+	badTplStart = regexp.MustCompile(`{{-?[^-\s\/]+`)
+	badTplEnd   = regexp.MustCompile(`[^\s-\/]+-?}}`)
 )
 
+// validateWhitespaceAroundTemplateDirectives checks for formatting errors on tpl directives
+//
+// The recommendation is that templates add at least one whitespace character between the
+// directive marker ({{ or {{-) and the directive. This enforces that.
+//
+// See https://github.com/helm/helm/issues/5763
 func validateWhitespaceAroundTemplateDirectives(template string) error {
 	badMatches := []string{}
 	if matches := badTplStart.FindAllString(template, 10); matches != nil {

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -180,11 +180,11 @@ kind: ConfigMap
 metadata:
   name: foo
 data:
-  myval1: {{default "val" .Values.mymap.key1 }}
-  myval2: {{default "val" .Values.mymap.key2 }}
+  myval1: {{  default "val" .Values.mymap.key1 }}
+  myval2: {{  default "val" .Values.mymap.key2 }}
 `
 
-// TestSTrictTemplatePrasingMapError is a regression test.
+// TestStrictTemplatePrasingMapError is a regression test.
 //
 // The template engine should not produce an error when a map in values.yaml does
 // not contain all possible keys.

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -244,6 +244,7 @@ func TestValidateWhitespaceAroundTemplateDirectives(t *testing.T) {
 		`{{ legal }}{{illegal }}`:       false,
 		`{{ legal }}{{- legal -}}`:      true,
 		"{{\nlegal\n}}":                 true,
+		"{{/* comment */}}":             true,
 	} {
 		if err := validateWhitespaceAroundTemplateDirectives(example); (err == nil) != success {
 			st := "failure"

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -226,3 +226,31 @@ func TestStrictTemplateParsingMapError(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateWhitespaceAroundTemplateDirectives(t *testing.T) {
+	for example, success := range map[string]bool{
+		"{{foo}}":                       false,
+		"{{-foo-}}":                     false,
+		"{{ foo-}}":                     false,
+		"{{ foo}}":                      false,
+		"{{-foo }}":                     false,
+		"{{foo }}":                      false,
+		"{{ foo }}":                     true,
+		"{{ default 2 .Values.foo }}":   true,
+		"{{default 2 .Values.foo }}":    false,
+		"{{ default 2 .Values.foo}}":    false,
+		`{{ default "}" .Values.foo }}`: true,
+		`{{- foo }}`:                    true,
+		`{{ legal }}{{illegal }}`:       false,
+		`{{ legal }}{{- legal -}}`:      true,
+		"{{\nlegal\n}}":                 true,
+	} {
+		if err := validateWhitespaceAroundTemplateDirectives(example); (err == nil) != success {
+			st := "failure"
+			if success {
+				st = "success"
+			}
+			t.Errorf("Expected %s for %q", st, example)
+		}
+	}
+}

--- a/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
+++ b/pkg/lint/rules/testdata/albatross/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{define "name"}}{{default "nginx" .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{end}}
+{{ define "name" }}{{ default "nginx" .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{ end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec).
 */}}
-{{define "fullname"}}
+{{ define "fullname" }}
 {{- $name := default "nginx" .Values.nameOverride -}}
-{{printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{end}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{ end }}

--- a/pkg/lint/rules/testdata/albatross/templates/svc.yaml
+++ b/pkg/lint/rules/testdata/albatross/templates/svc.yaml
@@ -7,13 +7,13 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     kubeVersion: {{ .Capabilities.KubeVersion.Major }}
 spec:
   ports:
-  - port: {{default 80 .Values.httpPort | quote}}
+  - port: {{ default 80 .Values.httpPort | quote }}
     targetPort: 80
     protocol: TCP
     name: http
   selector:
-    app.kubernetes.io/name: {{template "fullname" .}}
+    app.kubernetes.io/name: {{ template "fullname" . }}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This adds a feature (per #5763) to emit an info message when a template does not follow the recommended guidelines for whitespace in chart directives.

IMPORTANT: This will emit INFO messages where previously no INFO messages were displayed. I _think_ that we should emit warnings, but I am not sure if adding a new WARN level linter is a breaking change.

**Special notes for your reviewer**:

I'm not great at regular expressions. The best I could do here is create two regexps, where one checks the opening sequence and another checks the closing sequence. (Remember, templates can span multiple lines, AND multiple templates can appear on the same line.) If anyone wants to take a shot at better regular expressions, that would be cool.

The ones here should never give a false positive, but there may be possible cases where a formatting error could slide by. (The only example I can think of is `{{ foo -  }}`, but I don't think that is actually the same as `{{ foo -}}`)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Closes #5763

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>