### PR TITLE
fix: check mode bits on kubeconfig file

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -204,5 +204,8 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	// Find and add plugins
 	loadPlugins(cmd, out)
 
+	// Check permissions on critical files
+	checkPerms(out)
+
 	return cmd, nil
 }

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+func checkPerms(out io.Writer) {
+	// This function MUST NOT FAIL, as it is just a check for a common permissions problem.
+	// If for some reason the function hits a stopping condition, it may panic. But only if
+	// we can be sure that it is panicing because Helm cannot proceed.
+
+	kc := settings.KubeConfig
+	if kc == "" {
+		kc = os.Getenv("KUBECONFIG")
+	}
+	if kc == "" {
+		u, err := user.Current()
+		if err != nil {
+			// No idea where to find KubeConfig, so return silently. Many helm commands
+			// can proceed happily without a KUBECONFIG, so this is not a fatal error.
+			return
+		}
+		kc = filepath.Join(u.HomeDir, ".kube", "config")
+	}
+	fi, err := os.Stat(kc)
+	if err != nil {
+		// DO NOT error if no KubeConfig is found. Not all commands require one.
+		return
+	}
+
+	perm := fi.Mode().Perm()
+	if perm&0040 > 0 {
+		fmt.Fprintf(out, "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: %s\n", kc)
+	}
+	if perm&0004 > 0 {
+		fmt.Fprintf(out, "WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: %s\n", kc)
+	}
+}

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckPerms(t *testing.T) {
+	tdir, err := ioutil.TempDir("", "helmtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tdir)
+	tfile := filepath.Join(tdir, "testconfig")
+	fh, err := os.OpenFile(tfile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0440)
+	if err != nil {
+		t.Errorf("Failed to create temp file: %s", err)
+	}
+
+	tconfig := settings.KubeConfig
+	settings.KubeConfig = tfile
+	defer func() { settings.KubeConfig = tconfig }()
+
+	var b bytes.Buffer
+	checkPerms(&b)
+	expectPrefix := "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location:"
+	if !strings.HasPrefix(b.String(), expectPrefix) {
+		t.Errorf("Expected to get a warning for group perms. Got %q", b.String())
+	}
+
+	if err := fh.Chmod(0404); err != nil {
+		t.Errorf("Could not change mode on file: %s", err)
+	}
+	b.Reset()
+	checkPerms(&b)
+	expectPrefix = "WARNING: Kubernetes configuration file is world-readable. This is insecure. Location:"
+	if !strings.HasPrefix(b.String(), expectPrefix) {
+		t.Errorf("Expected to get a warning for world perms. Got %q", b.String())
+	}
+
+}

--- a/cmd/helm/root_windows.go
+++ b/cmd/helm/root_windows.go
@@ -1,0 +1,24 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "io"
+
+func checkPerms(out io.Writer) {
+	// Not yet implemented on Windows. If you know how to do a comprehensive perms
+	// check on Windows, contributions welcomed!
+}


### PR DESCRIPTION
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This checks the file mode bits on kubeconfig

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
