### PR TITLE
refactor: alter constant `pluginFileName` to `PluginFileName`

### DIFF
--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"helm.sh/helm/v3/pkg/plugin"
 )
 
 // ErrMissingMetadata indicates that plugin.yaml is missing.
@@ -100,7 +102,7 @@ func isRemoteHTTPArchive(source string) bool {
 
 // isPlugin checks if the directory contains a plugin.yaml file.
 func isPlugin(dirname string) bool {
-	_, err := os.Stat(filepath.Join(dirname, "plugin.yaml"))
+	_, err := os.Stat(filepath.Join(dirname, plugin.PluginFileName))
 	return err == nil
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,7 +28,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 )
 
-const pluginFileName = "plugin.yaml"
+const PluginFileName = "plugin.yaml"
 
 // Downloaders represents the plugins capability if it can retrieve
 // charts from special sources
@@ -159,7 +159,7 @@ func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string, error) {
 
 // LoadDir loads a plugin from the given directory.
 func LoadDir(dirname string) (*Plugin, error) {
-	data, err := ioutil.ReadFile(filepath.Join(dirname, pluginFileName))
+	data, err := ioutil.ReadFile(filepath.Join(dirname, PluginFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func LoadDir(dirname string) (*Plugin, error) {
 func LoadAll(basedir string) ([]*Plugin, error) {
 	plugins := []*Plugin{}
 	// We want basedir/*/plugin.yaml
-	scanpath := filepath.Join(basedir, "*", pluginFileName)
+	scanpath := filepath.Join(basedir, "*", PluginFileName)
 	matches, err := filepath.Glob(scanpath)
 	if err != nil {
 		return plugins, err


### PR DESCRIPTION
Alter constant `pluginFileName` to `PluginFileName` in order to reuse the "plugin.yaml" value in installer package and avoid magic value in installer.go

Signed-off-by: Liu Ming <hit_oak_tree@126.com>
