### PR TITLE
include labels in History action

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -145,6 +145,9 @@ func (cfgmaps *ConfigMaps) Query(labels map[string]string) ([]*rspb.Release, err
 			cfgmaps.Log("query: failed to decode release: %s", err)
 			continue
 		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
 		results = append(results, rls)
 	}
 	return results, nil

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -147,6 +147,11 @@ func TestConfigMapQuery(t *testing.T) {
 	if len(rls) != 2 {
 		t.Errorf("Expected 2 results, got %d", len(rls))
 	}
+	for _, rls := range rls {
+		if rls.Labels["status"] != "deployed" {
+			t.Errorf("Expected status label on release")
+		}
+	}
 
 	_, err = cfgmaps.Query(map[string]string{"name": "notExist"})
 	if err != ErrReleaseNotFound {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -136,6 +136,9 @@ func (secrets *Secrets) Query(labels map[string]string) ([]*rspb.Release, error)
 			secrets.Log("query: failed to decode release: %s", err)
 			continue
 		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
 		results = append(results, rls)
 	}
 	return results, nil

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -147,6 +147,11 @@ func TestSecretQuery(t *testing.T) {
 	if len(rls) != 2 {
 		t.Fatalf("Expected 2 results, actual %d", len(rls))
 	}
+	for _, rls := range rls {
+		if rls.Labels["status"] != "deployed" {
+			t.Errorf("Expected status label on release")
+		}
+	}
 
 	_, err = secrets.Query(map[string]string{"name": "notExist"})
 	if err != ErrReleaseNotFound {


### PR DESCRIPTION
**What this PR does / why we need it**:

We are creating a Helm plugin which is making use of the new label feature introduced in this [change](https://github.com/helm/helm/commit/273d0364be30e3bbaa73041dceea2a338f666abe#diff-a4bb7547df65a394a7f784976d2d7bebR101) but have found that the labels aren't populated in the Releases returned from the History action.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
