### PR TITLE
test: improve repo_update test fatal message

### DIFF
--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -67,7 +67,7 @@ func TestUpdateCustomCacheCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(cachePath, "charts-index.yaml")); err != nil {
-		t.Fatalf("error finding created index file in custom cache: %#v", err)
+		t.Fatalf("error finding created index file in custom cache: %#v \ngot: %s", err, out.String())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: lemonli <liwenjun0323@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
I got error message when do `make test`: 
```
--- FAIL: TestUpdateCustomCacheCmd (76.01s)
repo_update_test.go:70: error finding created index file in custom cache: &os.PathError{Op:"stat", Path:"/var/folders/1m/pst1v4fd2t320wn5hx78vrdw6kv787/T/helm433448320/updcustomcache/charts-index.yaml", Err:0x2}
```
I don't known what is the reason until I read whole codes in repo_update. I think detail error message may be helpful.

`TestUpdateCustomCacheCmd` in `cmd/helm/repo_update_test.go` download index file from `https://kubernetes-charts.storage.googleapis.com` to cache dir. But in China, the url can not be reached without a VPN proxy. Detail error message may help to found this reason.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
