### PR TITLE
fix chart name verification does not meet the specification

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -36,7 +36,7 @@ import (
 // This regular expression is probably stricter than it needs to be. We can relax it
 // somewhat. Newline characters, as well as $, quotes, +, parens, and % are known to be
 // problematic.
-var chartName = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+var chartName = regexp.MustCompile("^[a-z0-9\\-]+$")
 
 const (
 	// ChartfileName is the default Chart file name.

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -160,8 +160,12 @@ func TestCreate_Overwrite(t *testing.T) {
 func TestValidateChartName(t *testing.T) {
 	for name, shouldPass := range map[string]bool{
 		"":                              false,
-		"abcdefghijklmnopqrstuvwxyz-_.": true,
-		"ABCDEFGHIJKLMNOPQRSTUVWXYZ-_.": true,
+		"abcdefghijklmnopqrstuvwxyz-_.": false,
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ-_.": false,
+		"abcdefghijklmnopqrstuvwxyz":    true,
+		"abcdefghijklmnopqrstuvwxyz_":   false,
+		"abcdefghijklmnopqrstuvwxyz-":   true,
+		"abcdefghijklmnopqrstuvwxyz.":   false,
 		"$hello":                        false,
 		"Hellô":                         false,
 		"he%%o":                         false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
fix #9179

**Special notes for your reviewer**:

from the doc ,https://helm.sh/docs/chart_best_practices/conventions/#chart-names

We know that chartsname needs to meet the following verification rules

```
Chart names must be lower case letters and numbers. Words may be separated with dashes (-):

Examples:

drupal
nginx-lego
aws-cluster-autoscaler
Neither uppercase letters nor underscores can be used in chart names. Dots should not be used in chart names.

The directory that contains a chart MUST have the same name as the chart. Thus, the chart nginx-lego MUST be created in a directory called nginx-lego/. This is not merely a stylistic detail, but a requirement of the Helm Chart format.
```

The current regular match has a bug

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
