### PR TITLE
corrected order of helm lint coalescing of multiple values files

### DIFF
--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -70,8 +70,9 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	// level values against the top-level expectations. Subchart values are not linted.
 	// We could change that. For now, though, we retain that strategy, and thus can
 	// coalesce tables (like reuse-values does) instead of doing the full chart
-	// CoalesceValues.
-	values = chartutil.CoalesceTables(values, overrides)
+	// CoalesceValues
+	coalescedValues := chartutil.CoalesceTables(make(map[string]interface{}, len(overrides)), overrides)
+	coalescedValues = chartutil.CoalesceTables(coalescedValues, values)
 
 	ext := filepath.Ext(valuesPath)
 	schemaPath := valuesPath[:len(valuesPath)-len(ext)] + ".schema.json"
@@ -82,5 +83,5 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	if err != nil {
 		return err
 	}
-	return chartutil.ValidateAgainstSingleSchema(values, schema)
+	return chartutil.ValidateAgainstSingleSchema(coalescedValues, schema)
 }

--- a/pkg/lint/rules/values_test.go
+++ b/pkg/lint/rules/values_test.go
@@ -104,7 +104,7 @@ func TestValidateValuesFileSchemaFailure(t *testing.T) {
 }
 
 func TestValidateValuesFileSchemaOverrides(t *testing.T) {
-	yaml := "username: admin"
+	yaml := "username: admin\npassword:"
 	overrides := map[string]interface{}{
 		"password": "swordfish",
 	}
@@ -116,6 +116,23 @@ func TestValidateValuesFileSchemaOverrides(t *testing.T) {
 	if err := validateValuesFile(valfile, overrides); err != nil {
 		t.Fatalf("Failed validation with %s", err)
 	}
+}
+
+func TestValidateValuesFileSchemaOverridesFailure(t *testing.T) {
+	yaml := "username: admin\npassword:"
+	overrides := map[string]interface{}{
+		"username": "anotherUser",
+	}
+	tmpdir := ensure.TempFile(t, "values.yaml", []byte(yaml))
+	defer os.RemoveAll(tmpdir)
+	createTestingSchema(t, tmpdir)
+
+	valfile := filepath.Join(tmpdir, "values.yaml")
+	err := validateValuesFile(valfile, overrides)
+	if err == nil {
+		t.Fatalf("expected values file to fail parsing")
+	}
+	assert.Contains(t, err.Error(), "Expected: string, given: null", "Null value for password should be caught by schema")
 }
 
 func createTestingSchema(t *testing.T, dir string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Example**

The following command is run with the below value files and a json schema specifying service.port is required.

```bash
helm lint ./testchart --values ./testchart/second_values.yaml
```

_values.yaml_
```yaml
{
...
service:
  type: ClusterIP
  port:
...
}
```

_second_values.yaml_
```yaml
{
...
service:
  port: 80
...
}
```

The result is an error.
```bash
helm lint ./testchart --values ./testchart/second_values.yaml
==> Linting ./testchart
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - service: port is required


Error: 1 chart(s) linted, 1 chart(s) failed
```

See the attached chart below for the full, runnable example.
[testchart-0.1.0.zip](https://github.com/helm/helm/files/5850689/testchart-0.1.0.zip)


**Problem**

Running helm lint with the flag -f/--values specifies a user-provided values file.  When using helm lint if a user-provided values file exists, then the user-provided values file and chart provided values.yaml are coalesced to create a single values file.  When coalescing the values files if a value exists, see port above, in both the chart provided values.yaml and a user-provided values file, see second_values.yaml above, helm lint uses the value in the chart provided values.yaml.

This behavior is backwards as the user-provided values file should take precedent over the chart provided values.yaml.


**Solution**

The values files are coalesced in the following line of _pkg/lint/rules/values.go_
```go
values = chartutil.CoalesceTables(values, overrides)
```
The CoalesceTables function states the following
```go
// CoalesceTables merges a source map into a destination map.
//
// dest is considered authoritative.
func CoalesceTables(dst, src map[string]interface{}) map[string]interface{
```
Since dst is authoritative, overrides should be dst.  Also overrides is passed in so in order to not manipulate it, a deep copy of overrides should be used.

**Special notes for your reviewer**:
Fixes #8880 
Fixes #8892 

**If applicable**:
- [ ] this PR contains documentation
- [*] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
