### PR TITLE
[#7696] Avoid crash in chart loader on unexpected file sequence

### DIFF
--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -73,10 +73,11 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 	c := new(chart.Chart)
 	subcharts := make(map[string][]*BufferedFile)
 
+	// do not rely on assumed ordering of files in the chart and crash
+	// if Chart.yaml was not coming early enough to initialize metadata
 	for _, f := range files {
 		c.Raw = append(c.Raw, &chart.File{Name: f.Name, Data: f.Data})
-		switch {
-		case f.Name == "Chart.yaml":
+		if f.Name == "Chart.yaml" {
 			if c.Metadata == nil {
 				c.Metadata = new(chart.Metadata)
 			}
@@ -89,6 +90,14 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if c.Metadata.APIVersion == "" {
 				c.Metadata.APIVersion = chart.APIVersionV1
 			}
+		}
+	}
+	for _, f := range files {
+		c.Raw = append(c.Raw, &chart.File{Name: f.Name, Data: f.Data})
+		switch {
+		case f.Name == "Chart.yaml":
+			// already processed
+			continue
 		case f.Name == "Chart.lock":
 			c.Lock = new(chart.Lock)
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -93,7 +93,6 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		}
 	}
 	for _, f := range files {
-		c.Raw = append(c.Raw, &chart.File{Name: f.Name, Data: f.Data})
 		switch {
 		case f.Name == "Chart.yaml":
 			// already processed


### PR DESCRIPTION
Make sure, that chart metadata is initialized by the time the processing
of the chart is started.

Helm inspect crashes in 3.2, 3.3, and 3.4.0 if the files in the chart do not arrive in a presumed order. If for example requirements.yaml will precede Chart.yaml in the file list, the helm process will sigsegv due to uninitialized metadata.

Tested with charts generated with 2.16.11, 2.17.0, 3.2.4, and 3.4.0 in a project where charts generated with these versions provoked this crash in 3.2.4, 3.3.x, and 3.4.0.

refs #7696

Signed-off-by: Lehel Gyuro <lehel@freemail.hu>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: helm inspect crashes, if file sequence of the chart does not include Chart.yaml as first.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
