### PR TITLE
engine: make template function map public

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -105,7 +105,7 @@ func warnWrap(warn string) string {
 
 // initFunMap creates the Engine's FuncMap and adds context-specific functions.
 func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]renderable) {
-	funcMap := funcMap()
+	funcMap := FuncMap()
 	includedNames := make(map[string]int)
 
 	// Add the 'include' function here so we can close over t.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -61,7 +61,7 @@ func TestSortTemplates(t *testing.T) {
 }
 
 func TestFuncMap(t *testing.T) {
-	fns := funcMap()
+	fns := FuncMap()
 	forbidden := []string{"env", "expandenv"}
 	for _, f := range forbidden {
 		if _, ok := fns[f]; ok {

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// funcMap returns a mapping of all of the functions that Engine has.
+// FuncMap returns a mapping of all of the functions that Engine has.
 //
 // Because some functions are late-bound (e.g. contain context-sensitive
 // data), the functions may not all perform identically outside of an Engine
@@ -41,7 +41,7 @@ import (
 // These are late-bound in Engine.Render().  The
 // version included in the FuncMap is a placeholder.
 //
-func funcMap() template.FuncMap {
+func FuncMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")
 	delete(f, "expandenv")

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -103,7 +103,7 @@ func TestFuncs(t *testing.T) {
 
 	for _, tt := range tests {
 		var b strings.Builder
-		err := template.Must(template.New("test").Funcs(funcMap()).Parse(tt.tpl)).Execute(&b, tt.vars)
+		err := template.Must(template.New("test").Funcs(FuncMap()).Parse(tt.tpl)).Execute(&b, tt.vars)
 		assert.NoError(t, err)
 		assert.Equal(t, tt.expect, b.String(), tt.tpl)
 	}
@@ -155,7 +155,7 @@ func TestMerge(t *testing.T) {
 	}
 	tpl := `{{merge .dst .src1 .src2}}`
 	var b strings.Builder
-	err := template.Must(template.New("test").Funcs(funcMap()).Parse(tpl)).Execute(&b, dict)
+	err := template.Must(template.New("test").Funcs(FuncMap()).Parse(tpl)).Execute(&b, dict)
 	assert.NoError(t, err)
 
 	expected := map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Benjamin Ash <bash@intelerad.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: We have some template rendering needs that are satisfied by the template funcMap from pkg/engine.go.  Currently engine.funcMap() is private so we cannot use it in our code. This PR makes the function public.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
