### PR TITLE
Fixing typo in engine comments

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -40,7 +40,7 @@ type Engine struct {
 	Strict bool
 	// In LintMode, some 'required' template values may be missing, so don't fail
 	LintMode bool
-	// the rest config to connect to te kubernetes api
+	// the rest config to connect to the kubernetes api
 	config *rest.Config
 }
 


### PR DESCRIPTION
Signed-off-by: Paul Brousseau <object88@gmail.com>

**What this PR does / why we need it**:

Fixes a typo in the `engine.Engine` struct

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
