### PR TITLE
Wait: turn the debug logs into stdout print

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -120,7 +120,6 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	}
 	w := waiter{
 		c:       cs,
-		log:     c.Log,
 		timeout: timeout,
 	}
 	return w.waitForResources(resources)

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -19,6 +19,7 @@ package kube // import "helm.sh/helm/v3/pkg/kube"
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -44,7 +45,10 @@ import (
 type waiter struct {
 	c       kubernetes.Interface
 	timeout time.Duration
-	log     func(string, ...interface{})
+}
+
+func (w *waiter) log(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stdout, fmt.Sprintf("%s\n", format), v...)
 }
 
 // waitForResources polls to get the current status of all pods, PVCs, and Services


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

if `--wait` flag for helm `install/upgrade` is specified, Helm will log to standard output (`stdout`) the wait informations.

Before: it was logged only with `--debug` flag to `stderr`.

Solve https://github.com/helm/helm/issues/7760

**Example output:**

using a sample `values.yaml` containing:
```yaml
persistence:
    enabled: false
replication:
    enabled: false
    slaveReplicas: 3
```

```bash
bin/helm upgrade --install test stable/postgresql --wait --values values.yaml
Release "test" does not exist. Installing it now.
WARNING: This chart is deprecated
beginning wait for 6 resources with timeout of 5m0s
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 1 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods have been scheduled
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
StatefulSet is not ready: default/test-postgresql-slave. 2 out of 3 expected pods are ready
NAME: test
LAST DEPLOYED: Tue Aug 11 17:21:25 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
[Here go the traditional postgresql deployment notes]
```

**Special notes for your reviewer**:

Note that this is a purely naive implementation to be used as a starting point, and I would be happy to change it in order to have a more unified way of logging (Since there are several ways of doing it in Helm: giving `out` as parameter and using `fmt.Fprintf`, using `fmt.Fprintf` with `os.Stdout`, using `log.Output`, ...) or at least that follows existing conventions. In fact, it would be nice to use `log` everywhere without short file name and make its format configurable.

My current concern is about backward compatibility if people used output in batch scripts.