### PR TITLE
Using flags instead of persistent flags on status

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -74,7 +74,7 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		return compListReleases(toComplete, cfg)
 	})
 
-	f := cmd.PersistentFlags()
+	f := cmd.Flags()
 
 	f.IntVar(&client.Version, "revision", 0, "if set, display the status of the named release with revision")
 	flag := f.Lookup("revision")


### PR DESCRIPTION
Persistent flags are available on sub-commands. Status does not
need the persistent nature.

Closes #8149