### PR TITLE
fix(comp): Disable file comp for output formats

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -69,7 +69,7 @@ func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {
 				formatNames = append(formatNames, format)
 			}
 		}
-		return formatNames, cobra.ShellCompDirectiveDefault
+		return formatNames, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	if err != nil {

--- a/cmd/helm/testdata/output/output-comp.txt
+++ b/cmd/helm/testdata/output/output-comp.txt
@@ -1,5 +1,5 @@
 table
 json
 yaml
-:0
-Completion ended with directive: ShellCompDirectiveDefault
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
**What this PR does / why we need it**:

It does not make sense to suggest files to the user as output formats.
This PR fixed that.

Currently:
```
bash-5.0$ bin/helm status --output <TAB>
json   table  yaml
bash-5.0$ bin/helm status --output go.<TAB>
go.mod  go.sum
```
Notice that the `go.*` files are mistakenly suggested when the real completions don't match.
With this PR:
```
bash-5.0$ bin/helm status --output <TAB>
json   table  yaml
bash-5.0$ bin/helm status --output go.<TAB>
# No suggestions
```

Unit test has been corrected.