### PR TITLE
fix(engine): clone Template for tpl

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -738,3 +738,38 @@ func TestRenderRecursionLimit(t *testing.T) {
 	}
 
 }
+
+func TestRenderLoadTemplateForTplFromFile(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "TplLoadFromFile"},
+		Templates: []*chart.File{
+			{Name: "templates/base", Data: []byte(`{{ tpl (.Files.Get .Values.filename) . }}`)},
+			{Name: "templates/_function", Data: []byte(`{{define "test-function"}}test-function{{end}}`)},
+		},
+		Files: []*chart.File{
+			{Name: "test", Data: []byte(`{{ tpl (.Files.Get .Values.filename2) .}}`)},
+			{Name: "test2", Data: []byte(`{{include "test-function" .}}{{define "nested-define"}}nested-define-content{{end}} {{include "nested-define" .}}`)},
+		},
+	}
+
+	v := chartutil.Values{
+		"Values": chartutil.Values{
+			"filename":  "test",
+			"filename2": "test2",
+		},
+		"Chart": c.Metadata,
+		"Release": chartutil.Values{
+			"Name": "TestRelease",
+		},
+	}
+
+	out, err := Render(c, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := "test-function nested-define-content"
+	if got := out["TplLoadFromFile/templates/base"]; got != expect {
+		t.Fatalf("Expected %q, got %q", expect, got)
+	}
+}


### PR DESCRIPTION
See https://github.com/helm/helm/issues/8002

**What this PR does / why we need it**:

This PR makes `tpl` function more performant. Using `Template.Clone` method, `tpl` works in isolation from "real" templates and avoids excessive and expensive `Parse` calls.

**Special notes for your reviewer**:

The new unit test makes sure that `tpl` function can be nested and has access to defines in partials. 

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
