### PR TITLE
Fix-9253: Change the deprecated charts repo URL in release notes

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -70,7 +70,7 @@ The community keeps growing, and we'd love to see you there!
   - `#helm-users` for questions and just to hang out
   - `#helm-dev` for discussing PRs, code, and bugs
 - Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
-- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)
+- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)
 
 ## Notable Changes
 


### PR DESCRIPTION
What this PR does / why we need it:
Fix for issue #9253. The link has been taken from the Helm GitHub front page for consistency across the documentation.

**What this PR does / why we need it**:
Fixed a deprecated link within the release-note.sh file
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
