### PR TITLE
Report full template result if it is invalid YAML

### DIFF
--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -143,7 +143,7 @@ func (file *manifestFile) sort(result *result) error {
 
 		var entry SimpleHead
 		if err := yaml.Unmarshal([]byte(m), &entry); err != nil {
-			return errors.Wrapf(err, "YAML parse error on %s", file.path)
+			return errors.Wrapf(err, "Error in template %s:\n### RESULT START\n%s\n### RESULT END\nYAML parse error on %s", file.path, m, file.path)
 		}
 
 		if !hasAnyAnnotation(entry) {


### PR DESCRIPTION
Signed-off-by: Karoline Pauls <code@karolinepauls.com>

**What this PR does / why we need it**:

This PR contains a simple change that could have saved me cumulative hours of debugging the dreaded "UPGRADE FAILED: YAML parse error on <FILE>.yaml: error converting YAML to JSON: yaml: line <NUMBER>: <YAML ERROR>". It adds full contents of the incorrectly rendered file that is the culprit for the failure.

I am not aware of another way to retrieve the result of template rendering when the resulting file contains a YAML syntax error.

When this error occurs, the only helpful bits of information are the file and the line where it contains the error. The user won't be bothered by the volume of output. It is impossible to know which lines are relevant in a general case, however it may be beneficial to display them with line numbers.

**Special notes for your reviewer**:

I am not a Go programmer. I've never programmed in Go before.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
