### PR TITLE
fix: explicitly set namespace on KubeClient

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -35,6 +35,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/gates"
+	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -130,7 +131,9 @@ func loadReleasesInMemory(actionConfig *action.Configuration) {
 		return
 	}
 
-	actionConfig.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
+	actionConfig.GetKubeClient = func(namespace string) kube.Interface {
+		return &kubefake.PrintingKubeClient{Out: ioutil.Discard}
+	}
 
 	for _, path := range filePaths {
 		b, err := ioutil.ReadFile(path)

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -112,11 +112,11 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	fake := &kubefake.PrintingKubeClient{Out: ioutil.Discard}
 
 	actionConfig := &action.Configuration{
-		Do: func(namespace string) kube.Interface {
+		GetKubeClient: func(namespace string) kube.Interface {
 			return fake
 		},
 		Releases:     store,
-		KubeClient:   fake,
+		KubeClient:   nil,
 		Capabilities: chartutil.DefaultCapabilities,
 		Log:          func(format string, v ...interface{}) {},
 	}

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -32,6 +32,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
@@ -108,9 +109,14 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 
 	buf := new(bytes.Buffer)
 
+	fake := &kubefake.PrintingKubeClient{Out: ioutil.Discard}
+
 	actionConfig := &action.Configuration{
+		Do: func(namespace string) kube.Interface {
+			return fake
+		},
 		Releases:     store,
-		KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
+		KubeClient:   fake,
 		Capabilities: chartutil.DefaultCapabilities,
 		Log:          func(format string, v ...interface{}) {},
 	}

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -116,7 +116,6 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 			return fake
 		},
 		Releases:     store,
-		KubeClient:   nil,
 		Capabilities: chartutil.DefaultCapabilities,
 		Log:          func(format string, v ...interface{}) {},
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -424,7 +424,6 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 		client.Namespace = namespace
 		return client
 	}
