### PR TITLE
fix template command use --show-only flags error in windows environment

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -102,6 +102,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					var manifestsToRender []string
 					for _, f := range showFiles {
 						missing := true
+						// Use linux-style filepath separators to unify user's input path
+						f = filepath.ToSlash(f)
 						for _, manifestKey := range manifestsKeys {
 							manifest := splitManifests[manifestKey]
 							submatch := manifestNameRegex.FindStringSubmatch(manifest)
@@ -112,7 +114,9 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							// manifest.Name is rendered using linux-style filepath separators on Windows as
 							// well as macOS/linux.
 							manifestPathSplit := strings.Split(manifestName, "/")
-							manifestPath := filepath.Join(manifestPathSplit...)
+							// manifest.Path is connected using linux-style filepath separators on Windows as
+							// well as macOS/linux
+							manifestPath := strings.Join(manifestPathSplit, "/")
 
 							// if the filepath provided matches a manifest path in the
 							// chart, render that manifest


### PR DESCRIPTION
Signed-off-by: ShenXinkang <610716076@qq.com>

**What this PR does / why we need it**:
when I use "helm template” command with "--show-only" flags, command error in windows envrionment.
![image](https://user-images.githubusercontent.com/19555166/84120393-5bb30100-aa68-11ea-9de7-8cfce787342d.png)
change path style and command success:
![image](https://user-images.githubusercontent.com/19555166/84217728-7be1cf00-aaff-11ea-9b96-ffcb70c179b6.png)

I run template_test.go and print manifests and f, the output is:
> manifestPath: templates\subdir\serviceaccount.yaml, f: templates/service.yaml

**filepath.Join and user's input path style** cause this problem and I fix it.

Now everything is ok.
![image](https://user-images.githubusercontent.com/19555166/84121166-5c986280-aa69-11ea-8c00-82ffab56b146.png)
![image](https://user-images.githubusercontent.com/19555166/84217958-04f90600-ab00-11ea-82dc-87b23f524275.png)
