### PR TITLE
Force input to start at templates/ directory so path matching works as expected.

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -119,6 +119,17 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						missing := true
 						// Use linux-style filepath separators to unify user's input path
 						f = filepath.ToSlash(f)
+						// the following path matching assumes starting at the "templates/" directory
+						// so we will split the input path on "/" and reslice starting at "templates" if it exists
+						fileSplit := strings.Split(f, "/")
+						for i,v := range fileSplit {
+							if v == "templates" {
+								fileSplit = fileSplit[i:]
+								break;
+							}
+						}
+						f = strings.Join(fileSplit, "/")
+
 						for _, manifestKey := range manifestsKeys {
 							manifest := splitManifests[manifestKey]
 							submatch := manifestNameRegex.FindStringSubmatch(manifest)


### PR DESCRIPTION
Signed-off-by: Aaron Stults <aaron710@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
closes #9033 
When running `helm template` with the `--show-only` option, it assumes the path starts at the `templates/` directory which isn't intuitive if you are running the command from outside of the helm chart directory on a local chart. This PR trims the path provided to match starting at the assumed templates/ directory. An example is provided in #9033 

**Special notes for your reviewer**:
As mentioned in the issue, if this is better resolved by updating documentation, I'm happy to do that as well if someone can point me in the right direction!

