### PR TITLE
fix helm dep build/update doesn't inherit --insecure-skip-tls-verify from helm repo add

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -310,7 +310,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 
 		// Any failure to resolve/download a chart should fail:
 		// https://github.com/helm/helm/issues/1439
-		churl, username, password, err := m.findChartURL(dep.Name, dep.Version, dep.Repository, repos)
+		churl, username, password, insecureskiptlsverify, err := m.findChartURL(dep.Name, dep.Version, dep.Repository, repos)
 		if err != nil {
 			saveError = errors.Wrapf(err, "could not find %s", churl)
 			break
@@ -332,6 +332,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			Getters:          m.Getters,
 			Options: []getter.Option{
 				getter.WithBasicAuth(username, password),
+				getter.WithInsecureSkipVerifyTLS(insecureskiptlsverify),
 			},
 		}
 
@@ -685,9 +686,9 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 // repoURL is the repository to search
 //
 // If it finds a URL that is "relative", it will prepend the repoURL.
-func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRepository) (url, username, password string, err error) {
+func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRepository) (url, username, password string, insecureskiptlsverify bool, err error) {
 	if strings.HasPrefix(repoURL, "oci://") {
-		return fmt.Sprintf("%s/%s:%s", repoURL, name, version), "", "", nil
+		return fmt.Sprintf("%s/%s:%s", repoURL, name, version), "", "", false, nil
 	}
 
 	for _, cr := range repos {
@@ -709,15 +710,16 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			}
 			username = cr.Config.Username
 			password = cr.Config.Password
+			insecureskiptlsverify = cr.Config.InsecureSkipTLSverify
 			return
 		}
 	}
 	url, err = repo.FindChartInRepoURL(repoURL, name, version, "", "", "", m.Getters)
 	if err == nil {
-		return url, username, password, err
+		return url, username, password, false, err
 	}
 	err = errors.Errorf("chart %s not found in %s: %s", name, repoURL, err)
-	return url, username, password, err
+	return url, username, password, false, err
 }
 
 // findEntryByName finds an entry in the chart repository whose name matches the given name.

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -81,11 +81,37 @@ func TestFindChartURL(t *testing.T) {
 	version := "0.1.0"
 	repoURL := "http://example.com/charts"
 
-	churl, username, password, err := m.findChartURL(name, version, repoURL, repos)
+	churl, username, password, insecureSkipTLSVerify, err := m.findChartURL(name, version, repoURL, repos)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if churl != "https://charts.helm.sh/stable/alpine-0.1.0.tgz" {
+		t.Errorf("Unexpected URL %q", churl)
+	}
+	if username != "" {
+		t.Errorf("Unexpected username %q", username)
+	}
+	if password != "" {
+		t.Errorf("Unexpected password %q", password)
+	}
+	if insecureSkipTLSVerify {
+		t.Errorf("Unexpected insecureSkipTLSVerify %t", insecureSkipTLSVerify)
+	}
+
+	name = "tlsfoo"
+	version = "1.2.3"
+	repoURL = "https://example-https-insecureskiptlsverify.com"
+
+	churl, username, password, insecureSkipTLSVerify, err = m.findChartURL(name, version, repoURL, repos)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !insecureSkipTLSVerify {
+		t.Errorf("Unexpected insecureSkipTLSVerify %t", insecureSkipTLSVerify)
+	}
+	if churl != "https://example.com/tlsfoo-1.2.3.tgz" {
 		t.Errorf("Unexpected URL %q", churl)
 	}
 	if username != "" {

--- a/pkg/downloader/testdata/repositories.yaml
+++ b/pkg/downloader/testdata/repositories.yaml
@@ -21,3 +21,6 @@ repositories:
     certFile: "cert"
     keyFile: "key"
     caFile: "ca"
+  - name: testing-https-insecureskip-tls-verify
+    url: "https://example-https-insecureskiptlsverify.com"
+    insecure_skip_tls_verify: true 

--- a/pkg/downloader/testdata/repository/testing-https-insecureskip-tls-verify-index.yaml
+++ b/pkg/downloader/testdata/repository/testing-https-insecureskip-tls-verify-index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  tlsfoo:
+    - name: tlsfoo 
+      description: TLS FOO Chart
+      home: https://helm.sh/helm
+      keywords: []
+      maintainers: []
+      sources:
+        - https://github.com/helm/charts
+      urls:
+        - https://example.com/tlsfoo-1.2.3.tgz
+      version: 1.2.3
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b7373


### PR DESCRIPTION
fix helm dep build/update doesn't inherit --insecure-skip-tls-verify from helm repo add

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
resolve https://github.com/helm/helm/issues/8868
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
