### PR TITLE
helm search supports semver pre version numbers starting with 0

### DIFF
--- a/cmd/helm/search_repo_test.go
+++ b/cmd/helm/search_repo_test.go
@@ -69,6 +69,14 @@ func TestSearchRepositoriesCmd(t *testing.T) {
 		cmd:    "search repo maria --output json",
 		golden: "output/search-output-json.txt",
 	}, {
+		name:   "search for 'maria', expect one match with semver begin with zero development version",
+		cmd:    "search repo maria --devel",
+		golden: "output/search-semver-pre-zero-devel-release.txt",
+	}, {
+		name:   "search for 'nginx-ingress', expect one match with invalid development pre version",
+		cmd:    "search repo nginx-ingress --devel",
+		golden: "output/search-semver-pre-invalid-release.txt",
+	}, {
 		name:   "search for 'alpine', expect valid yaml output",
 		cmd:    "search repo alpine --output yaml",
 		golden: "output/search-output-yaml.txt",

--- a/cmd/helm/testdata/helmhome/helm/repository/testing-index.yaml
+++ b/cmd/helm/testdata/helmhome/helm/repository/testing-index.yaml
@@ -55,3 +55,33 @@ entries:
         - name: Bitnami
           email: containers@bitnami.com
       icon: ""
+    - name: mariadb
+      url: https://charts.helm.sh/stable/mariadb-0.3.0-0565674.tgz
+      checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
+      home: https://mariadb.org
+      sources:
+        - https://github.com/bitnami/bitnami-docker-mariadb
+      version: 0.3.0-0565674
+      description: Chart for MariaDB
+      keywords:
+        - mariadb
+        - mysql
+        - database
+        - sql
+      maintainers:
+        - name: Bitnami
+          email: containers@bitnami.com
+      icon: ""
+  nginx-ingress:
+    - name: nginx-ingress
+      url: https://github.com/kubernetes/ingress-nginx/ingress-a.b.c.sdfsdf.tgz
+      checksum: 25229f6de44a2be9f215d11dbff31167ddc8ba56
+      home: https://github.com/kubernetes/ingress-nginx
+      sources:
+        - https://github.com/kubernetes/ingress-nginx
+      version: a.b.c.sdfsdf
+      description: Chart for nginx-ingress
+      keywords:
+        - ingress
+        - nginx
+      icon: ""

--- a/cmd/helm/testdata/output/search-semver-pre-invalid-release.txt
+++ b/cmd/helm/testdata/output/search-semver-pre-invalid-release.txt
@@ -1,0 +1,2 @@
+NAME                 	CHART VERSION	APP VERSION	DESCRIPTION            
+testing/nginx-ingress	a.b.c.sdfsdf 	           	Chart for nginx-ingress

--- a/cmd/helm/testdata/output/search-semver-pre-zero-devel-release.txt
+++ b/cmd/helm/testdata/output/search-semver-pre-zero-devel-release.txt
@@ -1,0 +1,2 @@
+NAME           	CHART VERSION	APP VERSION	DESCRIPTION      
+testing/mariadb	0.3.0-0565674	           	Chart for MariaDB


### PR DESCRIPTION
fix #8924

**What this PR does / why we need it**:
If the current helm repo version number contains illegal semver rules (pre version starts with 0), helm repo search will not work properly

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
