### PR TITLE
Allow uninstall to process ALL manifests (including hooks)

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -174,8 +174,8 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 		return rel.Manifest, []error{errors.Wrap(err, "could not get apiVersions from Kubernetes")}
 	}
 
-	manifests := releaseutil.SplitManifests(rel.Manifest)
-	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
+	manifests := releaseutil.SplitAllManifests(rel)
+	files, err := releaseutil.SortAllManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
 	if err != nil {
 		// We could instead just delete everything in no particular order.
 		// FIXME: One way to delete at this point would be to try a label-based

--- a/pkg/releaseutil/manifest_test.go
+++ b/pkg/releaseutil/manifest_test.go
@@ -19,6 +19,8 @@ package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
 import (
 	"reflect"
 	"testing"
+
+	"helm.sh/helm/v3/pkg/release"
 )
 
 const mockManifestFile = `
@@ -57,5 +59,20 @@ func TestSplitManifest(t *testing.T) {
 	expected := map[string]string{"manifest-0": expectedManifest}
 	if !reflect.DeepEqual(manifests, expected) {
 		t.Errorf("Expected %v, got %v", expected, manifests)
+	}
+}
+
+func TestSplitAllManifests(t *testing.T) {
+	mockRelease := release.Mock(&release.MockReleaseOptions{})
+	manifests := SplitAllManifests(mockRelease)
+	if len(manifests) != 2 {
+		t.Errorf("Expected 2 manifests (including one containing a hook), got %v", len(manifests))
+	}
+	if len(mockRelease.Hooks) != 1 {
+		t.Errorf("Expected 1 hook, got %v", len(mockRelease.Hooks))
+	}
+	manifestsLessHooks := SplitManifests(mockRelease.Manifest)
+	if len(manifestsLessHooks) != 1 {
+		t.Errorf("Expected 1 manifest without a hook, got %v", len(manifestsLessHooks))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Sean Dukehart <tomcruise81@users.noreply.github.com>

closes #9206

**What this PR does / why we need it**: This PR handles cleanup of hooks alongside other manifests as part of calls to `helm uninstall`. 

_Caveat_ - It does **NOT** prevent `pre-delete` or `post-delete` hooks from running, and if a `post-delete` hook exists for a given manifest, what gets created during the `post-delete` hook has the potential to be orphaned.

- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
   - New global methods have been created in lieu of manipulating existing global methods to ensure backwards compatibility
   - It seeks to complete the Helm 3.x work alluded to at https://helm.sh/docs/topics/charts_hooks/#hook-resources-are-not-managed-with-corresponding-releases