### PR TITLE
adding toJsonPretty function variant of toJson

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -70,7 +70,7 @@ func TestFuncMap(t *testing.T) {
 	}
 
 	// Test for Engine-specific template functions.
-	expect := []string{"include", "required", "tpl", "toYaml", "fromYaml", "toToml", "toJson", "fromJson", "lookup"}
+	expect := []string{"include", "required", "tpl", "toYaml", "fromYaml", "toToml", "toJson", "toJsonPretty", "fromJson", "lookup"}
 	for _, f := range expect {
 		if _, ok := fns[f]; !ok {
 			t.Errorf("Expected add-on function %q", f)
@@ -89,6 +89,7 @@ func TestRender(t *testing.T) {
 			{Name: "templates/test2", Data: []byte("{{.Values.global.callme | lower }}")},
 			{Name: "templates/test3", Data: []byte("{{.noValue}}")},
 			{Name: "templates/test4", Data: []byte("{{toJson .Values}}")},
+			{Name: "templates/test5", Data: []byte("{{toJsonPretty .Values}}")},
 		},
 		Values: map[string]interface{}{"outer": "DEFAULT", "inner": "DEFAULT"},
 	}

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -53,6 +53,7 @@ func funcMap() template.FuncMap {
 		"fromYaml":      fromYAML,
 		"fromYamlArray": fromYAMLArray,
 		"toJson":        toJSON,
+		"toJsonPretty":  toJSONPretty,
 		"fromJson":      fromJSON,
 		"fromJsonArray": fromJSONArray,
 
@@ -139,6 +140,20 @@ func toTOML(v interface{}) string {
 // This is designed to be called from a template.
 func toJSON(v interface{}) string {
 	data, err := json.Marshal(v)
+	if err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return string(data)
+}
+
+// toJSONPretty takes an interface, marshals it to json (with indent of two
+// spaces, and returns a string. It will always return a string, even on marshal
+// error (empty string).
+//
+// This is designed to be called from a template.
+func toJSONPretty(v interface{}) string {
+	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		// Swallow errors inside of a template.
 		return ""

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -41,6 +41,10 @@ func TestFuncs(t *testing.T) {
 		tpl:    `{{ toJson . }}`,
 		expect: `{"foo":"bar"}`,
 		vars:   map[string]interface{}{"foo": "bar"},
+	}, {}, {
+		tpl:    `{{ toJsonPretty . }}`,
+		expect: "{\n  \"foo\": \"bar\"\n}",
+		vars:   map[string]interface{}{"foo": "bar"},
 	}, {
 		tpl:    `{{ fromYaml . }}`,
 		expect: "map[hello:world]",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Adding `toJsonPretty`, which is a copy of toJson, but instead of `json.Marshal` is using `json.MarshalIndent` to pretty-print JSON

closes #8229 

**Special notes for your reviewer**:
Perhaps, it would be nice to add a way to specify the prefix and indent..

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
