### PR TITLE
[WIP] Use `NewCapabilities()` func instead of global `DefaultCapabilities`

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -111,7 +111,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	actionConfig := &action.Configuration{
 		Releases:     store,
 		KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
-		Capabilities: chartutil.DefaultCapabilities,
+		Capabilities: chartutil.NewCapabilities(),
 		Log:          func(format string, v ...interface{}) {},
 	}
 

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -83,7 +83,7 @@ func actionConfigFixture(t *testing.T) *Configuration {
 	return &Configuration{
 		Releases:       storage.Init(driver.NewMemory()),
 		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
-		Capabilities:   chartutil.DefaultCapabilities,
+		Capabilities:   chartutil.NewCapabilities(),
 		RegistryClient: registryClient,
 		Log: func(format string, v ...interface{}) {
 			t.Helper()

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -196,7 +196,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	if i.ClientOnly {
 		// Add mock objects in here so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
-		i.cfg.Capabilities = chartutil.DefaultCapabilities
+		i.cfg.Capabilities = chartutil.NewCapabilities()
 		i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
 		i.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -118,7 +118,7 @@ func TestInstallReleaseClientOnly(t *testing.T) {
 	instAction.ClientOnly = true
 	instAction.Run(buildChart(), nil) // disregard output
 
-	is.Equal(instAction.cfg.Capabilities, chartutil.DefaultCapabilities)
+	is.Equal(instAction.cfg.Capabilities, chartutil.NewCapabilities())
 	is.Equal(instAction.cfg.KubeClient, &kubefake.PrintingKubeClient{Out: ioutil.Discard})
 }
 

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -35,17 +35,6 @@ const (
 var (
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()
-
-	// DefaultCapabilities is the default set of capabilities.
-	DefaultCapabilities = &Capabilities{
-		KubeVersion: KubeVersion{
-			Version: fmt.Sprintf("v%d.%d.0", k8sVersionMajor, k8sVersionMinor),
-			Major:   strconv.Itoa(k8sVersionMajor),
-			Minor:   strconv.Itoa(k8sVersionMinor),
-		},
-		APIVersions: DefaultVersionSet,
-		HelmVersion: helmversion.Get(),
-	}
 )
 
 // Capabilities describes the capabilities of the Kubernetes cluster.
@@ -56,6 +45,19 @@ type Capabilities struct {
 	APIVersions VersionSet
 	// HelmVersion is the build information for this helm version
 	HelmVersion helmversion.BuildInfo
+}
+
+// NewCapabilities returns the default set of capabilities.
+func NewCapabilities() *Capabilities {
+	return &Capabilities{
+		KubeVersion: KubeVersion{
+			Version: fmt.Sprintf("v%d.%d.0", k8sVersionMajor, k8sVersionMinor),
+			Major:   strconv.Itoa(k8sVersionMajor),
+			Minor:   strconv.Itoa(k8sVersionMinor),
+		},
+		APIVersions: DefaultVersionSet,
+		HelmVersion: helmversion.Get(),
+	}
 }
 
 // KubeVersion is the Kubernetes version.

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -41,7 +41,7 @@ func TestDefaultVersionSet(t *testing.T) {
 }
 
 func TestDefaultCapabilities(t *testing.T) {
-	kv := DefaultCapabilities.KubeVersion
+	kv := NewCapabilities().KubeVersion
 	if kv.String() != "v1.20.0" {
 		t.Errorf("Expected default KubeVersion.String() to be v1.20.0, got %q", kv.String())
 	}
@@ -60,8 +60,7 @@ func TestDefaultCapabilities(t *testing.T) {
 }
 
 func TestDefaultCapabilitiesHelmVersion(t *testing.T) {
-	hv := DefaultCapabilities.HelmVersion
-
+	hv := NewCapabilities().HelmVersion
 	if hv.Version != "v3.5" {
 		t.Errorf("Expected default HelmVersion to be v3.5, got %q", hv.Version)
 	}

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -136,7 +136,7 @@ type ReleaseOptions struct {
 // This takes both ReleaseOptions and Capabilities to merge into the render values.
 func ToRenderValues(chrt *chart.Chart, chrtVals map[string]interface{}, options ReleaseOptions, caps *Capabilities) (Values, error) {
 	if caps == nil {
-		caps = DefaultCapabilities
+		caps = NewCapabilities()
 	}
 	top := map[string]interface{}{
 		"Chart":        chrt.Metadata,


### PR DESCRIPTION
Signed-off-by: Wahab Ali <wahabalimk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Proposing the use of `NewCapabilities()` instead of the global `DefaultCapabilities` variable.  Reason being, so that long-running processes (read: server processes) that are using helm libraries do not retain values appended to `Capabilities.APIVersions` (using `--api-versions`) across multiple calls for template.

I know this doesn't effect the functionality of Helm CLI, but it would be nice to have for anybody using the libraries in this repository.

**Special notes for your reviewer**:
**Scenario that shows the problem addressed by this PR:**
- I am using helm libraries to provide the functionality similar to `helm template` in my Helm registry.
- All parameters work fine except for `helm template --apiversions`. This argument is used to provide a list of additional Kubernetes API versions to be used for the `Capabilities.APIVersions` object of a Helm chart.
- When calling the API endpoint that I have for templating a chart with `?apiversions=dummy`, I could see dummy appended to the list as expected.
```bash
$ curl -k --request GET "https://$HOST/charts/api/admin/myrepo/charts/chart1/0.2.0/template?api-versions=dummy" -u admin:password1234
. . . . . . .
  # Source: chart1/templates/configmap.yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: RELEASE-NAME
  data:
    apiVersions.txt: |
      [v1 admissionregistration.k8s.io/v1 admissionregistration.k8s.io/v1beta1 apps/v1 apps/v1beta1 apps/v1beta2 auditregistration.k8s.io/v1alpha1 authentication.k8s.io/v1 authentication.k8s.io/v1beta1 authorization.k8s.io/v1 authorization.k8s.io/v1beta1 autoscaling/v1 autoscaling/v2beta1 autoscaling/v2beta2 batch/v1 batch/v1beta1 batch/v2alpha1 certificates.k8s.io/v1beta1 coordination.k8s.io/v1beta1 coordination.k8s.io/v1 discovery.k8s.io/v1alpha1 discovery.k8s.io/v1beta1 events.k8s.io/v1beta1 extensions/v1beta1 flowcontrol.apiserver.k8s.io/v1alpha1 networking.k8s.io/v1 networking.k8s.io/v1beta1 node.k8s.io/v1alpha1 node.k8s.io/v1beta1 policy/v1beta1 rbac.authorization.k8s.io/v1 rbac.authorization.k8s.io/v1beta1 rbac.authorization.k8s.io/v1alpha1 scheduling.k8s.io/v1alpha1 scheduling.k8s.io/v1beta1 scheduling.k8s.io/v1 settings.k8s.io/v1alpha1 storage.k8s.io/v1beta1 storage.k8s.io/v1 storage.k8s.io/v1alpha1 apiextensions.k8s.io/v1beta1 apiextensions.k8s.io/v1 dummy]
. . . . . . . 
```
- But when calling the API endpoint again, I see the value `dummy` repeated twice:
```bash
$ curl -k --request GET "https://$HOST/charts/api/admin/myrepo/charts/chart1/0.2.0/template?api-versions=dummy" -u admin:password1234
. . . . . . .
  # Source: chart1/templates/configmap.yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: RELEASE-NAME
  data:
    apiVersions.txt: |
      [v1 admissionregistration.k8s.io/v1 admissionregistration.k8s.io/v1beta1 apps/v1 apps/v1beta1 apps/v1beta2 auditregistration.k8s.io/v1alpha1 authentication.k8s.io/v1 authentication.k8s.io/v1beta1 authorization.k8s.io/v1 authorization.k8s.io/v1beta1 autoscaling/v1 autoscaling/v2beta1 autoscaling/v2beta2 batch/v1 batch/v1beta1 batch/v2alpha1 certificates.k8s.io/v1beta1 coordination.k8s.io/v1beta1 coordination.k8s.io/v1 discovery.k8s.io/v1alpha1 discovery.k8s.io/v1beta1 events.k8s.io/v1beta1 extensions/v1beta1 flowcontrol.apiserver.k8s.io/v1alpha1 networking.k8s.io/v1 networking.k8s.io/v1beta1 node.k8s.io/v1alpha1 node.k8s.io/v1beta1 policy/v1beta1 rbac.authorization.k8s.io/v1 rbac.authorization.k8s.io/v1beta1 rbac.authorization.k8s.io/v1alpha1 scheduling.k8s.io/v1alpha1 scheduling.k8s.io/v1beta1 scheduling.k8s.io/v1 settings.k8s.io/v1alpha1 storage.k8s.io/v1beta1 storage.k8s.io/v1 storage.k8s.io/v1alpha1 apiextensions.k8s.io/v1beta1 apiextensions.k8s.io/v1 dummy dummy]
. . . . . . . 
```
- The problem is the global var DefaultCapabilities that is [used by the install client](https://github.com/helm/helm/blob/976d668dec032f7ce309f31f65a50cebb9b0be95/pkg/action/install.go#L198) to generate the template. Since helm CLI process exits after `helm template` command is used, this side effect of having a global variable is not felt.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
