### PR TITLE
Support fish completion

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -26,7 +26,7 @@ import (
 )
 
 const completionDesc = `
-Generate autocompletions script for Helm for the specified shell (bash or zsh).
+Generate autocompletions script for Helm for the specified shell (bash, zsh or fish).
 
 This command can generate shell autocompletions. e.g.
 
@@ -41,6 +41,7 @@ var (
 	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
 		"bash": runCompletionBash,
 		"zsh":  runCompletionZsh,
+		"fish": runCompletionFish,
 	}
 )
 
@@ -52,7 +53,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "completion SHELL",
-		Short: "generate autocompletions script for the specified shell (bash or zsh)",
+		Short: "generate autocompletions script for the specified shell (bash, zsh or fish)",
 		Long:  completionDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletion(out, cmd, args)
@@ -243,4 +244,8 @@ __helm_bash_source <(__helm_convert_bash_to_zsh)
 `
 	out.Write([]byte(zshTail))
 	return nil
+}
+
+func runCompletionFish(out io.Writer, cmd *cobra.Command) error {
+	return cmd.Root().GenFishCompletion(out, true)
 }

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -43,6 +43,7 @@ var (
 		"zsh":  runCompletionZsh,
 		"fish": runCompletionFish,
 	}
+	completionNoDesc bool
 )
 
 func newCompletionCmd(out io.Writer) *cobra.Command {
@@ -60,6 +61,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 		},
 		ValidArgs: shells,
 	}
+	cmd.Flags().BoolVar(&completionNoDesc, "no-descriptions", false, "disable completion descriptions for shells that support it")
 
 	return cmd
 }
@@ -247,5 +249,5 @@ __helm_bash_source <(__helm_convert_bash_to_zsh)
 }
 
 func runCompletionFish(out io.Writer, cmd *cobra.Command) error {
-	return cmd.Root().GenFishCompletion(out, true)
+	return cmd.Root().GenFishCompletion(out, !completionNoDesc)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR delegates support for completion entirely to cobra.

This allows to support more shells without the need to maintain specific code on helm side.

closes #8109


