### PR TITLE
feat(comp): Add support for fish completion

### DIFF
--- a/cmd/helm/completion_test.go
+++ b/cmd/helm/completion_test.go
@@ -55,4 +55,5 @@ func TestCompletionFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "completion", false)
 	checkFileCompletion(t, "completion bash", false)
 	checkFileCompletion(t, "completion zsh", false)
+	checkFileCompletion(t, "completion fish", false)
 }


### PR DESCRIPTION
Part of #8109
Replaces #8111 
  
**What this PR does / why we need it**:

Provides support for Fish shell completion through Cobra

**Special notes for your reviewer**:

This PR replaces #8111 because the contributor has not come back to his PR, which needs a rebase, since July 7th, 2020.
I've reached out three times but no luck. 

Also, a new flag `--no-descriptions` was added just for the command `helm completion fish`, to allow users to disable descriptions if they don't like to have them.  Descriptions are a feature of fish completion (and native zsh completion) that looks like this:
```
$ bin/helm s<TAB>
search  (search for a keyword in charts)  
show    (show information of a chart)  
status  (display the status of the named release)
```