### PR TITLE
fix for `helm dep up` fails if tmpcharts not removed 

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -246,6 +246,8 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	destPath := filepath.Join(m.ChartPath, "charts")
 	tmpPath := filepath.Join(m.ChartPath, "tmpcharts")
 
+	// remove tmpPath after this function returns
+	defer os.RemoveAll(tmpPath)
 	// Create 'charts' directory if it doesn't already exist.
 	if fi, err := os.Stat(destPath); err != nil {
 		if err := os.MkdirAll(destPath, 0755); err != nil {


### PR DESCRIPTION
Fixing `helm dep up` failure if `tmpcharts` not removed

**What this PR does / why we need it**:
1. Remove tmpPath at the return of `downloadAll` function by adding `defer` function.
2. Adding **unit test** for `downloadAll`
3. **Closes** #5567 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:
- Added comment in the unit test for downloadAll
- Tested the code after changes
- Test the changes using `go test ../../helm.sh/helm/pkg/downloader -v -run TestDownloadAll`
- Can you please add the label **#hacktoberfest-accepted** to the PR when it is ready to merge

**Applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backward compatibility