### PR TITLE
feat(comp): Completion for the docs --type flag

### DIFF
--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -68,6 +68,17 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&o.docTypeString, "type", "markdown", "the type of documentation to generate (markdown, man, bash)")
 	f.BoolVar(&o.generateHeaders, "generate-headers", false, "generate standard headers for markdown files")
 
+	cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		types := []string{"bash", "man", "markdown"}
+		var comps []string
+		for _, t := range types {
+			if strings.HasPrefix(t, toComplete) {
+				comps = append(comps, t)
+			}
+		}
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	})
+
 	return cmd
 }
 

--- a/cmd/helm/docs_test.go
+++ b/cmd/helm/docs_test.go
@@ -20,6 +20,19 @@ import (
 	"testing"
 )
 
+func TestDocsTypeFlagCompletion(t *testing.T) {
+	tests := []cmdTestCase{{
+		name:   "completion for docs --type",
+		cmd:    "__complete docs --type ''",
+		golden: "output/docs-type-comp.txt",
+	}, {
+		name:   "completion for docs --type",
+		cmd:    "__complete docs --type mar",
+		golden: "output/docs-type-filtered-comp.txt",
+	}}
+	runTestCmd(t, tests)
+}
+
 func TestDocsFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "docs", false)
 }

--- a/cmd/helm/testdata/output/docs-type-comp.txt
+++ b/cmd/helm/testdata/output/docs-type-comp.txt
@@ -1,0 +1,5 @@
+bash
+man
+markdown
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/docs-type-filtered-comp.txt
+++ b/cmd/helm/testdata/output/docs-type-filtered-comp.txt
@@ -1,0 +1,3 @@
+markdown
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
**What this PR does / why we need it**:

Add completion for the `--type` flag of the `docs` command.

Although the `docs` command is a hidden one, and therefore does not trigger completion, once someone has chosen to use it, might as well help them with some completion

**Special notes for your reviewer**:

We should remove the generation of the `bash` completion script from the `docs` command, but it will have to wait for helm v4

**If applicable**:
- [x] this PR contains unit tests
