### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-coverage:
 
 .PHONY: test-style
 test-style:
-	GO111MODULE=on golangci-lint run
+	GO111MODULE=on golangci-lint run --timeout 5m0s
 	@scripts/validate-license.sh
 
 .PHONY: test-acceptance


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm not sure we need this change.
Recently, CircleCI has been timing out on `make test-style` for all PRs (4 PRs and over 10 build attempts).  I've restarted the build multiple times without success.  It only worked when I increased the timeout for golangci-lint. This all works locally without problem. 

