### PR TITLE
Revert "group command for easy read"

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"helm.sh/helm/v3/internal/completion"
 	"helm.sh/helm/v3/internal/experimental/registry"
@@ -133,47 +132,31 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	flags.Parse(args)
 
-	commandGroups := templates.CommandGroups{
-		{
-			Message: "Release Management Commands:",
-			Commands: []*cobra.Command{
-				newInstallCmd(actionConfig, out),
-				newListCmd(actionConfig, out),
-				newGetCmd(actionConfig, out),
-				newStatusCmd(actionConfig, out),
-				newUpgradeCmd(actionConfig, out),
-				newHistoryCmd(actionConfig, out),
-				newRollbackCmd(actionConfig, out),
-				newReleaseTestCmd(actionConfig, out),
-				newUninstallCmd(actionConfig, out),
-			},
-		},
-		{
-			Message: "Chart Commands:",
-			Commands: []*cobra.Command{
-				newCreateCmd(out),
-				newDependencyCmd(out),
-				newPackageCmd(out),
-				newTemplateCmd(actionConfig, out),
-				newLintCmd(out),
-				newVerifyCmd(out),
-			},
-		},
-		{
-			Message: "Chart Repository Commands:",
-			Commands: []*cobra.Command{
-				newRepoCmd(out),
-				newSearchCmd(out),
-				newPullCmd(out),
-				newShowCmd(out),
-			},
-		},
-	}
-	commandGroups.Add(cmd)
-	templates.ActsAsRootCommand(cmd, []string{"options"}, commandGroups...)
-
 	// Add subcommands
 	cmd.AddCommand(
+		// chart commands
+		newCreateCmd(out),
+		newDependencyCmd(out),
+		newPullCmd(out),
+		newShowCmd(out),
+		newLintCmd(out),
+		newPackageCmd(out),
+		newRepoCmd(out),
+		newSearchCmd(out),
+		newVerifyCmd(out),
+
+		// release commands
+		newGetCmd(actionConfig, out),
+		newHistoryCmd(actionConfig, out),
+		newInstallCmd(actionConfig, out),
+		newListCmd(actionConfig, out),
+		newReleaseTestCmd(actionConfig, out),
+		newRollbackCmd(actionConfig, out),
+		newStatusCmd(actionConfig, out),
+		newTemplateCmd(actionConfig, out),
+		newUninstallCmd(actionConfig, out),
+		newUpgradeCmd(actionConfig, out),
+
 		newCompletionCmd(out),
 		newEnvCmd(out),
 		newPluginCmd(out),


### PR DESCRIPTION
Revert "group command for easy read"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Revert "group command for easy read", becuse it make many behavioural changes and bug

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
