### PR TITLE
Add requested version to install error output

### DIFF
--- a/cmd/helm/show_test.go
+++ b/cmd/helm/show_test.go
@@ -50,6 +50,13 @@ func TestShowPreReleaseChart(t *testing.T) {
 			expectedErr: "failed to download \"test/pre-release-chart\"",
 		},
 		{
+			name:        "show pre-release chart",
+			args:        "test/pre-release-chart",
+			fail:        true,
+			flags:       "--version 1.0.0",
+			expectedErr: "failed to download \"test/pre-release-chart\" at version \"1.0.0\"",
+		},
+		{
 			name:  "show pre-release chart with 'devel' flag",
 			args:  "test/pre-release-chart",
 			flags: "--devel",

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -677,5 +677,9 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		return filename, err
 	}
 
-	return filename, errors.Errorf("failed to download %q (hint: running `helm repo update` may help)", name)
+	atVersion := ""
+	if version != "" {
+		atVersion = fmt.Sprintf(" at version %q", version)
+	}
+	return filename, errors.Errorf("failed to download %q%s (hint: running `helm repo update` may help)", name, atVersion)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When installing a helm chart with incorrect version, the resulting error message is ambiguous:

```console
$ helm repo add bitnami https://charts.bitnami.com/bitnami
$ helm repo update
$ helm3 install test bitnami/nginx --version 1.19.1
Error: failed to download "bitnami/nginx" (hint: running `helm repo update` may help)
```

```console
$ helm3 search repo bitnami/nginx
NAME                            	CHART VERSION	APP VERSION	DESCRIPTION
bitnami/nginx                   	6.1.0        	1.19.1     	Chart for the nginx server
```

This is patch improves the error message to read:
```console
$ helm3 install test bitnami/nginx --version 1.19.1
Error: failed to download "bitnami/nginx" at version "1.19.1" (hint: running `helm repo update` may help)
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility


In this simplified example it seem obvious. In a CI context when the user may specify the version indirectly, it is a tremendous help when the version is in the actual error message. It may help with obvious typos as well as it hints that the error may not be in the repository url but rather the version itself.