### PR TITLE
Remove deprecated function BuildNameToCertificate()

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -99,7 +99,6 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "can't create TLS config for client")
 		}
-		tlsConf.BuildNameToCertificate()
 
 		sni, err := urlutil.ExtractHostname(g.opts.url)
 		if err != nil {

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -187,7 +187,6 @@ func TestDownloadTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "can't create TLS config for client"))
 	}
-	tlsConf.BuildNameToCertificate()
 	tlsConf.ServerName = "helm.sh"
 	tlsSrv.TLS = tlsConf
 	tlsSrv.StartTLS()

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -159,7 +159,6 @@ func (s *Server) StartTLS() {
 	if err != nil {
 		panic(err)
 	}
-	tlsConf.BuildNameToCertificate()
 	tlsConf.ServerName = "helm.sh"
 	s.srv.TLS = tlsConf
 	s.srv.StartTLS()


### PR DESCRIPTION
Since commit eb93c684d40d ("crypto/tls: select only compatible chains from Certificates") has deprecated BuildNameToCertificate, just leave NameToCertificate nil.

```
➜  helm git:(master) ✗ go version
go version go1.14.6 linux/amd64
➜  helm git:(master) make test
GO111MODULE=on go build  -tags '' -ldflags '-w -s -X
helm.sh/helm/v3/internal/version.metadata=unreleased -X
helm.sh/helm/v3/internal/version.gitCommit=94438b67221d4af3c9993945a42275be7ffc6baa
-X helm.sh/helm/v3/internal/version.gitTreeState=clean' -o
'/data/workspace/helm/bin'/helm ./cmd/helm
GO111MODULE=on golangci-lint run
pkg/repo/repotest/server.go:162:2: SA1019: tlsConf.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
        tlsConf.BuildNameToCertificate()
        ^
pkg/getter/httpgetter.go:102:3: SA1019: tlsConf.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
                tlsConf.BuildNameToCertificate()
                ^
pkg/getter/httpgetter_test.go:190:2: SA1019: tlsConf.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
        tlsConf.BuildNameToCertificate()
        ^
make: *** [Makefile:92: test-style] Error 1
```

Signed-off-by: Lu Fengqi <lufq.fnst@cn.fujitsu.com>

**What this PR does / why we need it**:
Fix lint error on go 1.14

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
