### PR TITLE
fix: do not merge and import values from disabled dependencies

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -150,7 +150,7 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		}
 
 		fmt.Fprintln(out, "COMPUTED VALUES:")
-		err = output.EncodeYAML(out, cfg.AsMap())
+		err = output.EncodeYAML(out, cfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -206,10 +206,6 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		i.cfg.Log("API Version list given outside of client only mode, this list will be ignored")
 	}
 
-	if err := chartutil.ProcessDependencies(chrt, vals); err != nil {
-		return nil, err
-	}
-
 	// Make sure if Atomic is set, that wait is set as well. This makes it so
 	// the user doesn't have to specify both
 	i.Wait = i.Wait || i.Atomic

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -60,6 +60,12 @@ func (p *Package) Run(path string, vals map[string]interface{}) (string, error) 
 		return "", err
 	}
 
+	combinedVals, err := chartutil.CoalesceRoot(ch, vals)
+	if err != nil {
+		return "", err
+	}
+	ch.Values = combinedVals
+
 	// If version is set, modify the version.
 	if p.Version != "" {
 		if err := setVersion(ch, p.Version); err != nil {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -198,10 +198,6 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	if err := chartutil.ProcessDependencies(chart, vals); err != nil {
-		return nil, nil, err
-	}
-
 	// Increment revision count. This is passed to templates, and also stored on
 	// the release object.
 	revision := lastRelease.Version + 1
@@ -445,7 +441,7 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release, newV
 		u.cfg.Log("reusing the old release's values")
 
 		// We have to regenerate the old coalesced values:
-		oldVals, err := chartutil.CoalesceValues(current.Chart, current.Config)
+		oldVals, err := chartutil.CoalesceRoot(current.Chart, current.Config)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to rebuild old values")
 		}

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -34,7 +34,7 @@ import (
 //	- Scalar values and arrays are replaced, maps are merged
 //	- A chart has access to all of the variables for it, as well as all of
 //		the values destined for its dependencies.
-func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (Values, error) {
+func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (map[string]interface{}, error) {
 	v, err := copystructure.Copy(vals)
 	if err != nil {
 		return vals, err

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -108,7 +108,7 @@ func TestCoalesceValues(t *testing.T) {
 	// taking a copy of the values before passing it
 	// to CoalesceValues as argument, so that we can
 	// use it for asserting later
-	valsCopy := make(Values, len(vals))
+	valsCopy := make(map[string]interface{}, len(vals))
 	for key, value := range vals {
 		valsCopy[key] = value
 	}

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -22,16 +22,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 )
 
-// ProcessDependencies checks through this chart's dependencies, processing accordingly.
-func ProcessDependencies(c *chart.Chart, v Values) error {
-	if err := processDependencyEnabled(c, v, ""); err != nil {
-		return err
-	}
-	return processDependencyImportValues(c)
-}
-
 // processDependencyConditions disables charts based on condition path value in values
-func processDependencyConditions(reqs []*chart.Dependency, cvals Values, cpath string) {
+func processDependencyConditions(reqs []*chart.Dependency, cvals Values) {
 	if reqs == nil {
 		return
 	}
@@ -39,7 +31,7 @@ func processDependencyConditions(reqs []*chart.Dependency, cvals Values, cpath s
 		for _, c := range strings.Split(strings.TrimSpace(r.Condition), ",") {
 			if len(c) > 0 {
 				// retrieve value
-				vv, err := cvals.PathValue(cpath + c)
+				vv, err := cvals.PathValue(c)
 				if err == nil {
 					// if not bool, warn
 					if bv, ok := vv.(bool); ok {
@@ -58,18 +50,14 @@ func processDependencyConditions(reqs []*chart.Dependency, cvals Values, cpath s
 }
 
 // processDependencyTags disables charts based on tags in values
-func processDependencyTags(reqs []*chart.Dependency, cvals Values) {
-	if reqs == nil {
-		return
-	}
-	vt, err := cvals.Table("tags")
-	if err != nil {
+func processDependencyTags(reqs []*chart.Dependency, tags map[string]interface{}) {
+	if reqs == nil || tags == nil {
 		return
 	}
 	for _, r := range reqs {
 		var hasTrue, hasFalse bool
 		for _, k := range r.Tags {
-			if b, ok := vt[k]; ok {
+			if b, ok := tags[k]; ok {
 				// if not bool, warn
 				if bv, ok := b.(bool); ok {
 					if bv {
@@ -88,6 +76,14 @@ func processDependencyTags(reqs []*chart.Dependency, cvals Values) {
 			r.Enabled = true
 		}
 	}
+}
+
+func GetTags(cvals Values) map[string]interface{} {
+	vt, err := cvals.Table("tags")
+	if err != nil {
+		return nil
+	}
+	return vt
 }
 
 func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Chart {
@@ -114,8 +110,8 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 	return nil
 }
 
-// processDependencyEnabled removes disabled charts from dependencies
-func processDependencyEnabled(c *chart.Chart, v map[string]interface{}, path string) error {
+// ProcessDependencyEnabled removes disabled charts from dependencies
+func ProcessDependencyEnabled(c *chart.Chart, v map[string]interface{}, tags map[string]interface{}) error {
 	if c.Metadata.Dependencies == nil {
 		return nil
 	}
@@ -150,13 +146,9 @@ Loop:
 	for _, lr := range c.Metadata.Dependencies {
 		lr.Enabled = true
 	}
-	cvals, err := CoalesceValues(c, v)
-	if err != nil {
-		return err
-	}
 	// flag dependencies as enabled/disabled
-	processDependencyTags(c.Metadata.Dependencies, cvals)
-	processDependencyConditions(c.Metadata.Dependencies, cvals, path)
+	processDependencyTags(c.Metadata.Dependencies, tags)
+	processDependencyConditions(c.Metadata.Dependencies, v)
 	// make a map of charts to remove
 	rm := map[string]struct{}{}
 	for _, r := range c.Metadata.Dependencies {
@@ -179,14 +171,6 @@ Loop:
 	for _, n := range c.Metadata.Dependencies {
 		if _, ok := rm[n.Name]; !ok {
 			cdMetadata = append(cdMetadata, n)
-		}
-	}
-
-	// recursively call self to process sub dependencies
-	for _, t := range cd {
-		subpath := path + t.Metadata.Name + "."
-		if err := processDependencyEnabled(t, cvals, subpath); err != nil {
-			return err
 		}
 	}
 	// set the correct dependencies in metadata
@@ -217,70 +201,47 @@ func set(path []string, data map[string]interface{}) map[string]interface{} {
 }
 
 // processImportValues merges values from child to parent based on the chart's dependencies' ImportValues field.
-func processImportValues(c *chart.Chart) error {
+func processImportValues(c *chart.Chart, cvals Values) error {
 	if c.Metadata.Dependencies == nil {
 		return nil
 	}
-	// combine chart values and empty config to get Values
-	var cvals Values
-	cvals, err := CoalesceValues(c, nil)
-	if err != nil {
-		return err
-	}
-	b := make(map[string]interface{})
+
 	// import values from each dependency if specified in import-values
 	for _, r := range c.Metadata.Dependencies {
-		var outiv []interface{}
 		for _, riv := range r.ImportValues {
+			var child, parent string
 			switch iv := riv.(type) {
 			case map[string]interface{}:
-				child := iv["child"].(string)
-				parent := iv["parent"].(string)
-
-				outiv = append(outiv, map[string]string{
-					"child":  child,
-					"parent": parent,
-				})
-
-				// get child table
-				vv, err := cvals.Table(r.Name + "." + child)
-				if err != nil {
-					log.Printf("Warning: ImportValues missing table from chart %s: %v", r.Name, err)
-					continue
-				}
-				// create value map from child to be merged into parent
-				b = CoalesceTables(cvals, pathToMap(parent, vv))
+				child = iv["child"].(string)
+				parent = iv["parent"].(string)
 			case string:
-				child := "exports." + iv
-				outiv = append(outiv, map[string]string{
-					"child":  child,
-					"parent": ".",
-				})
-				vm, err := cvals.Table(r.Name + "." + child)
-				if err != nil {
-					log.Printf("Warning: ImportValues missing table: %v", err)
-					continue
-				}
-				b = CoalesceTables(b, vm)
+				child = "exports." + iv
+				parent = "."
 			}
+			// get child table
+			vv, err := cvals.Table(r.Name + "." + child)
+			if err != nil {
+				log.Printf("Warning: ImportValues missing table %s from chart %s: %v", child, r.Name, err)
+				continue
+			}
+			// create value map from child to be merged into parent
+			CoalesceTables(cvals, pathToMap(parent, vv))
 		}
-		// set our formatted import values
-		r.ImportValues = outiv
 	}
-
-	// set the new values
-	c.Values = CoalesceTables(b, cvals)
 
 	return nil
 }
 
-// processDependencyImportValues imports specified chart values from child to parent.
-func processDependencyImportValues(c *chart.Chart) error {
+// ProcessDependencyImportValues imports specified chart values from child to parent.
+//
+// v is expected to have existing path for every sub chart
+func ProcessDependencyImportValues(c *chart.Chart, v map[string]interface{}) error {
 	for _, d := range c.Dependencies() {
 		// recurse
-		if err := processDependencyImportValues(d); err != nil {
+		dv := v[d.Name()].(map[string]interface{})
+		if err := ProcessDependencyImportValues(d, dv); err != nil {
 			return err
 		}
 	}
-	return processImportValues(c)
+	return processImportValues(c, v)
 }

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -222,6 +222,7 @@ func processImportValues(c *chart.Chart) error {
 		return nil
 	}
 	// combine chart values and empty config to get Values
+	var cvals Values
 	cvals, err := CoalesceValues(c, nil)
 	if err != nil {
 		return err
@@ -248,7 +249,7 @@ func processImportValues(c *chart.Chart) error {
 					continue
 				}
 				// create value map from child to be merged into parent
-				b = CoalesceTables(cvals, pathToMap(parent, vv.AsMap()))
+				b = CoalesceTables(cvals, pathToMap(parent, vv))
 			case string:
 				child := "exports." + iv
 				outiv = append(outiv, map[string]string{
@@ -260,7 +261,7 @@ func processImportValues(c *chart.Chart) error {
 					log.Printf("Warning: ImportValues missing table: %v", err)
 					continue
 				}
-				b = CoalesceTables(b, vm.AsMap())
+				b = CoalesceTables(b, vm)
 			}
 		}
 		// set our formatted import values

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -135,7 +135,7 @@ func TestToRenderValues(t *testing.T) {
 		t.Error("Expected Capabilities to have a Kube version")
 	}
 
-	vals := res["Values"].(Values)
+	vals := res["Values"].(map[string]interface{})
 	if vals["name"] != "Haroun" {
 		t.Errorf("Expected 'Haroun', got %q (%v)", vals["name"], vals)
 	}
@@ -171,6 +171,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		panic(err)
@@ -195,6 +196,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		t.Fatalf("Failed to parse the White Whale: %s", err)
@@ -265,6 +267,7 @@ chapter:
   three:
     title: "The Spouter Inn"
 `
+	var d Values
 	d, err := ReadValues([]byte(doc))
 	if err != nil {
 		t.Fatalf("Failed to parse the White Whale: %s", err)

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -141,9 +141,10 @@ func TestToRenderValues(t *testing.T) {
 	}
 	where := vals["where"].(map[string]interface{})
 	expects := map[string]string{
-		"city":  "Baghdad",
-		"date":  "809 CE",
-		"title": "caliph",
+		"city": "Baghdad",
+		"date": "809 CE",
+		// ToRenderValues no longer coallesce chart values
+		// "title": "caliph",
 	}
 	for field, expect := range expects {
 		if got := where[field]; got != expect {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -245,7 +245,7 @@ func (e Engine) renderWithReferences(tpls, referenceTpls map[string]renderable) 
 		}
 		// At render time, add information about the template that is being rendered.
 		vals := tpls[filename].vals
-		vals["Template"] = chartutil.Values{"Name": filename, "BasePath": tpls[filename].basePath}
+		vals["Template"] = map[string]interface{}{"Name": filename, "BasePath": tpls[filename].basePath}
 		var buf strings.Builder
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
 			return map[string]string{}, cleanupExecError(filename, err)
@@ -340,7 +340,7 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, vals chartutil.
 		"Files":        newFiles(c.Files),
 		"Release":      vals["Release"],
 		"Capabilities": vals["Capabilities"],
-		"Values":       make(chartutil.Values),
+		"Values":       map[string]interface{}{},
 	}
 
 	// If there is a {{.Values.ThisChart}} in the parent metadata,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -409,7 +409,7 @@ func TestRenderNestedValues(t *testing.T) {
 	inject := chartutil.Values{
 		"Values": tmp,
 		"Chart":  outer.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "dyin",
 		},
 	}
@@ -464,9 +464,9 @@ func TestRenderBuiltinValues(t *testing.T) {
 	outer.AddDependency(inner)
 
 	inject := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  outer.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "Aeneid",
 		},
 	}
@@ -510,9 +510,9 @@ func TestAlterFuncMap_include(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "Mistah Kurtz",
 		},
 	}
@@ -544,12 +544,12 @@ func TestAlterFuncMap_require(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"who":   "us",
 			"bases": 2,
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "That 90s meme",
 		},
 	}
@@ -571,11 +571,11 @@ func TestAlterFuncMap_require(t *testing.T) {
 	// test required without passing in needed values with lint mode on
 	// verifies lint replaces required with an empty string (should not fail)
 	lintValues := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"who": "us",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "That 90s meme",
 		},
 	}
@@ -605,11 +605,11 @@ func TestAlterFuncMap_tpl(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -634,11 +634,11 @@ func TestAlterFuncMap_tplfunc(t *testing.T) {
 	}
 
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -663,11 +663,11 @@ func TestAlterFuncMap_tplinclude(t *testing.T) {
 		},
 	}
 	v := chartutil.Values{
-		"Values": chartutil.Values{
+		"Values": map[string]interface{}{
 			"value": "myvalue",
 		},
 		"Chart": c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}
@@ -694,9 +694,9 @@ func TestRenderRecursionLimit(t *testing.T) {
 		},
 	}
 	v := chartutil.Values{
-		"Values": "",
+		"Values": map[string]interface{}{},
 		"Chart":  c.Metadata,
-		"Release": chartutil.Values{
+		"Release": map[string]interface{}{
 			"Name": "TestRelease",
 		},
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -18,11 +18,13 @@ package engine
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
@@ -153,7 +155,9 @@ func TestRenderRefsOrdering(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		out, err := Render(parentChart, chartutil.Values{})
+		out, err := Render(parentChart, chartutil.Values{
+			"Values": map[string]interface{}{},
+		})
 		if err != nil {
 			t.Fatalf("Failed to render templates: %s", err)
 		}
@@ -333,7 +337,9 @@ func TestRenderDependency(t *testing.T) {
 		},
 	})
 
-	out, err := Render(ch, map[string]interface{}{})
+	out, err := Render(ch, map[string]interface{}{
+		"Values": map[string]interface{}{},
+	})
 	if err != nil {
 		t.Fatalf("failed to render chart: %s", err)
 	}
@@ -737,4 +743,312 @@ func TestRenderRecursionLimit(t *testing.T) {
 		t.Errorf("Expected %q, got %q (%v)", expect, got, out)
 	}
 
+}
+
+func TestUpdateRenderValues_dependencies(t *testing.T) {
+	values := map[string]interface{}{}
+	rv := map[string]interface{}{
+		"Release": map[string]interface{}{
+			"Name": "Test Name",
+		},
+		"Values": values,
+	}
+	c := loadChart(t, "testdata/dependencies")
+
+	if err := new(Engine).updateRenderValues(c, rv); err != nil {
+		t.Fatal(err)
+	}
+	// check for conditions
+	if vm, ok := values["condition_true"]; !ok {
+		t.Errorf("chart 'condition_true' not evaluated")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["evaluated"]; !ok || !v.(bool) {
+			t.Errorf("chart 'condition_true' not evaluated")
+		}
+	}
+	if _, ok := values["condition_false"]; ok {
+		t.Errorf("chart 'condition_false' evaluated")
+	}
+	if vm, ok := values["condition_null"]; !ok {
+		t.Errorf("chart 'condition_null' not evaluated")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["evaluated"]; !ok || !v.(bool) {
+			t.Errorf("chart 'condition_null' not evaluated")
+		}
+	}
+	// check for tags
+	if vm, ok := values["tags_true"]; !ok {
+		t.Errorf("chart 'tags_true' not evaluated")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["evaluated"]; !ok || !v.(bool) {
+			t.Errorf("chart 'tags_true' not evaluated")
+		}
+	}
+	if _, ok := values["tags_false"]; ok {
+		t.Errorf("chart 'tags_false' evaluated")
+	}
+	// check for sub tags
+	if vm, ok := values["tags_sub"]; !ok {
+		t.Errorf("chart 'tags_sub' not evaluated")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["evaluated"]; !ok || !v.(bool) {
+			t.Errorf("chart 'tags_sub' not evaluated")
+		}
+		if vm, ok := m["tags_sub_true"]; !ok {
+			t.Errorf("chart 'tags_sub/tags_sub_true' not evaluated")
+		} else {
+			m := vm.(map[string]interface{})
+			if v, ok := m["evaluated"]; !ok || !v.(bool) {
+				t.Errorf("chart 'tags_sub/tags_sub_true' not evaluated")
+			}
+		}
+		if _, ok := m["tags_sub/tags_sub_false"]; ok {
+			t.Errorf("chart 'tags_sub/tags_sub_false' evaluated")
+		}
+	}
+	// check for import-values
+	if vm, ok := values["import_values"]; !ok {
+		t.Errorf("chart 'import_values' not evaluated")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["evaluated"]; !ok || !v.(bool) {
+			t.Errorf("chart 'import_values' not evaluated")
+		}
+	}
+	if vm, ok := values["importValues"]; !ok {
+		t.Errorf("value 'importValues' not imported")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["imported"]; !ok || !v.(bool) {
+			t.Errorf("value 'importValues.imported' not imported")
+		}
+	}
+	if vm, ok := values["subImport"]; !ok {
+		t.Errorf("value 'subImport' not imported")
+	} else {
+		m := vm.(map[string]interface{})
+		if v, ok := m["old"]; !ok {
+			t.Errorf("value 'subImport.old' not imported")
+		} else if vs, ok := v.(string); !ok || vs != "values.yaml" {
+			t.Errorf("wrong 'subImport.old' imported: %v", v)
+		}
+	}
+
+	names := extractChartNames(c)
+	except := []string{
+		"parentchart",
+		"parentchart.condition_null",
+		"parentchart.condition_true",
+		"parentchart.import_values",
+		"parentchart.tags_sub",
+		"parentchart.tags_sub.tags_sub_true",
+		"parentchart.tags_true",
+	}
+	if len(names) != len(except) {
+		t.Errorf("dependencies values do not match got %v, expected %v", names, except)
+	} else {
+		for i := range names {
+			if names[i] != except[i] {
+				t.Errorf("dependencies values do not match got %v, expected %v", names, except)
+				break
+			}
+		}
+	}
+}
+
+// copied from chartutil/values_test.go:TestToRenderValues
+// because ToRenderValues no longer coalesces chart values
+func TestUpdateRenderValues_ToRenderValues(t *testing.T) {
+
+	chartValues := map[string]interface{}{
+		"name": "al Rashid",
+		"where": map[string]interface{}{
+			"city":  "Basrah",
+			"title": "caliph",
+		},
+	}
+
+	overideValues := map[string]interface{}{
+		"name": "Haroun",
+		"where": map[string]interface{}{
+			"city":  "Baghdad",
+			"date":  "809 CE",
+			"title": "caliph",
+		},
+	}
+
+	c := &chart.Chart{
+		Metadata:  &chart.Metadata{Name: "test"},
+		Templates: []*chart.File{},
+		Values:    chartValues,
+		Files: []*chart.File{
+			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+		},
+	}
+	c.AddDependency(&chart.Chart{
+		Metadata: &chart.Metadata{Name: "where"},
+	})
+
+	o := chartutil.ReleaseOptions{
+		Name:      "Seven Voyages",
+		Namespace: "default",
+		Revision:  1,
+		IsInstall: true,
+	}
+
+	res, err := chartutil.ToRenderValues(c, overideValues, o, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = new(Engine).updateRenderValues(c, res); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the top-level values are all set.
+	if name := res["Chart"].(*chart.Metadata).Name; name != "test" {
+		t.Errorf("Expected chart name 'test', got %q", name)
+	}
+	relmap := res["Release"].(map[string]interface{})
+	if name := relmap["Name"]; name.(string) != "Seven Voyages" {
+		t.Errorf("Expected release name 'Seven Voyages', got %q", name)
+	}
+	if namespace := relmap["Namespace"]; namespace.(string) != "default" {
+		t.Errorf("Expected namespace 'default', got %q", namespace)
+	}
+	if revision := relmap["Revision"]; revision.(int) != 1 {
+		t.Errorf("Expected revision '1', got %d", revision)
+	}
+	if relmap["IsUpgrade"].(bool) {
+		t.Error("Expected upgrade to be false.")
+	}
+	if !relmap["IsInstall"].(bool) {
+		t.Errorf("Expected install to be true.")
+	}
+	if !res["Capabilities"].(*chartutil.Capabilities).APIVersions.Has("v1") {
+		t.Error("Expected Capabilities to have v1 as an API")
+	}
+	if res["Capabilities"].(*chartutil.Capabilities).KubeVersion.Major != "1" {
+		t.Error("Expected Capabilities to have a Kube version")
+	}
+
+	vals := res["Values"].(map[string]interface{})
+	if vals["name"] != "Haroun" {
+		t.Errorf("Expected 'Haroun', got %q (%v)", vals["name"], vals)
+	}
+	where := vals["where"].(map[string]interface{})
+	expects := map[string]string{
+		"city":  "Baghdad",
+		"date":  "809 CE",
+		"title": "caliph",
+	}
+	for field, expect := range expects {
+		if got := where[field]; got != expect {
+			t.Errorf("Expected %q, got %q (%v)", expect, got, where)
+		}
+	}
+}
+
+// copied from chartutil/dependencies_test.go:TestDependencyEnabled
+// because ProcessDependencyEnabled is no longer recursive
+func TestUpdateRenderValues_TestDependencyEnabled(t *testing.T) {
+	type M = map[string]interface{}
+	tests := []struct {
+		name string
+		v    M
+		e    []string // expected charts including duplicates in alphanumeric order
+	}{{
+		"tags with no effect",
+		M{"tags": M{"nothinguseful": false}},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb"},
+	}, {
+		"tags disabling a group",
+		M{"tags": M{"front-end": false}},
+		[]string{"parentchart"},
+	}, {
+		"tags disabling a group and enabling a different group",
+		M{"tags": M{"front-end": false, "back-end": true}},
+		[]string{"parentchart", "parentchart.subchart2", "parentchart.subchart2.subchartb", "parentchart.subchart2.subchartc"},
+	}, {
+		"tags disabling only children, children still enabled since tag front-end=true in values.yaml",
+		M{"tags": M{"subcharta": false, "subchartb": false}},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb"},
+	}, {
+		"tags disabling all parents/children with additional tag re-enabling a parent",
+		M{"tags": M{"front-end": false, "subchart1": true, "back-end": false}},
+		[]string{"parentchart", "parentchart.subchart1"},
+	}, {
+		"conditions enabling the parent charts, but back-end (b, c) is still disabled via values.yaml",
+		M{"subchart1": M{"enabled": true}, "subchart2": M{"enabled": true}},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb", "parentchart.subchart2"},
+	}, {
+		"conditions disabling the parent charts, effectively disabling children",
+		M{"subchart1": M{"enabled": false}, "subchart2": M{"enabled": false}},
+		[]string{"parentchart"},
+	}, {
+		"conditions a child using the second condition path of child's condition",
+		M{"subchart1": M{"subcharta": M{"enabled": false}}},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subchartb"},
+	}, {
+		"tags enabling a parent/child group with condition disabling one child",
+		M{"subchart2": M{"subchartc": M{"enabled": false}}, "tags": M{"back-end": true}},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb", "parentchart.subchart2", "parentchart.subchart2.subchartb"},
+	}, {
+		"tags will not enable a child if parent is explicitly disabled with condition",
+		M{"subchart1": M{"enabled": false}, "tags": M{"front-end": true}},
+		[]string{"parentchart"},
+	}, {
+		"subcharts with alias also respect conditions",
+		M{"subchart1": M{"enabled": false}, "subchart2alias": M{"enabled": true, "subchartb": M{"enabled": true}}},
+		[]string{"parentchart", "parentchart.subchart2alias", "parentchart.subchart2alias.subchartb"},
+	}}
+
+	for _, tc := range tests {
+		c := loadChart(t, "../chartutil/testdata/subpop")
+		vals := map[string]interface{}{"Values": tc.v}
+		t.Run(tc.name, func(t *testing.T) {
+			if err := new(Engine).updateRenderValues(c, vals); err != nil {
+				t.Fatalf("error processing enabled dependencies %v", err)
+			}
+
+			names := extractChartNames(c)
+			if len(names) != len(tc.e) {
+				t.Fatalf("slice lengths do not match got %v, expected %v", len(names), len(tc.e))
+			}
+			for i := range names {
+				if names[i] != tc.e[i] {
+					t.Fatalf("slice values do not match got %v, expected %v", names, tc.e)
+				}
+			}
+		})
+	}
+}
+
+// copied from chartutil/dependencies_test.go:loadChart
+func loadChart(t *testing.T, path string) *chart.Chart {
+	t.Helper()
+	c, err := loader.Load(path)
+	if err != nil {
+		t.Fatalf("failed to load testdata: %s", err)
+	}
+	return c
+}
+
+// copied from chartutil/dependencies_test.go:extractChartNames
+// extractCharts recursively searches chart dependencies returning all charts found
+func extractChartNames(c *chart.Chart) []string {
+	var out []string
+	var fn func(c *chart.Chart)
+	fn = func(c *chart.Chart) {
+		out = append(out, c.ChartPath())
+		for _, d := range c.Dependencies() {
+			fn(d)
+		}
+	}
+	fn(c)
+	sort.Strings(out)
+	return out
 }

--- a/pkg/engine/testdata/dependencies/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: parentchart
+version: 0.1.0
+dependencies:
+- name: condition_true
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: condition.true
+- name: condition_false
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: condition.false
+- name: condition_null
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: condition.null
+- name: tags_true
+  repository: http://localhost:10191
+  version: 0.1.0
+  tags:
+  - true_tag
+- name: tags_false
+  repository: http://localhost:10191
+  version: 0.1.0
+  tags:
+  - false_tag
+- name: import_values
+  repository: http://localhost:10191
+  version: 0.1.0
+  import-values:
+  - child: importValues
+    parent: importValues
+  - child: importTemplate
+    parent: importTemplate
+  - child: import
+    parent: subImport

--- a/pkg/engine/testdata/dependencies/charts/condition_false/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_false/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: condition_false
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/condition_false/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_false/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/condition_null/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_null/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: condition_null
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/condition_null/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_null/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/condition_true/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_true/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: condition_true
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/condition_true/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/condition_true/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/import_values/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/import_values/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: import_values
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/import_values/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/import_values/values.yaml
@@ -1,0 +1,6 @@
+evaluated: true
+import:
+  old: "values.yaml"
+  common: "values.yaml"
+importValues:
+  imported: true

--- a/pkg/engine/testdata/dependencies/charts/tags_false/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_false/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: tags_false
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/tags_false/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_false/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: tags_sub
+version: 0.1.0
+dependencies:
+- name: tags_sub_true
+  repository: http://localhost:10191
+  version: 0.1.0
+  tags:
+  - true_tag
+- name: tags_sub_false
+  repository: http://localhost:10191
+  version: 0.1.0
+  tags:
+  - false_tag

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_false/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_false/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: tags_sub_false
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_false/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_false/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_true/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_true/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: tags_sub_true
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_true/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/charts/tags_sub_true/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/tags_sub/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_sub/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/charts/tags_true/Chart.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_true/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: tags_true
+version: 0.1.0

--- a/pkg/engine/testdata/dependencies/charts/tags_true/values.yaml
+++ b/pkg/engine/testdata/dependencies/charts/tags_true/values.yaml
@@ -1,0 +1,1 @@
+evaluated: true

--- a/pkg/engine/testdata/dependencies/values.yaml
+++ b/pkg/engine/testdata/dependencies/values.yaml
@@ -1,0 +1,7 @@
+condition:
+  "true": true
+  "false": false
+  "null": null
+tags:
+  true_tag: true
+  false_tag: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

This is the 2nd PR splitted from #6876, and should be merged after #8677

**What this PR does / why we need it**:

Prior to this PR, values from disabled dependencies would still be merged and imported to the parent values. This didn't have much consequences, but is incompatible with an implemention of values templating.

This PR makes the following changes:
- `pkg/chartutil/coalesce.go` and `pkg/chartutil/dependencies.go` are no longer recursive, recursivity is handled by `pkg/engine/engine.go`
- `chartutils.ToRenderValues` does not merge chart values anymore, this is done by `pkg/engine/engine.go`
- `pkg/engine/engine.go` now uses a recursive `Engine.updateRenderValues` function that:
        - parses and merge `values.yaml`
        - validates the values along the schema
        - evaluates if sub-charts are enabled
        - recursively treat the enabled subcharts
        - import the values of the enabled subcharts
- some `pkg/actions` have been addapted to the new way of merging values

Signed-off-by: Aurélien Lambert <aure@olli-ai.com>

**Special notes for your reviewer**:

We should wait for the next PRs to merge this one, I may include few additional changes in the future (but it should globally stay the same)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
