### PR TITLE
Cache chart layers without timestamp

### DIFF
--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -288,7 +288,7 @@ func (cache *Cache) saveChartConfig(ch *chart.Chart) (*ocispec.Descriptor, bool,
 func (cache *Cache) saveChartContentLayer(ch *chart.Chart) (*ocispec.Descriptor, bool, error) {
 	destDir := filepath.Join(cache.rootDir, ".build")
 	os.MkdirAll(destDir, 0755)
-	tmpFile, err := chartutil.Save(ch, destDir, chartutil.WithoutTimestamp())
+	tmpFile, err := chartutil.SaveWithOpts(ch, destDir, chartutil.WithoutTimestamp())
 	defer os.Remove(tmpFile)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to save")

--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -288,7 +288,7 @@ func (cache *Cache) saveChartConfig(ch *chart.Chart) (*ocispec.Descriptor, bool,
 func (cache *Cache) saveChartContentLayer(ch *chart.Chart) (*ocispec.Descriptor, bool, error) {
 	destDir := filepath.Join(cache.rootDir, ".build")
 	os.MkdirAll(destDir, 0755)
-	tmpFile, err := chartutil.Save(ch, destDir)
+	tmpFile, err := chartutil.Save(ch, destDir, chartutil.WithoutTimestamp())
 	defer os.Remove(tmpFile)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to save")

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -128,26 +128,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 //
 // This returns the absolute path to the chart archive file.
 func Save(c *chart.Chart, outDir string) (string, error) {
-	tgzWriter, err := createTarGzipWriter(c, outDir)
-	if err != nil {
-		return "", err
-	}
-
-	filename := tgzWriter.File.Name()
-	rollback := false
-
-	defer func() {
-		tgzWriter.Close()
-		if rollback {
-			os.Remove(filename)
-		}
-	}()
-
-	if err := writeTarContents(tgzWriter.TarWriter, c, "", time.Now()); err != nil {
-		rollback = true
-		return filename, err
-	}
-	return filename, nil
+	return SaveWithOpts(c, outDir)
 }
 
 func SaveWithOpts(c *chart.Chart, outDir string, opts ...SaveOpt) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit allows for the creation of a tar.gz archive of a chart
without a timestamp. Doing so ensures that charts with identical content
will have identical digests, which is important for storage in a
registry. Effort was made to ensure the functionality of `helm package`
was not affected.

Additionally, a unit test for the registry cache's StoreReference
function, to help track this bug.

closes #8212

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility