### PR TITLE
feat: Detect missing selector during lint

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -131,6 +131,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 			linter.RunLinterRule(support.ErrorSev, path, validateYamlContent(err))
 			linter.RunLinterRule(support.ErrorSev, path, validateMetadataName(&yamlStruct))
 			linter.RunLinterRule(support.ErrorSev, path, validateNoDeprecations(&yamlStruct))
+			linter.RunLinterRule(support.ErrorSev, path, validateMatchSelector(&yamlStruct, renderedContent))
 		}
 	}
 }
@@ -181,6 +182,19 @@ func validateNoCRDHooks(manifest []byte) error {
 func validateNoReleaseTime(manifest []byte) error {
 	if releaseTimeSearch.Match(manifest) {
 		return errors.New(".Release.Time has been removed in v3, please replace with the `now` function in your templates")
+	}
+	return nil
+}
+
+// validateMatchSelector ensures that template specs have a selector declared.
+// See https://github.com/helm/helm/issues/1990
+func validateMatchSelector(yamlStruct *K8sYamlStruct, manifest string) error {
+	switch yamlStruct.Kind {
+	case "Deployment", "ReplicaSet", "DaemonSet", "StatefulSet":
+		// verify that matchLabels or matchExpressions is present
+		if !(strings.Contains(manifest, "matchLabels") || strings.Contains(manifest, "matchExpressions")) {
+			return fmt.Errorf("a %s must contain matchLabels or matchExpressions, and %q does not", yamlStruct.Kind, yamlStruct.Metadata.Name)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This issue closes #1990 by adding a quick test for `matchLabels` or `matchExpressions` in specific Kubernetes kinds. This was a requested feature because so many Helm issues were being filed because of malformed charts. I don't know if this is any longer necessary. If not, we can probably just close-won't-fix #1990.

Because a chart with no valid selector is _illegal_, this is an error. It catches `matchLabels` and `matchSelectors` (instead of just `selector`) because the requirement is that one of these two most be present. These are the fields frequently left off by chart authors.

Like all other chart lints, this does not enforce anything other than that the strings are present.

**Special notes for your reviewer**:

This change will definitely cause some charts that did not pass before to fail a lint now. However, those charts would have been broken had they been installed.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Closes #1990
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>
