### PR TITLE
Lockfiles without version ranges

### DIFF
--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -83,6 +83,17 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
+			name: "repo from valid local path with range resolution",
+			req: []*chart.Dependency{
+				{Name: "base", Repository: "file://base", Version: "^0.1.0"},
+			},
+			expect: &chart.Lock{
+				Dependencies: []*chart.Dependency{
+					{Name: "base", Repository: "file://base", Version: "0.1.0"},
+				},
+			},
+		},
+		{
 			name: "repo from invalid local path",
 			req: []*chart.Dependency{
 				{Name: "notexist", Repository: "file://testdata/notexist", Version: "0.1.0"},

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -171,6 +171,10 @@ func (m *Manager) Update() error {
 	// For the repositories Helm is not configured to know about, ensure Helm
 	// has some information about them and, when possible, the index files
 	// locally.
+	// TODO(mattfarina): Repositories should be explicitly added by end users
+	// rather than automattic. In Helm v4 require users to add repositories. They
+	// should have to add them in order to make sure they are aware of the
+	// respoitories and opt-in to any locations. For security.
 	repoNames, err = m.ensureMissingRepos(repoNames, req)
 	if err != nil {
 		return err

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -389,3 +389,33 @@ func TestErrRepoNotFound_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect string
+	}{
+		{
+			name:   "file:////tmp",
+			expect: "afeed3459e92a874f6373aca264ce1459bfa91f9c1d6612f10ae3dc2ee955df3",
+		},
+		{
+			name:   "https://example.com/charts",
+			expect: "7065c57c94b2411ad774638d76823c7ccb56415441f5ab2f5ece2f3845728e5d",
+		},
+		{
+			name:   "foo/bar/baz",
+			expect: "15c46a4f8a189ae22f36f201048881d6c090c93583bedcf71f5443fdef224c82",
+		},
+	}
+
+	for _, tt := range tests {
+		o, err := key(tt.name)
+		if err != nil {
+			t.Fatalf("unable to generate key for %q with error: %s", tt.name, err)
+		}
+		if o != tt.expect {
+			t.Errorf("wrong key name generated for %q, expected %q but got %q", tt.name, tt.expect, o)
+		}
+	}
+}


### PR DESCRIPTION
There were two situations where a lockfile could end up with a version range as a version instead of a pinned version.

1. When `file://` was used. This would point to the file location on the filesystem but, instead of using the version in that chart at that file location the version range would be used.
2. If a repository was used that was not added with `helm repo add`. Instead of causing an error that the repository was not available the version range was used in the lockfile. This is not locking.

This change looks to correct these problems. The `file://` handling fix was fairly straight forward. In that case update gets the current version of the dependency on disk and locks to that.

Handling unknown repos went through 4 different major versions. This 4th one is the one that settled on because all the changes are in the download manager which handles network issues. Other cases had added network operations to the resolver which is meant to iterate over existing versions. I chose this as the network and downloading stay in the same struct and it's methods are largely reusable within the new logic.

Closes #8449 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
