### PR TITLE
Update default ingress values section to correspond with template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -152,7 +152,11 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+      - path: /
+        backend:
+          serviceName: chart-example.local
+          servicePort: 80
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit updates the default section in values.yaml for the example ingress definition to correspond with the template.

Fixes #9231.

