### PR TITLE
Fix linting `kind: List` metadata

### DIFF
--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -134,6 +134,23 @@ func TestValidateMetadataName(t *testing.T) {
 	}
 }
 
+func TestListOfResources(t *testing.T) {
+	testData := map[string]int{
+		"./testdata/good_list_of_resources": 0,
+		"./testdata/bad_list_of_resources":  2,
+	}
+
+	for testDir, expectedErrs := range testData {
+		linter := support.Linter{ChartDir: testDir}
+		Templates(&linter, values, namespace, strict)
+		res := linter.Messages
+
+		if len(res) != expectedErrs {
+			t.Fatalf("Expected %d error(s) in %s, got %d, %v", expectedErrs, testDir, len(res), res)
+		}
+	}
+}
+
 func TestDeprecatedAPIFails(t *testing.T) {
 	mychart := chart.Chart{
 		Metadata: &chart.Metadata{

--- a/pkg/lint/rules/testdata/bad_list_of_resources/Chart.yaml
+++ b/pkg/lint/rules/testdata/bad_list_of_resources/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: bad list of resources
+description: list of resources testing chart
+version: 199.44.12345-Alpha.1+cafe009
+icon: http://riverrun.io

--- a/pkg/lint/rules/testdata/bad_list_of_resources/templates/list_resource.yaml
+++ b/pkg/lint/rules/testdata/bad_list_of_resources/templates/list_resource.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+  - apiVersion: v1
+    kind: ConfigMap

--- a/pkg/lint/rules/testdata/bad_list_of_resources/values.yaml
+++ b/pkg/lint/rules/testdata/bad_list_of_resources/values.yaml
@@ -1,0 +1,1 @@
+name: "bad list of resources"

--- a/pkg/lint/rules/testdata/good_list_of_resources/Chart.yaml
+++ b/pkg/lint/rules/testdata/good_list_of_resources/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: good list of resources
+description: list of resources testing chart
+version: 199.44.12345-Alpha.1+cafe009
+icon: http://riverrun.io

--- a/pkg/lint/rules/testdata/good_list_of_resources/templates/list_resource.yaml
+++ b/pkg/lint/rules/testdata/good_list_of_resources/templates/list_resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config1
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config2

--- a/pkg/lint/rules/testdata/good_list_of_resources/values.yaml
+++ b/pkg/lint/rules/testdata/good_list_of_resources/values.yaml
@@ -1,0 +1,1 @@
+name: "good list of resources"


### PR DESCRIPTION
Helm v2 didn't validate that resource names were valid. Helm v3
introduces this check, failing lint checks that were previously
passing.

This PR adds a check to validate metadata for a list of resources if
present, otherwise falling back to previous behavior of validating the
metadata.

Closes #8615 

Signed-off-by: Chris Bui <christopher.d.bui@gmail.com>
