### PR TITLE
fix(helm): Don't discard pre-releases upon index merge

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -135,8 +135,13 @@ func (i IndexFile) Add(md *chart.Metadata, filename, baseURL, digest string) {
 
 // Has returns true if the index has an entry for a chart with the given name and exact version.
 func (i IndexFile) Has(name, version string) bool {
-	_, err := i.Get(name, version)
-	return err == nil
+	vs := i.Entries[name]
+	for _, v := range vs {
+		if v.Version == version {
+			return true
+		}
+	}
+	return false
 }
 
 // SortEntries sorts the entries by version in descending order.


### PR DESCRIPTION
Previously, when attempting to merge a new version into an existing
index.yaml which includes overlapping release and pre-release versions
(such as 0.1.0 and 0.1-dev), the merge would silently discard the
pre-release version from the newly merged index.

Fix this by performing an exact semantic comparison of the versions from
the provided index file.