### PR TITLE
improved user-facing error messages to explain the underlying problem

### DIFF
--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -143,6 +143,10 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		}
 	}
 
+	if c.Metadata == nil {
+		return c, errors.New("Chart.yaml file is missing")
+	}
+
 	if err := c.Validate(); err != nil {
 		return c, err
 	}

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -275,7 +275,7 @@ icon: https://example.com/64x64.png
 	if _, err = LoadFiles([]*BufferedFile{}); err == nil {
 		t.Fatal("Expected err to be non-nil")
 	}
-	if err.Error() != "validation: chart.metadata is required" {
+	if err.Error() != "Chart.yaml file is missing" {
 		t.Errorf("Expected chart metadata missing error, got '%s'", err.Error())
 	}
 }
@@ -349,7 +349,7 @@ func TestLoadInvalidArchive(t *testing.T) {
 		{"illegal-name.tgz", "./.", "chart illegally contains content outside the base directory"},
 		{"illegal-name2.tgz", "/./.", "chart illegally contains content outside the base directory"},
 		{"illegal-name3.tgz", "missing-leading-slash", "chart illegally contains content outside the base directory"},
-		{"illegal-name4.tgz", "/missing-leading-slash", "validation: chart.metadata is required"},
+		{"illegal-name4.tgz", "/missing-leading-slash", "Chart.yaml file is missing"},
 		{"illegal-abspath.tgz", "//foo", "chart illegally contains absolute paths"},
 		{"illegal-abspath2.tgz", "///foo", "chart illegally contains absolute paths"},
 		{"illegal-abspath3.tgz", "\\\\foo", "chart illegally contains absolute paths"},
@@ -383,8 +383,8 @@ func TestLoadInvalidArchive(t *testing.T) {
 	illegalChart = filepath.Join(tmpdir, "abs-path2.tgz")
 	writeTar(illegalChart, "files/whatever.yaml", []byte("hello: world"))
 	_, err = Load(illegalChart)
-	if err.Error() != "validation: chart.metadata is required" {
-		t.Error(err)
+	if err.Error() != "Chart.yaml file is missing" {
+		t.Errorf("Unexpected error message: %s", err)
 	}
 
 	// Finally, test that drive letter gets stripped off on Windows


### PR DESCRIPTION
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The issue #7747 is a little bit meandering, but at root, the solution is to fix our error messages to be clearer on why a chart load failed. This replaces a terse error message with one that is more easily understood.

I added some tests, and also modified some existing tests.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
