### PR TITLE
Unified error handling when calling newRootCmd.

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -75,8 +75,7 @@ func main() {
 	actionConfig := new(action.Configuration)
 	cmd, err := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 	if err != nil {
-		debug("%+v", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	// run when each command's execute method is called

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -116,7 +115,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	})
 
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	// Setup shell completion for the kube-context flag
@@ -142,7 +141,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	})
 
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	// We can safely ignore any errors that flags.Parse encounters since


### PR DESCRIPTION
Unified error handling when calling newRootCmd.

Signed-off-by: yxxhero <aiopsclub@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When calling newRootCmd function, if an error occurred when call registry.NewClient in root.go file, it only exit with code 1, dispaly nothing to the user. This is not friendly for users to use helm client.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
