### PR TITLE
Fix: If `storage.Create` fails to clean up least-recent releases, return an error

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -61,7 +61,10 @@ func (s *Storage) Create(rls *rspb.Release) error {
 	s.Log("creating release %q", makeKey(rls.Name, rls.Version))
 	if s.MaxHistory > 0 {
 		// Want to make space for one more release.
-		s.removeLeastRecent(rls.Name, s.MaxHistory-1)
+		if err := s.removeLeastRecent(rls.Name, s.MaxHistory-1); err != nil &&
+			!errors.Is(err, driver.ErrReleaseNotFound) {
+			return err
+		}
 	}
 	return s.Driver.Create(makeKey(rls.Name, rls.Version), rls)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`storage.Create` cleans up the least-recent release versions. Prior to this PR, when clean up failed, it would ignore the error. This meant that a user that relied on the least-recent release version cleanup would not be notified if that cleanup failed, and release versions could grow without bound.

Users have no alternative in helm itself to clean up least-recent release versions. There was a proposal for a `prune` command (#5944), but it was not implemented.

Closes #9145.

**Special notes for your reviewer**:
The first commit is a unit test. It fails, because release cleanup fails, but `storage.Create` does not return an error. The second commit is the fix. With the fix, the unit test passes.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
