### PR TITLE
WIP: Adds support of storing release labels in storage backends

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -149,6 +149,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, the installation process deletes the installation on failure. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.StringVarP(&client.Labels, "labels", "l", "", "Labels that would be added to relese metadata. Should be divided by comma")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -126,6 +126,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVarP(&client.Limit, "max", "m", 256, "maximum number of releases to fetch")
 	f.IntVar(&client.Offset, "offset", 0, "next release name in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
+	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	bindOutputFlag(cmd, &outfmt)
 
 	return cmd

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -126,7 +126,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVarP(&client.Limit, "max", "m", 256, "maximum number of releases to fetch")
 	f.IntVar(&client.Offset, "offset", 0, "next release name in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
-	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Works only for secret(default) and configmap storage backends.")
 	bindOutputFlag(cmd, &outfmt)
 
 	return cmd

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -417,3 +417,19 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 
 	return nil
 }
+
+func parseLabels(labels string) (map[string]string, error) {
+	if len(labels) == 0 {
+		return map[string]string{}, nil
+	}
+
+	labelsMap := make(map[string]string)
+	for _, label := range strings.Split(labels, ",") {
+		parts := strings.Split(label, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("Can't parse label: %s", label)
+		}
+		labelsMap[parts[0]] = parts[1]
+	}
+	return labelsMap, nil
+}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -353,3 +353,20 @@ func TestValidName(t *testing.T) {
 		}
 	}
 }
+
+func TestParseLabels(t *testing.T) {
+	names := map[string]bool{
+		"":                  true,
+		"foo":               false,
+		"foo=bar":           true,
+		"foo=bar1,foo2=bar": true,
+		"foo=bar1=bar2":     false,
+	}
+	for input, expectPass := range names {
+		_, err := parseLabels(input)
+		passed := err == nil
+		if passed != expectPass {
+			t.Errorf("Expected %q to %s", input, st)
+		}
+	}
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -236,11 +236,8 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 
 	rel := i.createRelease(chrt, vals)
 
-	// FIXME: Rework me
-	rel.Labels = make(map[string]string)
-	for _, label := range strings.Split(i.Labels, ",") {
-		parts := strings.Split(label, "=")
-		rel.Labels[parts[0]] = parts[1]
+	if rel.Labels, err = parseLabels(i.Labels); err != nil {
+		return nil, err
 	}
 
 	var manifestDoc *bytes.Buffer

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -100,6 +100,7 @@ type Install struct {
 	// OutputDir/<ReleaseName>
 	UseReleaseName bool
 	PostRenderer   postrender.PostRenderer
+	Labels         string
 }
 
 // ChartPathOptions captures common options used for controlling chart paths
@@ -234,6 +235,13 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	}
 
 	rel := i.createRelease(chrt, vals)
+
+	// FIXME: Rework me
+	rel.Labels = make(map[string]string)
+	for _, label := range strings.Split(i.Labels, ",") {
+		parts := strings.Split(label, "=")
+		rel.Labels[parts[0]] = parts[1]
+	}
 
 	var manifestDoc *bytes.Buffer
 	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, i.DryRun)

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -126,6 +126,7 @@ type List struct {
 	Deployed     bool
 	Failed       bool
 	Pending      bool
+	Selector     string
 }
 
 // NewList constructs a new *List

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -172,10 +172,10 @@ func (l *List) Run() ([]*release.Release, error) {
 		}
 
 		// Skip anything that doesn't match the selector
-		if ! selectorObj.Matches(labels.Set(rel.Labels)) {
+		if !selectorObj.Matches(labels.Set(rel.Labels)) {
 			return false
 		}
-		
+
 		return true
 	})
 

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -270,3 +270,49 @@ func TestFilterList(t *testing.T) {
 		assert.ElementsMatch(t, expectedFilteredList, filteredList)
 	})
 }
