### PR TITLE
fix watch error due to elb/proxy timeout

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -35,6 +35,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -478,7 +479,7 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err = watchtools.ListWatchUntil(ctx, lw, func(e watch.Event) (bool, error) {
+	_, err = watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, nil, func(e watch.Event) (bool, error) {
 		// Make sure the incoming object is versioned as we use unstructured
 		// objects when we build manifests
 		obj := convertWithMapper(e.Object, info.Mapping)


### PR DESCRIPTION
**What this PR does / why we need it**: 

- If there is a release hook, that takes long time, we have observed that the ELB (in front of API server) closes the watch connection and that causes "Error event for " error and fails the rollout
- this issue has been addressed in kubectl commands. one such PR: https://github.com/kubernetes/kubernetes/pull/67817 

**Special notes for your reviewer**: we have successfully tested the fix with our pipeline which uses helm-v2. We thought it might be useful in helm-v3 as well.

**If applicable**:
- [X] this PR has been tested for backwards compatibility

I am marking the PR as WIP to be able to fix if any issues found during helm's PR auto-tests.