-	c.KubeClient = nil
 	c.Releases = store
 	c.Log = log
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -77,19 +77,21 @@ var (
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 var ValidName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
-type DoMake func(namespace string) kube.Interface
+// GetKubeClientFunc returns a Kube client with the specified namespace
+type GetKubeClientFunc func(namespace string) kube.Interface
 
 // Configuration injects the dependencies that all actions share.
 type Configuration struct {
 	// RESTClientGetter is an interface that loads Kubernetes clients.
 	RESTClientGetter genericclioptions.RESTClientGetter
 
-	Do DoMake
+	// GetKubeClient returns an instance of a Kubernetes API client.
+	GetKubeClient GetKubeClientFunc
 
 	// Releases stores records of releases.
 	Releases *storage.Storage
 
-	// KubeClient is a Kubernetes API client.
+	// Deprecated: KubeClient should not be used; use GetKubeClient instead
 	KubeClient kube.Interface
 
 	// RegistryClient is a client for working with registries
@@ -416,13 +418,13 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 	}
 
 	c.RESTClientGetter = getter
-	c.Do = func(namespace string) kube.Interface {
+	c.GetKubeClient = func(namespace string) kube.Interface {
 		client := kube.New(c.RESTClientGetter)
 		client.Log = c.Log
 		client.Namespace = namespace
 		return client
 	}
-	c.KubeClient = kc
+	c.KubeClient = nil
 	c.Releases = store
 	c.Log = log
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -365,6 +365,7 @@ func (c *Configuration) recordRelease(r *release.Release) {
 func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
 	kc.Log = log
+	kc.Namespace = namespace
 
 	lazyClient := &lazyClient{
 		namespace: namespace,

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v3/internal/experimental/registry"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
@@ -80,9 +81,12 @@ func actionConfigFixture(t *testing.T) *Configuration {
 		t.Fatal(err)
 	}
 
+	fake := &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}}
 	return &Configuration{
-		Releases:       storage.Init(driver.NewMemory()),
-		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
+		Releases: storage.Init(driver.NewMemory()),
+		GetKubeClient: func(namespace string) kube.Interface {
+			return fake
+		},
 		Capabilities:   chartutil.DefaultCapabilities,
 		RegistryClient: registryClient,
 		Log: func(format string, v ...interface{}) {

--- a/pkg/action/get.go
+++ b/pkg/action/get.go
@@ -39,7 +39,7 @@ func NewGet(cfg *Configuration) *Get {
 
 // Run executes 'helm get' against the given release.
 func (g *Get) Run(name string) (*release.Release, error) {
-	if err := g.cfg.KubeClient.IsReachable(); err != nil {
+	if err := g.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/get_values.go
+++ b/pkg/action/get_values.go
@@ -39,7 +39,7 @@ func NewGetValues(cfg *Configuration) *GetValues {
 
 // Run executes 'helm get values' against the given release.
 func (g *GetValues) Run(name string) (map[string]interface{}, error) {
-	if err := g.cfg.KubeClient.IsReachable(); err != nil {
+	if err := g.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -42,7 +42,7 @@ func NewHistory(cfg *Configuration) *History {
 
 // Run executes 'helm history' against the given release.
 func (h *History) Run(name string) ([]*release.Release, error) {
-	if err := h.cfg.KubeClient.IsReachable(); err != nil {
+	if err := h.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -171,7 +171,7 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 //
 // If DryRun is set to true, this will prepare the release, but not install it
 func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.Release, error) {
-	i.client = i.cfg.Do(i.Namespace)
+	i.client = i.cfg.GetKubeClient(i.Namespace)
 
 	// Check reachability of cluster unless in client-only mode (e.g. `helm template` without `--validate`)
 	if !i.ClientOnly {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -299,7 +299,6 @@ func TestInstallRelease_FailedHooks(t *testing.T) {
 	instAction.ReleaseName = "failed-hooks"
 	failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WatchUntilReadyError = fmt.Errorf("Failed watch")
-	// instAction.cfg.KubeClient = failer
 
 	vals := map[string]interface{}{}
 	res, err := instAction.Run(buildChart(), vals)
@@ -352,7 +351,6 @@ func TestInstallRelease_Wait(t *testing.T) {
 	instAction.ReleaseName = "come-fail-away"
 	failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
-	// instAction.cfg.KubeClient = failer
 	instAction.Wait = true
 	vals := map[string]interface{}{}
 
@@ -370,7 +368,6 @@ func TestInstallRelease_Atomic(t *testing.T) {
 		instAction.ReleaseName = "come-fail-away"
 		failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.WaitError = fmt.Errorf("I timed out")
-		// instAction.cfg.KubeClient = failer
 		instAction.Atomic = true
 		vals := map[string]interface{}{}
 
@@ -391,7 +388,6 @@ func TestInstallRelease_Atomic(t *testing.T) {
 		failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.WaitError = fmt.Errorf("I timed out")
 		failer.DeleteError = fmt.Errorf("uninstall fail")
-		// instAction.cfg.KubeClient = failer
 		instAction.Atomic = true
 		vals := map[string]interface{}{}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -31,6 +31,7 @@ import (
 	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -46,6 +47,9 @@ type nameTemplateTestCase struct {
 func installAction(t *testing.T) *Install {
 	config := actionConfigFixture(t)
 	instAction := NewInstall(config)
+	instAction.cfg.Do = func(namespace string) kube.Interface {
+		return config.KubeClient
+	}
 	instAction.Namespace = "spaced"
 	instAction.ReleaseName = "test-install-release"
 
@@ -119,7 +123,7 @@ func TestInstallReleaseClientOnly(t *testing.T) {
 	instAction.Run(buildChart(), nil) // disregard output
 
 	is.Equal(instAction.cfg.Capabilities, chartutil.DefaultCapabilities)
-	is.Equal(instAction.cfg.KubeClient, &kubefake.PrintingKubeClient{Out: ioutil.Discard})
+	is.Equal(instAction.client, &kubefake.PrintingKubeClient{Out: ioutil.Discard})
 }
 
 func TestInstallRelease_NoName(t *testing.T) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -31,7 +31,6 @@ import (
 	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
-	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -47,9 +46,6 @@ type nameTemplateTestCase struct {
 func installAction(t *testing.T) *Install {
 	config := actionConfigFixture(t)
 	instAction := NewInstall(config)
-	instAction.cfg.Do = func(namespace string) kube.Interface {
-		return config.KubeClient
-	}
 	instAction.Namespace = "spaced"
 	instAction.ReleaseName = "test-install-release"
 
@@ -301,9 +297,9 @@ func TestInstallRelease_FailedHooks(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)
 	instAction.ReleaseName = "failed-hooks"
-	failer := instAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WatchUntilReadyError = fmt.Errorf("Failed watch")
-	instAction.cfg.KubeClient = failer
+	// instAction.cfg.KubeClient = failer
 
 	vals := map[string]interface{}{}
 	res, err := instAction.Run(buildChart(), vals)
@@ -354,9 +350,9 @@ func TestInstallRelease_Wait(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)
 	instAction.ReleaseName = "come-fail-away"
-	failer := instAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
-	instAction.cfg.KubeClient = failer
+	// instAction.cfg.KubeClient = failer
 	instAction.Wait = true
 	vals := map[string]interface{}{}
 
@@ -372,9 +368,9 @@ func TestInstallRelease_Atomic(t *testing.T) {
 	t.Run("atomic uninstall succeeds", func(t *testing.T) {
 		instAction := installAction(t)
 		instAction.ReleaseName = "come-fail-away"
-		failer := instAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+		failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.WaitError = fmt.Errorf("I timed out")
-		instAction.cfg.KubeClient = failer
+		// instAction.cfg.KubeClient = failer
 		instAction.Atomic = true
 		vals := map[string]interface{}{}
 
@@ -392,10 +388,10 @@ func TestInstallRelease_Atomic(t *testing.T) {
 	t.Run("atomic uninstall fails", func(t *testing.T) {
 		instAction := installAction(t)
 		instAction.ReleaseName = "come-fail-away-with-me"
-		failer := instAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+		failer := instAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.WaitError = fmt.Errorf("I timed out")
 		failer.DeleteError = fmt.Errorf("uninstall fail")
-		instAction.cfg.KubeClient = failer
+		// instAction.cfg.KubeClient = failer
 		instAction.Atomic = true
 		vals := map[string]interface{}{}
 

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -141,7 +141,7 @@ func NewList(cfg *Configuration) *List {
 
 // Run executes the list command, returning a set of matches.
 func (l *List) Run() ([]*release.Release, error) {
-	if err := l.cfg.KubeClient.IsReachable(); err != nil {
+	if err := l.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -48,7 +48,7 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 
 // Run executes 'helm test' against the given release.
 func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
-	if err := r.cfg.KubeClient.IsReachable(); err != nil {
+	if err := r.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -43,7 +43,7 @@ func NewStatus(cfg *Configuration) *Status {
 
 // Run executes 'helm status' against the given release.
 func (s *Status) Run(name string) (*release.Release, error) {
-	if err := s.cfg.KubeClient.IsReachable(); err != nil {
+	if err := s.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -50,7 +50,7 @@ func NewUninstall(cfg *Configuration) *Uninstall {
 
 // Run uninstalls the given release.
 func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) {
-	if err := u.cfg.KubeClient.IsReachable(); err != nil {
+	if err := u.cfg.GetKubeClient("").IsReachable(); err != nil {
 		return nil, err
 	}
 
@@ -197,12 +197,14 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 		builder.WriteString("\n---\n" + file.Content)
 	}
 
-	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), false)
+	client := u.cfg.GetKubeClient(rel.Namespace)
+
+	resources, err := client.Build(strings.NewReader(builder.String()), false)
 	if err != nil {
 		return "", []error{errors.Wrap(err, "unable to build kubernetes objects for delete")}
 	}
 	if len(resources) > 0 {
-		_, errs = u.cfg.KubeClient.Delete(resources)
+		_, errs = client.Delete(resources)
 	}
 	return kept, errs
 }

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -48,9 +48,9 @@ func TestUpgradeRelease_Wait(t *testing.T) {
 	rel.Info.Status = release.StatusDeployed
 	upAction.cfg.Releases.Create(rel)
 
-	failer := upAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
-	upAction.cfg.KubeClient = failer
+	// upAction.cfg.KubeClient = failer
 	upAction.Wait = true
 	vals := map[string]interface{}{}
 
@@ -70,10 +70,10 @@ func TestUpgradeRelease_CleanupOnFail(t *testing.T) {
 	rel.Info.Status = release.StatusDeployed
 	upAction.cfg.Releases.Create(rel)
 
-	failer := upAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+	failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
 	failer.DeleteError = fmt.Errorf("I tried to delete nil")
-	upAction.cfg.KubeClient = failer
+	// upAction.cfg.KubeClient = failer
 	upAction.Wait = true
 	upAction.CleanupOnFail = true
 	vals := map[string]interface{}{}
@@ -97,10 +97,10 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		rel.Info.Status = release.StatusDeployed
 		upAction.cfg.Releases.Create(rel)
 
-		failer := upAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+		failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		// We can't make Update error because then the rollback won't work
 		failer.WatchUntilReadyError = fmt.Errorf("arming key removed")
-		upAction.cfg.KubeClient = failer
+		// upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
 		vals := map[string]interface{}{}
 
@@ -123,9 +123,9 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		rel.Info.Status = release.StatusDeployed
 		upAction.cfg.Releases.Create(rel)
 
-		failer := upAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
+		failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.UpdateError = fmt.Errorf("update fail")
-		upAction.cfg.KubeClient = failer
+		// upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
 		vals := map[string]interface{}{}
 

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -50,7 +50,6 @@ func TestUpgradeRelease_Wait(t *testing.T) {
 
 	failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
-	// upAction.cfg.KubeClient = failer
 	upAction.Wait = true
 	vals := map[string]interface{}{}
 
@@ -73,7 +72,6 @@ func TestUpgradeRelease_CleanupOnFail(t *testing.T) {
 	failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 	failer.WaitError = fmt.Errorf("I timed out")
 	failer.DeleteError = fmt.Errorf("I tried to delete nil")
-	// upAction.cfg.KubeClient = failer
 	upAction.Wait = true
 	upAction.CleanupOnFail = true
 	vals := map[string]interface{}{}
@@ -100,7 +98,6 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		// We can't make Update error because then the rollback won't work
 		failer.WatchUntilReadyError = fmt.Errorf("arming key removed")
-		// upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
 		vals := map[string]interface{}{}
 
@@ -125,7 +122,6 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 
 		failer := upAction.cfg.GetKubeClient("").(*kubefake.FailingKubeClient)
 		failer.UpdateError = fmt.Errorf("update fail")
-		// upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
 		vals := map[string]interface{}{}
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -21,9 +21,11 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
+	"helm.sh/helm/v3/pkg/cli"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -248,6 +250,84 @@ func TestBuild(t *testing.T) {
 
 			if len(infos) != tt.count {
 				t.Errorf("expected %d result objects, got %d", tt.count, len(infos))
+			}
+		})
+	}
+}
+
+func TestNamespace(t *testing.T) {
+	reset := func() func() {
+		var originalHelmNamespace *string
+		origEnv := os.Environ()
+		for _, pair := range origEnv {
+			kv := strings.SplitN(pair, "=", 2)
+			if kv[0] == "HELM_NAMESPACE" {
+				o := kv[1]
+				originalHelmNamespace = &o
+				break
+			}
+		}
+
+		return func() {
+			os.Unsetenv("HELM_NAMESPACE")
+			if originalHelmNamespace != nil {
+				os.Setenv("HELM_NAMESPACE", *originalHelmNamespace)
+			}
+		}
+	}
+
+	refstring := func(s string) *string {
+		return &s
+	}
+	tcs := []struct {
+		name              string
+		envNamespace      string
+		namespace         *string
+		expectedNamespace string
+	}{
+		{
+			name:              "unset-namespace",
+			envNamespace:      v1.NamespaceDefault,
+			namespace:         nil,
+			expectedNamespace: v1.NamespaceDefault,
+		}, {
+			name:              "test-namespace",
+			envNamespace:      v1.NamespaceDefault,
+			namespace:         refstring("test"),
+			expectedNamespace: "test",
+		}, {
+			name:              "non-default-env-namespace",
+			envNamespace:      "test",
+			namespace:         nil,
+			expectedNamespace: "test",
+		}, {
+			name:              "non-default-env-and-test-namespace",
+			envNamespace:      "stage",
+			namespace:         refstring("test"),
+			expectedNamespace: "test",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			defer reset()()
+
+			os.Setenv("HELM_NAMESPACE", tc.envNamespace)
+			c := New(cli.New().RESTClientGetter())
+			if tc.namespace != nil {
+				c.Namespace = *tc.namespace
+			}
+			reslist, err := c.Build(strings.NewReader(testServiceManifest), true)
+			if err != nil {
+				t.Errorf("unexpected error from Build: %v", err)
+			}
+			if len(reslist) != 1 {
+				t.Errorf("expected 1 resource; got %d", len(reslist))
+			}
+			res := reslist[0]
+			t.Logf("%#v\n", res)
+			if res.Namespace != tc.expectedNamespace {
+				t.Errorf("Incorrect namespace: expected '%s', got '%s'", tc.expectedNamespace, res.Namespace)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

There seems to be a problem in the Go SDK that deploys k8s resources to the namespace of the kube config, instead of a namespace specified by the action.  See the linked issues below.

**Special notes for your reviewer**:

This requires testing, etc.,  The PR is submitted to get a quick feedback, i.e., "this is not the right idea at all", or "yeah, seems like it could be legit".  Will write tests, etc.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #8780
closes #8685 
