### PR TITLE
change the DNS name limit

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -52,10 +52,10 @@ import (
 
 // releaseNameMaxLen is the maximum length of a release name.
 //
-// As of Kubernetes 1.4, the max limit on a name is 63 chars. We reserve 10 for
-// charts to add data. Effectively, that gives us 53 chars.
-// See https://github.com/helm/helm/issues/1528
-const releaseNameMaxLen = 53
+// As of Kubernetes 1.18, the max limit on a name is 253 chars. We reserve 10 for
+// charts to add data. Effectively, that gives us 231 chars.
+// See https://github.com/helm/helm/issues/6006#issuecomment-652291971
+const releaseNameMaxLen = 231
 
 // NOTESFILE_SUFFIX that we want to treat special. It goes through the templating engine
 // but it's not a yaml file (resource) hence can't have hooks, etc. And the user actually


### PR DESCRIPTION
Signed-off-by: Renato Suero <suerorenato@gmail.com>

closes #6006 

**What this PR does / why we need it**:
I've increased the limit for resource naming. The project was using 63(the value for Kubernetes version 1.4) now the new value is 253.  
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
