### PR TITLE
fix: helm template discard warnings

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -63,7 +64,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.ClientOnly = !validate
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			client.IncludeCRDs = includeCrds
-			rel, err := runInstall(args, client, valueOpts, out)
+			rel, err := runInstall(args, client, valueOpts, ioutil.Discard)
 
 			if err != nil && !settings.Debug {
 				if rel != nil {


### PR DESCRIPTION
Signed-off-by: fabiankramm <kramm@covexo.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When executing `helm template` warnings are still printed, which essentially makes the output of `helm template` useless for something like `helm template | kubectl apply -f -`. An example of such a case is `helm template redis redis --repo https://kubernetes-charts.storage.googleapis.com`, which prints `WARNING: This chart is deprecated` alongside the rendered manifests.  

This pull request solves this issue by discarding the output of the underlying install command (errors remain untouched). An alternative solution would be to save the output in a buffer and print it in an error case.  