+
+func TestSelectorList(t *testing.T) {
+	r1 := releaseStub()
+	r1.Name = "r1"
+	r1.Version = 1
+	r1.Labels = map[string]string{"key": "value1"}
+	r2 := releaseStub()
+	r2.Name = "r2"
+	r2.Version = 1
+	r2.Labels = map[string]string{"key": "value2"}
+	r3 := releaseStub()
+	r3.Name = "r3"
+	r3.Version = 1
+	r3.Labels = map[string]string{}
+
+	lister := newListFixture(t)
+	for _, rel := range []*release.Release{r1, r2, r3} {
+		if err := lister.cfg.Releases.Create(rel); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("should fail selector parsing", func(t *testing.T) {
+		is := assert.New(t)
+		lister.Selector = "a?=b"
+
+		_, err := lister.Run()
+		is.Error(err)
+	})
+
+	t.Run("should select one release with matching label", func(t *testing.T) {
+		lister.Selector = "key==value1"
+		res, _ := lister.Run()
+
+		expectedFilteredList := []*release.Release{r1}
+		assert.ElementsMatch(t, expectedFilteredList, res)
+	})
+
+	t.Run("should select two releases with non matching label", func(t *testing.T) {
+		lister.Selector = "key!=value1"
+		res, _ := lister.Run()
+
+		expectedFilteredList := []*release.Release{r2, r3}
+		assert.ElementsMatch(t, expectedFilteredList, res)
+	})
+}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,6 +37,8 @@ type Release struct {
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
+	// Labels of the release
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,8 +37,9 @@ type Release struct {
 	Version int `json:"version,omitempty"`
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
-	// Labels of the release
-	Labels map[string]string `json:"labels,omitempty"`
+	// Labels of the release.
+	// Disabled encoding into Json cause labels are stored in storage driver metadata field.
+	Labels map[string]string `json:"-"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -105,8 +105,10 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			cfgmaps.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
 		if filter(rls) {
-			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -106,6 +106,7 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			continue
 		}
 		if filter(rls) {
+			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -79,7 +79,7 @@ func (cfgmaps *ConfigMaps) Get(key string) (*rspb.Release, error) {
 		return nil, err
 	}
 
-	r.Labels = getLabelsFromCM(obj)
+	r.Labels = filterSystemLabels(obj.ObjectMeta.Labels)
 
 	// return the release object
 	return r, nil
@@ -109,7 +109,7 @@ func (cfgmaps *ConfigMaps) List(filter func(*rspb.Release) bool) ([]*rspb.Releas
 			continue
 		}
 
-		rls.Labels = getLabelsFromCM(&item)
+		rls.Labels = filterSystemLabels(item.ObjectMeta.Labels)
 
 		if filter(rls) {
 			results = append(results, rls)
@@ -260,14 +260,4 @@ func newConfigMapsObject(key string, rls *rspb.Release, lbs labels) (*v1.ConfigM
 		},
 		Data: map[string]string{"release": s},
 	}, nil
-}
-
-func getLabelsFromCM(obj *v1.ConfigMap) map[string]string {
-	labels := obj.ObjectMeta.Labels
-
-	for _, k := range []string{"name", "owner", "status", "version"} {
-		delete(labels, k)
-	}
-	
-	return labels
 }

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -244,7 +244,7 @@ func newConfigMapsObject(key string, rls *rspb.Release, lbs labels) (*v1.ConfigM
 	}
 
 	// apply user labels
-	lbs.fromMap(rls.Labels)
+	lbs.mergeUserLabels(rls.Labels)
 
 	// apply internal labels
 	lbs.set("name", rls.Name)

--- a/pkg/storage/driver/labels.go
+++ b/pkg/storage/driver/labels.go
@@ -46,3 +46,11 @@ func (lbs *labels) fromMap(kvs map[string]string) {
 		lbs.set(k, v)
 	}
 }
+
+func (lbs *labels) mergeUserLabels(list map[string]string) {
+	for k, v := range list {
+		if ! isSystemLabel(k) {
+			lbs.set(k, v)
+		}
+	}
+}

--- a/pkg/storage/driver/labels.go
+++ b/pkg/storage/driver/labels.go
@@ -49,7 +49,7 @@ func (lbs *labels) fromMap(kvs map[string]string) {
 
 func (lbs *labels) mergeUserLabels(list map[string]string) {
 	for k, v := range list {
-		if ! isSystemLabel(k) {
+		if !isSystemLabel(k) {
 			lbs.set(k, v)
 		}
 	}

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -40,8 +40,12 @@ func releaseStub(name string, vers int, namespace string, status rspb.Status) *r
 		Version:   vers,
 		Namespace: namespace,
 		Info:      &rspb.Info{Status: status},
-		Labels: map[string]string{"key": "value"},
+		Labels:    defaultTestLabels(),
 	}
+}
+
+func defaultTestLabels() map[string]string {
+	return map[string]string{"key1": "value1", "key2": "value2"}
 }
 
 func testKey(name string, vers int) string {

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -40,6 +40,7 @@ func releaseStub(name string, vers int, namespace string, status rspb.Status) *r
 		Version:   vers,
 		Namespace: namespace,
 		Info:      &rspb.Info{Status: status},
+		Labels: map[string]string{"key": "value"},
 	}
 }
 

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -97,8 +97,10 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			secrets.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
+		
+		rls.Labels = item.ObjectMeta.Labels
+
 		if filter(rls) {
-			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -97,7 +97,7 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			secrets.Log("list: failed to decode release: %v: %s", item, err)
 			continue
 		}
-		
+
 		rls.Labels = item.ObjectMeta.Labels
 
 		if filter(rls) {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -98,6 +98,7 @@ func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, 
 			continue
 		}
 		if filter(rls) {
+			rls.Labels = item.ObjectMeta.Labels
 			results = append(results, rls)
 		}
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -224,7 +224,7 @@ func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, er
 	}
 
 	// apply user labels
-	lbs.fromMap(rls.Labels)
+	lbs.mergeUserLabels(rls.Labels)
 
 	// apply internal labels
 	lbs.set("name", rls.Name)

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -451,6 +451,27 @@ func TestSqlDelete(t *testing.T) {
 			),
 		).RowsWillBeClosed()
 
+	queryLabels := fmt.Sprintf(
+		regexp.QuoteMeta("SELECT %s, %s FROM %s WHERE %s = $1 AND %s = $2"),
+		sqlLabelTableKeyColumn,
+		sqlLabelTableValueColumn,
+		sqlLabelTableName,
+		sqlLabelTableReleaseKeyColumn,
+		sqlLabelTableReleaseNamespaceColumn,
+	)
+
+	eq := mock.ExpectQuery(queryLabels).
+		WithArgs(key, namespace)
+
+	returnRows := mock.NewRows([]string{
+		sqlLabelTableKeyColumn,
+		sqlLabelTableValueColumn,
+	})
+	for k, v := range rel.Labels {
+		returnRows.AddRow(k, v)
+	}
+	eq.WillReturnRows(returnRows).RowsWillBeClosed()
+
 	deleteQuery := fmt.Sprintf(
 		"DELETE FROM %s WHERE %s = $1 AND %s = $2",
 		sqlReleaseTableName,

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -83,3 +83,11 @@ func decodeRelease(data string) (*rspb.Release, error) {
 	}
 	return &rls, nil
 }
+
+// Removes system labels
+func filterSystemLabels(lbs map[string]string) map[string]string {
+	for _, k := range []string{"name", "owner", "status", "version"} {
+		delete(lbs, k)
+	}
+	return lbs
+}

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -84,10 +84,24 @@ func decodeRelease(data string) (*rspb.Release, error) {
 	return &rls, nil
 }
 
+// Returns array of system labels' keys
+func systemLablesKeys() []string {
+	return []string{"name", "owner", "status", "version"}
+}
+
 // Removes system labels
 func filterSystemLabels(lbs map[string]string) map[string]string {
-	for _, k := range []string{"name", "owner", "status", "version"} {
+	for _, k := range systemLablesKeys() {
 		delete(lbs, k)
 	}
 	return lbs
+}
+
+func isSystemLabel(key string) bool {
+	for _, v := range systemLablesKeys() {
+		if key == v {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -85,7 +85,7 @@ func decodeRelease(data string) (*rspb.Release, error) {
 }
 
 // Returns array of system labels' keys
-func systemLablesKeys() []string {
+func systemLabelsKeys() []string {
 	return []string{"name", "owner", "status", "version", "createdAt", "modifiedAt"}
 }
 
@@ -93,7 +93,7 @@ func systemLablesKeys() []string {
 func filterSystemLabels(lbs map[string]string) map[string]string {
 	result := make(map[string]string)
 	for k, v := range lbs {
-		if !isSystemLabel(k){
+		if !isSystemLabel(k) {
 			result[k] = v
 		}
 	}
@@ -101,7 +101,7 @@ func filterSystemLabels(lbs map[string]string) map[string]string {
 }
 
 func isSystemLabel(key string) bool {
-	for _, v := range systemLablesKeys() {
+	for _, v := range systemLabelsKeys() {
 		if key == v {
 			return true
 		}

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -86,15 +86,18 @@ func decodeRelease(data string) (*rspb.Release, error) {
 
 // Returns array of system labels' keys
 func systemLablesKeys() []string {
-	return []string{"name", "owner", "status", "version"}
+	return []string{"name", "owner", "status", "version", "createdAt", "modifiedAt"}
 }
 
 // Removes system labels
 func filterSystemLabels(lbs map[string]string) map[string]string {
-	for _, k := range systemLablesKeys() {
-		delete(lbs, k)
+	result := make(map[string]string)
+	for k, v := range lbs {
+		if !isSystemLabel(k){
+			result[k] = v
+		}
 	}
-	return lbs
+	return result
 }
 
 func isSystemLabel(key string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR continues work started in https://github.com/helm/helm/pull/8532 .
It adds storing labels info in storage driver metadata fields. This would allow filter labels on storage side more efficiently.

**Special notes for your reviewer**:
I would prefer early review to be able to correct way of implementation based on maintainers opinion.

What is missing now:
- [ ] Labels input validation same as in kubectl
- [ ] `helm label` command to modify labels of existing release
- [ ] Reworking of list method of storage driver to handle selector on storage driver side
- [ ] Support of --labels option in upgrade command
- [ ] Tests for list with selector for each storage driver

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

related: https://github.com/helm/helm/issues/7007 https://github.com/helm/helm/issues/4639 https://github.com/helm/helm/issues/4639