### PR TITLE
Revert "pkg/*: Small linting fixes"

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -135,7 +135,7 @@ func (p *Package) Clearsign(filename string) error {
 // promptUser implements provenance.PassphraseFetcher
 func promptUser(name string) ([]byte, error) {
 	fmt.Printf("Password for key %q >  ", name)
-	pw, err := terminal.ReadPassword(syscall.Stdin)
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	return pw, err
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -172,7 +172,7 @@ func TestIndexCustomSchemeDownload(t *testing.T) {
 
 func verifyIndex(t *testing.T, actual *IndexFile) {
 	var empty time.Time
-	if actual.Generated.Equal(empty) {
+	if actual.Generated == empty {
 		t.Errorf("Generated should be greater than 0: %s", actual.Generated)
 	}
 
@@ -242,7 +242,7 @@ func verifyIndex(t *testing.T, actual *IndexFile) {
 			if len(g.Maintainers) != 2 {
 				t.Error("Expected 2 maintainers.")
 			}
-			if g.Created.Equal(empty) {
+			if g.Created == empty {
 				t.Error("Expected created to be non-empty")
 			}
 			if g.Description == "" {


### PR DESCRIPTION
Reverts helm/helm#8631

Building for windows produces the following error...

```
1 errors occurred:
--> windows/amd64 error: exit status 2
Stderr: go: downloading github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading github.com/konsorten/go-windows-terminal-sequences v1.0.3
# helm.sh/helm/v3/pkg/action
pkg/action/package.go:138:34: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.ReadPassword
```

It appears `syscall.Stdin` is not an int in all environments.