### PR TITLE
fix(helm): get/get-helm-3 whitespace support in runAsRoot

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -50,13 +50,11 @@ initOS() {
 
 # runs the given command as root (detects if we are root already)
 runAsRoot() {
-  local CMD="$*"
-
-  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
-    CMD="sudo $CMD"
+  if [ $EUID -ne 0 -a "$USE_SUDO" = "true" ]; then
+    sudo "${@}"
+  else
+    "${@}"
   fi
-
-  $CMD
 }
 
 # verifySupported checks that the os/arch combination is supported for

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -57,13 +57,11 @@ initOS() {
 
 # runs the given command as root (detects if we are root already)
 runAsRoot() {
-  local CMD="$*"
-
-  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
-    CMD="sudo $CMD"
+  if [ $EUID -ne 0 -a "$USE_SUDO" = "true" ]; then
+    sudo "${@}"
+  else
+    "${@}"
   fi
-
-  $CMD
 }
 
 # verifySupported checks that the os/arch combination is supported for


### PR DESCRIPTION
When `get`/`get-helm-3` is run with a HELM_INSTALL_DIR containing spaces, the installation fails.

This PR fixes the issues, by wrapping the parameters correctly.

Closes #9346