### PR TITLE
Fix RBAC resource name verification

### DIFF
--- a/pkg/chartutil/validate_name_test.go
+++ b/pkg/chartutil/validate_name_test.go
@@ -89,3 +89,24 @@ func TestValidateMetadataName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateRBACMetadataName(t *testing.T) {
+	names := map[string]bool{
+		"":      false,
+		".":     false,
+		"..":    false,
+		"foo/":  false,
+		"foo%":  false,
+		"foo/%": false,
+		"foo":   true,
+	}
+	for input, expectPass := range names {
+		if err := ValidateRBACMetadataName(input); (err == nil) != expectPass {
+			st := "fail"
+			if expectPass {
+				st = "succeed"
+			}
+			t.Errorf("Expected %q to %s", input, st)
+		}
+	}
+}

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -206,11 +206,18 @@ func validateMetadataName(obj *K8sYamlStruct) error {
 	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
 		return fmt.Errorf("object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
 	}
-	// This will return an error if the characters do not abide by the standard OR if the
-	// name is left empty.
-	if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {
-		return errors.Wrapf(err, "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+	if obj.APIVersion == "rbac.authorization.k8s.io/v1" {
+		if err := chartutil.ValidateRBACMetadataName(obj.Metadata.Name); err != nil {
+			return errors.Wrapf(err, "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+		}
+	} else {
+		// This will return an error if the characters do not abide by the standard OR if the
+		// name is left empty.
+		if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {
+			return errors.Wrapf(err, "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: wawa0210 <xiaozhang0210@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
fix #9197 and #9203

**Special notes for your reviewer**:
ref
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
https://github.com/kubernetes/kubernetes/blob/585fc57cc7aaf73baf6aef84bf6dab65bde0ef9e/pkg/apis/rbac/validation/validation.go#L32

The RBAC resource name verification in the kubernetes rules is different from other resources. kubernetes does not require all the object's metadata name obey the RFC 1123, but helm does not do some processing on this. All are processed in accordance with the RFC 1123 rules. Cause RBAC creation to be unsuccessful.
Therefore, helm needs to match the kubernetes verification rule

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
