### PR TITLE
WIP: [Install]: Change --dependency-update Behavior

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -209,32 +209,39 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		warning("This chart is deprecated")
 	}
 
+	// Only check dependencies if there are any
 	if req := chartRequested.Metadata.Dependencies; req != nil {
 		// If CheckDependencies returns an error, we have unfulfilled dependencies.
 		// As of Helm 2.4.0, this is treated as a stopping condition:
 		// https://github.com/helm/helm/issues/2209
-		if err := action.CheckDependencies(chartRequested, req); err != nil {
-			if client.DependencyUpdate {
-				man := &downloader.Manager{
-					Out:              out,
-					ChartPath:        cp,
-					Keyring:          client.ChartPathOptions.Keyring,
-					SkipUpdate:       false,
-					Getters:          p,
-					RepositoryConfig: settings.RepositoryConfig,
-					RepositoryCache:  settings.RepositoryCache,
-					Debug:            settings.Debug,
-				}
-				if err := man.Update(); err != nil {
-					return nil, err
-				}
-				// Reload the chart with the updated Chart.lock file.
-				if chartRequested, err = loader.Load(cp); err != nil {
-					return nil, errors.Wrap(err, "failed reloading chart after repo update")
-				}
-			} else {
+		// Update all dependencies if DependencyUpdate is true
+		if client.DependencyUpdate {
+			man := &downloader.Manager{
+				Out:              out,
+				ChartPath:        cp,
+				Keyring:          client.ChartPathOptions.Keyring,
+				SkipUpdate:       false,
+				Getters:          p,
+				RepositoryConfig: settings.RepositoryConfig,
+				RepositoryCache:  settings.RepositoryCache,
+				Debug:            settings.Debug,
+			}
+
+			// reload chart dependencies
+			if err := man.Update(); err != nil {
 				return nil, err
 			}
+
+			// Reload the chart with the updated Chart.lock file.
+			if chartRequested, err = loader.Load(cp); err != nil {
+				return nil, errors.Wrap(err, "failed reloading chart after repo update")
+			}
+
+		}
+
+		// If not all dependencies are locally fail
+		if err := action.CheckDependencies(chartRequested, req); err != nil {
+			return nil, err
 		}
 	}
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -211,10 +211,6 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 
 	// Only check dependencies if there are any
 	if req := chartRequested.Metadata.Dependencies; req != nil {
-		// If CheckDependencies returns an error, we have unfulfilled dependencies.
-		// As of Helm 2.4.0, this is treated as a stopping condition:
-		// https://github.com/helm/helm/issues/2209
-		// Update all dependencies if DependencyUpdate is true
 		if client.DependencyUpdate {
 			man := &downloader.Manager{
 				Out:              out,
@@ -239,7 +235,10 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 
 		}
 
-		// If not all dependencies are locally fail
+		// If CheckDependencies returns an error, we have unfulfilled dependencies.
+		// As of Helm 2.4.0, this is treated as a stopping condition:
+		// https://github.com/helm/helm/issues/2209
+		// Update all dependencies if DependencyUpdate is true
 		if err := action.CheckDependencies(chartRequested, req); err != nil {
 			return nil, err
 		}

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -111,7 +111,7 @@ func TestInstall(t *testing.T) {
 		{
 			name: "install with verification, valid",
 			cmd:  "install signtest testdata/testcharts/signtest-0.1.0.tgz --verify --keyring testdata/helm-test-key.pub",
-		},
+		}, 
 		// Install, chart with missing dependencies in /charts
 		{
 			name:      "install chart with missing dependencies",
@@ -120,7 +120,7 @@ func TestInstall(t *testing.T) {
 		},
 		// Install chart with update-dependency
 		{
-			name:   "install chart with missing dependencies",
+			name:   "install chart with missing dependencies with update",
 			cmd:    "install --dependency-update updeps testdata/testcharts/chart-with-subchart-update",
 			golden: "output/chart-with-subchart-update.txt",
 		},

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/storage/driver"
 )
@@ -105,6 +106,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.Wait = client.Wait
 					instClient.WaitForJobs = client.WaitForJobs
 					instClient.Devel = client.Devel
+					instClient.DependencyUpdate = client.DependencyUpdate
 					instClient.Namespace = client.Namespace
 					instClient.Atomic = client.Atomic
 					instClient.PostRenderer = client.PostRenderer
@@ -132,6 +134,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
+			p := getter.All(settings)
 			vals, err := valueOpts.MergeValues(getter.All(settings))
 			if err != nil {
 				return err
@@ -142,7 +145,33 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Only check dependencies if there are any
 			if req := ch.Metadata.Dependencies; req != nil {
+				// Update all dependencies if DependencyUpdate is true
+				if client.DependencyUpdate {
+					man := &downloader.Manager{
+						Out:              out,
+						ChartPath:        chartPath,
+						Keyring:          client.ChartPathOptions.Keyring,
+						SkipUpdate:       false,
+						Getters:          p,
+						RepositoryConfig: settings.RepositoryConfig,
+						RepositoryCache:  settings.RepositoryCache,
+						Debug:            settings.Debug,
+					}
+
+					// reload chart dependencies
+					if err := man.Update(); err != nil {
+						return err
+					}
+
+					// Reload the chart with the updated Chart.lock file.
+					if ch, err = loader.Load(chartPath); err != nil {
+						return errors.Wrap(err, "failed reloading chart after repo update")
+					}
+				}
+
+				// If not all dependencies are locally fail
 				if err := action.CheckDependencies(ch, req); err != nil {
 					return err
 				}
@@ -182,6 +211,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&client.WaitForJobs, "wait-for-jobs", false, "if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, upgrade process rolls back changes made in case of failed upgrade. The --wait flag will be set automatically if --atomic is used")
+	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "run helm dependency update before upgrading the chart")
 	f.IntVar(&client.MaxHistory, "history-max", settings.MaxHistory, "limit the maximum number of revisions saved per release. Use 0 for no limit")
 	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this upgrade when upgrade fails")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -171,7 +171,10 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					}
 				}
 
-				// If not all dependencies are locally fail
+				// If CheckDependencies returns an error, we have unfulfilled dependencies.
+				// As of Helm 2.4.0, this is treated as a stopping condition:
+				// https://github.com/helm/helm/issues/2209
+				// Update all dependencies if DependencyUpdate is true
 				if err := action.CheckDependencies(ch, req); err != nil {
 					return err
 				}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -98,6 +98,7 @@ type Upgrade struct {
 	PostRenderer postrender.PostRenderer
 	// DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
 	DisableOpenAPIValidation bool
+	DependencyUpdate         bool
 }
 
 // NewUpgrade creates a new Upgrade object with the given configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This Pull Request changes the functionality on how dependencies are handled when using the install subcommand and adds the same functionality to the `upgrade` subcommand. We noticed that when using the `--dependency-update` dependencies are only updated, if they are not existent in the **charts/**. If they are already existent no update will be made. In our opinion that's not the correct behavior. The update should always be made when adding the `--dependency-update`. That's what has changed on the `install` subcommand (We did not create a dedicated issue for this). We are not sure if that's the behavior you expected from this flag. But looking at the documentation it states:

```
--dependency-update            run helm dependency update before installing the chart
```

And the change actually enforces this behavior. For us this makes a lot more sense, especially when you have version ranges for dependencies. Let us know what you think about it. This change should be classified as bugfix but changes functionality, but is in our opinion backwards compatible.

The same functionality was implemented for the `upgrade` subcommand. It adds the `--dependency-update` flag dependencies are updated the same as on the install subcommand. If the `--install`flag is present, the parameter ist just given to the InstallClient. Issues regarding this change: 
  - fixes #7162 

This change should be classified as feature.

**Special notes for your reviewer**:

This is our first commit on this project. If you have any feedback please let us know :)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
