### PR TITLE
fix: Don't write to output-dir when doing a "helm install"

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -114,32 +114,6 @@ var manifestWithTestHook = `kind: Pod
 	  cmd: fake-command
   `
 
-var rbacManifests = `apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: schedule-agents
-rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/exec", "pods/log"]
-  verbs: ["*"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: schedule-agents
-  namespace: {{ default .Release.Namespace}}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: schedule-agents
-subjects:
-- kind: ServiceAccount
-  name: schedule-agents
-  namespace: {{ .Release.Namespace }}
-`
-
 type chartOptions struct {
 	*chart.Chart
 }
@@ -242,15 +216,6 @@ func withSampleIncludingIncorrectTemplates() chartOption {
 			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
 			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
 			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
-		}
-		opts.Templates = append(opts.Templates, sampleTemplates...)
-	}
-}
-
-func withMultipleManifestTemplate() chartOption {
-	return func(opts *chartOptions) {
-		sampleTemplates := []*chart.File{
-			{Name: "templates/rbac", Data: []byte(rbacManifests)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -62,8 +61,6 @@ const releaseNameMaxLen = 53
 // wants to see this file after rendering in the status command. However, it must be a suffix
 // since there can be filepath in front of it.
 const notesFileSuffix = "NOTES.txt"
-
-const defaultDirectoryPermission = 0755
 
 // Install performs an installation operation.
 type Install struct {
@@ -483,50 +480,6 @@ func (i *Install) replaceRelease(rel *release.Release) error {
 	// For any other status, mark it as superseded and store the old record
 	last.SetStatus(release.StatusSuperseded, "superseded by new release")
 	return i.recordRelease(last)
-}
-
-// write the <data> to <output-dir>/<name>. <append> controls if the file is created or content will be appended
-func writeToFile(outputDir string, name string, data string, append bool) error {
-	outfileName := strings.Join([]string{outputDir, name}, string(filepath.Separator))
-
-	err := ensureDirectoryForFile(outfileName)
-	if err != nil {
-		return err
-	}
-
-	f, err := createOrOpenFile(outfileName, append)
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	_, err = f.WriteString(fmt.Sprintf("---\n# Source: %s\n%s\n", name, data))
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("wrote %s\n", outfileName)
-	return nil
-}
-
-func createOrOpenFile(filename string, append bool) (*os.File, error) {
-	if append {
-		return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
-	}
-	return os.Create(filename)
-}
-
-// check if the directory exists to create file. creates if don't exists
-func ensureDirectoryForFile(file string) error {
-	baseDir := path.Dir(file)
-	_, err := os.Stat(baseDir)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return os.MkdirAll(baseDir, defaultDirectoryPermission)
 }
 
 // NameAndChart returns the name and chart that should be used.

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -19,16 +19,12 @@ package action
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -487,82 +483,6 @@ func TestNameTemplate(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestInstallReleaseOutputDir(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	instAction.OutputDir = dir
-
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(dir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
-}
-
-func TestInstallOutputDirWithReleaseName(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	instAction.OutputDir = dir
-	instAction.UseReleaseName = true
-	instAction.ReleaseName = "madra"
-
-	newDir := filepath.Join(dir, instAction.ReleaseName)
-
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(newDir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
 }
 
 func TestNameAndChart(t *testing.T) {


### PR DESCRIPTION
Even though --output-dir isn't a valid flag for `install`, I noticed there was code lying around for that ? We already have `helm template`-specific code that writes to the filesystem. 

```
$ helm install mychart --output-dir=/tmp/dump
Error: unknown flag: --output-dir
```

Removed the unit tests since they were no longer needed ( or should I keep them and check if they *aren't* created anymore :) )