### PR TITLE
Fixing import package issue

### DIFF
--- a/cmd/helm/root_windows.go
+++ b/cmd/helm/root_windows.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package main
 
-import "io"
-
 func checkPerms() {
 	// Not yet implemented on Windows. If you know how to do a comprehensive perms
 	// check on Windows, contributions welcomed!


### PR DESCRIPTION
When #8779 was merged it introduced an issue with windows builds,
which we do not test for in PR CI. This change fixes that problem.

- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
