### PR TITLE
Fix/8467 linter failing

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -17,6 +17,8 @@ limitations under the License.
 package rules
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -121,7 +123,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 
 		renderedContent := renderedContentMap[filepath.Join(chart.Name(), fileName)]
 		if strings.TrimSpace(renderedContent) != "" {
-			fmt.Printf("Template %s: \n %s", path, renderedContent)
+			linter.RunLinterRule(support.WarningSev, path, validateTopIndentLevel(renderedContent))
 			var yamlStruct K8sYamlStruct
 			// Even though K8sYamlStruct only defines a few fields, an error in any other
 			// key will be raised as well
@@ -135,6 +137,32 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 			linter.RunLinterRule(support.ErrorSev, path, validateMatchSelector(&yamlStruct, renderedContent))
 		}
 	}
+}
+
+// validateTopIndentLevel checks that the content does not start with an indent level > 0.
+//
+// This error can occur when a template accidentally inserts space. It can cause
+// unpredictable errors dependening on whether the text is normalized before being passed
+// into the YAML parser. So we trap it here.
+//
+// See https://github.com/helm/helm/issues/8467
+func validateTopIndentLevel(content string) error {
+	// Read lines until we get to a non-empty one
+	scanner := bufio.NewScanner(bytes.NewBufferString(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		// If line is empty, skip
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// If it starts with one or more spaces, this is an error
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			return fmt.Errorf("document starts with an illegal indent: %q, which may cause parsing problems", line)
+		}
+		// Any other condition passes.
+		return nil
+	}
+	return scanner.Err()
 }
 
 // Validation functions

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -121,6 +121,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 
 		renderedContent := renderedContentMap[filepath.Join(chart.Name(), fileName)]
 		if strings.TrimSpace(renderedContent) != "" {
+			fmt.Printf("Template %s: \n %s", path, renderedContent)
 			var yamlStruct K8sYamlStruct
 			// Even though K8sYamlStruct only defines a few fields, an error in any other
 			// key will be raised as well

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -305,3 +305,20 @@ spec:
 		t.Error("expected Deployment with no selector to fail")
 	}
 }
+
+func TestValidateTopIndentLevel(t *testing.T) {
+	for doc, shouldFail := range map[string]bool{
+		// Should not fail
+		"\n\n\n\t\n   \t\n":          false,
+		"apiVersion:foo\n  bar:baz":  false,
+		"\n\n\napiVersion:foo\n\n\n": false,
+		// Should fail
+		"  apiVersion:foo":         true,
+		"\n\n  apiVersion:foo\n\n": true,
+	} {
+		if err := validateTopIndentLevel(doc); (err == nil) == shouldFail {
+			t.Errorf("Expected %t for %q", shouldFail, doc)
+		}
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR addresses the problem identified in #8467. It adds a new linter rule that issues a warning when a YAML document starts out with extra spaces before the first YAML attribute.

For example, this YAML would produce a warning:

```yaml
  apiVersion: v1
kind: Pod
```

It warns that there are extra spaces before `apiVersion`.

The reason for warning is that the YAML parser we use calibrates its spaces to the first line. Thus, it is a formatting error to start with spaces.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
