### PR TITLE
Updating descriptions for HELM_KUBEASGROUPS & HELM_KUBEASUSER

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -62,8 +62,8 @@ Environment variables:
 | $HELM_REPOSITORY_CONFIG            | set the path to the repositories file.                                            |
 | $KUBECONFIG                        | set an alternative Kubernetes configuration file (default "~/.kube/config")       |
 | $HELM_KUBEAPISERVER                | set the Kubernetes API Server Endpoint for authentication                         |
-| $HELM_KUBEASGROUPS                 | set the Username to impersonate for the operation.                                |
-| $HELM_KUBEASUSER                   | set the Groups to use for impoersonation using a comma-separated list.            |
+| $HELM_KUBEASGROUPS                 | set the Groups to use for impersonation using a comma-separated list.             |
+| $HELM_KUBEASUSER                   | set the Username to impersonate for the operation.                                |
 | $HELM_KUBECONTEXT                  | set the name of the kubeconfig context.                                           |
 | $HELM_KUBETOKEN                    | set the Bearer KubeToken used for authentication.                                 |
 


### PR DESCRIPTION
It appears that these descriptions were transposed from the order that seems to have been intended when they were introduced in https://github.com/helm/helm/pull/8710; I'm correcting this here (and fixing a small typo).


Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
