### PR TITLE
fix(reference): Fix reference for tag (#8090)

### DIFF
--- a/internal/experimental/registry/reference.go
+++ b/internal/experimental/registry/reference.go
@@ -135,11 +135,15 @@ func fixSplitComponents(c []string) []string {
 	if len(c) <= 1 {
 		return c
 	}
+
 	possiblePortParts := strings.Split(c[1], "/")
-	if _, err := strconv.Atoi(possiblePortParts[0]); err == nil {
+
+	if _, err := strconv.Atoi(possiblePortParts[0]); err == nil && len(possiblePortParts) > 1 {
 		components := []string{strings.Join(c[:2], ":")}
 		components = append(components, c[2:]...)
+
 		return components
 	}
+
 	return c
 }

--- a/internal/experimental/registry/reference_test.go
+++ b/internal/experimental/registry/reference_test.go
@@ -116,4 +116,18 @@ func TestParseReference(t *testing.T) {
 	s = "localhost:5000/x/y/z:123:x:y"
 	_, err = ParseReference(s)
 	is.Error(err, "ref contains too many colons (4)")
+
+	s = "myrepo/mychart:1222222"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("myrepo/mychart", ref.Repo)
+	is.Equal("1222222", ref.Tag)
+	is.Equal("myrepo/mychart:1222222", ref.FullName())
+
+	s = "myrepo/mychart:5000:1222222"
+	ref, err = ParseReference(s)
+	is.NoError(err)
+	is.Equal("myrepo/mychart:5000", ref.Repo)
+	is.Equal("1222222", ref.Tag)
+	is.Equal("myrepo/mychart:5000:1222222", ref.FullName())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix issue #8090. Error when pull chart with `myregistry.azurecr.io/myapp:13546` pattern

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
