### PR TITLE
fix reuse values

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -442,15 +442,12 @@ func (u *Upgrade) reuseValues(chart *chart.Chart, current *release.Release, newV
 	if u.ReuseValues {
 		u.cfg.Log("reusing the old release's values")
 
-		// We have to regenerate the old coalesced values:
-		oldVals, err := chartutil.CoalesceValues(current.Chart, current.Config)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to rebuild old values")
-		}
+		// merge old chart values to new chart values
+		mergedChartValues := chartutil.CoalesceTables(chart.Values, current.Chart.Values)
 
 		newVals = chartutil.CoalesceTables(newVals, current.Config)
 
-		chart.Values = oldVals
+		chart.Values = mergedChartValues
 
 		return newVals, nil
 	}


### PR DESCRIPTION
fix reuse-values
If we add some new key values which readed from Values.yaml to the new chart ,upgrade release by reuse-values will fail to upgrade.
