### PR TITLE
improve tests on windows

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -77,6 +77,7 @@ func path(filename string) string {
 }
 
 func compare(actual []byte, filename string) error {
+	actual = normalize(actual)
 	if err := update(filename, actual); err != nil {
 		return err
 	}
@@ -85,6 +86,7 @@ func compare(actual []byte, filename string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to read testdata %s", filename)
 	}
+	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
 		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'\n", filename, expected, actual)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We have seen that the tests running on windows fail when the fixtures in `cmd/helm/testdata/output` have been generated in linux (and vica versa) due to the different ways the two OS handle line breaks (`\r\n` vs. `\n`). 
The changes in this PR us the normalize function from `internal/test/test.go` to replace `\r\n` by `\n` in the `actual` and the `expected` strings to achieve compatibility of the fixtures.