### PR TITLE
Adds support to print rendered charts on `helm lint --debug`

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -100,6 +100,12 @@ func newLintCmd(out io.Writer) *cobra.Command {
 					failed++
 				}
 
+				if settings.Debug {
+					for _, contents := range result.RenderedContents {
+						fmt.Fprintf(&message, "---\n# Source: %s\n%s\n", path, contents)
+					}
+				}
+
 				// Adding extra new line here to break up the
 				// results, stops this from being a big wall of
 				// text and makes it easier to follow.

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -102,7 +102,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 
 				if settings.Debug {
 					for _, contents := range result.RenderedContents {
-						fmt.Fprintf(&message, "---\n# Source: %s\n%s\n", path, contents)
+						fmt.Fprintf(&message, "---\n# Source: %s\n%s", path, contents)
 					}
 				}
 

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -33,6 +33,11 @@ func TestLintCmdWithSubchartsFlag(t *testing.T) {
 		cmd:       fmt.Sprintf("lint --with-subcharts %s", testChart),
 		golden:    "output/lint-chart-with-bad-subcharts-with-subcharts.txt",
 		wantError: true,
+	}, {
+		name:      "lint bad chart using --debug flag",
+		cmd:       fmt.Sprintf("lint %s --debug", "testdata/testcharts/chart-with-template-with-invalid-yaml"),
+		golden:    "output/lint-chart-with-template-with-invalid-yaml-with-debug.txt",
+		wantError: true,
 	}}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/lint-chart-with-template-with-invalid-yaml-with-debug.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-template-with-invalid-yaml-with-debug.txt
@@ -2,7 +2,6 @@
 [INFO] Chart.yaml: icon is recommended
 [ERROR] Chart.yaml: chart type is not valid in apiVersion 'v1'. It is valid in apiVersion 'v2'
 [ERROR] templates/alpine-pod.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 11: could not find expected ':'
-
 ---
 # Source: testdata/testcharts/chart-with-template-with-invalid-yaml
 apiVersion: v1

--- a/cmd/helm/testdata/output/lint-chart-with-template-with-invalid-yaml-with-debug.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-template-with-invalid-yaml-with-debug.txt
@@ -1,0 +1,19 @@
+==> Linting testdata/testcharts/chart-with-template-with-invalid-yaml
+[INFO] Chart.yaml: icon is recommended
+[ERROR] Chart.yaml: chart type is not valid in apiVersion 'v1'. It is valid in apiVersion 'v2'
+[ERROR] templates/alpine-pod.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 11: could not find expected ':'
+
+---
+# Source: testdata/testcharts/chart-with-template-with-invalid-yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "test-release-my-alpine"
+spec:
+  containers:
+  - name: waiter
+    image: "alpine:3.9"
+    command: ["/bin/sleep","9000"]
+invalid
+
+Error: 1 chart(s) linted, 1 chart(s) failed

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -41,6 +41,7 @@ type Lint struct {
 // LintResult is the result of Lint
 type LintResult struct {
 	TotalChartsLinted int
+	RenderedContents  []string
 	Messages          []support.Message
 	Errors            []error
 }
@@ -59,6 +60,9 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	result := &LintResult{}
 	for _, path := range paths {
 		linter, err := lintChart(path, vals, l.Namespace, l.Strict)
+
+		result.RenderedContents = append(result.RenderedContents, linter.RenderedContent...)
+
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -35,6 +35,7 @@ const badChartDir = "rules/testdata/badchartfile"
 const badValuesFileDir = "rules/testdata/badvaluesfile"
 const badYamlFileDir = "rules/testdata/albatross"
 const goodChartDir = "rules/testdata/goodone"
+const multiTemplateFail = "rules/testdata/multi-template-fail"
 
 func TestBadChart(t *testing.T) {
 	m := All(badChartDir, values, namespace, strict).Messages
@@ -102,6 +103,16 @@ func TestBadValues(t *testing.T) {
 	}
 	if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
 		t.Errorf("All didn't have the error for invalid key format: %s", m[0].Err)
+	}
+}
+
+func TestRenderedContent(t *testing.T) {
+	m := All(multiTemplateFail, values, namespace, strict).RenderedContent
+	if len(m) < 1 {
+		t.Fatalf("All didn't return any content, got %#v", m)
+	}
+	if !strings.Contains(m[0], "apiVersion: v1") {
+		t.Errorf("All didn't have expected content")
 	}
 }
 

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -82,10 +82,6 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 
 	renderOk := linter.RunLinterRule(support.ErrorSev, fpath, err)
 
-	if !renderOk {
-		return
-	}
-
 	/* Iterate over all the templates to check:
 	- It is a .yaml file
 	- All the values in the template file is defined
@@ -117,6 +113,14 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 
 		renderedContent := renderedContentMap[path.Join(chart.Name(), fileName)]
 		if strings.TrimSpace(renderedContent) != "" {
+
+			linter.NewRenderedContent(renderedContent)
+
+			// We check if the render was successful here to allow any invalid templates to be returned in debug
+			if !renderOk {
+				break
+			}
+
 			linter.RunLinterRule(support.WarningSev, fpath, validateTopIndentLevel(renderedContent))
 
 			decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(renderedContent), 4096)
@@ -132,7 +136,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 					break
 				}
 
-				// If YAML linting fails, we sill progress. So we don't capture the returned state
+				// If YAML linting fails, we still progress. So we don't capture the returned state
 				// on this linter run.
 				linter.RunLinterRule(support.ErrorSev, fpath, validateYamlContent(err))
 

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -36,6 +36,10 @@ var sev = []string{"UNKNOWN", "INFO", "WARNING", "ERROR"}
 // Linter encapsulates a linting run of a particular chart.
 type Linter struct {
 	Messages []Message
+
+	// Contains the rendered templates
+	RenderedContent []string
+
 	// The highest severity of all the failing lint rules
 	HighestSeverity int
 	ChartDir        string
@@ -47,6 +51,11 @@ type Message struct {
 	Severity int
 	Path     string
 	Err      error
+}
+
+// NewRenderedContent appends content
+func (l *Linter) NewRenderedContent(content string) {
+	l.RenderedContent = append(l.RenderedContent, content)
 }
 
 func (m Message) Error() string {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
closes #8982 (hopefully)

This PR is to add support to render out the YAML from `helm lint` by using the `--debug` flag. It should support both valid and invalid YAML. This has similar behaviour to `helm template --debug`

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
