### PR TITLE
use warning function

### DIFF
--- a/cmd/helm/registry_login.go
+++ b/cmd/helm/registry_login.go
@@ -104,7 +104,7 @@ func getUsernamePassword(usernameOpt string, passwordOpt string, passwordFromStd
 			}
 		}
 	} else {
-		fmt.Fprintln(os.Stderr, "WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
+		warning("Using --password via the CLI is insecure. Use --password-stdin.")
 	}
 
 	return username, password, nil

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -205,7 +205,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	loadPlugins(cmd, out)
 
 	// Check permissions on critical files
-	checkPerms(out)
+	checkPerms()
 
 	return cmd, nil
 }

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -19,14 +19,12 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"io"
 	"os"
 	"os/user"
 	"path/filepath"
 )
 
-func checkPerms(out io.Writer) {
+func checkPerms() {
 	// This function MUST NOT FAIL, as it is just a check for a common permissions problem.
 	// If for some reason the function hits a stopping condition, it may panic. But only if
 	// we can be sure that it is panicing because Helm cannot proceed.
@@ -52,9 +50,9 @@ func checkPerms(out io.Writer) {
 
 	perm := fi.Mode().Perm()
 	if perm&0040 > 0 {
-		fmt.Fprintf(out, "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: %s\n", kc)
+		warning("Kubernetes configuration file is group-readable. This is insecure. Location: %s", kc)
 	}
 	if perm&0004 > 0 {
-		fmt.Fprintf(out, "WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: %s\n", kc)
+		warning("Kubernetes configuration file is world-readable. This is insecure. Location: %s", kc)
 	}
 }

--- a/cmd/helm/root_windows.go
+++ b/cmd/helm/root_windows.go
@@ -18,7 +18,7 @@ package main
 
 import "io"
 
-func checkPerms(out io.Writer) {
+func checkPerms() {
 	// Not yet implemented on Windows. If you know how to do a comprehensive perms
 	// check on Windows, contributions welcomed!
 }

--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -184,7 +183,7 @@ func (o *searchRepoOptions) buildIndex() (*search.Index, error) {
 		f := filepath.Join(o.repoCacheDir, helmpath.CacheIndexFile(n))
 		ind, err := repo.LoadIndexFile(f)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: Repo %q is corrupt or missing. Try 'helm repo update'.", n)
+			warning("Repo %q is corrupt or missing. Try 'helm repo update'.", n)
 			continue
 		}
 


### PR DESCRIPTION
This ensures warning messages are displayed on stderr rather than stdout.

relates to an issue discovered in #8776.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>