### PR TITLE
release/mock: Ensure conversion from int to string yields a string

### DIFF
--- a/pkg/release/mock.go
+++ b/pkg/release/mock.go
@@ -17,6 +17,7 @@ limitations under the License.
 package release
 
 import (
+	"fmt"
 	"math/rand"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -53,7 +54,7 @@ func Mock(opts *MockReleaseOptions) *Release {
 
 	name := opts.Name
 	if name == "" {
-		name = "testrelease-" + string(rand.Intn(100))
+		name = "testrelease-" + fmt.Sprint(rand.Intn(100))
 	}
 
 	version := 1


### PR DESCRIPTION
With the release of go 1.15, the test-suite doesn't pass as `go test` got
a new warning for improper `string(x)` usage.

https://golang.org/doc/go1.15#vet

    $ make test-unit
    # helm.sh/helm/v3/pkg/release
    pkg/release/mock.go:56:27: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
    [snip]
    make: *** [Makefile:82: test-unit] Error 2

This patch changes ensures we are utilizing `fmt.Sprint` instead as
recommended.

Signed-off-by: Morten Linderud <morten@linderud.pw>
