### PR TITLE
Adding filtering of helm releases for configmap and secret backends during list command

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -126,6 +126,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVarP(&client.Limit, "max", "m", 256, "maximum number of releases to fetch")
 	f.IntVar(&client.Offset, "offset", 0, "next release name in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
+	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	bindOutputFlag(cmd, &outfmt)
 
 	return cmd

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -126,7 +126,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVarP(&client.Limit, "max", "m", 256, "maximum number of releases to fetch")
 	f.IntVar(&client.Offset, "offset", 0, "next release name in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
-	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Works only for secret(default) and configmap storage backends.")
 	bindOutputFlag(cmd, &outfmt)
 
 	return cmd

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -166,10 +166,10 @@ func (l *List) Run() ([]*release.Release, error) {
 		}
 
 		// Skip anything that doesn't match the selector
-		if ! selectorObj.Matches(labels.Set(rel.Labels)) {
+		if !selectorObj.Matches(labels.Set(rel.Labels)) {
 			return false
 		}
-		
+
 		return true
 	})
 

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -126,6 +126,7 @@ type List struct {
 	Deployed     bool
 	Failed       bool
 	Pending      bool
+	Selector     string
 }
 
 // NewList constructs a new *List

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,6 +37,8 @@ type Release struct {
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
+	// Labels of the release
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,8 +37,9 @@ type Release struct {
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
-	// Labels of the release
-	Labels map[string]string `json:"labels,omitempty"`
+	// Labels of the release.
+	// Disabled encoding into Json cause labels are stored in storage driver metadata field.
+	Labels map[string]string `json:"-"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -105,8 +105,10 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			cfgmaps.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
 		if filter(rls) {
-			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -106,6 +106,7 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			continue
 		}
 		if filter(rls) {
+			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -97,8 +97,10 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			secrets.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+		
+		rls.Labels = item.ObjectMeta.Labels
+
 		if filter(rls) {
-			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -97,7 +97,7 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			secrets.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
-		
+
 		rls.Labels = item.ObjectMeta.Labels
 
 		if filter(rls) {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -98,6 +98,7 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			continue
 		}
 		if filter(rls) {
+			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Adding labels filtering to list command.
Filtering behaves like k8s does.
For now only secrets and configmaps backends supported. Other backends not supported.
/resolves https://github.com/helm/helm/issues/4639

**Special notes for your reviewer**:
I would like some help with unit testing if that's possible.
Also I need some consultation if current behaviour would be fine for sql and in-memory storage backends.
**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
