### PR TITLE
fix(test): display error message

### DIFF
--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -67,7 +67,7 @@ func TestUpdateCustomCacheCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(cachePath, "charts-index.yaml")); err != nil {
-		t.Fatalf("error finding created index file in custom cache: %#v", err)
+		t.Fatalf("error finding created index file in custom cache: %v", err)
 	}
 }
 


### PR DESCRIPTION
This fixes the error output to display the error's default value (the error message) rather than
Go's internal representation of its value.

supersedes #8416.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
