### PR TITLE
Display dates in local time on `helm status` and `helm history`

### DIFF
--- a/cmd/helm/get_all_test.go
+++ b/cmd/helm/get_all_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/pkg/release"
 )
@@ -39,7 +40,11 @@ func TestGetCmd(t *testing.T) {
 		golden:    "output/get-all-no-args.txt",
 		wantError: true,
 	}}
+
+	prevLocal := time.Local
+	time.Local = time.UTC
 	runTestCmd(t, tests)
+	time.Local = prevLocal
 }
 
 func TestGetAllRevisionCompletion(t *testing.T) {

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -107,7 +107,7 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 	tbl := uitable.New()
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for _, item := range r {
-		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.Local().Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestInstall(t *testing.T) {
@@ -209,7 +210,10 @@ func TestInstall(t *testing.T) {
 		},
 	}
 
+	prevLocal := time.Local
+	time.Local = time.UTC
 	runTestActionCmd(t, tests)
+	time.Local = prevLocal
 }
 
 func TestInstallOutputCompletion(t *testing.T) {

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -115,7 +115,7 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 	}
 	fmt.Fprintf(out, "NAME: %s\n", s.release.Name)
 	if !s.release.Info.LastDeployed.IsZero() {
-		fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Format(time.ANSIC))
+		fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Local().Format(time.ANSIC))
 	}
 	fmt.Fprintf(out, "NAMESPACE: %s\n", s.release.Namespace)
 	fmt.Fprintf(out, "STATUS: %s\n", s.release.Info.Status.String())
@@ -135,8 +135,8 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 			}
 			fmt.Fprintf(out, "TEST SUITE:     %s\n%s\n%s\n%s\n",
 				h.Name,
-				fmt.Sprintf("Last Started:   %s", h.LastRun.StartedAt.Format(time.ANSIC)),
-				fmt.Sprintf("Last Completed: %s", h.LastRun.CompletedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Last Started:   %s", h.LastRun.StartedAt.Local().Format(time.ANSIC)),
+				fmt.Sprintf("Last Completed: %s", h.LastRun.CompletedAt.Local().Format(time.ANSIC)),
 				fmt.Sprintf("Phase:          %s", h.LastRun.Phase),
 			)
 		}

--- a/cmd/helm/testdata/output/history-utc+5.txt
+++ b/cmd/helm/testdata/output/history-utc+5.txt
@@ -1,0 +1,5 @@
+REVISION	UPDATED                 	STATUS    	CHART           	APP VERSION	DESCRIPTION 
+1       	Sat Sep  3 03:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+2       	Sat Sep  3 03:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+3       	Sat Sep  3 03:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	Release mock
+4       	Sat Sep  3 03:04:05 1977	deployed  	foo-0.1.0-beta.1	1.0        	Release mock

--- a/cmd/helm/testdata/output/status-utc+5.txt
+++ b/cmd/helm/testdata/output/status-utc+5.txt
@@ -1,0 +1,6 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 05:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE: None

--- a/cmd/helm/testdata/output/status-with-test-suite-utc+5.txt
+++ b/cmd/helm/testdata/output/status-with-test-suite-utc+5.txt
@@ -1,0 +1,13 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 05:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE:     passing-test
+Last Started:   Mon Jan  2 20:04:05 2006
+Last Completed: Mon Jan  2 20:04:07 2006
+Phase:          Succeeded
+TEST SUITE:     failing-test
+Last Started:   Mon Jan  2 20:10:05 2006
+Last Completed: Mon Jan  2 20:10:07 2006
+Phase:          Failed

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
@@ -169,7 +170,11 @@ func TestUpgradeCmd(t *testing.T) {
 			rels:      []*release.Release{relWithStatusMock("funny-bunny", 2, ch, release.StatusPendingInstall)},
 		},
 	}
+
+	prevLocal := time.Local
+	time.Local = time.UTC
 	runTestCmd(t, tests)
+	time.Local = prevLocal
 }
 
 func TestUpgradeWithValue(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

As mentioned in #9186, storing dates in arbitrary timezones and displaying them in a layout that does not have timezone information is misleading. This PR addresses the issue by displaying dates in the local time. Closes #9186.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
