### PR TITLE
Fixing issue with idempotent repo add

### DIFF
--- a/cmd/helm/testdata/output/repo-add2.txt
+++ b/cmd/helm/testdata/output/repo-add2.txt
@@ -1,0 +1,1 @@
+"test-name" already exists with the same configuration, skipping


### PR DESCRIPTION
A security issue fixed in 3.3.2 caught repos with the same name
being added a second time and produced an error. This caused an
issue for tools, such as helmfile, that will add the same name
with the same configuration multiple times.

This fix checks that the configuration on the existing and new
repo are the same. If there is no change it notes it and exists
with a 0 exit code. If there is a change the existing error is
returned (for reverse compat). If --force-update is given the
user opts in to changing the config for the name.

Closes #8771

- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
