### PR TITLE
add --labels flags to install/upgrade commands

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -149,6 +149,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, the installation process deletes the installation on failure. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.StringToStringVar(&client.Labels, "labels", nil, "if set, adds these labels to release metadata")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -184,6 +184,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this upgrade when upgrade fails")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
 	f.StringVar(&client.Description, "description", "", "add a custom description")
+	f.StringToStringVar(&client.Labels, "labels", nil, "if set, adds these labels to release metadata")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -100,6 +100,8 @@ type Install struct {
 	// OutputDir/<ReleaseName>
 	UseReleaseName bool
 	PostRenderer   postrender.PostRenderer
+
+	Labels map[string]string
 }
 
 // ChartPathOptions captures common options used for controlling chart paths
@@ -443,6 +445,7 @@ func (i *Install) createRelease(chrt *chart.Chart, rawVals map[string]interface{
 			Status:        release.StatusUnknown,
 		},
 		Version: 1,
+		Labels:  i.Labels,
 	}
 }
 

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -134,6 +134,7 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 		Version:  currentRelease.Version + 1,
 		Manifest: previousRelease.Manifest,
 		Hooks:    previousRelease.Hooks,
+		Labels:   previousRelease.Labels,
 	}
 
 	return currentRelease, targetRelease, nil

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -96,6 +96,8 @@ type Upgrade struct {
 	PostRenderer postrender.PostRenderer
 	// DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
 	DisableOpenAPIValidation bool
+
+	Labels map[string]string
 }
 
 // NewUpgrade creates a new Upgrade object with the given configuration.
@@ -230,6 +232,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		Version:  revision,
 		Manifest: manifestDoc.String(),
 		Hooks:    hooks,
+		Labels:   u.Labels,
 	}
 
 	if len(notesTxt) > 0 {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -38,8 +38,7 @@ type Release struct {
 	// Namespace is the kubernetes namespace of the release.
 	Namespace string `json:"namespace,omitempty"`
 	// Labels of the release.
-	// Disabled encoding into Json cause labels are stored in storage driver metadata field.
-	Labels map[string]string `json:"-"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -157,6 +157,10 @@ func (cfgmaps *ConfigMaps) Create(key string, rls *rspb.Release) error {
 	var lbs labels
 
 	lbs.init()
+
+	// add user provided labels here, so that user can't override builtin labels
+	lbs.fromMap(rls.Labels)
+
 	lbs.set("createdAt", strconv.Itoa(int(time.Now().Unix())))
 
 	// create a new configmap to hold the release
@@ -184,6 +188,10 @@ func (cfgmaps *ConfigMaps) Update(key string, rls *rspb.Release) error {
 	var lbs labels
 
 	lbs.init()
+
+	// add user provided labels here, so that user can't override builtin labels
+	lbs.fromMap(rls.Labels)
+
 	lbs.set("modifiedAt", strconv.Itoa(int(time.Now().Unix())))
 
 	// create a new configmap object to hold the release

--- a/pkg/storage/driver/records.go
+++ b/pkg/storage/driver/records.go
@@ -114,6 +114,10 @@ func newRecord(key string, rls *rspb.Release) *record {
 	var lbs labels
 
 	lbs.init()
+
+	// add user provided labels here, so that user can't override builtin labels
+	lbs.fromMap(rls.Labels)
+
 	lbs.set("name", rls.Name)
 	lbs.set("owner", "helm")
 	lbs.set("status", rls.Info.Status.String())

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -148,6 +148,10 @@ func (secrets *Secrets) Create(key string, rls *rspb.Release) error {
 	var lbs labels
 
 	lbs.init()
+
+	// add user provided labels here, so that user can't override builtin labels
+	lbs.fromMap(rls.Labels)
+
 	lbs.set("createdAt", strconv.Itoa(int(time.Now().Unix())))
 
 	// create a new secret to hold the release
@@ -173,6 +177,10 @@ func (secrets *Secrets) Update(key string, rls *rspb.Release) error {
 	var lbs labels
 
 	lbs.init()
+
+	// add user provided labels here, so that user can't override builtin labels
+	lbs.fromMap(rls.Labels)
+
 	lbs.set("modifiedAt", strconv.Itoa(int(time.Now().Unix())))
 
 	// create a new secret object to hold the release


### PR DESCRIPTION
Fixes #7007

I also needed functionality described in #7007 , so took the stab at implementing it. Labels added here can also be used to filter releases while listing using the functionality introduced in #8532


**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
