### PR TITLE
Allow template to connect to the cluster if the user so requests

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -43,6 +43,10 @@ import (
 // FeatureGateOCI is the feature gate for checking if `helm chart` and `helm registry` commands should work
 const FeatureGateOCI = gates.Gate("HELM_EXPERIMENTAL_OCI")
 
+// UnsafeTemplateLiveConn handles unsafe-template-live-conn arg as env var
+//  to simplify the integration with third party tools and plugins.
+const UnsafeTemplateLiveConn = gates.Gate("HELM_UNSAFE_TEMPLATE_LIVE_CONN")
+
 var settings = cli.New()
 
 func init() {

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -45,6 +45,7 @@ faked locally. Additionally, none of the server-side testing of chart validity
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
 	var includeCrds bool
+	var unsafeTemplateLiveConn bool
 	client := action.NewInstall(cfg)
 	valueOpts := &values.Options{}
 	var extraAPIs []string
@@ -59,6 +60,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			client.UnsafeTemplateLiveConn = unsafeTemplateLiveConn || UnsafeTemplateLiveConn.IsEnabled()
 			client.DryRun = true
 			client.ReleaseName = "RELEASE-NAME"
 			client.Replace = true // Skip the name check
@@ -147,6 +149,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.IsUpgrade, "is-upgrade", false, "set .Release.IsUpgrade instead of .Release.IsInstall")
 	f.StringArrayVarP(&extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
 	f.BoolVar(&client.UseReleaseName, "release-name", false, "use release name in the output-dir path.")
+	f.BoolVar(&unsafeTemplateLiveConn, "unsafe-template-live-conn", false, "enables the connection to the cluster. It is considered unsafe use under your own risk.")
 	bindPostRenderFlag(cmd, &client.PostRenderer)
 
 	return cmd

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -100,6 +100,8 @@ type Install struct {
 	// OutputDir/<ReleaseName>
 	UseReleaseName bool
 	PostRenderer   postrender.PostRenderer
+	// Handle case when user wants to retrieve date from the cluster during template
+	UnsafeTemplateLiveConn bool
 }
 
 // ChartPathOptions captures common options used for controlling chart paths
@@ -236,7 +238,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	rel := i.createRelease(chrt, vals)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, i.DryRun)
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, i.DryRun, i.UnsafeTemplateLiveConn)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -217,7 +217,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun, false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
closes #8137 

**What this PR does / why we need it**:

Turns on the live connection to a remote cluster during `helm template` when the user uses `--unsafe-template-live-conn` or sets the environment variable `HELM_UNSAFE_TEMPLATE_LIVE_CONN` to `true`. The last is for simplify the use of this feature on plugins like `helm-diff` or tools like `helmfile`.


**Special notes for your reviewer**:
I was unable to add a unit-test because `kubefake` don't let me mock Kubernetes Resources (or maybe I didn't find a way to do it.).

I tested the PR on my production environment with a Chart that uses the `lookup` function:
```
{{- $ca := genCA "pgbouncer-ca" 365 -}}
{{- $svcName := print (include "pgbouncerv2.fullname" .) "." .Release.Namespace ".svc.cluster.local" -}}
{{- $cert  := genSignedCert "pgbouncer" (list "127.0.0.1" )  (list $svcName ) 365 $ca -}}
{{- $secret := lookup "v1" "Secret" .Release.Namespace (print (include "pgbouncerv2.fullname" .) "-tls")  -}}

...

{{- if $secret }}
{{ $secret.data | toYaml | nindent 2 }}
{{- else }}
  CLIENT_TLS_KEY: {{ $cert.Key | b64enc }}
  CLIENT_TLS_CERT: {{ $cert.Cert | b64enc }}
  CLIENT_TLS_CA: {{ $ca.Cert | b64enc }}
{{- end }}
```
<img width="911" alt="Screen Shot 2020-06-30 at 23 59 00" src="https://user-images.githubusercontent.com/20688668/86202266-c61f0480-bb2f-11ea-80bf-19789367e41a.png">
