### PR TITLE
Adding a counter to the dependencies cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ jobs:
           version: 18.06.0-ce
       - restore_cache:
           keys:
-            - glide-{{ checksum "glide.yaml" }}-{{ checksum "glide.lock" }}
-            - glide- # used as a fall through if the checksum fails to find exact entry
+            - glide-2-{{ checksum "glide.yaml" }}-{{ checksum "glide.lock" }}
+            - glide-2- # used as a fall through if the checksum fails to find exact entry
       - run:
           name: install dependencies
           command: .circleci/bootstrap.sh
       - save_cache:
-          key: glide-{{ checksum "glide.yaml" }}-{{ checksum "glide.lock" }}
+          key: glide-2-{{ checksum "glide.yaml" }}-{{ checksum "glide.lock" }}
           paths:
             - /root/.glide  # Where the glide cache is stored
       - run:


### PR DESCRIPTION
The cache needed to be cleared due to an issue presented when the
source for one dependency moved from one place to another. To
accomplish this we add a counter. This is similar to the recommendation
in the CircleCI documentation on caching

Closes #8184

