### PR TITLE
[actions/stale] increase number of operations per run to 100

### DIFF
--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -13,3 +13,4 @@ jobs:
         exempt-issue-labels: 'keep+open,v4.x'
         days-before-stale: 90
         days-before-close: 30
+        operations-per-run: 100


### PR DESCRIPTION
The default number of operations the stale issue bot will run is 30. This is a good size for a small-to-medium sized project and it prevents rate limits. However, for a project as large as Helm, the number of operations need to be increased so that it can find and close stale issues.
