### PR TITLE
report name length errors in linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
+	github.com/Masterminds/goutils v1.1.0
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/Masterminds/squirrel v1.4.0

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -147,7 +147,8 @@ func validateReleaseName(releaseName string) error {
 		return errMissingRelease
 	}
 
-	if !ValidName.MatchString(releaseName) || (len(releaseName) > releaseNameMaxLen) {
+	// Check length first, since that is a less expensive operation.
+	if len(releaseName) > releaseNameMaxLen || !ValidName.MatchString(releaseName) {
 		return errInvalidName
 	}
 

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -164,6 +164,9 @@ func validateYamlContent(err error) error {
 }
 
 func validateMetadataName(obj *K8sYamlStruct) error {
+	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
+		return fmt.Errorf("object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
+	}
 	// This will return an error if the characters do not abide by the standard OR if the
 	// name is left empty.
 	if validName.MatchString(obj.Metadata.Name) {

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/goutils"
+
 	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -119,6 +121,14 @@ func TestValidateMetadataName(t *testing.T) {
 		"a..b":                      false,
 		"%^&#$%*@^*@&#^":            false,
 	}
+
+	// The length checker should catch this first. So this is not true fuzzing.
+	tooLong, err := goutils.RandomAlphaNumeric(300)
+	if err != nil {
+		t.Fatalf("Randomizer failed to initialize: %s", err)
+	}
+	names[tooLong] = false
+
 	for input, expectPass := range names {
 		obj := K8sYamlStruct{Metadata: k8sYamlMetadata{Name: input}}
 		if err := validateMetadataName(&obj); (err == nil) != expectPass {


### PR DESCRIPTION
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is a bug fix.

When I rewrote linter for Helm 3.3, I missed the length check on resource names. This now produces an error if a name is longer than the prescribed 253 characters.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
