### PR TITLE
chore(helm): Avoid confusion in command usage

### DIFF
--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -136,7 +136,8 @@ func newShowCmd(out io.Writer) *cobra.Command {
 
 	cmds := []*cobra.Command{all, readmeSubCmd, valuesSubCmd, chartSubCmd}
 	for _, subCmd := range cmds {
-		addShowFlags(showCommand, subCmd, client)
+		addShowFlags(subCmd, client)
+		showCommand.AddCommand(subCmd)
 
 		// Register the completion function for each subcommand
 		completion.RegisterValidArgsFunc(subCmd, validArgsFunc)
@@ -145,12 +146,11 @@ func newShowCmd(out io.Writer) *cobra.Command {
 	return showCommand
 }
 
-func addShowFlags(showCmd *cobra.Command, subCmd *cobra.Command, client *action.Show) {
+func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 	f := subCmd.Flags()
 
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
-	showCmd.AddCommand(subCmd)
 }
 
 func runShow(args []string, client *action.Show) (string, error) {


### PR DESCRIPTION
This is just a suggested tweak for maintainability.

Having both the `showCmd` and the `subCmd` passed to `addShowFlags()` can easily lead to mistakes in using the wrong command (well, I say 'easily' to make myself feel better for having made such a mistake on a change I'm working on 😄 ).  Instead, `addShowFlags()` should only focus on adding the flags to the `subCmd` and not handle the `addCommand()` call, which is independent.

What do you think @hickeyma? 
