### PR TITLE
feature(cmd): Add --output option to `helm dep list`

### DIFF
--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -23,6 +23,7 @@ import (
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli/output"
 )
 
 const dependencyDesc = `
@@ -99,8 +100,7 @@ func newDependencyCmd(out io.Writer) *cobra.Command {
 }
 
 func newDependencyListCmd(out io.Writer) *cobra.Command {
-	client := action.NewDependency()
-
+	var outfmt output.Format
 	cmd := &cobra.Command{
 		Use:     "list CHART",
 		Aliases: []string{"ls"},
@@ -112,8 +112,11 @@ func newDependencyListCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				chartpath = filepath.Clean(args[0])
 			}
-			return client.List(chartpath, out)
+			return outfmt.Write(out, &action.DependencyListWriter{Chartpath: chartpath})
 		},
 	}
+
+	bindOutputFlag(cmd, &outfmt)
+
 	return cmd
 }

--- a/pkg/action/dependency_test.go
+++ b/pkg/action/dependency_test.go
@@ -21,36 +21,93 @@ import (
 	"testing"
 
 	"helm.sh/helm/v3/internal/test"
+	"helm.sh/helm/v3/pkg/cli/output"
 )
 
 func TestList(t *testing.T) {
 	for _, tcase := range []struct {
 		chart  string
 		golden string
+		outfmt output.Format
 	}{
 		{
 			chart:  "testdata/charts/chart-with-compressed-dependencies",
 			golden: "output/compressed-deps.txt",
+			outfmt: output.Table,
 		},
 		{
 			chart:  "testdata/charts/chart-with-compressed-dependencies-2.1.8.tgz",
 			golden: "output/compressed-deps-tgz.txt",
+			outfmt: output.Table,
 		},
 		{
 			chart:  "testdata/charts/chart-with-uncompressed-dependencies",
 			golden: "output/uncompressed-deps.txt",
+			outfmt: output.Table,
 		},
 		{
 			chart:  "testdata/charts/chart-with-uncompressed-dependencies-2.1.8.tgz",
 			golden: "output/uncompressed-deps-tgz.txt",
+			outfmt: output.Table,
 		},
 		{
 			chart:  "testdata/charts/chart-missing-deps",
 			golden: "output/missing-deps.txt",
+			outfmt: output.Table,
+		},
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies",
+			golden: "output/compressed-deps.json",
+			outfmt: output.JSON,
+		},
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies-2.1.8.tgz",
+			golden: "output/compressed-deps-tgz.json",
+			outfmt: output.JSON,
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies",
+			golden: "output/uncompressed-deps.json",
+			outfmt: output.JSON,
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies-2.1.8.tgz",
+			golden: "output/uncompressed-deps-tgz.json",
+			outfmt: output.JSON,
+		},
+		{
+			chart:  "testdata/charts/chart-missing-deps",
+			golden: "output/missing-deps.json",
+			outfmt: output.JSON,
+		},
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies",
+			golden: "output/compressed-deps.yaml",
+			outfmt: output.YAML,
+		},
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies-2.1.8.tgz",
+			golden: "output/compressed-deps-tgz.yaml",
+			outfmt: output.YAML,
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies",
+			golden: "output/uncompressed-deps.yaml",
+			outfmt: output.YAML,
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies-2.1.8.tgz",
+			golden: "output/uncompressed-deps-tgz.yaml",
+			outfmt: output.YAML,
+		},
+		{
+			chart:  "testdata/charts/chart-missing-deps",
+			golden: "output/missing-deps.yaml",
+			outfmt: output.YAML,
 		},
 	} {
 		buf := bytes.Buffer{}
-		if err := NewDependency().List(tcase.chart, &buf); err != nil {
+		if err := tcase.outfmt.Write(&buf, &DependencyListWriter{Chartpath: tcase.chart}); err != nil {
 			t.Fatal(err)
 		}
 		test.AssertGoldenBytes(t, buf.Bytes(), tcase.golden)

--- a/pkg/action/testdata/output/compressed-deps-tgz.json
+++ b/pkg/action/testdata/output/compressed-deps-tgz.json
@@ -1,0 +1,1 @@
+[{"name":"mariadb","version":"4.x.x","repository":"https://kubernetes-charts.storage.googleapis.com/","status":"unpacked"}]

--- a/pkg/action/testdata/output/compressed-deps-tgz.yaml
+++ b/pkg/action/testdata/output/compressed-deps-tgz.yaml
@@ -1,0 +1,4 @@
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  status: unpacked
+  version: 4.x.x

--- a/pkg/action/testdata/output/compressed-deps.json
+++ b/pkg/action/testdata/output/compressed-deps.json
@@ -1,0 +1,1 @@
+[{"name":"mariadb","version":"4.x.x","repository":"https://kubernetes-charts.storage.googleapis.com/","status":"ok"}]

--- a/pkg/action/testdata/output/compressed-deps.yaml
+++ b/pkg/action/testdata/output/compressed-deps.yaml
@@ -1,0 +1,4 @@
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  status: ok
+  version: 4.x.x

--- a/pkg/action/testdata/output/missing-deps.json
+++ b/pkg/action/testdata/output/missing-deps.json
@@ -1,0 +1,1 @@
+[{"name":"mariadb","version":"4.x.x","repository":"https://kubernetes-charts.storage.googleapis.com/","status":"missing"}]

--- a/pkg/action/testdata/output/missing-deps.yaml
+++ b/pkg/action/testdata/output/missing-deps.yaml
@@ -1,0 +1,4 @@
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  status: missing
+  version: 4.x.x

--- a/pkg/action/testdata/output/uncompressed-deps-tgz.json
+++ b/pkg/action/testdata/output/uncompressed-deps-tgz.json
@@ -1,0 +1,1 @@
+[{"name":"mariadb","version":"4.x.x","repository":"https://kubernetes-charts.storage.googleapis.com/","status":"unpacked"}]

--- a/pkg/action/testdata/output/uncompressed-deps-tgz.yaml
+++ b/pkg/action/testdata/output/uncompressed-deps-tgz.yaml
@@ -1,0 +1,4 @@
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  status: unpacked
+  version: 4.x.x

--- a/pkg/action/testdata/output/uncompressed-deps.json
+++ b/pkg/action/testdata/output/uncompressed-deps.json
@@ -1,0 +1,1 @@
+[{"name":"mariadb","version":"4.x.x","repository":"https://kubernetes-charts.storage.googleapis.com/","status":"unpacked"}]

--- a/pkg/action/testdata/output/uncompressed-deps.yaml
+++ b/pkg/action/testdata/output/uncompressed-deps.yaml
@@ -1,0 +1,4 @@
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  status: unpacked
+  version: 4.x.x


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves issue #8064. 
some helm commands, like `helm repo list` support `--output` flag that can change the output format to table, json or yaml. There is even package and interface just for that (`output.Writer`). The `helm dep list` does follow this convention. I changed the `helm dep list` command implementation to implement `output.Writer` interface and by that allowing to change the format with the `--output` flag. The tests extended to check every output option, and of course for backward comparability when `--output` not specified.

**Special notes for your reviewer**:
Because this is my first issue in helm, I tried to make as less as possible bold changes for a more convenient code review process. But in my opinion, the `newDependencyListCmd()` method should be removed from `cmd/helm/dependency.go` and to move far from the `cmd/` directory to the `pkg/` directory. In addition, I would split `pkg/action/dependency.go` into another file, called `pkg/action/dependency_list.go`, and put there all what related to `helm dep list`, and of course move the relevant tests to `pkg/action/dependency_list_test.go`.
The thing is that as long as `newDependencyListCmd()` is not in the same package with the `pkg/action/` files, it force me to expose `DependencyListWriter` (the struct that implements `output.Writer`) to the public, although this is not really necessary.
And note, that all the other similar functions in `cmd/helm/dependency.go` are imported, like they should.
I can make the changes, I'd love to hear what you think.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
