### PR TITLE
fix newTemplateCmd

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -91,7 +91,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							if client.UseReleaseName {
 								newDir = filepath.Join(client.OutputDir, client.ReleaseName)
 							}
-							err = writeToFile(newDir, m.Path, m.Manifest, fileWritten[m.Path])
+							err := writeToFile(newDir, m.Path, m.Manifest, fileWritten[m.Path])
 							if err != nil {
 								return err
 							}


### PR DESCRIPTION
**What this PR does / why we need it**:

Redefine err in the if statement to prevent it from being assigned to the external err variable.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>
