### PR TITLE
Fix typo in comment

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -61,7 +61,7 @@ func NewPull() *Pull {
 	return NewPullWithOpts()
 }
 
-// NewPull creates a new pull, with configuration options.
+// NewPullWithOpts creates a new pull, with configuration options.
 func NewPullWithOpts(opts ...PullOpt) *Pull {
 	p := &Pull{}
 	for _, fn := range opts {


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

**What this PR does / why we need it**:
Fix comment typo in pkg/action/pull.go.