### PR TITLE
fix(pkg/chart): do not install CRDs for disabled dependencies 

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -181,17 +181,6 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		return nil, err
 	}
 
-	// Pre-install anything in the crd/ directory. We do this before Helm
-	// contacts the upstream server and builds the capabilities object.
-	if crds := chrt.CRDObjects(); !i.ClientOnly && !i.SkipCRDs && len(crds) > 0 {
-		// On dry run, bail here
-		if i.DryRun {
-			i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
-		} else if err := i.installCRDs(crds); err != nil {
-			return nil, err
-		}
-	}
-
 	if i.ClientOnly {
 		// Add mock objects in here so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
@@ -208,6 +197,17 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 
 	if err := chartutil.ProcessDependencies(chrt, vals); err != nil {
 		return nil, err
+	}
+
+	// Pre-install anything in the crd/ directory. We do this before Helm
+	// contacts the upstream server and builds the capabilities object.
+	if crds := chrt.CRDObjects(); !i.ClientOnly && !i.SkipCRDs && len(crds) > 0 {
+		// On dry run, bail here
+		if i.DryRun {
+			i.cfg.Log("WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.")
+		} else if err := i.installCRDs(crds); err != nil {
+			return nil, err
+		}
 	}
 
 	// Make sure if Atomic is set, that wait is set as well. This makes it so

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -162,7 +162,11 @@ func (ch *Chart) CRDObjects() []CRD {
 	}
 	// Get CRDs from dependencies, too.
 	for _, dep := range ch.Dependencies() {
-		crds = append(crds, dep.CRDObjects()...)
+		for _, req := range ch.Metadata.Dependencies {
+			if dep.Name() == req.Name && req.Enabled {
+				crds = append(crds, dep.CRDObjects()...)
+			}
+		}
 	}
 	return crds
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -210,7 +210,7 @@ func TestCRDObjects(t *testing.T) {
 	is.Equal(expected, crds)
 }
 
-func TestCRDObjectsWithDependecy(t *testing.T) {
+func TestCRDObjectsWithDependency(t *testing.T) {
 	chrt := createTestChartWithCrdAndDependency(true)
 	expected := []CRD{
 		{
@@ -236,7 +236,7 @@ func TestCRDObjectsWithDependecy(t *testing.T) {
 	is.Equal(expected, crds)
 }
 
-func TestCRDObjectsWithDependecyDisabled(t *testing.T) {
+func TestCRDObjectsWithDependencyDisabled(t *testing.T) {
 	chrt := createTestChartWithCrdAndDependency(false)
 	expected := []CRD{
 		{

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -209,3 +209,81 @@ func TestCRDObjects(t *testing.T) {
 	crds := chrt.CRDObjects()
 	is.Equal(expected, crds)
 }
+
+func TestCRDObjectsWithDependecy(t *testing.T) {
+	chrt := createTestChartWithCrdAndDependency(true)
+	expected := []CRD{
+		{
+			Name:     "crds/foo.yaml",
+			Filename: "crds/foo.yaml",
+			File: &File{
+				Name: "crds/foo.yaml",
+				Data: []byte("hello"),
+			},
+		},
+		{
+			Name:     "crds/baz.yaml",
+			Filename: "dependency1/crds/baz.yaml",
+			File: &File{
+				Name: "crds/baz.yaml",
+				Data: []byte("hello"),
+			},
+		},
+	}
+
+	is := assert.New(t)
+	crds := chrt.CRDObjects()
+	is.Equal(expected, crds)
+}
+
+func TestCRDObjectsWithDependecyDisabled(t *testing.T) {
+	chrt := createTestChartWithCrdAndDependency(false)
+	expected := []CRD{
+		{
+			Name:     "crds/foo.yaml",
+			Filename: "crds/foo.yaml",
+			File: &File{
+				Name: "crds/foo.yaml",
+				Data: []byte("hello"),
+			},
+		},
+	}
+
+	is := assert.New(t)
+	crds := chrt.CRDObjects()
+	is.Equal(expected, crds)
+}
+
+func createTestChartWithCrdAndDependency(dependencyEnabled bool) Chart {
+	chrt := Chart{
+		Files: []*File{
+			{
+				Name: "crds/foo.yaml",
+				Data: []byte("hello"),
+			},
+		},
+		dependencies: []*Chart{
+			{
+				Metadata: &Metadata{
+					Name: "dependency1",
+				},
+				Files: []*File{
+					{
+						Name: "crds/baz.yaml",
+						Data: []byte("hello"),
+					},
+				},
+			},
+		},
+		Metadata: &Metadata{
+			Dependencies: []*Dependency{
+				{
+					Name:    "dependency1",
+					Enabled: dependencyEnabled,
+				},
+			},
+		},
+	}
+
+	return chrt
+}

--- a/pkg/chartutil/validate_name.go
+++ b/pkg/chartutil/validate_name.go
@@ -39,11 +39,11 @@ var (
 	errMissingName = errors.New("no name provided")
 
 	// errInvalidName indicates that an invalid release name was provided
-	errInvalidName = errors.New("invalid release name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not longer than 53")
+	errInvalidName = errors.New("invalid release name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not be longer than 53")
 
 	// errInvalidKubernetesName indicates that the name does not meet the Kubernetes
 	// restrictions on metadata names.
-	errInvalidKubernetesName = errors.New("invalid metadata name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not longer than 253")
+	errInvalidKubernetesName = errors.New("invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253")
 )
 
 const (

--- a/pkg/chartutil/validate_name.go
+++ b/pkg/chartutil/validate_name.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chartutil
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -39,11 +40,15 @@ var (
 	errMissingName = errors.New("no name provided")
 
 	// errInvalidName indicates that an invalid release name was provided
-	errInvalidName = errors.New("invalid release name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not be longer than 53")
+	errInvalidName = errors.New(fmt.Sprintf(
+		"invalid release name, must match regex %s and the length must not be longer than 53",
+		validName.String()))
 
 	// errInvalidKubernetesName indicates that the name does not meet the Kubernetes
 	// restrictions on metadata names.
-	errInvalidKubernetesName = errors.New("invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253")
+	errInvalidKubernetesName = errors.New(fmt.Sprintf(
+		"invalid metadata name, must match regex %s and the length must not be longer than 253",
+		validName.String()))
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
closes #8508 
The original implementation installs all CRDs from dependencies without checking whether the dependency will actually be installed or not. This fix moves the CRD collection and installation process (`CRDObjects()`) a few lines down so the dependency check happens first, marking dependencies to be installed or not (`Metadata.Dependencies[].Enabled`). Furthermore, the `CRDObjects()` implementation is modified to actually check for this flag and only collect CRDs from enabled dependencies.

**Special notes for your reviewer**:
Unit tests are added for 2 cases: `CRDObjects()` call with a dependency that is enabled and has a CRD definition; and a variant where the dependency is disabled (and in this case we expect the dependent CRD to NOT get installed). The latter test would fail without this patch being applied. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
