### PR TITLE
Bugfix: panic when chart contains requirements.lock

### DIFF
--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -123,6 +123,9 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {
 				return c, errors.Wrap(err, "cannot load requirements.lock")
 			}
+			if c.Metadata == nil {
+				c.Metadata = new(chart.Metadata)
+			}
 			if c.Metadata.APIVersion == chart.APIVersionV1 {
 				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
 			}

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -206,6 +206,32 @@ func TestLoadFile(t *testing.T) {
 	verifyDependencies(t, c)
 }
 
+func TestLoadFiles_BadCases(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		bufferedFiles []*BufferedFile
+		expectError   string
+	}{
+		{
+			name: "These files contain only requirements.lock",
+			bufferedFiles: []*BufferedFile{
+				{
+					Name: "requirements.lock",
+					Data: []byte(""),
+				},
+			},
+			expectError: "validation: chart.metadata.apiVersion is required"},
+	} {
+		_, err := LoadFiles(tt.bufferedFiles)
+		if err == nil {
+			t.Fatal("expected error when load illegal files")
+		}
+		if !strings.Contains(err.Error(), tt.expectError) {
+			t.Errorf("Expected error to contain %q, got %q for %s", tt.expectError, err.Error(), tt.name)
+		}
+	}
+}
+
 func TestLoadFiles(t *testing.T) {
 	goodFiles := []*BufferedFile{
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
