### PR TITLE
Manifest digest

### DIFF
--- a/internal/experimental/registry/client.go
+++ b/internal/experimental/registry/client.go
@@ -240,7 +240,7 @@ func (c *Client) PrintChartTable() error {
 // printCacheRefSummary prints out chart ref summary
 func (c *Client) printCacheRefSummary(r *CacheRefSummary) {
 	fmt.Fprintf(c.out, "ref:     %s\n", r.Name)
-	fmt.Fprintf(c.out, "digest:  %s\n", r.Digest.Hex())
+	fmt.Fprintf(c.out, "digest:  %s\n", r.Manifest.Digest.Hex())
 	fmt.Fprintf(c.out, "size:    %s\n", byteCountBinary(r.Size))
 	fmt.Fprintf(c.out, "name:    %s\n", r.Chart.Metadata.Name)
 	fmt.Fprintf(c.out, "version: %s\n", r.Chart.Metadata.Version)
@@ -257,7 +257,7 @@ func (c *Client) getChartTableRows() ([][]interface{}, error) {
 		refsMap[r.Name] = map[string]string{
 			"name":    r.Chart.Metadata.Name,
 			"version": r.Chart.Metadata.Version,
-			"digest":  shortDigest(r.Digest.Hex()),
+			"digest":  shortDigest(r.Manifest.Digest.Hex()),
 			"size":    byteCountBinary(r.Size),
 			"created": timeAgo(r.CreatedAt),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Determine chart digest by manifest

Currently, whenever the chart is printed, the digest of the .tar.gz
content layer is printed as the digest. The manifest digest is important
for OCI purposes, particularly in pushing to a registry.

Resolves #8248

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
