### PR TITLE
fix helm template output-dir

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -201,6 +201,13 @@ func TestInstall(t *testing.T) {
 			name: "install chart with only crds",
 			cmd:  "install crd-test testdata/testcharts/chart-with-only-crds --namespace default",
 		},
+		// Install, chart with unknown field
+		{
+			name:      "install chart with unknown field",
+			cmd:       "install unknownfield testdata/testcharts/chart-unknown-field",
+			wantError: true,
+			golden:    "output/install-chart-unknown-field.txt",
+		},
 	}
 
 	runTestActionCmd(t, tests)

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -148,7 +148,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					for _, m := range manifestsToRender {
 						fmt.Fprintf(out, "---\n%s\n", m)
 					}
-				} else {
+				} else if client.OutputDir == "" {
 					fmt.Fprintf(out, "%s", manifests.String())
 				}
 			}

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -121,6 +121,12 @@ func TestTemplateCmd(t *testing.T) {
 			wantError: true,
 			golden:    "output/template-with-invalid-yaml-debug.txt",
 		},
+		{
+			name:      "chart with template with unknown field",
+			cmd:       fmt.Sprintf("template '%s' --validate --output-dir '%s'", "testdata/testcharts/chart-unknown-field", "output/dump"),
+			wantError: true,
+			golden:    "output/template-chart-unknown-field.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/install-chart-unknown-field.txt
+++ b/cmd/helm/testdata/output/install-chart-unknown-field.txt
@@ -1,0 +1,1 @@
+Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Pod.spec): unknown field "invalidKey" in io.k8s.api.core.v1.PodSpec

--- a/cmd/helm/testdata/output/template-chart-unknown-field.txt
+++ b/cmd/helm/testdata/output/template-chart-unknown-field.txt
@@ -1,0 +1,2 @@
+wrote output/dump/alpine/templates/alpine-pod.yaml
+Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Pod.spec): unknown field "invalidKey" in io.k8s.api.core.v1.PodSpec

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "3.9"
+description: Deploy a basic Alpine Linux pod
+home: https://helm.sh/helm
+name: alpine
+sources:
+- https://github.com/helm/helm
+version: 0.1.0

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/README.md
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/README.md
@@ -1,0 +1,13 @@
+# Alpine: A simple Helm chart
+
+Run a single pod of Alpine Linux.
+
+This example was generated using the command `helm create alpine`.
+
+The `templates/` directory contains a very simple pod resource with a
+couple of parameters.
+
+The `values.yaml` file contains the default values for the
+`alpine-pod.yaml` template.
+
+You can install this example using `helm install ./alpine`.

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/extra_values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/extra_values.yaml
@@ -1,0 +1,2 @@
+test:
+  Name: extra-values

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/more_values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/more_values.yaml
@@ -1,0 +1,2 @@
+test:
+  Name: more-values

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/templates/alpine-pod.yaml
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/templates/alpine-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{.Release.Name}}-{{.Values.Name}}"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    values: {{.Values.Name}}
+spec:
+  # This shows how to use a simple value. This will look for a passed-in value
+  # called restartPolicy. If it is not found, it will use the default value.
+  # {{default "Never" .restartPolicy}} is a slightly optimized version of the
+  # more conventional syntax: {{.restartPolicy | default "Never"}}
+  restartPolicy: {{default "Never" .Values.restartPolicy}}
+  containers:
+  - name: waiter
+    image: "alpine:{{ .Chart.AppVersion }}"
+    command: ["/bin/sleep","9000"]
+  invalidKey: invalidValue

--- a/cmd/helm/testdata/testcharts/chart-unknown-field/values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-unknown-field/values.yaml
@@ -1,0 +1,1 @@
+Name: my-alpine

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -183,22 +183,19 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
-			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Name, string(crd.File.Data[:]))
-			} else {
+			if outputDir != "" {
 				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data[:]), fileWritten[crd.Name])
 				if err != nil {
 					return hs, b, "", err
 				}
 				fileWritten[crd.Name] = true
 			}
+			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Name, string(crd.File.Data[:]))
 		}
 	}
 
 	for _, m := range manifests {
-		if outputDir == "" {
-			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, m.Content)
-		} else {
+		if outputDir != "" {
 			newDir := outputDir
 			if useReleaseName {
 				newDir = filepath.Join(outputDir, releaseName)
@@ -213,6 +210,7 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 			}
 			fileWritten[m.Name] = true
 		}
+		fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, m.Content)
 	}
 
 	if pr != nil {


### PR DESCRIPTION
helm template validation silently skipped if output-dir flag is set

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix Issue: helm template validation silently skipped if output-dir flag is set 

Close #9018 
