### PR TITLE
fix: remove print statement when writing data to an output directory

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -197,7 +197,6 @@ func writeToFile(outputDir string, name string, data string, append bool) error 
 		return err
 	}
 
-	fmt.Printf("wrote %s\n", outfileName)
 	return nil
 }
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -500,8 +500,6 @@ func writeToFile(outputDir string, name string, data string, append bool) error 
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("wrote %s\n", outfileName)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

**What this PR does / why we need it**:
This PR removes the print line when writing the data to an output directory. This line printed lot of statements, which made it hard to debug issues with helm template.

fixes #8672 