### PR TITLE
Make lint error message more specific

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -201,12 +201,12 @@ func validateYamlContent(err error) error {
 
 func validateMetadataName(obj *K8sYamlStruct) error {
 	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
-		return fmt.Errorf("object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
+		return fmt.Errorf("metadata object 'name' must be between 0 and 253 characters: %q", obj.Metadata.Name)
 	}
 	// This will return an error if the characters do not abide by the standard OR if the
 	// name is left empty.
 	if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {
-		return errors.Wrapf(err, "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+		return errors.Wrapf(err, "metadata object 'name' does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
 	}
 	return nil
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -201,12 +201,12 @@ func validateYamlContent(err error) error {
 
 func validateMetadataName(obj *K8sYamlStruct) error {
 	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
-		return fmt.Errorf("metadata object 'name' must be between 0 and 253 characters: %q", obj.Metadata.Name)
+		return fmt.Errorf("metadata object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
 	}
 	// This will return an error if the characters do not abide by the standard OR if the
 	// name is left empty.
 	if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {
-		return errors.Wrapf(err, "metadata object 'name' does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+		return errors.Wrapf(err, "metadata object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
the original error message does not specify where 'name' object belongs too, it's confusing to troubleshoot the charts relying only on lint console output. Current output example:

`````
==> Linting ./helm
[INFO] Chart.yaml: icon is recommended
[INFO] values.yaml: file does not exist
[ERROR] templates/deployment.yaml: object name must be between 0 and 253 characters: ""
[ERROR] templates/hpa.yaml: object name must be between 0 and 253 characters: ""
`````

Signed-off-by: Serguei Dmitriev <serguei.dmitriev@ssense.com>