### PR TITLE
add Docker authentication to CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ jobs:
     parallelism: 3
     docker:
       - image: golang:1.14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     environment:
       PROJECT_NAME: "kubernetes-helm"
     steps:


### PR DESCRIPTION
closes #8848

relies on #8884 as it re-uses the same credentials.