### PR TITLE
pkg/*: Small linting fixes

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -135,7 +135,7 @@ func (p *Package) Clearsign(filename string) error {
 // promptUser implements provenance.PassphraseFetcher
 func promptUser(name string) ([]byte, error) {
 	fmt.Printf("Password for key %q >  ", name)
-	pw, err := terminal.ReadPassword(int(syscall.Stdin))
+	pw, err := terminal.ReadPassword(syscall.Stdin)
 	fmt.Println()
 	return pw, err
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -172,7 +172,7 @@ func TestIndexCustomSchemeDownload(t *testing.T) {
 
 func verifyIndex(t *testing.T, actual *IndexFile) {
 	var empty time.Time
-	if actual.Generated == empty {
+	if actual.Generated.Equal(empty) {
 		t.Errorf("Generated should be greater than 0: %s", actual.Generated)
 	}
 
@@ -242,7 +242,7 @@ func verifyIndex(t *testing.T, actual *IndexFile) {
 			if len(g.Maintainers) != 2 {
 				t.Error("Expected 2 maintainers.")
 			}
-			if g.Created == empty {
+			if g.Created.Equal(empty) {
 				t.Error("Expected created to be non-empty")
 			}
 			if g.Description == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
I tested https://github.com/quasilyte/go-ruleguard with https://github.com/dgryski/semgrep-go today and run it against helm's code base, it detected those two small improvements.