### PR TITLE
Fix helm create sample chart `appVersion:` with quotes

### DIFF
--- a/cmd/helm/testdata/testcharts/chart-with-only-crds/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-only-crds/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
+# incremented each time you make changes to the application and recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/cmd/helm/testdata/testcharts/chart-with-only-crds/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-only-crds/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application and recommended to use it with quotes.
+# incremented each time you make changes to the application and it is recommended to use it with quotes.
 appVersion: "1.16.0"

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -99,7 +99,8 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
 `
 
 const defaultValues = `# Default values for %s.

--- a/pkg/lint/rules/testdata/multi-template-fail/Chart.yaml
+++ b/pkg/lint/rules/testdata/multi-template-fail/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
+# incremented each time you make changes to the application and recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/pkg/lint/rules/testdata/multi-template-fail/Chart.yaml
+++ b/pkg/lint/rules/testdata/multi-template-fail/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application and recommended to use it with quotes.
+# incremented each time you make changes to the application and it is recommended to use it with quotes.
 appVersion: "1.16.0"

--- a/pkg/lint/rules/testdata/v3-fail/Chart.yaml
+++ b/pkg/lint/rules/testdata/v3-fail/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
+# incremented each time you make changes to the application and recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/pkg/lint/rules/testdata/v3-fail/Chart.yaml
+++ b/pkg/lint/rules/testdata/v3-fail/Chart.yaml
@@ -17,5 +17,5 @@ type: application
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application and recommended to use it with quotes.
+# incremented each time you make changes to the application and it is recommended to use it with quotes.
 appVersion: "1.16.0"


### PR DESCRIPTION
This PR updates `helm create` command for the sample chart and adds quotes to the version `appVersion: "1.16.0"`
As there are many docker tags which do not follow semver, so in YAML it is float, for example `appVersion: 14.0` it will the helm lint, adding quotes appVersion: "14.0" it makes the string and helm lint will not fail for the chart.

The conclusion is that not wrapping it in quotes can lead to issues in some cases. That by doing it by default it can help people avoid those.
