### PR TITLE
Correct make target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ clean:
 .PHONY: release-notes
 release-notes:
 		@if [ ! -d "./_dist" ]; then \
-			echo "please run 'make fetch-release' first" && \
+			echo "please run 'make fetch-dist' first" && \
 			exit 1; \
 		fi
 		@if [ -z "${PREVIOUS_RELEASE}" ]; then \


### PR DESCRIPTION
When updating documentation I noticed that a typo was preventing this make target from working. This does not affect any automation around the build; it is only used in an optional step in the release checklist.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
