### PR TITLE
Add --file-only flag to helm dep up to update only file:// dependencies

### DIFF
--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -62,6 +62,7 @@ func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
 				ChartPath:        chartpath,
 				Keyring:          client.Keyring,
 				SkipUpdate:       client.SkipRefresh,
+        FileOnly:         client.FileOnly,
 				Getters:          getter.All(settings),
 				RepositoryConfig: settings.RepositoryConfig,
 				RepositoryCache:  settings.RepositoryCache,
@@ -78,6 +79,7 @@ func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Verify, "verify", false, "verify the packages against signatures")
 	f.StringVar(&client.Keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 	f.BoolVar(&client.SkipRefresh, "skip-refresh", false, "do not refresh the local repository cache")
+	f.BoolVar(&client.FileOnly, "file-only", false, "refresh only file:// dependencies")
 
 	return cmd
 }

--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -62,7 +62,7 @@ func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
 				ChartPath:        chartpath,
 				Keyring:          client.Keyring,
 				SkipUpdate:       client.SkipRefresh,
-        FileOnly:         client.FileOnly,
+				FileOnly:         client.FileOnly,
 				Getters:          getter.All(settings),
 				RepositoryConfig: settings.RepositoryConfig,
 				RepositoryCache:  settings.RepositoryCache,

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -208,6 +208,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 					ChartPath:        cp,
 					Keyring:          client.ChartPathOptions.Keyring,
 					SkipUpdate:       false,
+          FileOnly:         false,
 					Getters:          p,
 					RepositoryConfig: settings.RepositoryConfig,
 					RepositoryCache:  settings.RepositoryCache,

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -208,7 +208,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 					ChartPath:        cp,
 					Keyring:          client.ChartPathOptions.Keyring,
 					SkipUpdate:       false,
-          FileOnly:         false,
+					FileOnly:         false,
 					Getters:          p,
 					RepositoryConfig: settings.RepositoryConfig,
 					RepositoryCache:  settings.RepositoryCache,

--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -36,6 +36,7 @@ type Dependency struct {
 	Verify      bool
 	Keyring     string
 	SkipRefresh bool
+  FileOnly    bool
 }
 
 // NewDependency creates a new Dependency object with the given configuration.

--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -36,7 +36,7 @@ type Dependency struct {
 	Verify      bool
 	Keyring     string
 	SkipRefresh bool
-  FileOnly    bool
+	FileOnly    bool
 }
 
 // NewDependency creates a new Dependency object with the given configuration.

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -56,8 +56,8 @@ type Manager struct {
 	Keyring string
 	// SkipUpdate indicates that the repository should not be updated first.
 	SkipUpdate bool
-  // FileOnly  indicates that only file:// charts should be updated
-  FileOnly  bool
+	// FileOnly  indicates that only file:// charts should be updated
+	FileOnly bool
 	// Getter collection for the operation
 	Getters          []getter.Provider
 	RepositoryConfig string
@@ -280,9 +280,9 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			dep.Version = ver
 			continue
 		} else if m.FileOnly {
-      fmt.Fprintf(m.Out, "Updating file:// dependencies only - skip %s from repo %s\n", dep.Name, dep.Repository)
-      continue
-    }
+			fmt.Fprintf(m.Out, "Updating file:// dependencies only - skip %s from repo %s\n", dep.Name, dep.Repository)
+			continue
+		}
 
 		// Any failure to resolve/download a chart should fail:
 		// https://github.com/helm/helm/issues/1439

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -56,6 +56,8 @@ type Manager struct {
 	Keyring string
 	// SkipUpdate indicates that the repository should not be updated first.
 	SkipUpdate bool
+  // FileOnly  indicates that only file:// charts should be updated
+  FileOnly  bool
 	// Getter collection for the operation
 	Getters          []getter.Provider
 	RepositoryConfig string
@@ -277,7 +279,10 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			}
 			dep.Version = ver
 			continue
-		}
+		} else if m.FileOnly {
+      fmt.Fprintf(m.Out, "Updating file:// dependencies only - skip %s from repo %s\n", dep.Name, dep.Repository)
+      continue
+    }
 
 		// Any failure to resolve/download a chart should fail:
 		// https://github.com/helm/helm/issues/1439


### PR DESCRIPTION
Signed-off-by: Andy Kilpatrick <Andy.Kilpatrick@metaswitch.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This change adds a --file-only flag to helm dep up, so that only file:// dependencies are updated.  

Why:  Significant speed up test-fix cycle on helm charts when working from home (common at the moment...) 
on an umbrella chart with both local (file://) and third-party subcharts.  helm dep up is slow in this case as it downloads large subcharts from internet repos each time (with no actual changes)

Change: "helm dep up --file-only <my-chart>" skips these downloads, only updating file:// dependencies.  It prints out any skipped dependencies.  Sample output from `helm dep up mychart  --file-only`

```Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 12 charts
Updating file:// dependencies only - skip xxx from repo https://xxx.com/helm-virtual
Updating file:// dependencies only - skip elasticsearch from repo https://kubernetes-charts.storage.googleapis.com
Deleting outdated charts
```

**Special notes for your reviewer**:
I'm unclear if www-helm docs would be automatically updated by this change, or if a separate pull request is required for the docs.
This is my first github / helm change, apologies if I've made some mistakes in process.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
