### PR TITLE
fix incorrect wildcard expand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ fetch-dist:
 
 .PHONY: sign
 sign:
-	for f in _dist/*.{gz,zip,sha256,sha256sum} ; do \
+	for f in $$(ls _dist/*.{gz,zip,sha256,sha256sum} 2>/dev/null) ; do \
 		gpg --armor --detach-sign $${f} ; \
 	done
 
@@ -178,7 +178,7 @@ sign:
 # removed in Helm v4.
 .PHONY: checksum
 checksum:
-	for f in _dist/*.{gz,zip} ; do \
+	for f in $$(ls _dist/*.{gz,zip} 2>/dev/null) ; do \
 		shasum -a 256 "$${f}" | sed 's/_dist\///' > "$${f}.sha256sum" ; \
 		shasum -a 256 "$${f}" | awk '{print $$1}' > "$${f}.sha256" ; \
 	done


### PR DESCRIPTION
Previously, when there is no *.{gz,zip} files under _dist, the wildcard
will be expanded to 2 strings '_dist/*.gz' and '_dist/*.zip'(see below).
helm$ make checksum
for f in _dist/*.{gz,zip} ; do \
	shasum -a 256 "${f}" | sed 's/_dist\///' > "${f}.sha256sum" ; \
	shasum -a 256 "${f}" | awk '{print $1}' > "${f}.sha256" ; \
done
shasum: _dist/*.gz:
shasum: _dist/*.gz:
shasum: _dist/*.zip:
shasum: _dist/*.zip:

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
