### PR TITLE
helm-8700-package: removing the unused paramter 

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 )
@@ -50,7 +49,6 @@ unless your environment is otherwise configured.
 
 func newPackageCmd(out io.Writer) *cobra.Command {
 	client := action.NewPackage()
-	valueOpts := &values.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "package [CHART_PATH] [...]",
@@ -71,10 +69,6 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 			client.RepositoryConfig = settings.RepositoryConfig
 			client.RepositoryCache = settings.RepositoryCache
 			p := getter.All(settings)
-			vals, err := valueOpts.MergeValues(p)
-			if err != nil {
-				return err
-			}
 
 			for i := 0; i < len(args); i++ {
 				path, err := filepath.Abs(args[i])
@@ -100,7 +94,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 						return err
 					}
 				}
-				p, err := client.Run(path, vals)
+				p, err := client.Run(path)
 				if err != nil {
 					return err
 				}

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -54,7 +54,7 @@ func NewPackage() *Package {
 }
 
 // Run executes 'helm package' against the given chart and returns the path to the packaged chart.
-func (p *Package) Run(path string, vals map[string]interface{}) (string, error) {
+func (p *Package) Run(path string) (string, error) {
 	ch, err := loader.LoadDir(path)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR removes the formal parameter `val[string]interface{}` of the run method of the package command because it is unused
closes #8700 
