### PR TITLE
add authentication to CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     working_directory: ~/helm.sh/helm
     docker:
       - image: circleci/golang:1.14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
 
     environment:
       GOCACHE: "/tmp/go/cache"


### PR DESCRIPTION
closes #8848

relies on #8884 as it re-uses the same credentials.