### PR TITLE
fix(exit code): fix the return exit code 0 if subcommand excuted failed

### DIFF
--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -89,6 +89,7 @@ func newDependencyCmd(out io.Writer) *cobra.Command {
 		Short:   "manage a chart's dependencies",
 		Long:    dependencyDesc,
 		Args:    require.NoArgs,
+		Run:     func(cmd *cobra.Command, args []string) {},
 	}
 
 	cmd.AddCommand(newDependencyListCmd(out))

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -41,6 +41,7 @@ func newGetCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Short: "download extended information of a named release",
 		Long:  getHelp,
 		Args:  require.NoArgs,
+		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
 	cmd.AddCommand(newGetAllCmd(cfg, out))

--- a/cmd/helm/plugin.go
+++ b/cmd/helm/plugin.go
@@ -35,6 +35,7 @@ func newPluginCmd(out io.Writer) *cobra.Command {
 		Use:   "plugin",
 		Short: "install, list, or uninstall Helm plugins",
 		Long:  pluginHelp,
+		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 	cmd.AddCommand(
 		newPluginInstallCmd(out),

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -38,6 +38,7 @@ func newRepoCmd(out io.Writer) *cobra.Command {
 		Short: "add, list, remove, update, and index chart repositories",
 		Long:  repoHelm,
 		Args:  require.NoArgs,
+		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
 	cmd.AddCommand(newRepoAddCmd(out))

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -34,6 +34,7 @@ func newSearchCmd(out io.Writer) *cobra.Command {
 		Use:   "search [keyword]",
 		Short: "search for a keyword in charts",
 		Long:  searchDesc,
+		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
 	cmd.AddCommand(newSearchHubCmd(out))

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -60,6 +60,7 @@ func newShowCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"inspect"},
 		Long:    showDesc,
 		Args:    require.NoArgs,
+		Run:     func(cmd *cobra.Command, args []string) {},
 	}
 
 	// Function providing dynamic auto-completion


### PR DESCRIPTION
In fact, this error would be better resolved in the dependency library `cobra` and i am also trying to  fix this issue of `cobra`. 

I read the code of other projects using `cobra` like `kubectl , github cli` and these project solved this problem.
https://github.com/spf13/cobra/pull/1157

I think the way that `kubectl` used is better.  `kubectl ` adds `Run` function for those commands with subcommands:
https://github.com/kubernetes/kubernetes/blob/8a3fc2d7e2043bc980bb5301d2f4292020f1a2dd/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go#L155-L170

Therefore, I add empty `Run function` for commands with subcommands.(dependency,get,plugin,repo,search,show).Everything is ok.

Close: #8286

Signed-off-by: Dong Gang <dong.gang@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix #8286 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
