### PR TITLE
Report what cause finding chart to fail

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -571,7 +571,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 	if err == nil {
 		return
 	}
-	err = errors.Errorf("chart %s not found in %s", name, repoURL)
+	err = errors.Errorf("chart %s not found in %s: %s", name, repoURL, err)
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if finding a chart fails, the underlying error is discarded. That error can be non-obvious from the message produced (in my case a non-writeable cache directory)

**Special notes for your reviewer**:
-

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
