### PR TITLE
refactor: extract the logic in `LoadDir` into `LoadFile`

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -159,12 +159,17 @@ func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string, error) {
 
 // LoadDir loads a plugin from the given directory.
 func LoadDir(dirname string) (*Plugin, error) {
-	data, err := ioutil.ReadFile(filepath.Join(dirname, PluginFileName))
+	return LoadFile(dirname, filepath.Join(dirname, PluginFileName))
+}
+
+// LoadFile loads a plugin from the given plugin.yaml path.
+func LoadFile(pluginDir, pluginYaml string) (*Plugin, error) {
+	data, err := ioutil.ReadFile(pluginYaml)
 	if err != nil {
 		return nil, err
 	}
 
-	plug := &Plugin{Dir: dirname}
+	plug := &Plugin{Dir: pluginDir}
 	if err := yaml.Unmarshal(data, &plug.Metadata); err != nil {
 		return nil, err
 	}
@@ -187,9 +192,8 @@ func LoadAll(basedir string) ([]*Plugin, error) {
 		return plugins, nil
 	}
 
-	for _, yaml := range matches {
-		dir := filepath.Dir(yaml)
-		p, err := LoadDir(dir)
+	for _, pluginYaml := range matches {
+		p, err := LoadFile(filepath.Dir(pluginYaml), pluginYaml)
 		if err != nil {
 			return plugins, err
 		}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -204,6 +204,35 @@ func TestLoadDir(t *testing.T) {
 	}
 }
 
+func TestLoadFile(t *testing.T) {
+	pluginDir := "testdata/plugdir/hello"
+	pluginYaml := "testdata/plugdir/hello/plugin.yaml"
+	plug, err := LoadFile(pluginDir, pluginYaml)
+	if err != nil {
+		t.Fatalf("error loading Hello plugin: %s", err)
+	}
+
+	if plug.Dir != pluginDir {
+		t.Fatalf("Expected dir %q, got %q", pluginDir, plug.Dir)
+	}
+
+	expect := &Metadata{
+		Name:        "hello",
+		Version:     "0.1.0",
+		Usage:       "usage",
+		Description: "description",
+		Command:     "$HELM_PLUGIN_SELF/hello.sh",
+		IgnoreFlags: true,
+		Hooks: map[string]string{
+			Install: "echo installing...",
+		},
+	}
+
+	if !reflect.DeepEqual(expect, plug.Metadata) {
+		t.Fatalf("Expected plugin metadata %v, got %v", expect, plug.Metadata)
+	}
+}
+
 func TestDownloader(t *testing.T) {
 	dirname := "testdata/plugdir/downloader"
 	plug, err := LoadDir(dirname)


### PR DESCRIPTION
extract the logic in `LoadDir` into `LoadFile` to avoid duplicate conversions between plugin dir and plugin.yaml path

close #8105 

Signed-off-by: Liu Ming <hit_oak_tree@126.com>