### PR TITLE
Extend Getter Options with context.Context

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -18,6 +18,7 @@ package getter
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,7 @@ type options struct {
 	password              string
 	userAgent             string
 	timeout               time.Duration
+	context               context.Context
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -87,6 +89,13 @@ func WithTLSClientConfig(certFile, keyFile, caFile string) Option {
 func WithTimeout(timeout time.Duration) Option {
 	return func(opts *options) {
 		opts.timeout = timeout
+	}
+}
+
+// WithContext sets the context for requests
+func WithContext(ctx context.Context) Option {
+	return func(opts *options) {
+		opts.context = ctx
 	}
 }
 

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -51,6 +51,9 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 		return buf, err
 	}
 
+	if g.opts.context != nil {
+		req = req.WithContext(g.opts.context)
+	}
 	req.Header.Set("User-Agent", version.GetUserAgent())
 	if g.opts.userAgent != "" {
 		req.Header.Set("User-Agent", g.opts.userAgent)

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -18,7 +18,6 @@ package getter
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +28,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/tlsutil"
 	"helm.sh/helm/v3/internal/version"

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 package getter
 
 import (
+	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -27,8 +29,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/tlsutil"
 	"helm.sh/helm/v3/internal/version"
@@ -50,6 +50,7 @@ func TestHTTPGetter(t *testing.T) {
 	ca, pub, priv := join(cd, "rootca.crt"), join(cd, "crt.pem"), join(cd, "key.pem")
 	insecure := false
 	timeout := time.Second * 5
+	ctx := context.TODO()
 
 	// Test with options
 	g, err = NewHTTPGetter(
@@ -58,6 +59,7 @@ func TestHTTPGetter(t *testing.T) {
 		WithTLSClientConfig(pub, priv, ca),
 		WithInsecureSkipVerifyTLS(insecure),
 		WithTimeout(timeout),
+		WithContext(ctx),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -98,6 +100,10 @@ func TestHTTPGetter(t *testing.T) {
 
 	if hg.opts.timeout != timeout {
 		t.Errorf("Expected NewHTTPGetter to contain %s as Timeout flag, got %s", timeout, hg.opts.timeout)
+	}
+
+	if hg.opts.context != ctx {
+		t.Errorf("Expected NewHTTPGetter to contain %s as Context flag, got %s", ctx, hg.opts.context)
 	}
 
 	// Test if setting insecureSkipVerifyTLS is being passed to the ops

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -70,6 +70,9 @@ func (p *pluginGetter) Get(href string, options ...Option) (*bytes.Buffer, error
 	commands := strings.Split(p.command, " ")
 	argv := append(commands[1:], p.opts.certFile, p.opts.keyFile, p.opts.caFile, href)
 	prog := exec.Command(filepath.Join(p.base, commands[0]), argv...)
+	if p.opts.context != nil {
+		prog = exec.CommandContext(p.opts.context, filepath.Join(p.base, commands[0]), argv...)
+	}
 	plugin.SetupPluginEnv(p.settings, p.name, p.base)
 	prog.Env = os.Environ()
 	buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
Extend Getter Options with context.Context and have it propagate into downstream calls. This follows recommended Go practice
where IO exposes context for cancellation and metadata propagation.

Relates to #7430

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR is needed to be able to use Helm as a library, and be able to set context for HTTP requests.

**Special notes for your reviewer**:
Could also force each invocation of `Get` to supply a context (`Get(ctx, ...)`), but that would be a breaking change.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
