### PR TITLE
ref(cmd): prevent klogs flags from polluting the help text

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/output"
@@ -154,4 +156,25 @@ func compVersionFlag(chartRef string, toComplete string) ([]string, cobra.ShellC
 	}
 
 	return versions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// addKlogFlags adds flags from k8s.io/klog
+// marks the flags as hidden to avoid polluting the help text
+func addKlogFlags(fs *pflag.FlagSet) {
+	local := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(local)
+	local.VisitAll(func(fl *flag.Flag) {
+		fl.Name = normalize(fl.Name)
+		if fs.Lookup(fl.Name) != nil {
+			return
+		}
+		newflag := pflag.PFlagFromGoFlag(fl)
+		newflag.Hidden = true
+		fs.AddFlag(newflag)
+	})
+}
+
+// normalize replaces underscores with hyphens
+func normalize(s string) string {
+	return strings.ReplaceAll(s, "_", "-")
 }

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main // import "helm.sh/helm/v3/cmd/helm"
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -25,8 +24,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"k8s.io/klog"
 	"sigs.k8s.io/yaml"
 
 	// Import to initialize client auth plugins.
@@ -61,17 +58,7 @@ func warning(format string, v ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, v...)
 }
 
-func initKubeLogs() {
-	pflag.CommandLine.SetNormalizeFunc(wordSepNormalizeFunc)
-	gofs := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(gofs)
-	pflag.CommandLine.AddGoFlagSet(gofs)
-	pflag.CommandLine.Set("logtostderr", "true")
-}
-
 func main() {
-	initKubeLogs()
-
 	actionConfig := new(action.Configuration)
 	cmd, err := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 	if err != nil {
@@ -99,11 +86,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-}
-
-// wordSepNormalizeFunc changes all flags that contain "_" separators
-func wordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
 }
 
 func checkOCIFeatureGate() func(_ *cobra.Command, _ []string) error {

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -93,6 +93,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	flags := cmd.PersistentFlags()
 
 	settings.AddFlags(flags)
+	addKlogFlags(flags)
 
 	// Setup shell completion for the namespace flag
 	err := cmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Remove klog flags from help text.  No change to behavior.

```
...
Flags:
      --debug                      enable verbose output
  -h, --help                       help for helm
      --kube-apiserver string      the address and the port for the Kubernetes API server
      --kube-context string        name of the kubeconfig context to use
      --kube-token string          bearer token used for authentication
      --kubeconfig string          path to the kubeconfig file
  -n, --namespace string           namespace scope for this request
      --registry-config string     path to the registry config file (default "/Users/areese/.config/helm/registry.json")
      --repository-cache string    path to the file containing cached repository indexes (default "/Users/areese/.cache/helm/repository")
      --repository-config string   path to the file containing repository names and URLs (default "/Users/areese/.config/helm/repositories.yaml")
```