### PR TITLE
support insecure and plain-http options in helm chart pull and push c…

### DIFF
--- a/cmd/helm/chart_pull.go
+++ b/cmd/helm/chart_pull.go
@@ -32,7 +32,8 @@ This will store the chart in the local registry cache to be used later.
 `
 
 func newChartPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var insecureOpt, plainHTTPOpt bool
+	cmd := &cobra.Command{
 		Use:    "pull [ref]",
 		Short:  "pull a chart from remote",
 		Long:   chartPullDesc,
@@ -40,7 +41,13 @@ func newChartPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Hidden: !FeatureGateOCI.IsEnabled(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
-			return action.NewChartPull(cfg).Run(out, ref)
+			return action.NewChartPull(cfg).Run(out, ref, insecureOpt, plainHTTPOpt)
 		},
 	}
+
+	f := cmd.Flags()
+	f.BoolVarP(&insecureOpt, "insecure", "", false, "allow connections to TLS registry without certs")
+	f.BoolVarP(&plainHTTPOpt, "plain-http", "", false, "use plain http and not https")
+
+	return cmd
 }

--- a/cmd/helm/chart_push.go
+++ b/cmd/helm/chart_push.go
@@ -34,7 +34,8 @@ Must first run "helm chart save" or "helm chart pull".
 `
 
 func newChartPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var insecureOpt, plainHTTPOpt bool
+	cmd := &cobra.Command{
 		Use:    "push [ref]",
 		Short:  "push a chart to remote",
 		Long:   chartPushDesc,
@@ -42,7 +43,13 @@ func newChartPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Hidden: !FeatureGateOCI.IsEnabled(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
-			return action.NewChartPush(cfg).Run(out, ref)
+			return action.NewChartPush(cfg).Run(out, ref, insecureOpt, plainHTTPOpt)
 		},
 	}
+
+	f := cmd.Flags()
+	f.BoolVarP(&insecureOpt, "insecure", "", false, "allow connections to TLS registry without certs")
+	f.BoolVarP(&plainHTTPOpt, "plain-http", "", false, "use plain http and not https")
+
+	return cmd
 }

--- a/internal/experimental/registry/client_test.go
+++ b/internal/experimental/registry/client_test.go
@@ -187,13 +187,13 @@ func (suite *RegistryClientTestSuite) Test_3_PushChart() {
 	// non-existent ref
 	ref, err := ParseReference(fmt.Sprintf("%s/testrepo/whodis:9.9.9", suite.DockerRegistryHost))
 	suite.Nil(err)
-	err = suite.RegistryClient.PushChart(ref)
+	err = suite.RegistryClient.PushChart(ref, false, false)
 	suite.NotNil(err)
 
 	// existing ref
 	ref, err = ParseReference(fmt.Sprintf("%s/testrepo/testchart:1.2.3", suite.DockerRegistryHost))
 	suite.Nil(err)
-	err = suite.RegistryClient.PushChart(ref)
+	err = suite.RegistryClient.PushChart(ref, false, false)
 	suite.Nil(err)
 }
 
@@ -202,13 +202,13 @@ func (suite *RegistryClientTestSuite) Test_4_PullChart() {
 	// non-existent ref
 	ref, err := ParseReference(fmt.Sprintf("%s/testrepo/whodis:9.9.9", suite.DockerRegistryHost))
 	suite.Nil(err)
-	err = suite.RegistryClient.PullChart(ref)
+	err = suite.RegistryClient.PullChart(ref, false, false)
 	suite.NotNil(err)
 
 	// existing ref
 	ref, err = ParseReference(fmt.Sprintf("%s/testrepo/testchart:1.2.3", suite.DockerRegistryHost))
 	suite.Nil(err)
-	err = suite.RegistryClient.PullChart(ref)
+	err = suite.RegistryClient.PullChart(ref, false, false)
 	suite.Nil(err)
 }
 
@@ -245,7 +245,7 @@ func (suite *RegistryClientTestSuite) Test_8_ManInTheMiddle() {
 	suite.Nil(err)
 
 	// returns content that does not match the expected digest
-	err = suite.RegistryClient.PullChart(ref)
+	err = suite.RegistryClient.PullChart(ref, false, false)
 	suite.NotNil(err)
 	suite.True(errdefs.IsFailedPrecondition(err))
 }

--- a/pkg/action/chart_pull.go
+++ b/pkg/action/chart_pull.go
@@ -35,10 +35,10 @@ func NewChartPull(cfg *Configuration) *ChartPull {
 }
 
 // Run executes the chart pull operation
-func (a *ChartPull) Run(out io.Writer, ref string) error {
+func (a *ChartPull) Run(out io.Writer, ref string, insecure bool, plainHTTP bool) error {
 	r, err := registry.ParseReference(ref)
 	if err != nil {
 		return err
 	}
-	return a.cfg.RegistryClient.PullChart(r)
+	return a.cfg.RegistryClient.PullChart(r, insecure, plainHTTP)
 }

--- a/pkg/action/chart_push.go
+++ b/pkg/action/chart_push.go
@@ -35,10 +35,10 @@ func NewChartPush(cfg *Configuration) *ChartPush {
 }
 
 // Run executes the chart push operation
-func (a *ChartPush) Run(out io.Writer, ref string) error {
+func (a *ChartPush) Run(out io.Writer, ref string, insecure bool, plainHTTP bool) error {
 	r, err := registry.ParseReference(ref)
 	if err != nil {
 		return err
 	}
-	return a.cfg.RegistryClient.PushChart(r)
+	return a.cfg.RegistryClient.PushChart(r, insecure, plainHTTP)
 }


### PR DESCRIPTION
This pr tries to resolve issue #8464 and #6324.
helm only support `--insecure` option in the helm registry login command. In some cases we want to push or pull a chart to a insecure or http registry anonymously without login, so I add `--insecure` and `--plain-http` options to meet these cases.

close #6324

Signed-off-by: youyongsong <youyongsong@gmail.com>
