### PR TITLE
feat(test): Update golangci-lint to 1.27.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
     environment:
       GOCACHE: "/tmp/go/cache"
-      GOLANGCI_LINT_VERSION: "1.21.0"
+      GOLANGCI_LINT_VERSION: "1.27.0"
 
     steps:
       - checkout


### PR DESCRIPTION
Since we've moved to Go 1.14, golangci-lint has been silently failing on CircleCI.
This commit updates to a compatible version.