### PR TITLE
Prune the last release history in case no deployed succeed before

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -174,7 +174,9 @@ func (s *Storage) removeLeastRecent(name string, max int) error {
 	relutil.SortByRevision(h)
 
 	lastDeployed, err := s.Deployed(name)
-	if err != nil {
+	if errors.Is(err, driver.ErrNoDeployedReleases) {
+		// no-op
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

In case of a history of release has no `failed` release, they could grow over the number of `--max-history` configuration. 
`giantswarm` found out in some cases, helm secrets are counting almost ~1000 secrets for this reason.

This PR is to delete the last `failed` release history in case of no successful deployed yet, so we can respect `--max-history` for the edge cases.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
