### PR TITLE
Correctly determine lockfile path in helm repo add

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -95,7 +95,14 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	// Acquire a file lock for process synchronization
-	fileLock := flock.New(strings.Replace(o.repoFile, filepath.Ext(o.repoFile), ".lock", 1))
+	repoFileExt := filepath.Ext(o.repoFile)
+	var lockPath string
+	if len(repoFileExt) > 0 && len(repoFileExt) < len(o.repoFile) {
+		lockPath = strings.Replace(o.repoFile, repoFileExt, ".lock", 1)
+	} else {
+		lockPath = o.repoFile + ".lock"
+	}
+	fileLock := flock.New(lockPath)
 	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	locked, err := fileLock.TryLockContext(lockCtx, time.Second)

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -142,6 +142,18 @@ func TestRepoAddConcurrentDirNotExist(t *testing.T) {
 	repoAddConcurrent(t, testName, repoFile)
 }
 
+func TestRepoAddConcurrentNoFileExtension(t *testing.T) {
+	const testName = "test-name-3"
+	repoFile := filepath.Join(ensure.TempDir(t), "repositories")
+	repoAddConcurrent(t, testName, repoFile)
+}
+
+func TestRepoAddConcurrentHiddenFile(t *testing.T) {
+	const testName = "test-name-4"
+	repoFile := filepath.Join(ensure.TempDir(t), ".repositories")
+	repoAddConcurrent(t, testName, repoFile)
+}
+
 func repoAddConcurrent(t *testing.T, testName, repoFile string) {
 	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
`helm repo add` automatically creates a lockfile based on the repository config file path by replacing the file extension with `.lock`.
When the given filepath for `--repository-config` did not include a file extension, a lockfile in a nonexistent directory
would have been created.
For Example `helm --repository-config /tmp/repo-config repo add ...` resulted in Helm trying to create `.lock/tmp/repo-config`.
This PR corrects this, so that the extension is appended in those cases.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
