### PR TITLE
Add Warning when installing or upgrading a deprecated chart - replacing PR #8262

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -267,6 +267,10 @@ func (i *installCmd) run() error {
 		return prettyError(err)
 	}
 
+	if chartRequested.Metadata.Deprecated {
+		fmt.Fprintln(os.Stderr, "WARNING: This chart is deprecated")
+	}
+
 	if req, err := chartutil.LoadRequirements(chartRequested); err == nil {
 		// If checkDependencies returns an error, we have unfulfilled dependencies.
 		// As of Helm 2.4.0, this is treated as a stopping condition:

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -207,6 +207,14 @@ func TestInstall(t *testing.T) {
 			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "virgil"}),
 			expected: "info:\n  Description: Release mock\n  first_deployed:\n    seconds: 242085845\n  last_deployed:\n    seconds: 242085845\n  status:\n    code: 1\nname: virgil\nnamespace: default\n",
 		},
+		// Install deprecated chart
+		{
+			name:     "install with warning about deprecated chart",
+			args:     []string{"testdata/testcharts/deprecatedchart"},
+			flags:    []string{"--name", "deprecatedchart"},
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "deprecatedchart"}),
+			expected: "deprecatedchart",
+		},
 	}
 
 	runReleaseCases(t, tests, func(c *helm.FakeClient, out io.Writer) *cobra.Command {

--- a/cmd/helm/testdata/testcharts/deprecatedchart/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/deprecatedchart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: Deprecated testing chart
+home: https://helm.sh/helm
+name: deprecatedchart
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+deprecated: true

--- a/cmd/helm/testdata/testcharts/deprecatedchart/README.md
+++ b/cmd/helm/testdata/testcharts/deprecatedchart/README.md
@@ -1,0 +1,3 @@
+#Deprecated
+
+This space intentionally left blank.

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -264,6 +265,10 @@ func (u *upgradeCmd) run() error {
 		}
 	} else {
 		return prettyError(err)
+	}
+
+	if ch.Metadata.Deprecated {
+		fmt.Fprintln(os.Stderr, "WARNING: This chart is deprecated")
 	}
 
 	resp, err := u.client.UpdateReleaseFromChart(

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -85,6 +85,7 @@ func TestUpgradeCmd(t *testing.T) {
 	originalDepsPath := filepath.Join("testdata/testcharts/reqtest")
 	missingDepsPath := filepath.Join("testdata/testcharts/chart-missing-deps")
 	badDepsPath := filepath.Join("testdata/testcharts/chart-bad-requirements")
+	deprecatedChart := filepath.Join("testdata/testcharts/deprecatedchart")
 	var ch3 *chart.Chart
 	ch3, err = chartutil.Load(originalDepsPath)
 	if err != nil {
@@ -182,6 +183,13 @@ func TestUpgradeCmd(t *testing.T) {
 			args: []string{"bonkers-bunny", badDepsPath},
 			resp: helm.ReleaseMock(&helm.MockReleaseOptions{Name: "bonkers-bunny", Version: 1, Chart: ch3}),
 			err:  true,
+		},
+		{
+			name:     "upgrade a release with deprecated chart",
+			args:     []string{"crazy-bunny", deprecatedChart},
+			resp:     helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch}),
+			expected: "Release \"crazy-bunny\" has been upgraded.\n",
+			rels:     []*release.Release{helm.ReleaseMock(&helm.MockReleaseOptions{Name: "crazy-bunny", Version: 2, Chart: ch})},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Close #3724 
Replacing PR #8262 

Add warning when installing or upgrading a deprecated chart, for release-2.16

**Special notes for your reviewer**:

Signed-off-by: Stanton Xu <xjiefeng@gmail.com>

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
