### PR TITLE
add template file size to 3m and throw clearly error

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -166,6 +166,8 @@ func (cfgmaps *ConfigMaps) Create(key string, rls *rspb.Release) error {
 	if _, err := cfgmaps.impl.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return ErrReleaseExists
+		} else if apierrors.IsRequestEntityTooLargeError(err) {
+			return errors.Wrapf(err, "release: storage limit")
 		}
 
 		cfgmaps.Log("create: failed to create: %s", err)

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -17,11 +17,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-
 	rspb "helm.sh/helm/v3/pkg/release"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestConfigMapName(t *testing.T) {
@@ -178,6 +178,12 @@ func TestConfigMapCreate(t *testing.T) {
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
+
+	//  configmap overhead entity limit
+	if err := cfgmaps.Create(testKey("large-chart", 1), releaseStub("large-chart", 1, "", rspb.StatusDeployed)); !strings.Contains(err.Error(), "storage limit: Request entity too large") {
+		t.Errorf("Expected {%v}, got {%v}", "release: storage limit: Request entity too large: Request entity too large: limit is 3145728", err)
+	}
+
 }
 
 func TestConfigMapUpdate(t *testing.T) {

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -139,6 +139,9 @@ func (mock *MockConfigMapsInterface) Create(_ context.Context, cfgmap *v1.Config
 	if object, ok := mock.objects[name]; ok {
 		return object, apierrors.NewAlreadyExists(v1.Resource("tests"), name)
 	}
+	if name == "large-chart.v1" {
+		return nil, apierrors.NewRequestEntityTooLargeError("Request entity too large: limit is 3145728")
+	}
 	mock.objects[name] = cfgmap
 	return cfgmap, nil
 }

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -156,6 +156,8 @@ func (secrets *Secrets) Create(key string, rls *rspb.Release) error {
 	if _, err := secrets.impl.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return ErrReleaseExists
+		} else if apierrors.IsRequestEntityTooLargeError(err) {
+			return errors.Wrapf(err, "release: storage limit")
 		}
 
 		return errors.Wrap(err, "create: failed to create")
@@ -179,6 +181,11 @@ func (secrets *Secrets) Update(key string, rls *rspb.Release) error {
 	}
 	// push the secret object out into the kubiverse
 	_, err = secrets.impl.Update(context.Background(), obj, metav1.UpdateOptions{})
+
+	if apierrors.IsRequestEntityTooLargeError(err) {
+		return errors.Wrapf(err, "release: storage limit")
+	}
+
 	return errors.Wrap(err, "update: failed to update")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
It is to solve a problem that the error cannot be understood completely after the template creation fails.
**How to reproduce**：
Use a template package over 3m：
```shell
ll test-0.1.0.tgz
```
```
-rw-r--r--  1 xxx  staff    13M  6 20 22:17 test-0.1.0.tgz
```
```shell
helm install test test-0.1.0.tgz --debug
```
```
install.go:159: [debug] Original chart version: ""
install.go:176: [debug] CHART PATH: /Users/xxx/Desktop/test-0.1.0.tgz

Error: create: failed to create: Request entity too large: limit is 3145728
helm.go:84: [debug] Request entity too large: limit is 3145728
create: failed to create
helm.sh/helm/v3/pkg/storage/driver.(*Secrets).Create
	/home/circleci/helm.sh/helm/pkg/storage/driver/secrets.go:161
helm.sh/helm/v3/pkg/storage.(*Storage).Create
	/home/circleci/helm.sh/helm/pkg/storage/storage.go:66
helm.sh/helm/v3/pkg/action.(*Install).Run
	/home/circleci/helm.sh/helm/pkg/action/install.go:315
main.runInstall
	/home/circleci/helm.sh/helm/cmd/helm/install.go:229
main.newInstallCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/install.go:117
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:83
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
```

This is because the api-server [limits the size of the requested body](https://github.com/kubernetes/kubernetes/blob/release-1.18/staging/src/k8s.io/apiserver/pkg/server/config.go#L323) to 3m when creating secrets. Therefore, we can verify the size of the template problem before installation, avoid unnecessary requests, and give user-friendly prompts.
