### PR TITLE
Fixing PAX Header handling

### DIFF
--- a/pkg/chart/loader/archive_test.go
+++ b/pkg/chart/loader/archive_test.go
@@ -43,16 +43,22 @@ func TestLoadArchiveFiles(t *testing.T) {
 			generate: func(w *tar.Writer) {
 				// simulate the presence of a `pax_global_header` file like you would get when
 				// processing a GitHub release archive.
-				_ = w.WriteHeader(&tar.Header{
+				err := w.WriteHeader(&tar.Header{
 					Typeflag: tar.TypeXGlobalHeader,
 					Name:     "pax_global_header",
 				})
+				if err != nil {
+					t.Fatal(err)
+				}
 
 				// we need to have at least one file, otherwise we'll get the "no files in chart archive" error
-				_ = w.WriteHeader(&tar.Header{
+				err = w.WriteHeader(&tar.Header{
 					Typeflag: tar.TypeReg,
 					Name:     "dir/empty",
 				})
+				if err != nil {
+					t.Fatal(err)
+				}
 			},
 			check: func(t *testing.T, files []*BufferedFile, err error) {
 				if err != nil {

--- a/pkg/chart/loader/archive_test.go
+++ b/pkg/chart/loader/archive_test.go
@@ -64,32 +64,6 @@ func TestLoadArchiveFiles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "should ignore files with TypeXHeader type",
-			generate: func(w *tar.Writer) {
-				// simulate the presence of a `pax_header` file like you might get when
-				// processing a GitHub release archive.
-				_ = w.WriteHeader(&tar.Header{
-					Typeflag: tar.TypeXHeader,
-					Name:     "pax_header",
-				})
-
-				// we need to have at least one file, otherwise we'll get the "no files in chart archive" error
-				_ = w.WriteHeader(&tar.Header{
-					Typeflag: tar.TypeReg,
-					Name:     "dir/empty",
-				})
-			},
-			check: func(t *testing.T, files []*BufferedFile, err error) {
-				if err != nil {
-					t.Fatalf(`got unwanted error [%#v] for tar file with pax_header content`, err)
-				}
-
-				if len(files) != 1 {
-					t.Fatalf(`expected to get one file but got [%v]`, files)
-				}
-			},
-		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -188,6 +188,9 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 				return err
 			}
 			outFile.Close()
+		// We don't want to process these extension header files.
+		case tar.TypeXGlobalHeader, tar.TypeXHeader:
+			continue
 		default:
 			return errors.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
 		}

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -222,6 +222,19 @@ func TestExtract(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
+	// Add pax global headers. This should be ignored.
+	// Note the PAX header that isn't global cannot be written using WriteHeader.
+	// Details are in the internal Go function for the tar packaged named
+	// allowedFormats. For a TypeXHeader it will return a message stating
+	// "cannot manually encode TypeXHeader, TypeGNULongName, or TypeGNULongLink headers"
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "pax_global_header",
+		Typeflag: tar.TypeXGlobalHeader,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := tw.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR does two things.

First, somethings that create archives may add PAX headers to a plugin archive. Chart archives were already fixed for this but plugins were not. This carries the fix over so that plugins that have PAX headers added by the archiving tools don't cause helm to have an error when installing the plugin.

Second, it removes and cleans up archive PAX tests. In one case the error was not being checked and in the case of the one I removed there was an error being returned and ignored. PAX headers that aren't global cannot be written so the test wasn't doing anything.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
