### PR TITLE
feat(helm): prompt for password with helm repo add

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -24,11 +24,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -112,6 +114,16 @@ func (o *repoAddOptions) run(out io.Writer) error {
 
 	if o.noUpdate && f.Has(o.name) {
 		return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
+	}
+
+	if o.username != "" && o.password == "" {
+		fmt.Fprint(out, "Password:")
+		password, err := terminal.ReadPassword(syscall.Stdin)
+		fmt.Fprintln(out)
+		if err != nil {
+			return err
+		}
+		o.password = string(password)
 	}
 
 	c := repo.Entry{

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -117,7 +117,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	if o.username != "" && o.password == "" {
-		fmt.Fprint(out, "Password:")
+		fmt.Fprint(out, "Password: ")
 		password, err := terminal.ReadPassword(syscall.Stdin)
 		fmt.Fprintln(out)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Closes #7174

Previously in Helm 2, `helm repo add` would prompt for your password if you only provided the `--username` flag. This helps prevent someone's credentials from being logged in their shell's history, from showing up in process lists, and from being seen by others nearby.

**Special notes for your reviewer**:
This is my first time contributing to a large open-source project, please let me know if anything else is needed or desired and I'll do my best to address the concerns as soon as possible.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
