### PR TITLE
Fix issue with unhandled error on Stat

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -106,12 +106,17 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 
 	filename := fmt.Sprintf("%s-%s.tgz", c.Name(), c.Metadata.Version)
 	filename = filepath.Join(outDir, filename)
-	if stat, err := os.Stat(filepath.Dir(filename)); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
-			return "", err
+	dir := filepath.Dir(filename)
+	if stat, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			if err2 := os.MkdirAll(dir, 0755); err2 != nil {
+				return "", err2
+			}
+		} else {
+			return "", errors.Wrapf(err, "stat %s", dir)
 		}
 	} else if !stat.IsDir() {
-		return "", errors.Errorf("is not a directory: %s", filepath.Dir(filename))
+		return "", errors.Errorf("is not a directory: %s", dir)
 	}
 
 	f, err := os.Create(filename)


### PR DESCRIPTION
If stat returns an error other than the directory not existing
it was unhandled. When IsDir is called in one of these situations
it causes a panic.

Closes #8181

Note, not sure how to unit test this as it requires forcing the file system to return errors.