### PR TITLE
Detect kubeconfig as known argument in plugin invocations 

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -137,11 +137,21 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 		}
 		return false
 	}
+
+	isKnown := func(v string) string {
+		for _, i := range kvargs {
+			if i == v {
+				return v
+			}
+		}
+		return ""
+	}
+
 	for i := 0; i < len(args); i++ {
 		switch a := args[i]; a {
 		case "--debug":
 			known = append(known, a)
-		case "--host", "--kube-context", "--home", "--tiller-namespace":
+		case isKnown(a):
 			known = append(known, a, args[i+1])
 			i++
 		default:

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -128,7 +128,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 func manuallyProcessArgs(args []string) ([]string, []string) {
 	known := []string{}
 	unknown := []string{}
-	kvargs := []string{"--host", "--kube-context", "--home", "--tiller-namespace"}
+	kvargs := []string{"--host", "--kube-context", "--home", "--tiller-namespace", "--kubeconfig"}
 	knownArg := func(a string) bool {
 		for _, pre := range kvargs {
 			if strings.HasPrefix(a, pre+"=") {

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -34,6 +34,7 @@ func TestManuallyProcessArgs(t *testing.T) {
 		"--debug",
 		"--foo", "bar",
 		"--host", "example.com",
+		"--kubeconfig=/home/foo",
 		"--kube-context", "test1",
 		"--home=/tmp",
 		"--tiller-namespace=hello",
@@ -41,7 +42,7 @@ func TestManuallyProcessArgs(t *testing.T) {
 	}
 
 	expectKnown := []string{
-		"--debug", "--host", "example.com", "--kube-context", "test1", "--home=/tmp", "--tiller-namespace=hello",
+		"--debug", "--host", "example.com", "--kubeconfig=/home/foo", "--kube-context", "test1", "--home=/tmp", "--tiller-namespace=hello",
 	}
 
 	expectUnknown := []string{

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -197,4 +197,8 @@ func SetupPluginEnv(settings helm_env.EnvSettings,
 	if settings.Debug {
 		os.Setenv("HELM_DEBUG", "1")
 	}
+
+	if settings.KubeConfig != "" {
+		os.Setenv("KUBECONFIG", settings.KubeConfig)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With Helm 2 --kubeconfig is not detected as a known argument on plugin invocations. This means it depends on the order or arguments if helm picks it up or not which might not be under users control (for me in case of helmfile calling "helm diff").

Helm 3 has this fixed with https://github.com/helm/helm/commit/0650d6953de6267c0f20ca9014af25c5abb508f5

