### PR TITLE
Added support to pass values to sub-charts via `map.yaml`

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -201,6 +201,12 @@ func TestInstall(t *testing.T) {
 			name: "install chart with only crds",
 			cmd:  "install crd-test testdata/testcharts/chart-with-only-crds --namespace default",
 		},
+		// Install, base case with map and subcharts
+		{
+			name:   "basic install with a map and subcharts",
+			cmd:    "install aeneas testdata/testcharts/chart-with-map --namespace default",
+			golden: "output/install.txt",
+		},
 	}
 
 	runTestActionCmd(t, tests)

--- a/cmd/helm/testdata/testcharts/chart-with-map/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Chart with map and subcharts
+name: chart-with-map
+version: 0.0.1
+dependencies:
+  - name: subchart
+    version: 0.0.1

--- a/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: subchart
+name: subchart
+version: 0.0.1

--- a/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/map.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/map.yaml
@@ -1,0 +1,1 @@
+derived: {{ printf "%s-%s" .Values.default "a" }}

--- a/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/templates/test1.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/templates/test1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: "aaa"
+    labels:
+        derived: {{ .Values.derived }}
+        default: {{ .Values.default }}

--- a/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/charts/subchart/values.yaml
@@ -1,0 +1,1 @@
+default: "subchart-default"

--- a/cmd/helm/testdata/testcharts/chart-with-map/map.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/map.yaml
@@ -1,0 +1,4 @@
+derived: {{ printf "%s-%s" .Values.public1 "a" }}
+
+subchart:
+  default: "aa"

--- a/cmd/helm/testdata/testcharts/chart-with-map/templates/test1.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/templates/test1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: "aaa"
+    labels:
+        derived: {{ .Values.derived }}
+        public1: {{ .Values.public1 }}

--- a/cmd/helm/testdata/testcharts/chart-with-map/values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-map/values.yaml
@@ -1,0 +1,1 @@
+public1: a

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -42,6 +42,8 @@ type Chart struct {
 	Templates []*File `json:"templates"`
 	// Values are default config for this chart.
 	Values map[string]interface{} `json:"values"`
+	// Map are default derivations of values of this chart.
+	Map *File `json:"map"`
 	// Schema is an optional JSON schema for imposing structure on Values
 	Schema []byte `json:"schema"`
 	// Files are miscellaneous files in a chart archive,

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -99,6 +99,8 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if err := yaml.Unmarshal(f.Data, &c.Values); err != nil {
 				return c, errors.Wrap(err, "cannot load values.yaml")
 			}
+		case f.Name == "map.yaml":
+			c.Map = &chart.File{Name: f.Name, Data: f.Data}
 		case f.Name == "values.schema.json":
 			c.Schema = f.Data
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows developers to declare a `map.yaml` file on their chart, which can be used to map values in `values.yaml` to derived values that are used in templating, including sub-charts (see #8576 for the long explanation). This allows developers to write e.g.

```
apiVersion: v1
description: Chart with map and subcharts
name: chart-with-map
version: 0.0.1
dependencies:
  - name: backend
    version: 0.0.1
  - name: frontend
    version: 0.0.1
```

```
# values.yaml
domain: example.com
```

```
# map.yaml
backend:
  uri: {{ printf "https://api.%s" .Values.domain }}

frontend:
  uri: {{ printf "https://app.%s" .Values.domain }}

other_uri: {{ printf "https://blabla.%s" .Values.domain }}
```

thereby not having to expose `backend: uri`, `frontend: uri` in `values.yaml` (for the subchart), nor ask chart users to have to pass the same value in multiple keys for consistency (or use global names that lead to naming collisions).

I.e. it allows subcharts to be populated with derived (or `map`ed) values without exposing these values to `values.yaml` (the public interface of the chart).

This solves a long standing issue of being very painful to pass values to subcharts that derive values in `values.yaml` (more details in #8576). Closes #8576.

**Special notes for your reviewer**: This PR is not complete yet: this is part of the proposal, and is intended to demonstrate how the proposal is implemented in practice. There are at least three issues to address, two documented as `# todo`, plus   associated documentation.

To run the example,

```
make build
./bin/helm install test --debug --dry-run cmd/helm/testdata/testcharts/chart-with-map/
```

which leads to the manifest

```
---
# Source: chart-with-map/charts/subchart/templates/test1.yaml
apiVersion: v1
kind: Pod
metadata:
    name: "aaa"
    labels:
        derived: aa-a
        default: aa
---
# Source: chart-with-map/templates/test1.yaml
apiVersion: v1
kind: Pod
metadata:
    name: "aaa"
    labels:
        derived: a-a
        public1: a
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
