### PR TITLE
Updating Helm Hub references to Artifact Hub

### DIFF
--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -24,8 +24,8 @@ import (
 
 const searchDesc = `
 Search provides the ability to search for Helm charts in the various places
-they can be stored including the Helm Hub and repositories you have added. Use
-search subcommands to search different locations for charts.
+they can be stored including the Artifact Hub and repositories you have added.
+Use search subcommands to search different locations for charts.
 `
 
 func newSearchCmd(out io.Writer) *cobra.Command {

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -30,15 +30,16 @@ import (
 )
 
 const searchHubDesc = `
-Search the Helm Hub or an instance of Monocular for Helm charts.
+Search Artifact Hub or an instance of Monocular for Helm charts.
 
-The Helm Hub provides a centralized search for publicly available distributed
-charts. It is maintained by the Helm project. It can be visited at
-https://hub.helm.sh
+Artifact Hub (https://artifacthub.io/) provides a centralized search for
+publicly available packages and configurations for CNCF projects, including
+Helm charts. On GitHub: https://github.com/artifacthub/hub
+
 
 Monocular is a web-based application that enables the search and discovery of
-charts from multiple Helm Chart repositories. It is the codebase that powers the
-Helm Hub. You can find it at https://github.com/helm/monocular
+charts from multiple Helm Chart repositories.
+On GitHub: https://github.com/helm/monocular
 `
 
 type searchHubOptions struct {
@@ -52,7 +53,7 @@ func newSearchHubCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "hub [keyword]",
-		Short: "search for charts in the Helm Hub or an instance of Monocular",
+		Short: "search for charts in the Artifact Hub or an instance of Monocular",
 		Long:  searchHubDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(out, args)

--- a/internal/monocular/doc.go
+++ b/internal/monocular/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package monocular contains the logic for interacting with monocular instances
-// like the Helm Hub.
+// like the original version of Helm Hub.
 //
 // This is a library for interacting with monocular
 package monocular


### PR DESCRIPTION
Now that @mattfarina has set the redirect for hub.helm.sh to artifacthub.io in https://github.com/helm/hub/issues/439, we may want to clarify some places where we reference the past practice.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>


