### PR TITLE
Fix crashing `helm chart list` with large list

### DIFF
--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -357,6 +357,8 @@ func (cache *Cache) fetchBlob(desc *ocispec.Descriptor) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
+
 	bytes := make([]byte, desc.Size)
 	_, err = reader.ReadAt(bytes, 0)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
With a large list of charts, `helm chart list` will crash with the
following message:

```
$ helm chart list --debug
Error: open
/home/me/.cache/helm/registry/cache/blobs/sha256/109971e44d63f7fd11fff60d19db41c2429a136943be2e3f8fd3e4c165156536:
too many open files
helm.go:75: [debug] open
/home/me/.cache/helm/registry/cache/blobs/sha256/109971e44d63f7fd11fff60d19db41c2429a136943be2e3f8fd3e4c165156536:
too many open files
```

Closes #8219

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility