### PR TITLE
Add support to judge whether desired version is available or not

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -77,15 +77,19 @@ verifySupported() {
 
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
-  if [ "x$DESIRED_VERSION" == "x" ]; then
-    # Get tag from release URL
-    local release_url="https://github.com/helm/helm/releases"
-    if type "curl" > /dev/null; then
+  # Get available tags from release URL
+  local release_url="https://github.com/helm/helm/releases"
+  if type "curl" > /dev/null; then
+    available_tags=$(curl -Ls $release_url | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+  elif type "wget" > /dev/null; then
+    available_tags=$(wget $release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+  fi
 
-      TAG=$(curl -Ls $release_url | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    elif type "wget" > /dev/null; then
-      TAG=$(wget $release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    fi
+  if [ "x$DESIRED_VERSION" == "x" ]; then
+    TAG=$(echo $available_tags | cut -d ' ' -f 1)
+  elif ! echo $available_tags | grep $DESIRED_VERSION > /dev/null; then
+    echo "Helm $DESIRED_VERSION is unavailable"
+    exit 1
   else
     TAG=$DESIRED_VERSION
   fi

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -102,14 +102,19 @@ verifySupported() {
 
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
+  # Get available tags from release URL
+  local latest_release_url="https://github.com/helm/helm/releases"
+  if [ "${HAS_CURL}" == "true" ]; then
+    available_tags=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}') 
+  elif [ "${HAS_WGET}" == "true" ]; then
+    available_tags=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+  fi
+
   if [ "x$DESIRED_VERSION" == "x" ]; then
-    # Get tag from release URL
-    local latest_release_url="https://github.com/helm/helm/releases"
-    if [ "${HAS_CURL}" == "true" ]; then
-      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    elif [ "${HAS_WGET}" == "true" ]; then
-      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    fi
+    TAG=$(echo $available_tags | cut -d ' ' -f 1)
+  elif ! echo $available_tags | grep $DESIRED_VERSION > /dev/null; then
+    echo "Helm $DESIRED_VERSION is unavailable"
+    exit 1
   else
     TAG=$DESIRED_VERSION
   fi


### PR DESCRIPTION
  Now no matter what desired version provides, always give info "Helm ${TAG} is available.
Changing from version ${version}". It's obviously wrong.
  This patch check whether desired version is actually available or not
by compare desired vesion with all available version in
https://github.com/helm/helm/releases

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>
fix #8647

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility