### PR TITLE
fix: init `Storage` by the Log function used by `Configuration`, concrete `Driver`, etc.

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -186,7 +186,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, err
 	}
 
-	debug("CHART PATH: %s\n", cp)
+	debug("CHART PATH: %s", cp)
 
 	p := getter.All(settings)
 	vals, err := valueOpts.MergeValues(p)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -375,11 +375,11 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 	case "secret", "secrets", "":
 		d := driver.NewSecrets(newSecretClient(lazyClient))
 		d.Log = log
-		store = storage.Init(d)
+		store = storage.NewStorage(d, log)
 	case "configmap", "configmaps":
 		d := driver.NewConfigMaps(newConfigMapClient(lazyClient))
 		d.Log = log
-		store = storage.Init(d)
+		store = storage.NewStorage(d, log)
 	case "memory":
 		var d *driver.Memory
 		if c.Releases != nil {
@@ -394,7 +394,7 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 			d = driver.NewMemory()
 		}
 		d.SetNamespace(namespace)
-		store = storage.Init(d)
+		store = storage.NewStorage(d, log)
 	case "sql":
 		d, err := driver.NewSQL(
 			os.Getenv("HELM_DRIVER_SQL_CONNECTION_STRING"),
@@ -404,7 +404,7 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 		if err != nil {
 			panic(fmt.Sprintf("Unable to instantiate SQL driver: %v", err))
 		}
-		store = storage.Init(d)
+		store = storage.NewStorage(d, log)
 	default:
 		// Not sure what to do here.
 		panic("Unknown driver in HELM_DRIVER: " + helmDriver)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -192,7 +192,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 			}
 
 			kind := info.Mapping.GroupVersionKind.Kind
-			c.Log("Created a new %s called %q in %s\n", kind, info.Name, info.Namespace)
+			c.Log("Created a new %s called %q in %s", kind, info.Name, info.Namespace)
 			return nil
 		}
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -252,12 +252,17 @@ func makeKey(rlsname string, version int) string {
 // Init initializes a new storage backend with the driver d.
 // If d is nil, the default in-memory driver is used.
 func Init(d driver.Driver) *Storage {
+	return NewStorage(d, func(_ string, _ ...interface{}) {})
+}
+
+// NewStorage creates a new Storage object with the given Driver and log function.
+func NewStorage(d driver.Driver, debug func(format string, args ...interface{})) *Storage {
 	// default driver is in memory
 	if d == nil {
 		d = driver.NewMemory()
 	}
 	return &Storage{
 		Driver: d,
-		Log:    func(_ string, _ ...interface{}) {},
+		Log:    debug,
 	}
 }


### PR DESCRIPTION
commit message:

1. init `Storage` by the Log function used by `Configuration`, concrete `Driver`, etc.
2. fix some log output format for log style consistency

close #8108 

Signed-off-by: Liu Ming <hit_oak_tree@126.com>
