### PR TITLE
bump DefaultCapabilities to 1.18

### DIFF
--- a/cmd/helm/testdata/output/template-name-template.txt
+++ b/cmd/helm/testdata/output/template-name-template.txt
@@ -71,8 +71,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "foobar-YWJj-baz"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-set.txt
+++ b/cmd/helm/testdata/output/template-set.txt
@@ -71,8 +71,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template-show-only-one.txt
+++ b/cmd/helm/testdata/output/template-show-only-one.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template-values-files.txt
+++ b/cmd/helm/testdata/output/template-values-files.txt
@@ -71,8 +71,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-with-api-version.txt
+++ b/cmd/helm/testdata/output/template-with-api-version.txt
@@ -71,8 +71,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -87,8 +87,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template.txt
+++ b/cmd/helm/testdata/output/template.txt
@@ -71,8 +71,8 @@ metadata:
     helm.sh/chart: "subchart1-0.1.0"
     app.kubernetes.io/instance: "RELEASE-NAME"
     kube-version/major: "1"
-    kube-version/minor: "16"
-    kube-version/version: "v1.16.0"
+    kube-version/minor: "18"
+    kube-version/version: "v1.18.0"
 spec:
   type: ClusterIP
   ports:

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -29,9 +29,9 @@ var (
 	// DefaultCapabilities is the default set of capabilities.
 	DefaultCapabilities = &Capabilities{
 		KubeVersion: KubeVersion{
-			Version: "v1.16.0",
+			Version: "v1.18.0",
 			Major:   "1",
-			Minor:   "16",
+			Minor:   "18",
 		},
 		APIVersions: DefaultVersionSet,
 	}

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -42,19 +42,19 @@ func TestDefaultVersionSet(t *testing.T) {
 
 func TestDefaultCapabilities(t *testing.T) {
 	kv := DefaultCapabilities.KubeVersion
-	if kv.String() != "v1.16.0" {
-		t.Errorf("Expected default KubeVersion.String() to be v1.16.0, got %q", kv.String())
+	if kv.String() != "v1.18.0" {
+		t.Errorf("Expected default KubeVersion.String() to be v1.18.0, got %q", kv.String())
 	}
-	if kv.Version != "v1.16.0" {
-		t.Errorf("Expected default KubeVersion.Version to be v1.16.0, got %q", kv.Version)
+	if kv.Version != "v1.18.0" {
+		t.Errorf("Expected default KubeVersion.Version to be v1.18.0, got %q", kv.Version)
 	}
-	if kv.GitVersion() != "v1.16.0" {
-		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.16.0, got %q", kv.Version)
+	if kv.GitVersion() != "v1.18.0" {
+		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.18.0, got %q", kv.Version)
 	}
 	if kv.Major != "1" {
 		t.Errorf("Expected default KubeVersion.Major to be 1, got %q", kv.Major)
 	}
-	if kv.Minor != "16" {
+	if kv.Minor != "18" {
 		t.Errorf("Expected default KubeVersion.Minor to be 16, got %q", kv.Minor)
 	}
 }


### PR DESCRIPTION
This bumps the mocked kube version to match what is in go.mod.

closes #8113.