### PR TITLE
fix(cmd): display warnings on stderr

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -56,6 +56,11 @@ func debug(format string, v ...interface{}) {
 	}
 }
 
+func warning(format string, v ...interface{}) {
+	format = fmt.Sprintf("WARNING: %s\n", format)
+	fmt.Fprintf(os.Stderr, format, v...)
+}
+
 func initKubeLogs() {
 	pflag.CommandLine.SetNormalizeFunc(wordSepNormalizeFunc)
 	gofs := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"time"
@@ -207,7 +206,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	}
 
 	if chartRequested.Metadata.Deprecated {
-		fmt.Fprintln(out, "WARNING: This chart is deprecated")
+		warning("This chart is deprecated")
 	}
 
 	if req := chartRequested.Metadata.Dependencies; req != nil {

--- a/cmd/helm/testdata/output/deprecated-chart.txt
+++ b/cmd/helm/testdata/output/deprecated-chart.txt
@@ -1,4 +1,3 @@
-WARNING: This chart is deprecated
 NAME: aeneas
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -148,7 +148,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			}
 
 			if ch.Metadata.Deprecated {
-				fmt.Fprintln(out, "WARNING: This chart is deprecated")
+				warning("This chart is deprecated")
 			}
 
 			rel, err := client.Run(args[0], ch, vals)


### PR DESCRIPTION
The warnings introduced when a chart has been deprecated is displayed on standard out. This is a regression for users piping the output of `helm template` from a deprecated chart to `kubectl`. This changes the error message to display on standard error instead.

identified in #8262.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>