### PR TITLE
Allow colon in RBAC resource names

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -203,6 +203,12 @@ func validateMetadataName(obj *K8sYamlStruct) error {
 	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
 		return fmt.Errorf("object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
 	}
+
+	switch obj.Kind {
+	case "ClusterRole", "Role", "ClusterRoleBinding", "RoleBinding":
+		obj.Metadata.Name = strings.ReplaceAll(obj.Metadata.Name, ":", "")
+	}
+
 	// This will return an error if the characters do not abide by the standard OR if the
 	// name is left empty.
 	if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -134,6 +134,7 @@ func TestValidateMetadataName(t *testing.T) {
 		"one_two":                   false,
 		"a..b":                      false,
 		"%^&#$%*@^*@&#^":            false,
+		"example:com":               false,
 	}
 
 	// The length checker should catch this first. So this is not true fuzzing.
@@ -155,6 +156,17 @@ func TestValidateMetadataName(t *testing.T) {
 				t.Log(err)
 			}
 		}
+	}
+
+	md := &K8sYamlStruct{
+		Kind: "Role",
+		Metadata: k8sYamlMetadata{
+			Name: "system::kube-scheduler",
+		},
+	}
+
+	if err := validateMetadataName(md); err != nil {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Jake Smith <jakemgsmith@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

closes #8835

Allows colons in name of RBAC resources
 - Role
 - ClusterRole
 - RoleBinding
 - ClusterRoleBinding

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
