### PR TITLE
Clarify comments to match practice

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,11 +25,9 @@ import (
 var (
 	// version is the current version of Helm.
 	// Update this whenever making a new release.
-	// The version is of the format Major.Minor.Patch[-Prerelease][+BuildMetadata]
 	//
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
-	// Increment patch number for critical fixes to existing releases.
 	version = "v3.3"
 
 	// metadata is extra build time data


### PR DESCRIPTION
I'm updating the release documentation, and it seems there are some inaccurate comments in this file.

Based on the revision history in https://github.com/helm/helm/commits/master/internal/version/version.go it does not appear we update that file for patch releases, and it does not appear we currently use any format other than vX.y, so I am removing misleading comments.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
