### PR TITLE
Reinstating comment that is still accurate

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,6 +25,7 @@ import (
 var (
 	// version is the current version of Helm.
 	// Update this whenever making a new release.
+	// The version is of the format Major.Minor.Patch[-Prerelease][+BuildMetadata]
 	//
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.


### PR DESCRIPTION
According to @bacongobbler: "This version does apply once a tag is built. This statement holds true."

https://github.com/helm/helm/pull/8443/files#r454461216

So, while we may not always see this, it can occur and should be documented.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
