### PR TITLE
fix: unknown kind resources install/uninstall order

### DIFF
--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package releaseutil
 
 import (
+	"reflect"
 	"sort"
 
 	"helm.sh/helm/v3/pkg/release"
@@ -137,12 +138,11 @@ func lessByKind(a interface{}, b interface{}, kindA string, kindB string, o Kind
 	first, aok := ordering[kindA]
 	second, bok := ordering[kindB]
 
+	// both kinds are unknown
+	// the installing order of the unknown kinds is as the order that they are in original manifests/hooks,
+	// and the uninstalling order is the reverse order that they are in original manifests/hooks.
 	if !aok && !bok {
-		// if both are unknown then sort alphabetically by kind, keep original order if same kind
-		if kindA != kindB {
-			return kindA < kindB
-		}
-		return first < second
+		return reflect.DeepEqual(o, UninstallOrder)
 	}
 	// unknown kind is last
 	if !aok {


### PR DESCRIPTION
close #8291

Signed-off-by: Liu Ming <hit_oak_tree@126.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The order rule of install/uninstall unknown kind resources faces some problems, see #8291, and the PR is going to fix it.

**Special notes for your reviewer**:

The modified function `lessByKind` is also used by `sortHooksByKind`, I'm not sure this PR is suitable for hooks install/uninstall.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
