### PR TITLE
ISSUE-9100 POC on having better filter

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -124,6 +124,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Deployed, "deployed", false, "show deployed releases. If no other is specified, this will be automatically enabled")
 	f.BoolVar(&client.Failed, "failed", false, "show failed releases")
 	f.BoolVar(&client.Pending, "pending", false, "show pending releases")
+	f.StringVarP(&client.ServiceName, "servicename", "s", "", "Name of the helm deployment")
 	f.BoolVarP(&client.AllNamespaces, "all-namespaces", "A", false, "list releases across all namespaces")
 	f.IntVarP(&client.Limit, "max", "m", 256, "maximum number of releases to fetch")
 	f.IntVar(&client.Offset, "offset", 0, "next release name in the list, used to offset from start value")

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"os"
 	"path"
 	"regexp"
 
@@ -126,6 +127,7 @@ type List struct {
 	Uninstalled  bool
 	Superseded   bool
 	Uninstalling bool
+	ServiceName  string
 	Deployed     bool
 	Failed       bool
 	Pending      bool
@@ -154,7 +156,7 @@ func (l *List) Run() ([]*release.Release, error) {
 			return nil, err
 		}
 	}
-
+	os.Setenv("helm-serviceName", l.ServiceName)
 	results, err := l.cfg.Releases.List(func(rel *release.Release) bool {
 		// Skip anything that doesn't match the filter.
 		if filter != nil && !filter.MatchString(rel.Name) {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -18,6 +18,7 @@ package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -80,6 +81,12 @@ func (secrets *Secrets) Get(key string) (*rspb.Release, error) {
 // secret fails to retrieve the releases.
 func (secrets *Secrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
 	lsel := kblabels.Set{"owner": "helm"}.AsSelector()
+	if os.Getenv("helm-serviceName") != "" {
+		lsel = kblabels.Set{
+			"owner": "helm",
+			"name":  os.Getenv("helm-serviceName"),
+		}.AsSelector()
+	}
 	opts := metav1.ListOptions{LabelSelector: lsel.String()}
 
 	list, err := secrets.impl.List(context.Background(), opts)


### PR DESCRIPTION
Relates to [ISSUE-9100](https://github.com/helm/helm/issues/9100)


This is just a hacky POC. The limitation is mainly due to how the software is architect. It architect in a way that it's doing some rpc-like kind of function calls via `driver` and there's no way to change the behavior of driver's output base on input.  I have to get around that by using `env` variables; this PR is not meant to be merged. What's the best way to implement what I am trying to do?