### PR TITLE
feat(helm): Allow generating markdown docs headers

### DIFF
--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -16,8 +16,11 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -38,9 +41,10 @@ It can also generate bash autocompletions.
 `
 
 type docsOptions struct {
-	dest          string
-	docTypeString string
-	topCmd        *cobra.Command
+	dest            string
+	docTypeString   string
+	topCmd          *cobra.Command
+	generateHeaders bool
 }
 
 func newDocsCmd(out io.Writer) *cobra.Command {
@@ -62,6 +66,7 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&o.dest, "dir", "./", "directory to which documentation is written")
 	f.StringVar(&o.docTypeString, "type", "markdown", "the type of documentation to generate (markdown, man, bash)")
+	f.BoolVar(&o.generateHeaders, "generate-headers", false, "generate standard headers for markdown files")
 
 	return cmd
 }
@@ -69,6 +74,18 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 func (o *docsOptions) run(out io.Writer) error {
 	switch o.docTypeString {
 	case "markdown", "mdown", "md":
+		if o.generateHeaders {
+			standardLinks := func(s string) string { return s }
+
+			hdrFunc := func(filename string) string {
+				base := filepath.Base(filename)
+				name := strings.TrimSuffix(base, path.Ext(base))
+				title := strings.Title(strings.Replace(name, "_", " ", -1))
+				return fmt.Sprintf("---\ntitle: \"%s\"\n---\n\n", title)
+			}
+
+			return doc.GenMarkdownTreeCustom(o.topCmd, o.dest, hdrFunc, standardLinks)
+		}
 		return doc.GenMarkdownTree(o.topCmd, o.dest)
 	case "man":
 		manHdr := &doc.GenManHeader{Title: "HELM", Section: "1"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Generating the command docs requires adding the title of each page by hand.
At least that is what I understood from this documentation: https://github.com/helm/helm-www#updating-the-helm-cli-reference-docs

Cobra provides a way to add the header automatically, which is what this PR does.

The flag `--generate-headers` is added to the `docs` command to keep this feature backwards-compatible.

