### PR TITLE
fix: use yaml annotations for yaml.v2 validation

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -34,10 +34,10 @@ const pluginFileName = "plugin.yaml"
 // charts from special sources
 type Downloaders struct {
 	// Protocols are the list of schemes from the charts URL.
-	Protocols []string `json:"protocols"`
+	Protocols []string `json:"protocols" yaml:"protocols"`
 	// Command is the executable path with which the plugin performs
 	// the actual download for the corresponding Protocols
-	Command string `json:"command"`
+	Command string `json:"command" yaml:"command"`
 }
 
 // Metadata describes a plugin.
@@ -45,16 +45,16 @@ type Downloaders struct {
 // This is the plugin equivalent of a chart.Metadata.
 type Metadata struct {
 	// Name is the name of the plugin
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Version is a SemVer 2 version of the plugin.
-	Version string `json:"version"`
+	Version string `json:"version" yaml:"version"`
 
 	// Usage is the single-line usage text shown in help
-	Usage string `json:"usage"`
+	Usage string `json:"usage" yaml:"usage"`
 
 	// Description is a long description shown in places like `helm help`
-	Description string `json:"description"`
+	Description string `json:"description" yaml:"description"`
 
 	// Command is the command, as a single string.
 	//
@@ -64,26 +64,26 @@ type Metadata struct {
 	//
 	// Note that command is not executed in a shell. To do so, we suggest
 	// pointing the command to a shell script.
-	Command string `json:"command"`
+	Command string `json:"command" yaml:"command"`
 
 	// IgnoreFlags ignores any flags passed in from Helm
 	//
 	// For example, if the plugin is invoked as `helm --debug myplugin`, if this
 	// is false, `--debug` will be appended to `--command`. If this is true,
 	// the `--debug` flag will be discarded.
-	IgnoreFlags bool `json:"ignoreFlags"`
+	IgnoreFlags bool `json:"ignoreFlags" yaml:"ignoreFlags,omitempty"`
 
 	// UseTunnel indicates that this command needs a tunnel.
 	// Setting this will cause a number of side effects, such as the
 	// automatic setting of HELM_HOST.
-	UseTunnel bool `json:"useTunnel"`
+	UseTunnel bool `json:"useTunnel" yaml:"useTunnel,omitempty"`
 
 	// Hooks are commands that will run on events.
 	Hooks Hooks
 
 	// Downloaders field is used if the plugin supply downloader mechanism
 	// for special protocols.
-	Downloaders []Downloaders `json:"downloaders"`
+	Downloaders []Downloaders `json:"downloaders" yaml:"downloaders"`
 }
 
 // Plugin represents a plugin.


### PR DESCRIPTION
fixes an issue in dev-v2 where the yaml.v2 validation fix requires yaml type annotations to marshal/unmarshal yaml files.