### PR TITLE
support reading signing passphrase from file or stdin

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -114,6 +114,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Sign, "sign", false, "use a PGP private key to sign this package")
 	f.StringVar(&client.Key, "key", "", "name of the key to use when signing. Used if --sign is true")
 	f.StringVar(&client.Keyring, "keyring", defaultKeyring(), "location of a public keyring")
+	f.StringVar(&client.PassphraseFile, "passphrase-file", "", `location of a file which contains the passphrase for the signing key. Use "-" in order to read from stdin.`)
 	f.StringVar(&client.Version, "version", "", "set the version on the chart to this semver version")
 	f.StringVar(&client.AppVersion, "app-version", "", "set the appVersion on the chart to this version")
 	f.StringVarP(&client.Destination, "destination", "d", ".", "location to write the chart.")

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -39,6 +40,7 @@ type Package struct {
 	Sign             bool
 	Key              string
 	Keyring          string
+	PassphraseFile   string
 	Version          string
 	AppVersion       string
 	Destination      string
@@ -120,7 +122,15 @@ func (p *Package) Clearsign(filename string) error {
 		return err
 	}
 
-	if err := signer.DecryptKey(promptUser); err != nil {
+	passphraseFetcher := promptUser
+	if p.PassphraseFile != "" {
+		passphraseFetcher, err = passphraseFileFetcher(p.PassphraseFile, os.Stdin)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := signer.DecryptKey(passphraseFetcher); err != nil {
 		return err
 	}
 
@@ -138,4 +148,35 @@ func promptUser(name string) ([]byte, error) {
 	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return pw, err
+}
+
+func passphraseFileFetcher(passphraseFile string, stdin *os.File) (provenance.PassphraseFetcher, error) {
+	file, err := openPassphraseFile(passphraseFile, stdin)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	passphrase, _, err := reader.ReadLine()
+	if err != nil {
+		return nil, err
+	}
+	return func(name string) ([]byte, error) {
+		return passphrase, nil
+	}, nil
+}
+
+func openPassphraseFile(passphraseFile string, stdin *os.File) (*os.File, error) {
+	if passphraseFile == "-" {
+		stat, err := stdin.Stat()
+		if err != nil {
+			return nil, err
+		}
+		if (stat.Mode() & os.ModeNamedPipe) == 0 {
+			return nil, errors.New("specified reading passphrase from stdin, without input on stdin")
+		}
+		return stdin, nil
+	}
+	return os.Open(passphraseFile)
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Sdorra <sebastian.sdorra@cloudogu.com>

closes #8210 

**What this PR does / why we need it**:

In helm v2 we had the HELM_KEY_PASSPHRASE environment variable to pass the passphrase within a ci process, but in helm v3 we have no way to pass the passphrase without user interaction.

So this pr will add support for reading the signing passphrase from file or stdin e.g.:

```bash
echo secret > secret.txt
helm package --sign --key mykey --keyring secring.gpg --passphrase-file secret.txt my-chart
# or
echo secret | helm package --sign --key mykey --keyring secring.gpg --passphrase-file "-" my-chart
```

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
