### PR TITLE
feat: add charts versions in output of dependencies downloader

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -294,7 +294,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		}
 		if strings.HasPrefix(dep.Repository, "file://") {
 			if m.Debug {
-				fmt.Fprintf(m.Out, "Archiving %s from repo %s\n", dep.Name, dep.Repository)
+				fmt.Fprintf(m.Out, "Archiving %s %s from repo %s\n", dep.Name, dep.Version, dep.Repository)
 			}
 			ver, err := tarFromLocalDir(m.ChartPath, dep.Name, dep.Repository, dep.Version)
 			if err != nil {
@@ -314,11 +314,11 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		}
 
 		if _, ok := churls[churl]; ok {
-			fmt.Fprintf(m.Out, "Already downloaded %s from repo %s\n", dep.Name, dep.Repository)
+			fmt.Fprintf(m.Out, "Already downloaded %s %s from repo %s\n", dep.Name, dep.Version, dep.Repository)
 			continue
 		}
 
-		fmt.Fprintf(m.Out, "Downloading %s from repo %s\n", dep.Name, dep.Repository)
+		fmt.Fprintf(m.Out, "Downloading %s %s from repo %s\n", dep.Name, dep.Version, dep.Repository)
 
 		dl := ChartDownloader{
 			Out:              m.Out,


### PR DESCRIPTION
PR making output of `helm dependency update` prettier and more clear, especially in CI output.

**Why**

When you running `helm` as part of CI pipeline, its not clear which versions of charts are used during deployment.
This PR improving it, example of output:

```
> helm dependency update

...

Saving 3 charts
Downloading nginx 1.2.9 from repo https://...
Downloading posgresql 3.2.5 from repo https://...
Downloading gitlab-runners 1.0.1 from repo https://...
```