### PR TITLE
Fix issue with install and upgrade running all hooks

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -99,7 +99,9 @@ type Configuration struct {
 // renderResources renders the templates in a chart
 //
 // TODO: This function is badly in need of a refactor.
-func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, releaseName, outputDir string, subNotes, useReleaseName, includeCrds bool, disableHooks bool, pr postrender.PostRenderer, dryRun bool) ([]*release.Hook, *bytes.Buffer, string, error) {
+// TODO: As part of the refactor the duplicate code in cmd/helm/template.go should be removed
+//       This code has to do with writing files to dick.
+func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, releaseName, outputDir string, subNotes, useReleaseName, includeCrds bool, pr postrender.PostRenderer, dryRun bool) ([]*release.Hook, *bytes.Buffer, string, error) {
 	hs := []*release.Hook{}
 	b := bytes.NewBuffer(nil)
 
@@ -209,24 +211,6 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 				return hs, b, "", err
 			}
 			fileWritten[m.Name] = true
-		}
-	}
-
-	if !disableHooks && len(hs) > 0 {
-		for _, h := range hs {
-			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
-			} else {
-				newDir := outputDir
-				if useReleaseName {
-					newDir = filepath.Join(outputDir, releaseName)
-				}
-				err = writeToFile(newDir, h.Path, h.Manifest, fileWritten[h.Path])
-				if err != nil {
-					return hs, b, "", err
-				}
-				fileWritten[h.Path] = true
-			}
 		}
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -236,7 +236,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	rel := i.createRelease(chrt, vals)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.DisableHooks, i.PostRenderer, i.DryRun)
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, i.DryRun)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -499,9 +499,6 @@ func TestInstallReleaseOutputDir(t *testing.T) {
 	_, err = os.Stat(filepath.Join(dir, "hello/templates/with-partials"))
 	is.NoError(err)
 
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/hooks"))
-	is.NoError(err)
-
 	_, err = os.Stat(filepath.Join(dir, "hello/templates/rbac"))
 	is.NoError(err)
 
@@ -540,9 +537,6 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	is.NoError(err)
 
 	_, err = os.Stat(filepath.Join(newDir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/hooks"))
 	is.NoError(err)
 
 	_, err = os.Stat(filepath.Join(newDir, "hello/templates/rbac"))

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -222,7 +222,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, false, u.PostRenderer, u.DryRun)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
When #8156 was merged it had the side effect that all hooks were
run all the time. All the hooks were put in the flow of the
content rendered and sent to Kubernetes on every command.

For example, if you ran the following 2 commands the test hooks
would run:

    helm create foo
    helm install foo ./foo

This should not run any hooks. But, the generated test hook is run.

The change in this commit moves the writing of the hooks to output
or disk back into the template command rather than in a private
function within the actions. This is where it was for v3.2.

One side effect is that post renderers will not work on hooks. This
was the case in v3.2. Since this bug is blocking the release of v3.3.0
it is being rolled back. A refactor effort is underway for this section
of code. post renderer for hooks should be added back as part of that
work. Since post renderer hooks did not make it into a release it
is ok to roll it back for now.

There is code in the cmd/helm package that has been duplicated from
pkg/action. This is a temporary measure to fix the immediate bug
with plans to correct the situation as part of a refactor
of renderResources.

**What this PR does / why we need it**:

It fixes a release blocking bug to v3.3.0. v3.3.0-rc.1 currently runs all hooks on all commands (e.g., `helm install`).

**Special notes for your reviewer**:

@technosophos and I discussed this. He's volunteered to refactor this section of code for v3.4. If he doesn't, I will. There are mixes of concerns and some other bugs (e.g., post renderers don't work when helm template writes to an output directory). The other bugs are not regressions and were there in v3.2 so they are not release blockers.
