### PR TITLE
feat(cmd): Subcommands for the completion command

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -21,61 +21,70 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"helm.sh/helm/v3/cmd/helm/require"
 )
 
 const completionDesc = `
-Generate autocompletions script for Helm for the specified shell (bash or zsh).
+Generate autocompletions script for Helm for the specified shell.
+`
+const bashCompDesc = `
+Generate the autocompletion script for Helm for the bash shell.
 
-This command can generate shell autocompletions. e.g.
+To load completions in your current shell session:
+$ source <(helm completion bash)
 
-    $ helm completion bash
-
-Can be sourced as such
-
-    $ source <(helm completion bash)
+To load completions for every new session, execute once:
+Linux:
+  $ helm completion bash > /etc/bash_completion.d/helm
+MacOS:
+  $ helm completion bash > /usr/local/etc/bash_completion.d/helm
 `
 
-var (
-	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
-		"bash": runCompletionBash,
-		"zsh":  runCompletionZsh,
-	}
-)
+const zshCompDesc = `
+Generate the autocompletion script for Helm for the zsh shell.
+
+To load completions in your current shell session:
+$ source <(helm completion zsh)
+
+To load completions for every new session, execute once:
+$ helm completion zsh > "${fpath[1]}/_helm"
+`
 
 func newCompletionCmd(out io.Writer) *cobra.Command {
-	shells := []string{}
-	for s := range completionShells {
-		shells = append(shells, s)
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "generate autocompletions script for the specified shell",
+		Long:  completionDesc,
+		Args:  require.NoArgs,
 	}
 
-	cmd := &cobra.Command{
-		Use:   "completion SHELL",
-		Short: "generate autocompletions script for the specified shell (bash or zsh)",
-		Long:  completionDesc,
+	bash := &cobra.Command{
+		Use:                   "bash",
+		Short:                 "generate autocompletions script for bash",
+		Long:                  bashCompDesc,
+		Args:                  require.NoArgs,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCompletion(out, cmd, args)
+			return runCompletionBash(out, cmd)
 		},
-		ValidArgs: shells,
 	}
+
+	zsh := &cobra.Command{
+		Use:                   "zsh",
+		Short:                 "generate autocompletions script for zsh",
+		Long:                  zshCompDesc,
+		Args:                  require.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompletionZsh(out, cmd)
+		},
+	}
+
+	cmd.AddCommand(bash, zsh)
 
 	return cmd
-}
-
-func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return errors.New("shell not specified")
-	}
-	if len(args) > 1 {
-		return errors.New("too many arguments, expected only the shell type")
-	}
-	run, found := completionShells[args[0]]
-	if !found {
-		return errors.Errorf("unsupported shell type %q", args[0])
-	}
-
-	return run(out, cmd)
 }
 
 func runCompletionBash(out io.Writer, cmd *cobra.Command) error {

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -105,7 +105,8 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 		// We only do this when necessary (for the "completion" and "__complete" commands) to avoid the
 		// risk of a rogue plugin affecting Helm's normal behavior.
 		subCmd, _, err := baseCmd.Find(os.Args[1:])
-		if (err == nil && (subCmd.Name() == "completion" || subCmd.Name() == cobra.ShellCompRequestCmd)) ||
+		if (err == nil &&
+			((subCmd.HasParent() && subCmd.Parent().Name() == "completion") || subCmd.Name() == cobra.ShellCompRequestCmd)) ||
 			/* for the tests */ subCmd == baseCmd.Root() {
 			loadCompletionForPlugin(c, plug)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #8313.

This PR converts the `bash` and `zsh` arguments of the `completion` command to sub-commands.

Making each shell a subcommand of the `completion` command has multiple advantages:
- simplifies the code,
- allows to have different flags for each shell,
  for example, a future `--no-descriptions` flag for `fish` only,
- allows to tailor the help text per shell,
- allows Cobra to handle error cases (specifying an invalid shell).

**Special notes for your reviewer**:

This should be done before #8111 is released to users, or else it would technically become a breaking change.  This is because #8111 will add a new `--no-descriptions` flag to the `completion` command, and without this PR, we cannot restrict it to the `fish` shell.

The PR also improves on the help text for each shell.

**If applicable**:
- [x] this PR has been tested for backwards compatibility using the completion tests of the acceptance-testing repo
