### PR TITLE
scripts: do not use optional 'which' command in get-helm installation

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -175,7 +175,7 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
   set +e
-  HELM="$(which $PROJECT_NAME)"
+  HELM="$(command -v $PROJECT_NAME)"
   if [ "$?" = "1" ]; then
     echo "$PROJECT_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
     exit 1

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -165,7 +165,7 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
   set +e
-  HELM="$(which $BINARY_NAME)"
+  HELM="$(command -v $BINARY_NAME)"
   if [ "$?" = "1" ]; then
     echo "$BINARY_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
     exit 1


### PR DESCRIPTION
When installing Helm, the following warning gets printed on the console:

    Downloading https://get.helm.sh/helm-v2.16.6-linux-amd64.tar.gz
    Preparing to install helm and tiller into /usr/local/bin
    helm installed into /usr/local/bin/helm
    tiller installed into /usr/local/bin/tiller
    main: line 178: which: command not found
    Run 'helm init' to configure helm.

The 'which' command is optional, and not always installed on all
environments (like a Fedora container). Instead, use 'command -v' to
detect if the executable is in the $PATH.