### PR TITLE
Removing tiller language

### DIFF
--- a/pkg/engine/doc.go
+++ b/pkg/engine/doc.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package engine implements the Go template engine as a Tiller Engine.
+/*Package engine implements the Go text template engine as needed for Helm.
 
-Tiller provides a simple interface for taking a Chart and rendering its templates.
-The 'engine' package implements this interface using Go's built-in 'text/template'
-package.
+When Helm renders templates it does so with additional functions and different
+modes (e.g., strict, lint mode). This package handles the helm specific
+implementation.
 */
 package engine // import "helm.sh/helm/v3/pkg/engine"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -33,7 +33,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
-// Engine is an implementation of 'cmd/tiller/environment'.Engine that uses Go templates.
+// Engine is an implementation of the Helm rendering implementation for templates.
 type Engine struct {
 	// If strict is enabled, template rendering will fail if a template references
 	// a value that was not passed in.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -434,7 +434,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 
 		if patch == nil || string(patch) == "{}" {
 			c.Log("Looks like there are no changes for %s %q", target.Mapping.GroupVersionKind.Kind, target.Name)
-			// This needs to happen to make sure that tiller has the latest info from the API
+			// This needs to happen to make sure that Helm has the latest info from the API
 			// Otherwise there will be no labels and other functions that use labels will panic
 			if err := target.Get(); err != nil {
 				return errors.Wrap(err, "failed to refresh resource information")

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -57,7 +57,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		return
 	}
 
-	// Load chart and parse templates, based on tiller/release_server
+	// Load chart and parse templates
 	chart, err := loader.Load(linter.ChartDir)
 
 	chartLoaded := linter.RunLinterRule(support.ErrorSev, path, err)


### PR DESCRIPTION
Since Tiller is no longer part of Helm v3, internal documentation
language about Tiller can be removed

