### PR TITLE
Improve the console output for resource policy keep to align with helm2.

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -111,6 +111,10 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	kept, errs := u.deleteRelease(rel)
+
+	if kept != "" {
+		kept = "These resources were kept due to the resource policy:\n" + kept
+	}
 	res.Info = kept
 
 	if !u.DisableHooks {
@@ -189,7 +193,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 	filesToKeep, filesToDelete := filterManifestsToKeep(files)
 	var kept string
 	for _, f := range filesToKeep {
-		kept += f.Name + "\n"
+		kept += "[" + f.Head.Kind + "] " + f.Head.Metadata.Name + "\n"
 	}
 
 	var builder strings.Builder

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func uninstallAction(t *testing.T) *Uninstall {
+	config := actionConfigFixture(t)
+	unAction := NewUninstall(config)
+	return unAction
+}
+
+func TestUninstallRelease_deleteRelease(t *testing.T) {
+	is := assert.New(t)
+
+	unAction := uninstallAction(t)
+	unAction.DisableHooks = true
+	unAction.DryRun = false
+	unAction.KeepHistory = true
+
+	rel := releaseStub()
+	rel.Name = "keep-secret"
+	rel.Manifest = `{
+		"apiVersion": "v1",
+		"kind": "Secret",
+		"metadata": {
+		  "name": "secret",
+		  "annotations": {
+			"helm.sh/resource-policy": "keep"
+		  }
+		},
+		"type": "Opaque",
+		"data": {
+		  "password": "password"
+		}
+	}`
+	unAction.cfg.Releases.Create(rel)
+	res, err := unAction.Run(rel.Name)
+	is.NoError(err)
+	expected := `These resources were kept due to the resource policy:
+[Secret] secret
+`
+	is.Contains(res.Info, expected)
+}


### PR DESCRIPTION
Signed-off-by: Du Zheng <zsuzhengdu@gmail.com>

**What this PR does / why we need it**:

Improve the console output for resources with annotation `"helm.sh/resource-policy": keep` to align with helm2 [outputs](https://github.com/helm/helm/blob/release-2.16/pkg/tiller/resource_policy.go#L57).

In helm3, following is print out when uninstall or delete a release with `kind: Secret`:
```bash
manifest-1
manifest-2
manifest-3
manifest-4
manifest-6
manifest-7
manifest-8
```

Improved:
```bash
These resources were kept due to the resource policy:
[Secret] Metadata.Name
[Secret] Metadata.Name
[Secret] Metadata.Name
[Secret] Metadata.Name
[Secret] Metadata.Name
[Secret] Metadata.Name
[Secret] Metadata.Name
```
