### PR TITLE
feature(show): support jsonpath output for `helm show value`

### DIFF
--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -152,7 +152,7 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	if subCmd.Name() == "values" {
-		f.StringVar(&client.JsonPathTemplate, "jsonpath", "", "use jsonpath output format")
+		f.StringVar(&client.JSONPathTemplate, "jsonpath", "", "use jsonpath output format")
 	}
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -152,7 +152,7 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	if subCmd.Name() == "values" {
-		f.StringVar(&client.JSONPathTemplate, "jsonpath", "", "use jsonpath output format")
+		f.StringVar(&client.JSONPathTemplate, "jsonpath", "", "supply a JSONPath expression to filter the output")
 	}
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -151,6 +151,9 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 	f := subCmd.Flags()
 
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
+	if subCmd.Name() == "values" {
+		f.StringVar(&client.JsonPathTemplate, "jsonpath", "", "use jsonpath output format")
+	}
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 
 	err := subCmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/yaml"
 
@@ -92,7 +93,7 @@ func (s *Show) Run(chartpath string) (string, error) {
 		if s.JSONPathTemplate != "" {
 			printer, err := printers.NewJSONPathPrinter(s.JSONPathTemplate)
 			if err != nil {
-				return "", fmt.Errorf("error parsing jsonpath %s, %v", s.JSONPathTemplate, err)
+				return "", errors.Wrapf(err, "error parsing jsonpath %s", s.JSONPathTemplate)
 			}
 			printer.Execute(&out, s.chart.Values)
 		} else {

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/chartutil"
 )
 
 // ShowOutputFormat is the format of the output of `helm show`
@@ -52,9 +53,10 @@ func (o ShowOutputFormat) String() string {
 // It provides the implementation of 'helm show' and its respective subcommands.
 type Show struct {
 	ChartPathOptions
-	Devel        bool
-	OutputFormat ShowOutputFormat
-	chart        *chart.Chart // for testing
+	Devel            bool
+	OutputFormat     ShowOutputFormat
+	JsonPathTemplate string
+	chart            *chart.Chart // for testing
 }
 
 // NewShow creates a new Show object with the given configuration.
@@ -87,9 +89,17 @@ func (s *Show) Run(chartpath string) (string, error) {
 		if s.OutputFormat == ShowAll {
 			fmt.Fprintln(&out, "---")
 		}
-		for _, f := range s.chart.Raw {
-			if f.Name == chartutil.ValuesfileName {
-				fmt.Fprintln(&out, string(f.Data))
+		if s.JsonPathTemplate != "" {
+			printer, err := printers.NewJSONPathPrinter(s.JsonPathTemplate)
+			if err != nil {
+				return "", fmt.Errorf("error parsing jsonpath %s, %v\n", s.JsonPathTemplate, err)
+			}
+			printer.Execute(&out, s.chart.Values)
+		} else {
+			for _, f := range s.chart.Raw {
+				if f.Name == chartutil.ValuesfileName {
+					fmt.Fprintln(&out, string(f.Data))
+				}
 			}
 		}
 	}

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"helm.sh/helm/v3/pkg/chartutil"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 )
 
 // ShowOutputFormat is the format of the output of `helm show`
@@ -55,7 +55,7 @@ type Show struct {
 	ChartPathOptions
 	Devel            bool
 	OutputFormat     ShowOutputFormat
-	JsonPathTemplate string
+	JSONPathTemplate string
 	chart            *chart.Chart // for testing
 }
 
@@ -89,10 +89,10 @@ func (s *Show) Run(chartpath string) (string, error) {
 		if s.OutputFormat == ShowAll {
 			fmt.Fprintln(&out, "---")
 		}
-		if s.JsonPathTemplate != "" {
-			printer, err := printers.NewJSONPathPrinter(s.JsonPathTemplate)
+		if s.JSONPathTemplate != "" {
+			printer, err := printers.NewJSONPathPrinter(s.JSONPathTemplate)
 			if err != nil {
-				return "", fmt.Errorf("error parsing jsonpath %s, %v\n", s.JsonPathTemplate, err)
+				return "", fmt.Errorf("error parsing jsonpath %s, %v", s.JSONPathTemplate, err)
 			}
 			printer.Execute(&out, s.chart.Values)
 		} else {

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -72,7 +72,7 @@ func TestShowNoValues(t *testing.T) {
 
 func TestShowValuesByJsonPathFormat(t *testing.T) {
 	client := NewShow(ShowValues)
-	client.JsonPathTemplate = "{$.nestedKey.simpleKey}"
+	client.JSONPathTemplate = "{$.nestedKey.simpleKey}"
 	client.chart = buildChart(withSampleValues())
 	output, err := client.Run("")
 	if err != nil {

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -69,3 +69,17 @@ func TestShowNoValues(t *testing.T) {
 		t.Errorf("expected empty values buffer, got %s", output)
 	}
 }
+
+func TestShowValuesByJsonPathFormat(t *testing.T) {
+	client := NewShow(ShowValues)
+	client.JsonPathTemplate = "{$.nestedKey.simpleKey}"
+	client.chart = buildChart(withSampleValues())
+	output, err := client.Run("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := "simpleValue"
+	if output != expect {
+		t.Errorf("Expected\n%q\nGot\n%q\n", expect, output)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #7787

**Special notes for your reviewer**:
1. This is a preliminary realization. I will improve the implementation after listening to everyone's advice.
2. Only `helm show values` support the jsonpath format.
3. This is  implemented through Library `k8s.io/cli-runtime` and related document is [here](https://kubernetes.io/docs/reference/kubectl/jsonpath/).

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
