### PR TITLE
feat: add flag `--show-desc` to display description for `helm status`

### DIFF
--- a/cmd/helm/get_all.go
+++ b/cmd/helm/get_all.go
@@ -59,7 +59,7 @@ func newGetAllCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return tpl(template, data, out)
 			}
 
-			return output.Table.Write(out, &statusPrinter{res, true})
+			return output.Table.Write(out, &statusPrinter{res, true, false})
 		},
 	}
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -122,7 +122,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug})
+			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
 		},
 	}
 

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -61,7 +61,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 				return runErr
 			}
 
-			if err := outfmt.Write(out, &statusPrinter{rel, settings.Debug}); err != nil {
+			if err := outfmt.Write(out, &statusPrinter{rel, settings.Debug, false}); err != nil {
 				return err
 			}
 

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -45,6 +45,14 @@ func TestStatusCmd(t *testing.T) {
 			Status: release.StatusDeployed,
 		}),
 	}, {
+		name:   "get status of a deployed release, with desc",
+		cmd:    "status --show-desc flummoxed-chickadee",
+		golden: "output/status-with-desc.txt",
+		rels: releasesMockWithStatus(&release.Info{
+			Status:      release.StatusDeployed,
+			Description: "Mock description",
+		}),
+	}, {
 		name:   "get status of a deployed release with notes",
 		cmd:    "status flummoxed-chickadee",
 		golden: "output/status-with-notes.txt",

--- a/cmd/helm/testdata/output/status-with-desc.txt
+++ b/cmd/helm/testdata/output/status-with-desc.txt
@@ -1,0 +1,7 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 00:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+DESCRIPTION: Mock description
+TEST SUITE: None

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -115,7 +115,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return outfmt.Write(out, &statusPrinter{rel, settings.Debug})
+					return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
 				} else if err != nil {
 					return err
 				}
@@ -160,7 +160,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				fmt.Fprintf(out, "Release %q has been upgraded. Happy Helming!\n", args[0])
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug})
+			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
 		},
 	}
 

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -27,6 +27,11 @@ type Status struct {
 	cfg *Configuration
 
 	Version int
+
+	// If true, display description to output format,
+	// only affect print type table.
+	// TODO Helm 4: Remove this flag and output the description by default.
+	ShowDescription bool
 }
 
 // NewStatus creates a new Status object with the given configuration.


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes #8525 

Display description in `helm status` command.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
