### PR TITLE
fix lint error if parent chart doesn't have template directory

### DIFF
--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
@@ -1,6 +1,7 @@
 ==> Linting testdata/testcharts/chart-with-bad-subcharts
 [INFO] Chart.yaml: icon is recommended
 [WARNING] templates/: directory not found
+[ERROR] templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 
@@ -10,6 +11,7 @@
 [ERROR] Chart.yaml: version is required
 [INFO] Chart.yaml: icon is recommended
 [WARNING] templates/: directory not found
+[ERROR] templates/: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	validation: chart.metadata.name is required
 

--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts.txt
@@ -1,6 +1,7 @@
 ==> Linting testdata/testcharts/chart-with-bad-subcharts
 [INFO] Chart.yaml: icon is recommended
 [WARNING] templates/: directory not found
+[ERROR] templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -38,12 +38,12 @@ const goodChartDir = "rules/testdata/goodone"
 
 func TestBadChart(t *testing.T) {
 	m := All(badChartDir, values, namespace, strict).Messages
-	if len(m) != 8 {
+	if len(m) != 9 {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)
 	}
-	// There should be one INFO, 2 WARNINGs and 2 ERROR messages, check for them
-	var i, w, e, e2, e3, e4, e5, e6 bool
+	// There should be one INFO, 2 WARNINGs and 6 ERROR messages, check for them
+	var i, w, w2, e, e2, e3, e4, e5, e6 bool
 	for _, msg := range m {
 		if msg.Severity == support.InfoSev {
 			if strings.Contains(msg.Err.Error(), "icon is recommended") {
@@ -53,6 +53,9 @@ func TestBadChart(t *testing.T) {
 		if msg.Severity == support.WarningSev {
 			if strings.Contains(msg.Err.Error(), "directory not found") {
 				w = true
+			}
+			if strings.Contains(msg.Err.Error(), "directory not found") {
+				w2 = true
 			}
 		}
 		if msg.Severity == support.ErrorSev {
@@ -80,7 +83,7 @@ func TestBadChart(t *testing.T) {
 			}
 		}
 	}
-	if !e || !e2 || !e3 || !e4 || !e5 || !w || !i || !e6 {
+	if !e || !e2 || !e3 || !e4 || !e5 || !w || !w2 || !i || !e6 {
 		t.Errorf("Didn't find all the expected errors, got %#v", m)
 	}
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -50,12 +50,10 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	path := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, path)
 
-	templatesDirExist := linter.RunLinterRule(support.WarningSev, path, validateTemplatesDir(templatesPath))
-
-	// Templates directory is optional for now
-	if !templatesDirExist {
-		return
-	}
+	// Templates directory is optional
+	// if a warning level alarm occurs, just output the result,
+	// and then continue to execute the subsequent logic
+	linter.RunLinterRule(support.WarningSev, path, validateTemplatesDir(templatesPath))
 
 	// Load chart and parse templates
 	chart, err := loader.Load(linter.ChartDir)


### PR DESCRIPTION
Signed-off-by: wawa0210 <xiaozhang0210@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
At the time of helm lint, if the template directory does not exist, no error will be reported, just a warning prompt, which does not meet expectations

fix https://github.com/helm/helm/issues/8418
