### PR TITLE
Make helm ls return only current releases if providing state filter

### DIFF
--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -250,7 +250,8 @@ func (l *List) filterStateMask(releases []*release.Release) []*release.Release {
 
 	for _, rls := range releases {
 		currentStatus := l.StateMask.FromName(rls.Info.Status.String())
-		if l.StateMask&currentStatus == 0 {
+		mask := l.StateMask & currentStatus
+		if mask == 0 {
 			continue
 		}
 		desiredStateReleases = append(desiredStateReleases, rls)

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -152,12 +152,6 @@ func (l *List) Run() ([]*release.Release, error) {
 	}
 
 	results, err := l.cfg.Releases.List(func(rel *release.Release) bool {
-		// Skip anything that the mask doesn't cover
-		currentStatus := l.StateMask.FromName(rel.Info.Status.String())
-		if l.StateMask&currentStatus == 0 {
-			return false
-		}
-
 		// Skip anything that doesn't match the filter.
 		if filter != nil && !filter.MatchString(rel.Name) {
 			return false
@@ -173,7 +167,16 @@ func (l *List) Run() ([]*release.Release, error) {
 		return results, nil
 	}
 
-	results = filterList(results)
+	// by definition, superseded releases are never shown if
+	// only the latest releases are returned. so if requested statemask
+	// is _only_ ListSuperseded, skip the latest release filter
+	if l.StateMask != ListSuperseded {
+		results = filterLatestReleases(results)
+	}
+
+	// State mask application must occur after filtering to
+	// latest releases, otherwise outdated entries can be returned
+	results = l.filterStateMask(results)
 
 	// Unfortunately, we have to sort before truncating, which can incur substantial overhead
 	l.sort(results)
@@ -222,8 +225,8 @@ func (l *List) sort(rels []*release.Release) {
 	}
 }
 
-// filterList returns a list scrubbed of old releases.
-func filterList(releases []*release.Release) []*release.Release {
+// filterLatestReleases returns a list scrubbed of old releases.
+func filterLatestReleases(releases []*release.Release) []*release.Release {
 	latestReleases := make(map[string]*release.Release)
 
 	for _, rls := range releases {
@@ -240,6 +243,20 @@ func filterList(releases []*release.Release) []*release.Release {
 		list = append(list, rls)
 	}
 	return list
+}
+
+func (l *List) filterStateMask(releases []*release.Release) []*release.Release {
+	desiredStateReleases := make([]*release.Release, 0)
+
+	for _, rls := range releases {
+		currentStatus := l.StateMask.FromName(rls.Info.Status.String())
+		if l.StateMask&currentStatus == 0 {
+			continue
+		}
+		desiredStateReleases = append(desiredStateReleases, rls)
+	}
+
+	return desiredStateReleases
 }
 
 // SetStateMask calculates the state mask based on parameters.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Previously, the `helm ls --$state` operation would display outdated
releases under certain conditions.

Given the following set of releases:
```
NAME  REVISION  UPDATED                   STATUS    CHART      APP VERSION  NAMESPACE
bar   1         Wed Apr  8 16:54:39 2020  DEPLOYED  bar-4.0.0  1.0          default
foo   1         Fri Feb  7 06:16:56 2020  DEPLOYED  foo-0.1.0  1.0          default
foo   2         Mon May  4 07:16:56 2020  FAILED    foo-0.1.0  1.0          default
foo   3         Mon May  4 07:20:00 2020  FAILED    foo-0.1.0  1.0          default
foo   4         Tue May  5 08:16:56 2020  DEPLOYED  foo-0.2.0  1.0          default
qux   1         Tue Jun  9 10:32:00 2020  DEPLOYED  qux-4.0.3  1.0          default
qux   2         Tue Jun  9 10:57:00 2020  FAILED    qux-4.0.3  1.0          default
```

`helm ls --failed` produced the following output:
```
NAME  REVISION  UPDATED                   STATUS    CHART      APP VERSION  NAMESPACE
foo   3         Mon May  4 07:20:00 2020  FAILED    foo-0.1.0  1.0          default
qux   2         Tue Jun  9 10:57:00 2020  FAILED    qux-4.0.0  1.0          default
```

Including the `qux` release in that `helm ls --failed` output is not
controversial; the most recent revision of `qux` was not successful
and an operator should investigate.

Including the `foo` release in the output, however, is
questionable. Revision 3 of `foo` is _not_ the most recent release of
`foo`, and that FAILED release was fixed in a susubsequent upgrade. A
user may see that FAILED deploy and start taking inappropriate
action. Further, that issue was fixed months ago in this example --
troubleshooting an old deploy may not be safe if significant changes
have occurred. Concern over this behavior was raised in
https://github.com/helm/helm/issues/7495.

This behavior applied to all the state filter flags (--deployed,
--failed, --pending, etc.), and a user could pass multiple state
filter flags to a single command. The previous behavior can be
summarized as follows:

For each release name, all release revisions having any of the
supplied state flags were retrieved, and the most recent revision
among these was returned (regardless of whether a newer revision of an
unspecified state exists).

This change request alters the helm list action to match user
expectations such that only "current" releases are shown when
filtering on release state. After this change, the following output
would be produced by `helm ls --failed`:

```
NAME  REVISION  UPDATED                   STATUS    CHART      APP VERSION  NAMESPACE
qux   2         Tue Jun  9 10:57:00 2020  FAILED    qux-4.0.0  1.0          default
```
The command now returns only `qux` because it is the only "current" FAILED release.

This behavior change applies to all the state filters _except_
`superseded`, which now becomes a special case. By definition, at
least one newer release exists ahead of each superseded release. A
conditional is included in this change request to maintain the
preexisting behavior (return "most recent" superseded revison for
each release name) if the superseded state filter is requested.

---

Note that there is an alternate perspective that a state filter flag
should return all releases of a given state rather than only the
"current" releases. In the above example, `helm ls --failed` with this
alternate approach would return the following:
```
NAME  REVISION  UPDATED                   STATUS    CHART      APP VERSION  NAMESPACE
foo   2         Mon May  4 07:16:56 2020  FAILED    foo-0.1.0  1.0          default
foo   3         Mon May  4 07:20:00 2020  FAILED    foo-0.1.0  1.0          default
qux   2         Tue Jun  9 10:57:00 2020  FAILED    qux-4.0.0  1.0          default
```
Multiple FAILED `foo` revisions are included in the output, unlike the current behavior.

This approach is logical and achievable. It allows a user to find
exactly what is requested: all historical releases of a given
state. In order to achieve continuity with helm behavior, however, a
new filter (something like "current") would probably need to be
implemented and made the new default.

Given current helm behavior as well as the comments in the #7495, I
did not pursue this approach.

---

Technical details:

 - Moved list action state mask filter after latest release filter

Previously, the list operation in helm/pkg/action/list.go skipped
releases that were not covered by the state mask on _retrieval_ from
the Releases store:

```
results, err := l.cfg.Releases.List(func(rel *release.Release) bool {
		// Skip anything that the mask doesn't cover
		currentStatus := l.StateMask.FromName(rel.Info.Status.String())
		if l.StateMask&currentStatus == 0 {
			return false
		}
                ...
```
https://github.com/helm/helm/blob/8ea6b970ecd02365a230420692350057d48278e5/pkg/action/list.go#L154-L159

While filtering on retrieval in this manner avoided an extra iteration
through the entire list to check on the supplied condition later, it
introduced the possibility of returning an outdated release to the
user because newer releases (that would have otherwise squashed
outdated releases in the `filterList` function) are simply not
included in the set of working records.

This change moves the state mask filtering process to _after_ the set
of current releases is built. Outdated, potentially misleading
releases are scrubbed out prior to the application of the state mask
filter.

As written, this state mask filtration (in the new `filterStateMask`
method on `*List`) incurs an additional, potentially expensive
iteration over the set of releases to return to the user. An
alternative approach could avoid that extra iteration and fit this
logic into the existing `filterList` function at the cost of making
`filterList` function a little harder to understand.

 - Rename filterList to filterLatestReleases for clarity

Another function that filters the list is added, so update
to the more descriptive name here.

 - List superseded releases without filtering for latest

This change makes superseded releases a special case, as they would
_never_ be displayed otherwise (by definition, as superseded releases have been
replaced by a newer release), so a conditional maintains current
behavior ("return newest superseded revision for each release name")

Fixes #7495.

Signed-off-by: Andrew Melis <andrewmelis@gmail.com>

**Special notes for your reviewer**:

Fixes #7495.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
