### PR TITLE
fix: limit the usage of chartutil.Values to avoid conversion bugs

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -150,7 +150,7 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		}
 
 		fmt.Fprintln(out, "COMPUTED VALUES:")
-		err = output.EncodeYAML(out, cfg.AsMap())
+		err = output.EncodeYAML(out, cfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -34,7 +34,7 @@ import (
 //	- Scalar values and arrays are replaced, maps are merged
 //	- A chart has access to all of the variables for it, as well as all of
 //		the values destined for its dependencies.
-func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (Values, error) {
+func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (map[string]interface{}, error) {
 	v, err := copystructure.Copy(vals)
 	if err != nil {
 		return vals, err

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -108,7 +108,7 @@ func TestCoalesceValues(t *testing.T) {
 	// taking a copy of the values before passing it
 	// to CoalesceValues as argument, so that we can
 	// use it for asserting later
-	valsCopy := make(Values, len(vals))
+	valsCopy := make(map[string]interface{}, len(vals))
 	for key, value := range vals {
 		valsCopy[key] = value
 	}

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -222,6 +222,7 @@ func processImportValues(c *chart.Chart) error {
 		return nil
 	}
 	// combine chart values and empty config to get Values
+	var cvals Values
 	cvals, err := CoalesceValues(c, nil)
 	if err != nil {
 		return err
@@ -248,7 +249,7 @@ func processImportValues(c *chart.Chart) error {
 					continue
 				}
 				// create value map from child to be merged into parent
-				b = CoalesceTables(cvals, pathToMap(parent, vv.AsMap()))
+				b = CoalesceTables(cvals, pathToMap(parent, vv))
 			case string:
 				child := "exports." + iv
 				outiv = append(outiv, map[string]string{
@@ -260,7 +261,7 @@ func processImportValues(c *chart.Chart) error {
 					log.Printf("Warning: ImportValues missing table: %v", err)
 					continue
 				}
-				b = CoalesceTables(b, vm.AsMap())
+				b = CoalesceTables(b, vm)
 			}
 		}
 		// set our formatted import values

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -135,7 +135,7 @@ func TestToRenderValues(t *testing.T) {
 		t.Error("Expected Capabilities to have a Kube version")
 	}
 
-	vals := res["Values"].(Values)
+	vals := res["Values"].(map[string]interface{})
 	if vals["name"] != "Haroun" {
 		t.Errorf("Expected 'Haroun', got %q (%v)", vals["name"], vals)
 	}
@@ -171,6 +171,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		panic(err)
@@ -195,6 +196,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		t.Fatalf("Failed to parse the White Whale: %s", err)
@@ -265,6 +267,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		t.Fatalf("Failed to parse the White Whale: %s", err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -245,7 +245,7 @@ func (e Engine) renderWithReferences(tpls, referenceTpls map[string]renderable) 
 		}
 		// At render time, add information about the template that is being rendered.
 		vals := tpls[filename].vals
-		vals["Template"] = chartutil.Values{"Name": filename, "BasePath": tpls[filename].basePath}
+		vals["Template"] = map[string]interface{}{"Name": filename, "BasePath": tpls[filename].basePath}
 		var buf strings.Builder
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
 			return map[string]string{}, cleanupExecError(filename, err)
@@ -340,7 +340,7 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, vals chartutil.
 		"Files":        newFiles(c.Files),
 		"Release":      vals["Release"],
 		"Capabilities": vals["Capabilities"],
-		"Values":       make(chartutil.Values),
+		"Values":       map[string]interface{}{},
 	}
 
 	// If there is a {{.Values.ThisChart}} in the parent metadata,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -409,7 +409,7 @@ func TestRenderNestedValues(t *testing.T) {
 	inject := chartutil.Values{
 		"Values": tmp,
 		"Chart":  outer.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "dyin",
 		},
 	}
@@ -464,9 +464,9 @@ func TestRenderBuiltinValues(t *testing.T) {
 	outer.AddDependency(inner)
 
 	inject := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  outer.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "Aeneid",
 		},
 	}
@@ -510,9 +510,9 @@ func TestAlterFuncMap_include(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "Mistah Kurtz",
 		},
 	}
@@ -544,12 +544,12 @@ func TestAlterFuncMap_require(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"who":   "us",
 			"bases": 2,
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "That 90s meme",
 		},
 	}
@@ -571,11 +571,11 @@ func TestAlterFuncMap_require(t *testing.T) {
 	// test required without passing in needed values with lint mode on
 	// verifies lint replaces required with an empty string (should not fail)
 	lintValues := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"who": "us",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "That 90s meme",
 		},
 	}
@@ -605,11 +605,11 @@ func TestAlterFuncMap_tpl(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -634,11 +634,11 @@ func TestAlterFuncMap_tplfunc(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -663,11 +663,11 @@ func TestAlterFuncMap_tplinclude(t *testing.T) {
 		},
 	}
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -694,9 +694,9 @@ func TestRenderRecursionLimit(t *testing.T) {
 		},
 	}
 	v := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}


### PR DESCRIPTION
This is the 1st PR splitted from #6876

**What this PR does / why we need it**:

Golang allows implicit conversion between `map[string]interface{}` and `chartutil.Values`, but not when converted to `interface{}` first. The usage of `chartutil.Values` as values of a root `chartutil.Values` leads to various bugs, only avoided by the usage of `.AsMap` and some random checks. This was previously believed to be the consequence of `nil` values.

This PR finally gets rid of those random bugs by limitating the usage of `chartutil.Values` and preventing its conversion to `iterface{}`.

- All functions now return `map[string]interface{}`. Implicit conversion to `chartutil.Values` makes those changes quite transparent, and avoid accidentally turning `chartutil.Values` to `interface{}`.
- All creations of a `chartutil.Values{...}` have been replaced by a `map[string]interface{}{...}`.
- In general, `chartutil.Values` are only used in one of those 2 cases:
  - when `chartutil.Values` methods are used (often as argument of a function, implicitly converted on function call)
  - when `chartutil.Values` represents the root value for templates (as in `chart.Values` expressions)
- `chartutil.Values.AsMap` has been removed to discorage the usage of `chartutil.Values` (implicit conversion works anyway).
- Tries to convert `interface{}` to `chartutil.Values` have also been removed to avoid hiding bad usages of `chartutil.Values`.

Signed-off-by: Aurélien Lambert <aure@olli-ai.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:

We should wait for the next PRs to merge this one, I may include few additional changes in the future (but it should globally stay the same)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
