### PR TITLE
Clarifies action needed to list new stable repo

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -252,8 +252,10 @@ func checkForExpiredRepos(repofile string) {
 		if url := r.URL; strings.Contains(url, exp.old) {
 			fmt.Fprintf(
 				os.Stderr,
-				"WARNING: %q is deprecated for %q and will be deleted Nov. 13, 2020.\nWARNING: You should switch to %q\nWARNING: Switch via: helm repo add stable https://charts.helm.sh/stable --force-update",
+				"WARNING: %q is deprecated for %q and will be deleted Nov. 13, 2020.\nWARNING: You should switch to %q via:\nWARNING: helm repo add %q %q --force-update\n",
 				exp.old,
+				exp.name,
+				exp.new,
 				exp.name,
 				exp.new,
 			)

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -252,7 +252,7 @@ func checkForExpiredRepos(repofile string) {
 		if url := r.URL; strings.Contains(url, exp.old) {
 			fmt.Fprintf(
 				os.Stderr,
-				"WARNING: %q is deprecated for %q and will be deleted Nov. 13, 2020.\nWARNING: You should switch to %q\n",
+				"WARNING: %q is deprecated for %q and will be deleted Nov. 13, 2020.\nWARNING: You should switch to %q\nWARNING: Switch via: helm repo add stable https://charts.helm.sh/stable --force-update",
 				exp.old,
 				exp.name,
 				exp.new,


### PR DESCRIPTION
I'm seeing that https://github.com/helm/helm/pull/8903 adds warnings around the stable repo URL change (thanks, @technosophos) but I'm wondering if we want to go farther and explicitly tell people what they need to do. This may help avert some user confusion.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>


