### PR TITLE
feat(install): introduce --adopt

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -136,6 +136,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
+	f.BoolVar(&client.Adopt, "adopt", false, "if set, adopt the resources already exist and aren't owned by any other releases.")
 	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an install")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during install")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -87,6 +87,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						fmt.Fprintf(out, "Release %q does not exist. Installing it now.\n", args[0])
 					}
 					instClient := action.NewInstall(cfg)
+					instClient.Adopt = client.Adopt
 					instClient.CreateNamespace = createNamespace
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.DryRun = client.DryRun
@@ -166,6 +167,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	})
 
 	f := cmd.Flags()
+	f.BoolVar(&client.Adopt, "adopt", false, "if set, adopt the resources already exist and aren't owned by any other releases.")
 	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -46,6 +46,25 @@ func newDeploymentResource(name, namespace string) *resource.Info {
 	}
 }
 
+func TestCheckAssignedRelease(t *testing.T) {
+	deployFoo := newDeploymentResource("foo", "ns-a")
+
+	// Don't set annotations the resource and verify no errors
+	err := checkAssignedRelease(deployFoo.Object, "rel-a")
+	assert.NoError(t, err)
+
+	// Set other release name annotation and verify annotation error message
+	_ = accessor.SetAnnotations(deployFoo.Object, map[string]string{
+		helmReleaseNameAnnotation: "rel-a",
+	})
+	err = checkAssignedRelease(deployFoo.Object, "rel-b")
+	assert.EqualError(t, err, `adoption error: "rel-a" is the owner`)
+
+	// Set same release name annotation andverify no errors
+	err = checkAssignedRelease(deployFoo.Object, "rel-a")
+	assert.NoError(t, err)
+}
+
 func TestCheckOwnership(t *testing.T) {
 	deployFoo := newDeploymentResource("foo", "ns-a")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

I add `--adopt` option to `helm install` and `helm upgrade`.

Purpose:

- #7649 make it possible to adopt existing resource. However, manually adding two annotations and a label is a bit tiring. I wanna do this using helm command.

behavior:

- Resources with the same name already exist, add two annotations and a label to be automatically in order to adopt it. Therefore installation and updation command will complete successfully
- As https://github.com/helm/helm/pull/7649#issuecomment-626875788 says, I think it's dangerous to adopt resources already included in other releases. In this case, the resources aren't adopted.

e.g.)

```
# situation: release 'hhh' is owner of the Deployment and `helm install` is going to deploy a same name Deployment
[~/work]$ kubectl get deploy hoge
NAME   READY   UP-TO-DATE   AVAILABLE   AGE
hoge   1/1     1            1           3m42s
[~/work]$ kubectl annotate deploy hoge meta.helm.sh/release-name=hhh
deployment.apps/hoge annotated
[~/work]$ ./helm install hoge --adopt ./chart
Error: rendered manifests contain a resource that already exists. Unable to continue with install: Deployment "hoge" in namespace "default" is already used in other release: adoption error: "hhh" is the owner

# then delete meta.helm.sh/release-name=hhh. it means there is no owner of the resource.
[~/work]$ kubectl annotate deploy hoge meta.helm.sh/release-name-
deployment.apps/hoge annotated
[~/work]$ ./helm install hoge --adopt ./chart
NAME: hoge
LAST DEPLOYED: Tue May 19 05:42:56 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=hoge,app.kubernetes.io/instance=hoge" -o jsonpath="{.items[0].metadata.name}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace default port-forward $POD_NAME 8080:80
[~/work]$ helm list
NAME	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART     	APP VERSION
hoge	default  	1       	2020-05-19 05:42:56.364813 +0900 JST	deployed	hoge-0.1.0	1.17.3
```


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
