### PR TITLE
fix test that modifies the wrong cache data

### DIFF
--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -40,11 +40,12 @@ func TestRepoAddCmd(t *testing.T) {
 	}
 	defer srv.Stop()
 
-	repoFile := filepath.Join(ensure.TempDir(t), "repositories.yaml")
+	tmpdir := ensure.TempDir(t)
+	repoFile := filepath.Join(tmpdir, "repositories.yaml")
 
 	tests := []cmdTestCase{{
 		name:   "add a repository",
-		cmd:    fmt.Sprintf("repo add test-name %s --repository-config %s", srv.URL(), repoFile),
+		cmd:    fmt.Sprintf("repo add test-name %s --repository-config %s --repository-cache %s", srv.URL(), repoFile, tmpdir),
 		golden: "output/repo-add.txt",
 	}}
 


### PR DESCRIPTION
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This fixes the bug where every time you run a test, it updates a timestamp in `cmd/helm/testdata/helmhome/helm/repository/test-name-index.yaml`

A recent fix to the search cache did indeed fix a bug, but also broke a unit test. The test was incorrectly pointing to the testdata from another test. As a result, the test was overwriting the wrong cache.

This is a simple fix that sets the correct cache data on the TestRepoAdd test.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
