### PR TITLE
warn and block old repo URLs

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -37,12 +37,19 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 )
 
+// Repositories that have been permanently deleted and no longer work
+var deprecatedRepos = map[string]string{
+	"//kubernetes-charts.storage.googleapis.com":           "https://charts.helm.sh/stable",
+	"//kubernetes-charts-incubator.storage.googleapis.com": "https://charts.helm.sh/incubator",
+}
+
 type repoAddOptions struct {
-	name        string
-	url         string
-	username    string
-	password    string
-	forceUpdate bool
+	name                 string
+	url                  string
+	username             string
+	password             string
+	forceUpdate          bool
+	allowDeprecatedRepos bool
 
 	certFile              string
 	keyFile               string
@@ -83,11 +90,21 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&o.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&o.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 	f.BoolVar(&o.insecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the repository")
+	f.BoolVar(&o.allowDeprecatedRepos, "allow-deprecated-repos", false, "by default, this command will not allow adding official repos that have been permanently deleted. This disables that behavior")
 
 	return cmd
 }
 
 func (o *repoAddOptions) run(out io.Writer) error {
+	// Block deprecated repos
+	if !o.allowDeprecatedRepos {
+		for oldURL, newURL := range deprecatedRepos {
+			if strings.Contains(o.url, oldURL) {
+				return fmt.Errorf("repo %q is no longer available; try %q instead", o.url, newURL)
+			}
+		}
+	}
+
 	//Ensure the file directory exists as it is required for file locking
 	err := os.MkdirAll(filepath.Dir(o.repoFile), os.ModePerm)
 	if err != nil && !os.IsExist(err) {


### PR DESCRIPTION
Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is the least heavy-handed way I could come up with to stop people from using the old charts repo.

- It warns if `stable` or `incubator` are mapped to one of the old URLs (but allows someone to, say, map them to `oldstable`)
- It refuses to add one of the old URLs using `helm repo add` unless you supply `--allow-deprecated-repos`

**This is a breaking change**, but one that the core maintainers, org maintainers, and chart maintainers have agreed is necessary. Google will turn off the old chart repository on Nov. 13, 2020. This provides warnings to users who are pointing to the old repo, and prevents users from adding the deprecated repos. It stops short of rewriting the repos on the user's behalf.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
