### PR TITLE
feat(comp): Improve completion for plugin commands

### DIFF
--- a/cmd/helm/plugin_list.go
+++ b/cmd/helm/plugin_list.go
@@ -51,12 +51,37 @@ func newPluginListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+// Returns all plugins from plugins, except those with names matching ignoredPluginNames
+func filterPlugins(plugins []*plugin.Plugin, ignoredPluginNames []string) []*plugin.Plugin {
+	// if ignoredPluginNames is nil, just return plugins
+	if ignoredPluginNames == nil {
+		return plugins
+	}
+
+	var filteredPlugins []*plugin.Plugin
+	for _, plugin := range plugins {
+		found := false
+		for _, ignoredName := range ignoredPluginNames {
+			if plugin.Metadata.Name == ignoredName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			filteredPlugins = append(filteredPlugins, plugin)
+		}
+	}
+
+	return filteredPlugins
+}
+
 // Provide dynamic auto-completion for plugin names
-func compListPlugins(toComplete string) []string {
+func compListPlugins(toComplete string, ignoredPluginNames []string) []string {
 	var pNames []string
 	plugins, err := plugin.FindPlugins(settings.PluginsDirectory)
-	if err == nil {
-		for _, p := range plugins {
+	if err == nil && len(plugins) > 0 {
+		filteredPlugins := filterPlugins(plugins, ignoredPluginNames)
+		for _, p := range filteredPlugins {
 			if strings.HasPrefix(p.Metadata.Name, toComplete) {
 				pNames = append(pNames, p.Metadata.Name)
 			}

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -305,6 +305,50 @@ func TestLoadPlugins_HelmNoPlugins(t *testing.T) {
 	}
 }
 
+func TestPluginCmdsCompletion(t *testing.T) {
+
+	tests := []cmdTestCase{{
+		name:   "completion for plugin update",
+		cmd:    "__complete plugin update ''",
+		golden: "output/plugin_list_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin update repetition",
+		cmd:    "__complete plugin update args ''",
+		golden: "output/plugin_repeat_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin uninstall",
+		cmd:    "__complete plugin uninstall ''",
+		golden: "output/plugin_list_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin uninstall repetition",
+		cmd:    "__complete plugin uninstall args ''",
+		golden: "output/plugin_repeat_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin list",
+		cmd:    "__complete plugin list ''",
+		golden: "output/empty_nofile_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin install no args",
+		cmd:    "__complete plugin install ''",
+		golden: "output/empty_default_comp.txt",
+		rels:   []*release.Release{},
+	}, {
+		name:   "completion for plugin install one arg",
+		cmd:    "__complete plugin list /tmp ''",
+		golden: "output/empty_nofile_comp.txt",
+		rels:   []*release.Release{},
+	}, {}}
+	for _, test := range tests {
+		settings.PluginsDirectory = "testdata/helmhome/helm/plugins"
+		runTestCmd(t, []cmdTestCase{test})
+	}
+}
+
 func TestPluginFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "plugin", false)
 }

--- a/cmd/helm/plugin_uninstall.go
+++ b/cmd/helm/plugin_uninstall.go
@@ -39,10 +39,7 @@ func newPluginUninstallCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"rm", "remove"},
 		Short:   "uninstall one or more Helm plugins",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			return compListPlugins(toComplete), cobra.ShellCompDirectiveNoFileComp
+			return compListPlugins(toComplete, args), cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return o.complete(args)

--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -40,10 +40,7 @@ func newPluginUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "update one or more Helm plugins",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			return compListPlugins(toComplete), cobra.ShellCompDirectiveNoFileComp
+			return compListPlugins(toComplete, args), cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return o.complete(args)

--- a/cmd/helm/testdata/output/empty_default_comp.txt
+++ b/cmd/helm/testdata/output/empty_default_comp.txt
@@ -1,0 +1,2 @@
+:0
+Completion ended with directive: ShellCompDirectiveDefault

--- a/cmd/helm/testdata/output/empty_nofile_comp.txt
+++ b/cmd/helm/testdata/output/empty_nofile_comp.txt
@@ -1,0 +1,2 @@
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/plugin_list_comp.txt
+++ b/cmd/helm/testdata/output/plugin_list_comp.txt
@@ -1,0 +1,7 @@
+args
+echo
+env
+exitwith
+fullenv
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/plugin_repeat_comp.txt
+++ b/cmd/helm/testdata/output/plugin_repeat_comp.txt
@@ -1,0 +1,6 @@
+echo
+env
+exitwith
+fullenv
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
**What this PR does / why we need it**:

The `plugin update` and `plugin uninstall` commands can accept more than one plugin name as arguments; this commit teaches the completion logic to respect that.

**Special notes for your reviewer**:

The logic to not suggest a plugin that is already on the command-line is the same as the logic for completion of the `helm repo rm` command which also takes multiple arguments. See https://github.com/helm/helm/blob/64c8df187af892c2a9f872f91e892a717df2e7ff/cmd/helm/repo_list.go#L103

**If applicable**:
- [x] this PR contains unit tests
