### PR TITLE
Resource watch in pkg/kube to update use watchtools.UntilWithSync

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1003,7 +1003,7 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err = watchtools.ListWatchUntil(ctx, lw, func(e watch.Event) (bool, error) {
+	_, err = watchtools.UntilWithSync(ctx, lw, resourceInfoToObject(info, c), nil, func(e watch.Event) (bool, error) {
 		switch e.Type {
 		case watch.Added, watch.Modified:
 			// For things like a secret or a config map, this is the best indicator
@@ -1020,7 +1020,7 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 			return true, nil
 		case watch.Error:
 			// Handle error and return with an error.
-			c.Log("Error event for %s", info.Name)
+			c.Log("Error event for %s: %v", info.Name, e.Object)
 			return true, fmt.Errorf("Failed to deploy %s", info.Name)
 		default:
 			return false, nil
@@ -1096,7 +1096,7 @@ func (c *Client) watchPodUntilComplete(timeout time.Duration, info *resource.Inf
 	c.Log("Watching pod %s for completion with timeout of %v", info.Name, timeout)
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err := watchtools.ListWatchUntil(ctx, lw, func(e watch.Event) (bool, error) {
+	_, err := watchtools.UntilWithSync(ctx, lw, resourceInfoToObject(info, c), nil, func(e watch.Event) (bool, error) {
 		return isPodComplete(e)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Long running hook watch (watch > 60 min) to K8s with HAProxy 10 min timeout will get a chance failed to get the job completion event trigger, causing the chart install timeout, but the job actually completed.

Please refer to https://godoc.org/k8s.io/client-go/tools/watch#UntilWithSync as a much better function to use

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
