### PR TITLE
Fixing version and spelling errors

### DIFF
--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -55,7 +55,7 @@ func TestDefaultCapabilities(t *testing.T) {
 		t.Errorf("Expected default KubeVersion.Major to be 1, got %q", kv.Major)
 	}
 	if kv.Minor != "18" {
-		t.Errorf("Expected default KubeVersion.Minor to be 16, got %q", kv.Minor)
+		t.Errorf("Expected default KubeVersion.Minor to be 18, got %q", kv.Minor)
 	}
 }
 
@@ -63,6 +63,6 @@ func TestDefaultCapabilitiesHelmVersion(t *testing.T) {
 	hv := DefaultCapabilities.HelmVersion
 
 	if hv.Version != "v3.3" {
-		t.Errorf("Expected default HelmVerison to be v3.3, got %q", hv.Version)
+		t.Errorf("Expected default HelmVersion to be v3.3, got %q", hv.Version)
 	}
 }


### PR DESCRIPTION
Corrections: 
- updated error output for a new version
- fixed a typo in error output

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
