### PR TITLE
feat: Encode chart information into metadata

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -129,6 +129,14 @@ func (ch *Chart) AppVersion() string {
 	return ch.Metadata.AppVersion
 }
 
+// Version returns the chartversion of the chart.
+func (ch *Chart) Version() string {
+	if ch.Metadata == nil {
+		return ""
+	}
+	return ch.Metadata.Version
+}
+
 // CRDs returns a list of File objects in the 'crds/' directory of a Helm chart.
 // Deprecated: use CRDObjects()
 func (ch *Chart) CRDs() []*File {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -94,6 +94,7 @@ func TestMetadata(t *testing.T) {
 
 	is.Equal("foo.yaml", chrt.Name())
 	is.Equal("1.0.0", chrt.AppVersion())
+	is.Equal("1.0.0", chrt.Version())
 	is.Equal(nil, chrt.Validate())
 }
 

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -31,6 +31,7 @@ import (
 	kblabels "k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	chart "helm.sh/helm/v3/pkg/chart"
 	rspb "helm.sh/helm/v3/pkg/release"
 )
 
@@ -40,6 +41,14 @@ func releaseStub(name string, vers int, namespace string, status rspb.Status) *r
 		Version:   vers,
 		Namespace: namespace,
 		Info:      &rspb.Info{Status: status},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{
+				APIVersion: "v1",
+				Name:       "hello",
+				Version:    "0.1.0",
+				AppVersion: "0.2.0",
+			},
+		},
 	}
 }
 

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -224,6 +224,8 @@ func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, er
 	lbs.set("owner", owner)
 	lbs.set("status", rls.Info.Status.String())
 	lbs.set("version", strconv.Itoa(rls.Version))
+	lbs.set("appVersion", rls.Chart.AppVersion())
+	lbs.set("chartVersion", rls.Chart.Version())
 
 	// create and return secret object.
 	// Helm 3 introduced setting the 'Type' field


### PR DESCRIPTION
**What this PR does / why we need it**:
As a helm user we want to retrieve information about state of
our helm deployments, so that we can have a cluster-level dashboard for it.

Our approach was employing https://github.com/sstarcher/helm-exporter to
expose helm metadata via prometheus. Unfortunately with the chosen secret
storage backend, read access is required to get the information about deployed
chart and application versions.
Kubernetes does not allow to differentiate between different types of secrets
on a namespace, so providing read access to secrets could leak other secret
information (API Tokens, Certificate Keys, Credentials) through such an
exporter.
This change exposes chart and application versions in the metadata, so we
don't have to provide read access to secrets for helm-exporter anymore, but
helm-exporter could simply use a "list" RBAC permission to read the
metadata.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
