### PR TITLE
fix(repo): Repo cache setting not recognized

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -130,6 +130,9 @@ func (o *repoAddOptions) run(out io.Writer) error {
 		return err
 	}
 
+	if o.repoCache != "" {
+		r.CachePath = o.repoCache
+	}
 	if _, err := r.DownloadIndexFile(); err != nil {
 		return errors.Wrapf(err, "looks like %q is not a valid chart repository or cannot be reached", o.url)
 	}

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -37,8 +37,9 @@ Information is cached locally, where it is used by commands like 'helm search'.
 var errNoRepositories = errors.New("no repositories found. You must add one before updating")
 
 type repoUpdateOptions struct {
-	update   func([]*repo.ChartRepository, io.Writer)
-	repoFile string
+	update    func([]*repo.ChartRepository, io.Writer)
+	repoFile  string
+	repoCache string
 }
 
 func newRepoUpdateCmd(out io.Writer) *cobra.Command {
@@ -52,6 +53,7 @@ func newRepoUpdateCmd(out io.Writer) *cobra.Command {
 		Args:    require.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.repoFile = settings.RepositoryConfig
+			o.repoCache = settings.RepositoryCache
 			return o.run(out)
 		},
 	}
@@ -68,6 +70,9 @@ func (o *repoUpdateOptions) run(out io.Writer) error {
 		r, err := repo.NewChartRepository(cfg, getter.All(settings))
 		if err != nil {
 			return err
+		}
+		if o.repoCache != "" {
+			r.CachePath = o.repoCache
 		}
 		repos = append(repos, r)
 	}


### PR DESCRIPTION
Fix `repo add` and `repo update` to use the repository cache set with the `--repository-cache` flag

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>
Signed-off-by: Trond Hindenes <trond@hindenes.com>

Supersedes #7166 

Fixes #7141

**What this PR does / why we need it**:
`--repository-cache` flag not current being recognized with commands:
- `helm repo add`
- `helm repo update`

**Special notes for your reviewer**:

Test before the change and it should add nothing to the new cache directory ` /tmp/cache`. Test with PR and it should work as follows:

```
$ ls -lrt /tmp/cache
total 0

$ helm repo add astronomer http://helm.astronomer.io --repository-cache /tmp/cache
"astronomer" has been added to your repositories

$ ls -lrt /tmp/cache
total 712
-rw-r--r-- 1 root root 721299 May 18 18:16 astronomer-index.yaml
-rw-r--r-- 1 root root     97 May 18 18:16 astronomer-charts.txt

$ helm repo update --repository-cache /tmp/cache
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "astronomer" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 

$ ls -lrt /tmp/cache
total 8936
-rw-r--r-- 1 root root  721299 May 18 18:17 astronomer-index.yaml
-rw-r--r-- 1 root root      97 May 18 18:17 astronomer-charts.txt
-rw-r--r-- 1 root root 8415351 May 18 18:17 stable-index.yaml
-rw-r--r-- 1 root root    3370 May 18 18:17 stable-charts.txt
```

**If applicable**:
- [x] this PR contains unit tests
