### PR TITLE
Fix "list all" behavior in pkg/action and pkg/cli

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -209,8 +209,12 @@ func compListReleases(toComplete string, cfg *action.Configuration) ([]string, c
 	}
 
 	var choices []string
+	uniqueNames := map[string]bool{}
 	for _, res := range results {
-		choices = append(choices, res.Name)
+		if ok := uniqueNames[res.Name]; !ok {
+			uniqueNames[res.Name] = true
+			choices = append(choices, res.Name)
+		}
 	}
 
 	return choices, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/list-all.txt
+++ b/cmd/helm/testdata/output/list-all.txt
@@ -5,5 +5,6 @@ groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chi
 hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
 iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
 rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0	0.0.1      
+starlord   	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0	0.0.1      
 starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
 thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -172,10 +172,10 @@ func (l *List) Run() ([]*release.Release, error) {
 		return results, nil
 	}
 
-	// by definition, superseded releases are never shown if
-	// only the latest releases are returned. so if requested statemask
-	// is _only_ ListSuperseded, skip the latest release filter
-	if l.StateMask != ListSuperseded {
+	// If superseded releases should be returned, then do not filter for only
+	// the latest releases, because the latest releases exclude superseded
+	// releases, by definition.
+	if (l.StateMask & ListSuperseded) == 0 {
 		results = filterLatestReleases(results)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes an error in the `pkg/action/List.Run` logic that would return only the latest releases, even when all releases were requested. Adds a unit test to verify the logic. Also fixes a "list all" CLI test, which was passing because the "golden" output was an incomplete list of releases. 
- Fixes a in the "list" shell completion that would output duplicates; this bug was masked by the logic error above.

 Fixes #9028.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
