### PR TITLE
Make helm repo add insensitive to trailing slashes

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -160,10 +160,8 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	// 2. When the config is different require --force-update
 	if !o.forceUpdate && f.Has(o.name) {
 		existing := f.Get(o.name)
-		existing.URL = existing.URLWithTrailingSlash()
-		c.URL = c.URLWithTrailingSlash()
 		// Only fail with an error if the configs are different.
-		if c != *existing {
+		if c.URLWithTrailingSlash() != existing.URLWithTrailingSlash() {
 			return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
 		}
 

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -160,11 +160,10 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	// 2. When the config is different require --force-update
 	if !o.forceUpdate && f.Has(o.name) {
 		existing := f.Get(o.name)
-		// In case of of the repo URLs ends with a trailing slash and the other
-		// one doesn't, the config is considered to be different even though they
-		// refer to the same repository.
-		// Only fail with an error if the configs actually are different.
-		if c != *existing && c.URLWithTrailingSlash() != existing.URLWithTrailingSlash() {
+		existing.URL = existing.URLWithTrailingSlash()
+		c.URL = c.URLWithTrailingSlash()
+		// Only fail with an error if the configs are different.
+		if c != *existing {
 			return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
 		}
 

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -161,10 +161,13 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	if !o.forceUpdate && f.Has(o.name) {
 		existing := f.Get(o.name)
 		if c != *existing {
-
-			// The input coming in for the name is different from what is already
-			// configured. Return an error.
-			return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
+			// In case of of the repo URLs ends with a trailing slash and the other
+			// one doesn't, the config is considered to be different even though they
+			// refer to the same repository.
+			// Only fail with an error if the configs actually are different.
+			if c.URLWithTrailingSlash() != existing.URLWithTrailingSlash() {
+				return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
+			}
 		}
 
 		// The add is idempotent so do nothing

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -160,14 +160,12 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	// 2. When the config is different require --force-update
 	if !o.forceUpdate && f.Has(o.name) {
 		existing := f.Get(o.name)
-		if c != *existing {
-			// In case of of the repo URLs ends with a trailing slash and the other
-			// one doesn't, the config is considered to be different even though they
-			// refer to the same repository.
-			// Only fail with an error if the configs actually are different.
-			if c.URLWithTrailingSlash() != existing.URLWithTrailingSlash() {
-				return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
-			}
+		// In case of of the repo URLs ends with a trailing slash and the other
+		// one doesn't, the config is considered to be different even though they
+		// refer to the same repository.
+		// Only fail with an error if the configs actually are different.
+		if c != *existing && c.URLWithTrailingSlash() != existing.URLWithTrailingSlash() {
+			return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
 		}
 
 		// The add is idempotent so do nothing

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -292,3 +292,13 @@ func (e *Entry) String() string {
 	}
 	return string(buf)
 }
+
+// URLWithTrailingSlash returns the repository URL with a trailing slash.
+// If the URL already ends with a slash, it will be returned unchanged.
+func (e *Entry) URLWithTrailingSlash() string {
+	if e.URL[len(e.URL)-1:] == "/" {
+		return e.URL
+	}
+
+	return e.URL + "/"
+}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -296,9 +296,5 @@ func (e *Entry) String() string {
 // URLWithTrailingSlash returns the repository URL with a trailing slash.
 // If the URL already ends with a slash, it will be returned unchanged.
 func (e *Entry) URLWithTrailingSlash() string {
-	if e.URL[len(e.URL)-1:] == "/" {
-		return e.URL
-	}
-
-	return e.URL + "/"
+	return strings.TrimSuffix(e.URL, "/") + "/"
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -413,6 +413,6 @@ func TestEntry_URLWithTrailingSlash(t *testing.T) {
 	e = Entry{URL: urlWithoutTrailingSlash}
 
 	if e.URLWithTrailingSlash() != urlWithTrailingSlash {
-		t.Errorf("Expected repository URL without trailing slash")
+		t.Errorf("Expected repository URL with trailing slash")
 	}
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -400,3 +400,19 @@ func TestResolveReferenceURL(t *testing.T) {
 		t.Errorf("%s", chartURL)
 	}
 }
+
+func TestEntry_URLWithTrailingSlash(t *testing.T) {
+	urlWithTrailingSlash := "http://someserver/something/"
+	e := Entry{URL: urlWithTrailingSlash}
+
+	if e.URLWithTrailingSlash() != urlWithTrailingSlash {
+		t.Errorf("Expected unchanged repository URL")
+	}
+
+	urlWithoutTrailingSlash := strings.TrimSuffix(urlWithTrailingSlash, "/")
+	e = Entry{URL: urlWithoutTrailingSlash}
+
+	if e.URLWithTrailingSlash() != urlWithTrailingSlash {
+		t.Errorf("Expected repository URL without trailing slash")
+	}
+}


### PR DESCRIPTION
Closes #9092. 

**What this PR does / why we need it**:

`helm repo add` currently is sensitive to trailing slashes. This means that adding the same repository twice - one time with and the other time without a trailing slash, as explained in issue #9092 - will result in an unnecessary error.

I've tested multiple approaches, but I found adding the `URLWithTrailingSlash` method and always comparing URLs with a trailing slash to be most elegant solution as it avoids many nested `if`s.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
