### PR TITLE
feat(helm): add new update-policy annotation to recreate resources

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -439,7 +439,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	if len(toBeAdopted) == 0 && len(resources) > 0 {
 		_, err = i.cfg.KubeClient.Create(resources)
 	} else if len(resources) > 0 {
-		_, err = i.cfg.KubeClient.Update(toBeAdopted, resources, i.Force)
+		_, err = updateWithTimeoutOrFallback(i.cfg.KubeClient, toBeAdopted, resources, i.Force, i.Timeout)
 	}
 	if err != nil {
 		return rel, err

--- a/pkg/action/interface_compat.go
+++ b/pkg/action/interface_compat.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"time"
+
+	"helm.sh/helm/v3/pkg/kube"
+)
+
+// updateWithTimeoutOrFallback is a compatibility function to fallback for Helm 3 clients (implementors of kube.Interface only)
+// this function can be inlined in Helm 4, when there is no fallback necessary anymore.
+func updateWithTimeoutOrFallback(kubeClient kube.Interface, original, target kube.ResourceList, force bool, timeout time.Duration) (*kube.Result, error) {
+	if kubeClient, ok := kubeClient.(kube.UpdateWithTimeout); ok {
+		return kubeClient.UpdateWithTimeout(original, target, force, timeout)
+	}
+	return kubeClient.Update(original, target, force)
+}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -188,8 +188,8 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to set metadata visitor from target release")
 	}
-	results, err := r.cfg.KubeClient.Update(current, target, r.Force)
 
+	results, err := updateWithTimeoutOrFallback(r.cfg.KubeClient, current, target, r.Force, r.Timeout)
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)
 		r.cfg.Log("warning: %s", msg)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -407,7 +407,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 		u.cfg.Log("upgrade hooks disabled for %s", upgradedRelease.Name)
 	}
 
-	results, err := u.cfg.KubeClient.Update(current, target, u.Force)
+	results, err := updateWithTimeoutOrFallback(u.cfg.KubeClient, current, target, u.Force, u.Timeout)
 	if err != nil {
 		u.cfg.recordRelease(originalRelease)
 		u.reportToPerformUpgrade(c, upgradedRelease, results.Created, err)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -178,7 +178,7 @@ func TestUpgradeRelease_Atomic(t *testing.T) {
 		upAction.cfg.Releases.Create(rel)
 
 		failer := upAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
-		failer.UpdateError = fmt.Errorf("update fail")
+		failer.UpdateWithTimeoutError = fmt.Errorf("update fail")
 		upAction.cfg.KubeClient = failer
 		upAction.Atomic = true
 		vals := map[string]interface{}{}

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -41,6 +41,7 @@ type FailingKubeClient struct {
 	DeleteWithPropagationError       error
 	WatchUntilReadyError             error
 	UpdateError                      error
+	UpdateWithTimeoutError           error
 	BuildError                       error
 	BuildTableError                  error
 	BuildDummy                       bool
@@ -112,6 +113,13 @@ func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool)
 		return &kube.Result{}, f.UpdateError
 	}
 	return f.PrintingKubeClient.Update(r, modified, ignoreMe)
+}
+
+func (f *FailingKubeClient) UpdateWithTimeout(r, modified kube.ResourceList, ignoreMe bool, timeout time.Duration) (*kube.Result, error) {
+	if f.UpdateWithTimeoutError != nil {
+		return &kube.Result{}, f.UpdateWithTimeoutError
+	}
+	return f.PrintingKubeClient.UpdateWithTimeout(r, modified, ignoreMe, 0)
 }
 
 // Build returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -90,7 +90,11 @@ func (p *PrintingKubeClient) WatchUntilReady(resources kube.ResourceList, _ time
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kube.Result, error) {
+func (p *PrintingKubeClient) Update(original, target kube.ResourceList, force bool) (*kube.Result, error) {
+	return p.UpdateWithTimeout(original, target, force, 0)
+}
+
+func (p *PrintingKubeClient) UpdateWithTimeout(_, modified kube.ResourceList, _ bool, _ time.Duration) (*kube.Result, error) {
 	_, err := io.Copy(p.Out, bufferize(modified))
 	if err != nil {
 		return nil, err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -110,7 +110,17 @@ type InterfaceResources interface {
 	BuildTable(reader io.Reader, validate bool) (ResourceList, error)
 }
 
+// UpdateWithTimeout is introduced to avoid breaking backwards compatibility for Interface and InterfaceExt implementers.
+// It extends Interface.Update by a timeout, which is used to wait until a resource is deleted in case the a replacement
+// is necessary due to the "helm.sh/update-policy".
+//
+// TODO Helm 4: Remove UpdateWithTimeout and integrate its method(s) into the Interface.
+type UpdateWithTimeout interface {
+	UpdateWithTimeout(original, target ResourceList, force bool, timeout time.Duration) (*Result, error)
+}
+
 var _ Interface = (*Client)(nil)
 var _ InterfaceExt = (*Client)(nil)
 var _ InterfaceDeletionPropagation = (*Client)(nil)
 var _ InterfaceResources = (*Client)(nil)
+var _ UpdateWithTimeout = (*Client)(nil)


### PR DESCRIPTION
Add annotation handling of new annotation helm.sh/update-policy with values recreate-on-conflict and recreate-on-invalid values to better deal with the following cases.
The server responds with 'invalid' e.g. if a certain resource contains an immutable field, which cannot be patched or updated by a PUT. In theses cases it can be helpful to delete the resource and recreate it. Examples for theses cases are:

 * roleRef in RoleBinding
 * spec.clusterIP in Service
 * parameters in StorageClass

If a chart developer has made sure that recreating a resource is safe, the annotation can be added to a resource template. Alternatively a user may add the annotation manually to an existing resource to allow Helm to recreate a certain resource.

Adding the new annotation in general by default or changing the default behaviour of Helm is not a good idea, since deletion and recreation of certain resources can lead to an unwanted or undefined state as described in detail in https://github.com/helm/helm/pull/7431#issuecomment-666735299:

"[...] selectively deleting/re-creating volume-backed resources (Secrets, Services, ConfigMaps, PVCs) without touching the Deployment. If a Persistent Volume Claim is deleted and re-created, there is a risk that an application (Deployment) consuming that Persistent Volume Claim will not receive the new volume's mount point. The same can be said for Secrets, Configmaps, Services, and other resources which are deployed and relied upon by another resource. Environment variables populated in a Deployment from a Service won't be updated until the Pods are destroyed."

Closes #7082.

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>

**Special notes for your reviewer**:

This is an alternative approach to https://github.com/helm/helm/pull/7431 as proposed in https://github.com/helm/helm/issues/7082#issuecomment-687752364. 

There is a new timeout parameter introduced to `Update` in a backwards compatible way as `UpdateWithTimeout` as suggested in https://github.com/helm/helm/pull/9174#discussion_r1186547143. In Helm 4 this should be cleaned up as stated in the comments.  

The `update-policy` and its possible values is a proposal related to the `delete-policy` of hooks and could be changed to something different. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
