### PR TITLE
Added parameter to download dependencies when using upgrade command

### DIFF
--- a/cmd/helm/testdata/output/upgrade-with-dependency-update.txt
+++ b/cmd/helm/testdata/output/upgrade-with-dependency-update.txt
@@ -1,0 +1,9 @@
+Release "updeps" has been upgraded. Happy Helming!
+NAME: updeps
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 2
+TEST SUITE: None
+NOTES:
+PARENT NOTES

--- a/cmd/helm/testdata/output/upgrade-with-install-dependency-update.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install-dependency-update.txt
@@ -1,0 +1,9 @@
+Release "updeps" does not exist. Installing it now.
+NAME: updeps
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+PARENT NOTES

--- a/cmd/helm/testdata/output/upgrade-with-install-missing-dependencies.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install-missing-dependencies.txt
@@ -1,0 +1,2 @@
+Release "nodeps" does not exist. Installing it now.
+Error: found in Chart.yaml, but missing in charts/ directory: reqsubchart2

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/storage/driver"
 )
@@ -110,6 +111,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 					instClient.SubNotes = client.SubNotes
 					instClient.Description = client.Description
+					instClient.DependencyUpdate = client.DependencyUpdate
 
 					rel, err := runInstall(args, instClient, valueOpts, out)
 					if err != nil {
@@ -131,7 +133,8 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
-			vals, err := valueOpts.MergeValues(getter.All(settings))
+			p := getter.All(settings)
+			vals, err := valueOpts.MergeValues(p)
 			if err != nil {
 				return err
 			}
@@ -141,9 +144,30 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			if req := ch.Metadata.Dependencies; req != nil {
 				if err := action.CheckDependencies(ch, req); err != nil {
-					return err
+					if client.DependencyUpdate {
+						man := &downloader.Manager{
+							Out:              out,
+							ChartPath:        chartPath,
+							Keyring:          client.ChartPathOptions.Keyring,
+							SkipUpdate:       false,
+							Getters:          p,
+							RepositoryConfig: settings.RepositoryConfig,
+							RepositoryCache:  settings.RepositoryCache,
+							Debug:            settings.Debug,
+						}
+						if err := man.Update(); err != nil {
+							return err
+						}
+						// Reload the chart with the updated Chart.lock file.
+						if ch, err = loader.Load(chartPath); err != nil {
+							return errors.Wrap(err, "failed reloading chart after repo update")
+						}
+					} else {
+						return err
+					}
 				}
 			}
 
@@ -184,6 +208,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this upgrade when upgrade fails")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
 	f.StringVar(&client.Description, "description", "", "add a custom description")
+	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "run helm dependency update before upgrading the chart")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -126,6 +126,17 @@ func TestUpgradeCmd(t *testing.T) {
 			rels:   []*release.Release{relMock("crazy-bunny", 1, ch)},
 		},
 		{
+			name:      "install a release with missing dependencies",
+			cmd:       fmt.Sprintf("upgrade bonkers-bunny -i '%s'", missingDepsPath),
+			golden:    "output/upgrade-with-install-missing-dependencies.txt",
+			wantError: true,
+		},
+		{
+			name:   "install a release with missing dependencies",
+			cmd:    fmt.Sprintf("upgrade bonkers-bunny -i --dependency-update '%s'", missingDepsPath),
+			golden: "output/upgrade-with-install-dependency-update.txt",
+		},
+		{
 			name:   "upgrade a release with wait",
 			cmd:    fmt.Sprintf("upgrade crazy-bunny --wait '%s'", chartPath),
 			golden: "output/upgrade-with-wait.txt",
@@ -136,6 +147,11 @@ func TestUpgradeCmd(t *testing.T) {
 			cmd:       fmt.Sprintf("upgrade bonkers-bunny %s", missingDepsPath),
 			golden:    "output/upgrade-with-missing-dependencies.txt",
 			wantError: true,
+		},
+		{
+			name:   "upgrade a release with missing dependencies",
+			cmd:    fmt.Sprintf("upgrade --dependency-update bonkers-bunny %s", missingDepsPath),
+			golden: "output/upgrade-with-dependency-update.txt",
 		},
 		{
 			name:      "upgrade a release with bad dependencies",

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -127,13 +127,13 @@ func TestUpgradeCmd(t *testing.T) {
 		},
 		{
 			name:      "install a release with missing dependencies",
-			cmd:       fmt.Sprintf("upgrade bonkers-bunny -i '%s'", missingDepsPath),
+			cmd:       "upgrade nodeps -i testdata/testcharts/chart-missing-deps",
 			golden:    "output/upgrade-with-install-missing-dependencies.txt",
 			wantError: true,
 		},
 		{
 			name:   "install a release with missing dependencies",
-			cmd:    fmt.Sprintf("upgrade bonkers-bunny -i --dependency-update '%s'", missingDepsPath),
+			cmd:    "upgrade updeps -i --dependency-update testdata/testcharts/chart-with-subchart-update",
 			golden: "output/upgrade-with-install-dependency-update.txt",
 		},
 		{
@@ -150,8 +150,9 @@ func TestUpgradeCmd(t *testing.T) {
 		},
 		{
 			name:   "upgrade a release with missing dependencies",
-			cmd:    fmt.Sprintf("upgrade --dependency-update bonkers-bunny %s", missingDepsPath),
+			cmd:    "upgrade updeps --dependency-update testdata/testcharts/chart-with-subchart-update",
 			golden: "output/upgrade-with-dependency-update.txt",
+			rels:   []*release.Release{relMock("updeps", 1, ch)},
 		},
 		{
 			name:      "upgrade a release with bad dependencies",

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -96,6 +96,8 @@ type Upgrade struct {
 	PostRenderer postrender.PostRenderer
 	// DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
 	DisableOpenAPIValidation bool
+	// Run dependency update
+	DependencyUpdate bool
 }
 
 // NewUpgrade creates a new Upgrade object with the given configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Impl for https://github.com/helm/helm/issues/7162

This will make simple to upgrade charts that have dependencies similar to `install --dependency-update` but for an `upgrade` command

Also when used together with `--install` it is possible to propagate the `--dependency-update` from a `helm upgrade`

```

helm upgrade --install --dependency-update ...

```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
