### PR TITLE
Fix Quick Start Guide Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you want to use a package manager:
 - [GoFish](https://gofi.sh/) users can use `gofish install helm`.
 - [Snapcraft](https://snapcraft.io/) users can use `snap install helm --classic`
 
-To rapidly get Helm up and running, start with the [Quick Start Guide](https://docs.helm.sh/using_helm/#quickstart-guide).
+To rapidly get Helm up and running, start with the [Quick Start Guide](https://helm.sh/docs/intro/quickstart/).
 
 See the [installation guide](https://helm.sh/docs/intro/install/) for more options,
 including installing pre-releases.


### PR DESCRIPTION
The previous link https://docs.helm.sh/using_helm/#quickstart-guide was redirecting into https://helm.sh/ja/docs/intro/ which is a Japanese version of the docs. I've fixed the link so it goes into the English version instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This fixes the **Quick Start Guide** link in the **[Install](https://github.com/helm/helm/blob/master/README.md#Install)** section of [README.md](https://github.com/helm/helm/blob/master/README.md)
**Special notes for your reviewer**:
None
**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
