### PR TITLE
Tweak LDFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,24 +33,23 @@ GIT_DIRTY  = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo 
 
 ifdef VERSION
 	BINARY_VERSION = $(VERSION)
+else
+	BINARY_VERSION = $(GIT_TAG)
 endif
-BINARY_VERSION ?= ${GIT_TAG}
 
 # Only set Version if building a tag or VERSION is set
 ifneq ($(BINARY_VERSION),)
-	LDFLAGS += -X helm.sh/helm/v3/internal/version.version=${BINARY_VERSION}
+	VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.version=$(BINARY_VERSION)
 endif
 
-VERSION_METADATA = unreleased
-# Clear the "unreleased" string in BuildMetadata
-ifneq ($(GIT_TAG),)
-	VERSION_METADATA =
+# Set the "unreleased" string in BuildMetadata
+ifeq ($(GIT_TAG),)
+	VERSION_METADATA = unreleased
 endif
 
-LDFLAGS += -X helm.sh/helm/v3/internal/version.metadata=${VERSION_METADATA}
-LDFLAGS += -X helm.sh/helm/v3/internal/version.gitCommit=${GIT_COMMIT}
-LDFLAGS += -X helm.sh/helm/v3/internal/version.gitTreeState=${GIT_DIRTY}
-LDFLAGS += $(EXT_LDFLAGS)
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.metadata=${VERSION_METADATA}
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitCommit=${GIT_COMMIT}
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitTreeState=${GIT_DIRTY}
 
 .PHONY: all
 all: build
@@ -62,7 +61,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
+	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS) $(VERSION_LDFLAGS) $(EXT_LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
 
 # ------------------------------------------------------------------------------
 #  install

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ ifeq ($(GIT_TAG),)
 	VERSION_METADATA = unreleased
 endif
 
-VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.metadata=${VERSION_METADATA}
-VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitCommit=${GIT_COMMIT}
-VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitTreeState=${GIT_DIRTY}
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.metadata=$(VERSION_METADATA)
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitCommit=$(GIT_COMMIT)
+VERSION_LDFLAGS += -X helm.sh/helm/v3/internal/version.gitTreeState=$(GIT_DIRTY)
 
 .PHONY: all
 all: build
@@ -103,8 +103,8 @@ test-style:
 .PHONY: test-acceptance
 test-acceptance: TARGETS = linux/amd64
 test-acceptance: build build-cross
-	@if [ -d "${ACCEPTANCE_DIR}" ]; then \
-		cd ${ACCEPTANCE_DIR} && \
+	@if [ -d "$(ACCEPTANCE_DIR)" ]; then \
+		cd $(ACCEPTANCE_DIR) && \
 			ROBOT_RUN_TESTS=$(ACCEPTANCE_RUN_TESTS) ROBOT_HELM_PATH='$(BINDIR)' make acceptance; \
 	else \
 		echo "You must clone the acceptance_testing repo under $(ACCEPTANCE_DIR)"; \
@@ -142,7 +142,7 @@ $(GOIMPORTS):
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GOX)
-	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS) $(VERSION_LDFLAGS) $(EXT_LDFLAGS)' ./cmd/helm
 
 .PHONY: dist
 dist:
@@ -150,16 +150,16 @@ dist:
 		cd _dist && \
 		$(DIST_DIRS) cp ../LICENSE {} \; && \
 		$(DIST_DIRS) cp ../README.md {} \; && \
-		$(DIST_DIRS) tar -zcf helm-${VERSION}-{}.tar.gz {} \; && \
-		$(DIST_DIRS) zip -r helm-${VERSION}-{}.zip {} \; \
+		$(DIST_DIRS) tar -zcf helm-$(VERSION)-{}.tar.gz {} \; && \
+		$(DIST_DIRS) zip -r helm-$(VERSION)-{}.zip {} \; \
 	)
 
 .PHONY: fetch-dist
 fetch-dist:
 	mkdir -p _dist
 	cd _dist && \
-	for obj in ${TARGET_OBJS} ; do \
-		curl -sSL -o helm-${VERSION}-$${obj} https://get.helm.sh/helm-${VERSION}-$${obj} ; \
+	for obj in $(TARGET_OBJS) ; do \
+		curl -sSL -o helm-$(VERSION)-$${obj} https://get.helm.sh/helm-$(VERSION)-$${obj} ; \
 	done
 
 .PHONY: sign
@@ -194,18 +194,18 @@ release-notes:
 			echo "please run 'make fetch-dist' first" && \
 			exit 1; \
 		fi
-		@if [ -z "${PREVIOUS_RELEASE}" ]; then \
+		@if [ -z "$(PREVIOUS_RELEASE)" ]; then \
 			echo "please set PREVIOUS_RELEASE environment variable" \
 			&& exit 1; \
 		fi
 
-		@./scripts/release-notes.sh ${PREVIOUS_RELEASE} ${VERSION}
+		@./scripts/release-notes.sh $(PREVIOUS_RELEASE) $(VERSION)
 
 
 
 .PHONY: info
 info:
-	 @echo "Version:           ${VERSION}"
-	 @echo "Git Tag:           ${GIT_TAG}"
-	 @echo "Git Commit:        ${GIT_COMMIT}"
-	 @echo "Git Tree State:    ${GIT_DIRTY}"
+	 @echo "Version:           $(VERSION)"
+	 @echo "Git Tag:           $(GIT_TAG)"
+	 @echo "Git Commit:        $(GIT_COMMIT)"
+	 @echo "Git Tree State:    $(GIT_DIRTY)"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR tweaks the use of LDFLAGS in the Makefile to allow overriding LDFLAGS at the time of running `make`, while still retaining the necessary version linker flags. This was a problem in helm package in Archlinux, which overrides linker flags with:

```
make LDFLAGS="-s -w -linkmode external" GOFLAGS="-buildmode=pie -trimpath"
```

Due to the nature of make variables, this meant that the necessary version linker flags do not include the version linker flags, leading to `helm version` being incorrect:

```
$ helm version
version.BuildInfo{Version:"v3.3", GitCommit:"", GitTreeState:"", GoVersion:"go1.15.2"}
```

After these changes, the helm binary is correctly built and reports version correctly:

```
$ helm version
version.BuildInfo{Version:"v3.3.1", GitCommit:"249e5215cde0c3fa72e27eb7a30e8d55c9696144", GitTreeState:"clean", GoVersion:"go1.15.2"}
```


This PR also consistently uses parentheses for make variables (parentheses and braces are interchangeable in a Makefile so this is just for tidiness, not functionality).

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
