### PR TITLE
Prefix USE_SUDO with HELM_INSTALL

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -18,7 +18,7 @@
 # the package manager for Go: https://github.com/Masterminds/glide.sh/blob/master/get
 
 : ${BINARY_NAME:="helm"}
-: ${USE_SUDO:="true"}
+: ${HELM_INSTALL_USE_SUDO:="true"}
 : ${DEBUG:="false"}
 : ${VERIFY_CHECKSUM:="true"}
 : ${VERIFY_SIGNATURES:="false"}
@@ -58,7 +58,7 @@ initOS() {
 runAsRoot() {
   local CMD="$*"
 
-  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+  if [ $EUID -ne 0 -a $HELM_INSTALL_USE_SUDO = "true" ]; then
     CMD="sudo $CMD"
   fi
 
@@ -301,7 +301,7 @@ while [[ $# -gt 0 ]]; do
        fi
        ;;
     '--no-sudo')
-       USE_SUDO="false"
+       HELM_INSTALL_USE_SUDO="false"
        ;;
     '--help'|-h)
        help


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Because we probably want to set HELM_INSTALL_DIR and USE_SUDO in our`.bashrc` file, the variable name `USE_SUDO` is too wide. It's safier to use `HELM_INSTALL_USE_SUDO`.


**Special notes for your reviewer**:

Maybe we can leave `USE_SUDO` that reads `HELM_INSTALL_USE_SUDO` for backward compatibility

Signed-off-by: Patrice Ferlet <metal3d@gmail.com>
