### PR TITLE
Builds with go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ jobs:
   build:
     working_directory: ~/helm.sh/helm
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
+      
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
Note, our current Go 1.14 will move out of support while we are still maintaining Helm 2.5.x.
