### PR TITLE
fix(repo): Backport from Helm 3 to allow serverInfo field on index files

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -86,6 +86,9 @@ type IndexFile struct {
 
 // IndexValidation is used to validate the integrity of an index file
 type IndexValidation struct {
+	// This is used ONLY for validation against chartmuseum's index files and
+	// is discarded after validation.
+	ServerInfo map[string]interface{} `yaml:"serverInfo,omitempty"`
 	APIVersion string                 `yaml:"apiVersion"`
 	Generated  time.Time              `yaml:"generated"`
 	Entries    map[string]interface{} `yaml:"entries"`

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -30,9 +30,31 @@ import (
 )
 
 const (
-	testfile          = "testdata/local-index.yaml"
-	unorderedTestfile = "testdata/local-index-unordered.yaml"
-	testRepo          = "test-repo"
+	testfile            = "testdata/local-index.yaml"
+	chartmuseumtestfile = "testdata/chartmuseum-index.yaml"
+	unorderedTestfile   = "testdata/local-index-unordered.yaml"
+	testRepo            = "test-repo"
+	indexWithDuplicates = `
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+  nginx:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+      name: alpine
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
+`
 )
 
 func TestIndexFile(t *testing.T) {
@@ -79,15 +101,42 @@ func TestIndexFile(t *testing.T) {
 }
 
 func TestLoadIndex(t *testing.T) {
-	b, err := ioutil.ReadFile(testfile)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		Name     string
+		Filename string
+	}{
+		{
+			Name:     "regular index file",
+			Filename: testfile,
+		},
+		{
+			Name:     "chartmuseum index file",
+			Filename: chartmuseumtestfile,
+		},
 	}
-	i, err := loadIndex(b)
-	if err != nil {
-		t.Fatal(err)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			b, err := ioutil.ReadFile(tc.Filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			i, err := loadIndex(b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifyLocalIndex(t, i)
+		})
 	}
-	verifyLocalIndex(t, i)
+}
+
+// TestLoadIndex_Duplicates is a regression to make sure that we don't non-deterministically allow duplicate packages.
+func TestLoadIndex_Duplicates(t *testing.T) {
+	if _, err := loadIndex([]byte(indexWithDuplicates)); err == nil {
+		t.Errorf("Expected an error when duplicate entries are present")
+	}
 }
 
 func TestLoadIndexFile(t *testing.T) {
@@ -420,21 +469,5 @@ func TestIndexAdd(t *testing.T) {
 
 	if i.Entries["deis"][0].URLs[0] != "http://example.com/charts/deis-0.1.0.tgz" {
 		t.Errorf("Expected http://example.com/charts/deis-0.1.0.tgz, got %s", i.Entries["deis"][0].URLs[0])
-	}
-}
-
-const mockDuplicateIndex = `
-entries:
-  foo: {}
-  bar: {}
-  baz: {}
-  bar: {}
-`
-
-func TestValidateIndex(t *testing.T) {
-	expect := `key "bar" already set in map`
-	err := validateIndex([]byte(mockDuplicateIndex))
-	if strings.Contains(expect, err.Error()) {
-		t.Errorf("Unexpected error: %s", err)
 	}
 }

--- a/pkg/repo/testdata/chartmuseum-index.yaml
+++ b/pkg/repo/testdata/chartmuseum-index.yaml
@@ -1,0 +1,50 @@
+serverInfo:
+  contextPath: /v1/helm
+apiVersion: v1
+entries:
+  nginx:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz
+      name: nginx
+      description: string
+      version: 0.2.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz
+      name: nginx
+      description: string
+      version: 0.1.0
+      home: https://github.com/something
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+  alpine:
+    - urls:
+        - https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz
+        - http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz
+      name: alpine
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      keywords:
+        - linux
+        - alpine
+        - small
+        - sumtin
+      digest: "sha256:1234567890abcdef"
+  chartWithNoURL:
+    - name: chartWithNoURL
+      description: string
+      version: 1.0.0
+      home: https://github.com/something
+      keywords:
+        - small
+        - sumtin
+      digest: "sha256:1234567890abcdef"


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #8762 

Partial fix #8761 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
