### PR TITLE
introduce stale issue bot

### DIFF
--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
+        exempt-issue-labels: 'keep open'
+        days-before-stale: 90
+        days-before-close: 30

--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -10,6 +10,6 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
-        exempt-issue-labels: 'keep open'
+        exempt-issue-labels: 'keep open,v4.x'
         days-before-stale: 90
         days-before-close: 30

--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -10,6 +10,6 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
-        exempt-issue-labels: 'keep open,v4.x'
+        exempt-issue-labels: 'keep+open,v4.x'
         days-before-stale: 90
         days-before-close: 30


### PR DESCRIPTION
running once per day, this action will check to see if any issues have been stale for 90 days. After an additional 30 days, the issue will be automatically closed.

This is in response to the growing number of issues in the queue. Threads can be marked as "keep open" if they want to be kept open.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
