### PR TITLE
Remove duplicate variable definition

### DIFF
--- a/pkg/action/resource_policy.go
+++ b/pkg/action/resource_policy.go
@@ -19,17 +19,9 @@ package action
 import (
 	"strings"
 
+	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/releaseutil"
 )
-
-// resourcePolicyAnno is the annotation name for a resource policy
-const resourcePolicyAnno = "helm.sh/resource-policy"
-
-// keepPolicy is the resource policy type for keep
-//
-// This resource policy type allows resources to skip being deleted
-//   during an uninstallRelease action.
-const keepPolicy = "keep"
 
 func filterManifestsToKeep(manifests []releaseutil.Manifest) (keep, remaining []releaseutil.Manifest) {
 	for _, m := range manifests {
@@ -38,14 +30,14 @@ func filterManifestsToKeep(manifests []releaseutil.Manifest) (keep, remaining []
 			continue
 		}
 
-		resourcePolicyType, ok := m.Head.Metadata.Annotations[resourcePolicyAnno]
+		resourcePolicyType, ok := m.Head.Metadata.Annotations[kube.ResourcePolicyAnno]
 		if !ok {
 			remaining = append(remaining, m)
 			continue
 		}
 
 		resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
-		if resourcePolicyType == keepPolicy {
+		if resourcePolicyType == kube.KeepPolicy {
 			keep = append(keep, m)
 		}
 


### PR DESCRIPTION
Variable values `helm.sh/resource-policy` and `keep` are duplicately
defined in resource_policy.go (`resourcePolicyAnno` `keepPolicy`) and
resource_policy.go (`ResourcePolicyAnno` `KeepPolicy`), remove the
varibales in resource_policy.go to keep the code clean.

Signed-off-by: Liu Ming <hit_oak_tree@126.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
