### PR TITLE
Fail message is now the same as the required message.

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -173,6 +173,16 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 		return val, nil
 	}
 
+	// Override sprig fail function for linting and wrapping message
+	funcMap["fail"] = func(msg string) (string, error) {
+		if e.LintMode {
+			// Don't fail when linting
+			log.Printf("[INFO] Fail: %s", msg)
+			return "", nil
+		}
+		return "", errors.New(warnWrap(msg))
+	}
+
 	// If we are not linting and have a cluster connection, provide a Kubernetes-backed
 	// implementation.
 	if !e.LintMode && e.config != nil {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -289,7 +289,7 @@ func TestExecErrors(t *testing.T) {
 func TestFailErrors(t *testing.T) {
 	vals := chartutil.Values{"Values": map[string]interface{}{}}
 
-	failtpl := `{{ fail "This is an error" }}`
+	failtpl := `All your base are belong to us{{ fail "This is an error" }}`
 	tplsFailed := map[string]renderable{
 		"failtpl": {tpl: failtpl, vals: vals},
 	}
@@ -300,6 +300,18 @@ func TestFailErrors(t *testing.T) {
 	expected := `execution error at (failtpl:1:3): This is an error`
 	if err.Error() != expected {
 		t.Errorf("Expected '%s', got %q", expected, err.Error())
+	}
+
+	var e Engine
+	e.LintMode = true
+	out, err := e.render(tplsFailed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectStr := "All your base are belong to us"
+	if gotStr := out["failtpl"]; gotStr != expectStr {
+		t.Errorf("Expected %q, got %q (%v)", expectStr, gotStr, out)
 	}
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -286,6 +286,23 @@ func TestExecErrors(t *testing.T) {
 	}
 }
 
+func TestFailErrors(t *testing.T) {
+	vals := chartutil.Values{"Values": map[string]interface{}{}}
+
+	failtpl := `{{ fail "This is an error" }}`
+	tplsFailed := map[string]renderable{
+		"failtpl": {tpl: failtpl, vals: vals},
+	}
+	_, err := new(Engine).render(tplsFailed)
+	if err == nil {
+		t.Fatalf("Expected failures while rendering: %s", err)
+	}
+	expected := `execution error at (failtpl:1:3): This is an error`
+	if err.Error() != expected {
+		t.Errorf("Expected '%s', got %q", expected, err.Error())
+	}
+}
+
 func TestAllTemplates(t *testing.T) {
 	ch1 := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "ch1"},

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -297,7 +297,7 @@ func TestFailErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected failures while rendering: %s", err)
 	}
-	expected := `execution error at (failtpl:1:3): This is an error`
+	expected := `execution error at (failtpl:1:33): This is an error`
 	if err.Error() != expected {
 		t.Errorf("Expected '%s', got %q", expected, err.Error())
 	}


### PR DESCRIPTION
closes #8973 Helm function 'fail' should not fail when doing 'helm lint'

Signed-off-by: Marcus Speight <marcus.speight@hotmail.co.uk>

**What this PR does / why we need it**:
The fail function output does not match the required function output.

e.g.
`{{ required "This is an error" .notExist }}` produces `Error: execution error at (example/templates/required.yaml:1:3): This is an error`
`{{ fail "This is an error" }}` produces `Error: template: example/templates/fail.yaml:1:3: executing "example/templates/service.yaml" at <fail "This is an error">: error calling fail: This is an error`

This PR makes the fail message identical to the required message.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
