### PR TITLE
fix 8298: prevent global values from subcharts to affect parent and sibling charts

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -112,6 +112,7 @@ func coalesceGlobals(dest, src map[string]interface{}) {
 			if destv, ok := dg[key]; !ok {
 				// Here there is no merge. We're just adding.
 				dg[key] = vv
+				continue
 			} else {
 				if destvmap, ok := destv.(map[string]interface{}); !ok {
 					log.Printf("Conflict: cannot merge map onto non-map for %q. Skipping.", key)

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -78,11 +78,20 @@ func TestCoalesceValues(t *testing.T) {
 			"right":    "exists",
 			"scope":    "moby",
 			"top":      "nope",
+			"global": map[string]interface{}{
+				"nested2": map[string]interface{}{"l0": "moby"},
+			},
 		},
 	},
 		withDeps(&chart.Chart{
 			Metadata: &chart.Metadata{Name: "pequod"},
-			Values:   map[string]interface{}{"name": "pequod", "scope": "pequod"},
+			Values: map[string]interface{}{
+				"name":  "pequod",
+				"scope": "pequod",
+				"global": map[string]interface{}{
+					"nested2": map[string]interface{}{"l1": "pequod"},
+				},
+			},
 		},
 			&chart.Chart{
 				Metadata: &chart.Metadata{Name: "ahab"},
@@ -91,12 +100,20 @@ func TestCoalesceValues(t *testing.T) {
 					"name":   "ahab",
 					"boat":   true,
 					"nested": map[string]interface{}{"foo": false, "bar": true},
+					"global": map[string]interface{}{
+						"nested2": map[string]interface{}{"l2": "ahab"},
+					},
 				},
 			},
 		),
 		&chart.Chart{
 			Metadata: &chart.Metadata{Name: "spouter"},
-			Values:   map[string]interface{}{"scope": "spouter"},
+			Values: map[string]interface{}{
+				"scope": "spouter",
+				"global": map[string]interface{}{
+					"nested2": map[string]interface{}{"l1": "spouter"},
+				},
+			},
 		},
 	)
 
@@ -147,6 +164,19 @@ func TestCoalesceValues(t *testing.T) {
 		{"{{.spouter.global.nested.boat}}", "true"},
 		{"{{.pequod.global.nested.sail}}", "true"},
 		{"{{.spouter.global.nested.sail}}", "<no value>"},
+
+		{"{{.global.nested2.l0}}", "moby"},
+		{"{{.global.nested2.l1}}", "<no value>"},
+		{"{{.global.nested2.l2}}", "<no value>"},
+		{"{{.pequod.global.nested2.l0}}", "moby"},
+		{"{{.pequod.global.nested2.l1}}", "pequod"},
+		{"{{.pequod.global.nested2.l2}}", "<no value>"},
+		{"{{.pequod.ahab.global.nested2.l0}}", "moby"},
+		{"{{.pequod.ahab.global.nested2.l1}}", "pequod"},
+		{"{{.pequod.ahab.global.nested2.l2}}", "ahab"},
+		{"{{.spouter.global.nested2.l0}}", "moby"},
+		{"{{.spouter.global.nested2.l1}}", "spouter"},
+		{"{{.spouter.global.nested2.l2}}", "<no value>"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes issue 8298, which is about global values defined in subchart can affect globals in parent chart or sibling charts.
The current behavior violates this statement, which can be found in https://helm.sh/docs/topics/charts/:
  "There is no way for a subchart to influence the values of the parent chart."

**Special notes for your reviewer**:

The fix consists of 3 commits.
- 1. a unit test enhancement, which failed before the fix was implemented.
- 2. the actual fix, which was just a missing 'continue' statement, such that the intended code was later overrule
- 3. an additional code improvement of coalesce.go to get rid or continue statement and using appropriate else
      blocks instead. This is not actually necessary for the fix, but should improve the code to make a similar issue
      less likely.

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #8298