### PR TITLE
Linking the README to a more complete list of meeting details in the community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can reach the Helm community and developers via the following channels:
   - [#charts](https://kubernetes.slack.com/messages/charts)
 - Mailing List:
   - [Helm Mailing List](https://lists.cncf.io/g/cncf-helm)
-- Developer Call: Thursdays at 9:30-10:00 Pacific. [https://zoom.us/j/696660622](https://zoom.us/j/696660622)
+- Developer Call: Thursdays at 9:30-10:00 Pacific ([meeting details](https://github.com/helm/community/blob/master/communication.md#meetings))
 
 ### Code of conduct
 


### PR DESCRIPTION
Instead of updating the Zoom link in two places, I suggest that we link to the more complete list of meeting details which I update in https://github.com/helm/community/pull/151.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
