### PR TITLE
Remove warning for nil tables

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -157,7 +157,11 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}) {
 				// if v[key] is a table, merge nv's val table into v[key].
 				src, ok := val.(map[string]interface{})
 				if !ok {
-					log.Printf("warning: skipped value for %s: Not a table.", key)
+					// If the original value is nil, there is nothing to coalesce, so we don't print
+					// the warning but simply continue
+					if val != nil {
+						log.Printf("warning: skipped value for %s: Not a table.", key)
+					}
 					continue
 				}
 				// Because v has higher precedence than nv, dest values override src
@@ -195,7 +199,7 @@ func CoalesceTables(dst, src map[string]interface{}) map[string]interface{} {
 			} else {
 				log.Printf("warning: cannot overwrite table with non table for %s (%v)", key, val)
 			}
-		} else if istable(dv) {
+		} else if istable(dv) && val != nil {
 			log.Printf("warning: destination for %s is a table. Ignoring non-table value %v", key, val)
 		}
 	}


### PR DESCRIPTION
Fixes #8283

**What this PR does / why we need it**:

When moving from helm v2 to helm v3, we started getting worrisome warnings like:
```
coalesce.go:160: warning: skipped value for labels: Not a table.
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
```

They are caused by helm attempting to coalesce a table into a `nil`.
However, I would consider a `nil` table a valid table, especially since helm v2 used to not complain.
With that in mind, this PR removes the warning for the `nil` table case.

**Note to reviewers:**

The root of the problem is a `values.yaml` file with content like:
```
label:
  # name: value
```
So a fix would be for the chart authors to change the `values.yaml` to
```
label: {}
  # name: value
```
 However, I think helm can be nice and support this particular case without printing a warning, to avoid many people hitting this situation.

**To reproduce:**
Use any chart  and have a `values.yaml` that contains:
```
labels:
  #name1: value1
service:
  annotations:
    # name2: value2
``` 
and then run:
```
$ helm install --dry-run test ./chart --set labels.key=value --set service.annotations.key=value >/dev/null
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:160: warning: skipped value for labels: Not a table.
```