### PR TITLE
Fix  invalid semver version number of the helm package command will escape

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/terminal"
 
-	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/provenance"
@@ -64,9 +63,11 @@ func (p *Package) Run(path string, vals map[string]interface{}) (string, error) 
 
 	// If version is set, modify the version.
 	if p.Version != "" {
-		if err := setVersion(ch, p.Version); err != nil {
-			return "", err
-		}
+		ch.Metadata.Version = p.Version
+	}
+
+	if err := validateVersion(ch.Metadata.Version); err != nil {
+		return "", err
 	}
 
 	if p.AppVersion != "" {
@@ -103,14 +104,11 @@ func (p *Package) Run(path string, vals map[string]interface{}) (string, error) 
 	return name, err
 }
 
-func setVersion(ch *chart.Chart, ver string) error {
-	// Verify that version is a Version, and error out if it is not.
+// validateVersion Verify that version is a Version, and error out if it is not.
+func validateVersion(ver string) error {
 	if _, err := semver.NewVersion(ver); err != nil {
 		return err
 	}
-
-	// Set the version field on the chart.
-	ch.Metadata.Version = ver
 	return nil
 }
 

--- a/pkg/action/package_test.go
+++ b/pkg/action/package_test.go
@@ -22,30 +22,10 @@ import (
 	"path"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
+
 	"helm.sh/helm/v3/internal/test/ensure"
-	"helm.sh/helm/v3/pkg/chart"
 )
-
-func TestSetVersion(t *testing.T) {
-	c := &chart.Chart{
-		Metadata: &chart.Metadata{
-			Name:    "prow",
-			Version: "0.0.1",
-		},
-	}
-	expect := "1.2.3-beta.5"
-	if err := setVersion(c, expect); err != nil {
-		t.Fatal(err)
-	}
-
-	if c.Metadata.Version != expect {
-		t.Errorf("Expected %q, got %q", expect, c.Metadata.Version)
-	}
-
-	if err := setVersion(c, "monkeyface"); err == nil {
-		t.Error("Expected bogus version to return an error.")
-	}
-}
 
 func TestPassphraseFileFetcher(t *testing.T) {
 	secret := "secret"
@@ -98,5 +78,48 @@ func TestPassphraseFileFetcher_WithInvalidStdin(t *testing.T) {
 
 	if _, err := passphraseFileFetcher("-", stdin); err == nil {
 		t.Error("Expected passphraseFileFetcher returning an error")
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	type args struct {
+		ver string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			"normal semver version",
+			args{
+				ver: "1.1.3-23658",
+			},
+			nil,
+		},
+		{
+			"Pre version number starting with 0",
+			args{
+				ver: "1.1.3-023658",
+			},
+			semver.ErrSegmentStartsZero,
+		},
+		{
+			"Invalid version number",
+			args{
+				ver: "1.1.3.sd.023658",
+			},
+			semver.ErrInvalidSemVer,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateVersion(tt.args.ver); err != nil {
+				if err != tt.wantErr {
+					t.Errorf("Expected {%v}, got {%v}", tt.wantErr, err)
+				}
+
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Create a chart package and use helm package to package it. If we enter a version number that does not conform to the semver specification, an error will be reported, as expected

command is as follows

```
helm create nginx 
helm package --version 1.17.0-0565674
Error: Version segment starts with 0
```

But if we write the non-compliant version directly in Cahrts.yaml, and then use the helm package command to package, this verification is escaped. A package with a version number that does not conform to the semver specification is generated
```
➜  myrepo cat nginx/Chart.yaml | grep "version:"
version: 0.1.0-0234257
➜  myrepo helm package nginx
Successfully packaged chart and saved it to: /Users/zhangxiao/myrepo/nginx-0.1.0-0234257.tgz
```

**Special notes for your reviewer**:
Prevent charts with illegal semver version numbers from being packaged

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility


ref 
#8932
#8864