### PR TITLE
fix for linting on templates with only comments

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -123,6 +123,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		// linter.RunLinterRule(support.WarningSev, fpath, validateQuotes(string(preExecutedTemplate)))
 
 		renderedContent := renderedContentMap[path.Join(chart.Name(), fileName)]
+		renderedContent = cleanseRenderedContent(renderedContent)
 		if strings.TrimSpace(renderedContent) != "" {
 			linter.RunLinterRule(support.WarningSev, fpath, validateTopIndentLevel(renderedContent))
 			var yamlStruct K8sYamlStruct
@@ -164,6 +165,17 @@ func validateTopIndentLevel(content string) error {
 		return nil
 	}
 	return scanner.Err()
+}
+
+func cleanseRenderedContent(renderedContent string) string {
+	renderedArray := strings.Split(strings.Replace(renderedContent, "\r\n", "\n", -1), "\n")
+	cleansedContent := []string{}
+	for _, line := range renderedArray {
+		if !(strings.HasPrefix(line, "#") || strings.HasPrefix(line, "---")) {
+			cleansedContent = append(cleansedContent, line)
+		}
+	}
+	return strings.Join(cleansedContent, "\n")
 }
 
 // Validation functions

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -330,5 +330,27 @@ func TestValidateTopIndentLevel(t *testing.T) {
 			t.Errorf("Expected %t for %q", shouldFail, doc)
 		}
 	}
+}
 
+func TestCleanseRenderedContent(t *testing.T) {
+	input := `
+#comments about the template file
+apiVersion: v1
+kind: ConfigMap
+# Metadata
+metadata:
+  name: mychart-configmap-1
+  namespace: default
+`
+	expect := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mychart-configmap-1
+  namespace: default
+`
+	output := cleanseRenderedContent(input)
+	if output != expect {
+		t.Errorf("Expected : %+v , but got : %+v", expect, output)
+	}
 }

--- a/pkg/lint/rules/testdata/albatross/templates/blank.yaml
+++ b/pkg/lint/rules/testdata/albatross/templates/blank.yaml
@@ -1,0 +1,25 @@
+# comment on first line
+{{- if .Values.condition }}
+apiVersion: v1
+kind: ConfigMap
+# Metadata
+metadata:
+  name: mychart-configmap-1
+  namespace: default
+data:
+  myvalue: "Hello World"
+{{- end }}
+
+---
+
+# comment on first line
+{{- if .Values.condition }}
+apiVersion: v1
+kind: ConfigMap
+# Metadata
+metadata:
+  name: mychart-configmap-2
+  namespace: default
+data:
+  myvalue: "Hello World"
+{{- end }}

--- a/pkg/lint/rules/testdata/albatross/values.yaml
+++ b/pkg/lint/rules/testdata/albatross/values.yaml
@@ -1,1 +1,2 @@
 name: "mariner"
+condition: false


### PR DESCRIPTION
Signed-off-by: Tarun Kumar <fidato.july13@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Closes #8621 

This PR handles the error scenario wherein the linting fails when the template files contain only comments.

**Special notes for your reviewer**: 

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
