### PR TITLE
Print an error message when helm fails to access `~/.config`

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -62,8 +62,7 @@ func main() {
 	actionConfig := new(action.Configuration)
 	cmd, err := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 	if err != nil {
-		debug("%+v", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	// run when each command's execute method is called


### PR DESCRIPTION
This is done by calling log.Fatal() instead of debug(). I think an
error causing helm to exit can be considered fatal.

This closes #8606

Signed-off-by: Hanyu Cui <hanyuc.gml@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: This PR closes #8606

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
