### PR TITLE
fix(sql storage): Query() should return ErrReleaseNotFound immediately when no records are found

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -310,6 +310,10 @@ func (s *SQL) Query(labels map[string]string) ([]*rspb.Release, error) {
 		return nil, err
 	}
 
+	if len(records) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
 	var releases []*rspb.Release
 	for _, record := range records {
 		release, err := decodeRelease(record.Body)
@@ -318,10 +322,6 @@ func (s *SQL) Query(labels map[string]string) ([]*rspb.Release, error) {
 			continue
 		}
 		releases = append(releases, release)
-	}
-
-	if len(releases) == 0 {
-		return nil, ErrReleaseNotFound
 	}
 
 	return releases, nil

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -324,6 +324,10 @@ func (s *SQL) Query(labels map[string]string) ([]*rspb.Release, error) {
 		releases = append(releases, release)
 	}
 
+	if len(releases) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
 	return releases, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**What this PR does / why we need it**:
There is an inconsistency (and maybe wrong) of how `ErrReleaseNotFound` is being returned in the sql storage driver Query() function.
In both secrets and cfgmap drivers,
https://github.com/helm/helm/blob/master/pkg/storage/driver/secrets.go#L125-L138
https://github.com/helm/helm/blob/master/pkg/storage/driver/cfgmaps.go#L134-L147
the number of items are checked first and if it's zero return `ErrReleaseNotFound`. But that's not the case for sql driver.
It's possible for the sql driver to failed to decode all the releases and return the error  `ErrReleaseNotFound` but that's misleading and not true because the release exists just failed to decode.

This change is to sql driver Query() consistent with the other drivers.

**Special notes for your reviewer**:
related https://github.com/helm/helm/issues/8458 and https://github.com/helm/helm/pull/7372

**If applicable**:
- [NA] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
