### PR TITLE
added a line to remove tmpPath

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -245,6 +245,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 
 	destPath := filepath.Join(m.ChartPath, "charts")
 	tmpPath := filepath.Join(m.ChartPath, "tmpcharts")
+	defer os.RemoveAll(tmpPath)
 
 	// Create 'charts' directory if it doesn't already exist.
 	if fi, err := os.Stat(destPath); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR fixes next `helm dep up` run failure if `tmpcharts` was not removed during last run

**Fixes #5567 



