### PR TITLE
print warning message instead of debug message when ~/.config exists but is not accessible

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -62,7 +62,7 @@ func main() {
 	actionConfig := new(action.Configuration)
 	cmd, err := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
 	if err != nil {
-		debug("%+v", err)
+		warning("%+v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

If helm does not have appropriate right to access helm config file it exits without comment.
In order not to affect compatibility, changing it to a warning message might be a feasible solution.

fix #9216

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
