### PR TITLE
feat(cmd): add Chart Version to helm list output

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -132,13 +132,14 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type releaseElement struct {
-	Name       string `json:"name"`
-	Namespace  string `json:"namespace"`
-	Revision   string `json:"revision"`
-	Updated    string `json:"updated"`
-	Status     string `json:"status"`
-	Chart      string `json:"chart"`
-	AppVersion string `json:"app_version"`
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	Revision     string `json:"revision"`
+	Updated      string `json:"updated"`
+	Status       string `json:"status"`
+	Chart        string `json:"chart"`
+	AppVersion   string `json:"app_version"`
+	ChartVersion string `json:"chart_version"`
 }
 
 type releaseListWriter struct {
@@ -150,12 +151,13 @@ func newReleaseListWriter(releases []*release.Release) *releaseListWriter {
 	elements := make([]releaseElement, 0, len(releases))
 	for _, r := range releases {
 		element := releaseElement{
-			Name:       r.Name,
-			Namespace:  r.Namespace,
-			Revision:   strconv.Itoa(r.Version),
-			Status:     r.Info.Status.String(),
-			Chart:      fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version),
-			AppVersion: r.Chart.Metadata.AppVersion,
+			Name:         r.Name,
+			Namespace:    r.Namespace,
+			Revision:     strconv.Itoa(r.Version),
+			Status:       r.Info.Status.String(),
+			Chart:        fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version),
+			AppVersion:   r.Chart.Metadata.AppVersion,
+			ChartVersion: r.Chart.Metadata.Version,
 		}
 		t := "-"
 		if tspb := r.Info.LastDeployed; !tspb.IsZero() {
@@ -169,9 +171,9 @@ func newReleaseListWriter(releases []*release.Release) *releaseListWriter {
 
 func (r *releaseListWriter) WriteTable(out io.Writer) error {
 	table := uitable.New()
-	table.AddRow("NAME", "NAMESPACE", "REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION")
+	table.AddRow("NAME", "NAMESPACE", "REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "CHART VERSION")
 	for _, r := range r.releases {
-		table.AddRow(r.Name, r.Namespace, r.Revision, r.Updated, r.Status, r.Chart, r.AppVersion)
+		table.AddRow(r.Name, r.Namespace, r.Revision, r.Updated, r.Status, r.Chart, r.AppVersion, r.ChartVersion)
 	}
 	return output.EncodeTable(out, table)
 }

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -1,9 +1,9 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          	APP VERSION
-drax       	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling   	chickadee-1.0.0	0.0.1      
-gamora     	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0	0.0.1      
-groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chickadee-1.0.0	0.0.1      
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0	0.0.1      
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
-thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          	APP VERSION	CHART VERSION
+drax       	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling   	chickadee-1.0.0	0.0.1      	1.0.0        
+gamora     	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0	0.0.1      	1.0.0        
+groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chickadee-1.0.0	0.0.1      	1.0.0        
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      	1.0.0        
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      	1.0.0        
+thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-date-reversed.txt
+++ b/cmd/helm/testdata/output/list-date-reversed.txt
@@ -1,5 +1,5 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-date.txt
+++ b/cmd/helm/testdata/output/list-date.txt
@@ -1,5 +1,5 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-failed.txt
+++ b/cmd/helm/testdata/output/list-failed.txt
@@ -1,2 +1,2 @@
-NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          	APP VERSION
-rocket	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed	chickadee-1.0.0	0.0.1      
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS	CHART          	APP VERSION	CHART VERSION
+rocket	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-filter.txt
+++ b/cmd/helm/testdata/output/list-filter.txt
@@ -1,5 +1,5 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-max.txt
+++ b/cmd/helm/testdata/output/list-max.txt
@@ -1,2 +1,2 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-namespace.txt
+++ b/cmd/helm/testdata/output/list-namespace.txt
@@ -1,2 +1,2 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-starlord	milano   	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+starlord	milano   	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-offset.txt
+++ b/cmd/helm/testdata/output/list-offset.txt
@@ -1,4 +1,4 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-iguana  	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket  	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-starlord	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+iguana  	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket  	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-pending.txt
+++ b/cmd/helm/testdata/output/list-pending.txt
@@ -1,2 +1,2 @@
-NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          	APP VERSION
-thanos	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      
+NAME  	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          	APP VERSION	CHART VERSION
+thanos	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-reverse.txt
+++ b/cmd/helm/testdata/output/list-reverse.txt
@@ -1,5 +1,5 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-superseded.txt
+++ b/cmd/helm/testdata/output/list-superseded.txt
@@ -1,3 +1,3 @@
-NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS    	CHART          	APP VERSION
-gamora  	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0	0.0.1      
-starlord	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0	0.0.1      
+NAME    	NAMESPACE	REVISION	UPDATED                      	STATUS    	CHART          	APP VERSION	CHART VERSION
+gamora  	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-uninstalled.txt
+++ b/cmd/helm/testdata/output/list-uninstalled.txt
@@ -1,2 +1,2 @@
-NAME 	NAMESPACE	REVISION	UPDATED                      	STATUS     	CHART          	APP VERSION
-groot	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled	chickadee-1.0.0	0.0.1      
+NAME 	NAMESPACE	REVISION	UPDATED                      	STATUS     	CHART          	APP VERSION	CHART VERSION
+groot	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list-uninstalling.txt
+++ b/cmd/helm/testdata/output/list-uninstalling.txt
@@ -1,2 +1,2 @@
-NAME	NAMESPACE	REVISION	UPDATED                      	STATUS      	CHART          	APP VERSION
-drax	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling	chickadee-1.0.0	0.0.1      
+NAME	NAMESPACE	REVISION	UPDATED                      	STATUS      	CHART          	APP VERSION	CHART VERSION
+drax	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling	chickadee-1.0.0	0.0.1      	1.0.0        

--- a/cmd/helm/testdata/output/list.txt
+++ b/cmd/helm/testdata/output/list.txt
@@ -1,5 +1,5 @@
-NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION
-hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
-rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      
-starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS  	CHART          	APP VERSION	CHART VERSION
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed  	chickadee-1.0.0	0.0.1      	1.0.0        
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed	chickadee-1.0.0	0.0.1      	1.0.0        


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements the proposal in #8503 to add the "Chart Version" to the `helm list` output.

Closes #8503.