### PR TITLE
fix windows build failure caused by #8431

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -117,8 +116,9 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	if o.username != "" && o.password == "" {
+		fd := int(os.Stdin.Fd())
 		fmt.Fprint(out, "Password: ")
-		password, err := terminal.ReadPassword(syscall.Stdin)
+		password, err := terminal.ReadPassword(fd)
 		fmt.Fprintln(out)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix broken `windows/amd64` build caused by #8431 

**Special notes for your reviewer**:
This time I also ran `make build-cross` to ensure it builds for all target OSs and architectures.
Furthermore, I tested natively on `linux/arm`, `linux/arm64`, `linux/amd64` and `darwin/amd64`. I tested `windows/amd64` using WINE, as I do not have Windows.