### PR TITLE
Replace Helm Hub with Artifact Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helm is a tool for managing Charts. Charts are packages of pre-configured Kubern
 
 Use Helm to:
 
-- Find and use [popular software packaged as Helm Charts](https://hub.helm.sh) to run in Kubernetes
+- Find and use [popular software packaged as Helm Charts](https://artifacthub.io/packages/search?kind=0) to run in Kubernetes
 - Share your own applications as Helm Charts
 - Create reproducible builds of your Kubernetes applications
 - Intelligently manage your Kubernetes manifest files

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -24,8 +24,8 @@ import (
 
 const searchDesc = `
 Search provides the ability to search for Helm charts in the various places
-they can be stored including the Helm Hub and repositories you have added. Use
-search subcommands to search different locations for charts.
+they can be stored including the Artifact Hub and repositories you have added.
+Use search subcommands to search different locations for charts.
 `
 
 func newSearchCmd(out io.Writer) *cobra.Command {

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -68,7 +68,7 @@ func newSearchHubCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&o.searchEndpoint, "endpoint", "https://artifacthub.io", "Hub instance to query for charts")
+	f.StringVar(&o.searchEndpoint, "endpoint", "https://hub.helm.sh", "Hub instance to query for charts")
 	f.UintVar(&o.maxColWidth, "max-col-width", 50, "maximum column width for output table")
 	bindOutputFlag(cmd, &o.outputFormat)
 

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -39,7 +39,7 @@ Foundation sandbox project. You can browse the hub at https://artifacthub.io/
 
 The [KEYWORD] argument accepts either a keyword string, or quoted string of rich
 query options. For rich query options documentation, see
-https://artifacthub.github.io/hub/api/#/Packages/get_packages_search
+https://artifacthub.github.io/hub/api/?urls.primaryName=Monocular%20compatible%20search%20API#/Monocular/get_api_chartsvc_v1_charts_search
 
 Previous versions of Helm used an instance of Monocular as the default
 'endpoint', so for backwards compatibility Artifact Hub is compatible with the

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -106,7 +106,14 @@ type hubSearchWriter struct {
 func newHubSearchWriter(results []monocular.SearchResult, endpoint string, columnWidth uint) *hubSearchWriter {
 	var elements []hubChartElement
 	for _, r := range results {
+		// Backwards compatibility for Monocular
 		url := endpoint + "/charts/" + r.ID
+
+		// Check for artifactHub compatibility
+		if r.ArtifactHub.PackageURL != "" {
+			url = r.ArtifactHub.PackageURL
+		}
+
 		elements = append(elements, hubChartElement{url, r.Relationships.LatestChartVersion.Data.Version, r.Relationships.LatestChartVersion.Data.AppVersion, r.Attributes.Description})
 	}
 	return &hubSearchWriter{elements, columnWidth}

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -30,15 +30,23 @@ import (
 )
 
 const searchHubDesc = `
-Search the Helm Hub or an instance of Monocular for Helm charts.
+Search for Helm charts in the Artifact Hub or your own hub instance.
 
-The Helm Hub provides a centralized search for publicly available distributed
-charts. It is maintained by the Helm project. It can be visited at
-https://hub.helm.sh
+Artifact Hub is a web-based application that enables finding, installing, and
+publishing packages and configurations for CNCF projects, including publicly
+available distributed charts Helm charts. It is a Cloud Native Computing
+Foundation sandbox project. You can browse the hub at https://artifacthub.io/
 
-Monocular is a web-based application that enables the search and discovery of
-charts from multiple Helm Chart repositories. It is the codebase that powers the
-Helm Hub. You can find it at https://github.com/helm/monocular
+The [KEYWORD] argument accepts either a keyword string, or quoted string of rich
+query options. For rich query options documentation, see
+https://artifacthub.github.io/hub/api/#/Packages/get_packages_search
+
+Previous versions of Helm used an instance of Monocular as the default
+'endpoint', so for backwards compatibility Artifact Hub is compatible with the
+Monocular search API. Similarly, when setting the 'endpoint' flag, the specified
+endpoint must also be implement a Monocular compatible search API endpoint.
+Note that when specifying a Monocular instance as the 'endpoint', rich queries
+are not supported. For API details, see https://github.com/helm/monocular
 `
 
 type searchHubOptions struct {
@@ -51,8 +59,8 @@ func newSearchHubCmd(out io.Writer) *cobra.Command {
 	o := &searchHubOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "hub [keyword]",
-		Short: "search for charts in the Helm Hub or an instance of Monocular",
+		Use:   "hub [KEYWORD]",
+		Short: "search for charts in the Artifact Hub or your own hub instance",
 		Long:  searchHubDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(out, args)
@@ -60,7 +68,7 @@ func newSearchHubCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&o.searchEndpoint, "endpoint", "https://hub.helm.sh", "monocular instance to query for charts")
+	f.StringVar(&o.searchEndpoint, "endpoint", "https://artifacthub.io", "Hub instance to query for charts")
 	f.UintVar(&o.maxColWidth, "max-col-width", 50, "maximum column width for output table")
 	bindOutputFlag(cmd, &o.outputFormat)
 

--- a/internal/monocular/client_test.go
+++ b/internal/monocular/client_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	c, err := New("https://hub.helm.sh")
+	c, err := New("https://artifacthub.io")
 	if err != nil {
 		t.Errorf("error creating client: %s", err)
 	}
-	if c.BaseURL != "https://hub.helm.sh" {
-		t.Errorf("incorrect BaseURL. Expected \"https://hub.helm.sh\" but got %q", c.BaseURL)
+	if c.BaseURL != "https://artifacthub.io" {
+		t.Errorf("incorrect BaseURL. Expected \"https://artifacthub.io\" but got %q", c.BaseURL)
 	}
 }

--- a/internal/monocular/client_test.go
+++ b/internal/monocular/client_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	c, err := New("https://artifacthub.io")
+	c, err := New("https://hub.helm.sh")
 	if err != nil {
 		t.Errorf("error creating client: %s", err)
 	}
-	if c.BaseURL != "https://artifacthub.io" {
-		t.Errorf("incorrect BaseURL. Expected \"https://artifacthub.io\" but got %q", c.BaseURL)
+	if c.BaseURL != "https://hub.helm.sh" {
+		t.Errorf("incorrect BaseURL. Expected \"https://hub.helm.sh\" but got %q", c.BaseURL)
 	}
 }

--- a/internal/monocular/doc.go
+++ b/internal/monocular/doc.go
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package monocular contains the logic for interacting with monocular instances
-// like the Helm Hub.
+// Package monocular contains the logic for interacting with a Monocular
+// compatible search API endpoint. For example, as implemented by the Artifact
+// Hub.
 //
-// This is a library for interacting with monocular
+// This is a library for interacting with a monocular compatible search API
 package monocular

--- a/internal/monocular/search.go
+++ b/internal/monocular/search.go
@@ -40,10 +40,16 @@ const SearchPath = "api/chartsvc/v1/charts/search"
 // SearchResult represents an individual chart result
 type SearchResult struct {
 	ID            string        `json:"id"`
+	ArtifactHub   ArtifactHub   `json:"artifactHub"`
 	Type          string        `json:"type"`
 	Attributes    Chart         `json:"attributes"`
 	Links         Links         `json:"links"`
 	Relationships Relationships `json:"relationships"`
+}
+
+// ArtifactHub represents data specific to Artifact Hub instances
+type ArtifactHub struct {
+	PackageURL string `json:"packageUrl"`
 }
 
 // Chart is the attributes for the chart


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm Hub is going away in favor of Artifact Hub (pending lazy consensus, EOD Today).

There is a plan in place to safely migrate so end users will not experience any difference when using `helm search hub`, even without this change to the helm client. See https://github.com/helm/hub/issues/439

This PR updates:
- The `helm search hub` `--endpoint` flag default to https://artifacthub.io/
- This ensures user output will match the browsable page, so search URLs correctly display the final destination
- this also allows the `[KEYWORD]` arg to optionally accept quoted rich queries. But single keyword continues to work
- tests
- cli help
- other docs and references

**Special notes for your reviewer**:

For backwards compatibility, previous versions of helm client will still work:
- helm search hub output URLs for hub.helm.sh will DNS redirect to artifacthub.io 👉 
- cli help and documentation won't be correct, but there's nothing we can do about that for previous versions of the client 🤷 

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
