### PR TITLE
Fixes Error: could not find protocol handler for

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -453,6 +453,12 @@ func (m *Manager) ensureMissingRepos(repoNames map[string]string, deps []*chart.
 
 	for _, dd := range deps {
 
+		// If the chart is in the local charts directory no repository needs
+		// to be specified.
+		if dd.Repository == "" {
+			continue
+		}
+
 		// When the repoName for a dependency is known we can skip ensuring
 		if _, ok := repoNames[dd.Name]; ok {
 			continue

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -249,6 +249,76 @@ func TestUpdateBeforeBuild(t *testing.T) {
 	}
 }
 
+// TestUpdateWithNoRepo is for the case of a dependency that has no repo listed.
+// This happens when the dependency is in the charts directory and does not need
+// to be fetched.
+func TestUpdateWithNoRepo(t *testing.T) {
+	// Set up a fake repo
+	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+	if err := srv.LinkIndices(); err != nil {
+		t.Fatal(err)
+	}
+	dir := func(p ...string) string {
+		return filepath.Join(append([]string{srv.Root()}, p...)...)
+	}
+
+	// Setup the dependent chart
+	d := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "dep-chart",
+			Version:    "0.1.0",
+			APIVersion: "v1",
+		},
+	}
+
+	// Save a chart with the dependency
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "with-dependency",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+			Dependencies: []*chart.Dependency{{
+				Name:    d.Metadata.Name,
+				Version: "0.1.0",
+			}},
+		},
+	}
+	if err := chartutil.SaveDir(c, dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save dependent chart into the parents charts directory. If the chart is
+	// not in the charts directory Helm will return an error that it is not
+	// found.
+	if err := chartutil.SaveDir(d, dir(c.Metadata.Name, "charts")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set-up a manager
+	b := bytes.NewBuffer(nil)
+	g := getter.Providers{getter.Provider{
+		Schemes: []string{"http", "https"},
+		New:     getter.NewHTTPGetter,
+	}}
+	m := &Manager{
+		ChartPath:        dir(c.Metadata.Name),
+		Out:              b,
+		Getters:          g,
+		RepositoryConfig: dir("repositories.yaml"),
+		RepositoryCache:  dir(),
+	}
+
+	// Test the update
+	err = m.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // This function is the skeleton test code of failing tests for #6416 and #6871 and bugs due to #5874.
 //
 // This function is used by below tests that ensures success of build operation


### PR DESCRIPTION
A previous update to automate finding charts in repos when update
was run did not take into account the case for no repo being
specified. This fixes that situation.

Closes #8940

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes #8940

**Special notes for your reviewer**:
N/A

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
