### PR TITLE
Use generated temp directory for helm dependencies

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -247,7 +247,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	}
 
 	destPath := filepath.Join(m.ChartPath, "charts")
-	tmpPath, err := ioutil.TempDir("", "tmpcharts-*")
+	tmpPath, err := ioutil.TempDir(m.ChartPath, "tmpcharts-*")
 	if err != nil {
 		return errors.Wrap(err, "failed to create tmpcharts dir")
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -247,7 +247,11 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	}
 
 	destPath := filepath.Join(m.ChartPath, "charts")
-	tmpPath := filepath.Join(m.ChartPath, "tmpcharts")
+	tmpPath, err := ioutil.TempDir("", "tmpcharts-*")
+	if err != nil {
+		return errors.Wrap(err, "failed to create tmpcharts dir")
+	}
+	os.Remove(tmpPath)
 
 	// Create 'charts' directory if it doesn't already exist.
 	if fi, err := os.Stat(destPath); err != nil {

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -17,10 +17,13 @@ package downloader
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"helm.sh/helm/v3/internal/third_party/dep/fs"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -188,22 +191,29 @@ func TestDownloadAll(t *testing.T) {
 	// 2nd downloadAll copies existing charts to tmpcharts and fails but tmpcharts folder will be removed
 	// 3rd downloadAll again runs with another dependency
 	b := bytes.NewBuffer(nil)
+	testDir, _ := ioutil.TempDir("", "helm-manager-test-*")
 	m := &Manager{
 		Out:              b,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
+		ChartPath:        testDir,
 	}
-	// remove charts folder at the end of test
-	defer os.RemoveAll("charts")
+	// remove Chart folder at the end of test
+	defer os.RemoveAll(testDir)
+
+	testChartPath := "./testdata/signtest"
+
+	// Copy the test chart to our testing area
+	fs.CopyDir(testChartPath, filepath.Join(testDir, testChartPath))
 
 	// call downloadAll so that it will create charts directory
 	err := m.downloadAll([]*chart.Dependency{
-		{Name: "local-dep", Repository: "file://./testdata/signtest", Version: "0.1.0"},
+		{Name: "local-dep", Repository: "file://" + testChartPath, Version: "0.1.0"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// this will copy charts directory content to tmp directory and recreates new charts
+	// this will copy charts directory content to tmp directory and recreate new charts
 	err = m.downloadAll([]*chart.Dependency{
 		{Name: "local-subchart", Repository: ""},
 	})
@@ -211,7 +221,7 @@ func TestDownloadAll(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = m.downloadAll([]*chart.Dependency{
-		{Name: "local-dep", Repository: "file://./testdata/signtest", Version: "0.1.0"},
+		{Name: "local-dep", Repository: "file://" + testChartPath, Version: "0.1.0"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Masterminds/goutils"
 
 	"helm.sh/helm/v3/internal/test/ensure"
+	"helm.sh/helm/v3/internal/third_party/dep/fs"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/lint/support"
@@ -75,8 +76,8 @@ var ignoredTemplatePath = filepath.Join(templateTestBasedir, "fail.yaml.ignored"
 // namespaces, partial templates
 func TestTemplateIntegrationHappyPath(t *testing.T) {
 	// Rename file so it gets ignored by the linter
-	os.Rename(wrongTemplatePath, ignoredTemplatePath)
-	defer os.Rename(ignoredTemplatePath, wrongTemplatePath)
+	fs.RenameWithFallback(wrongTemplatePath, ignoredTemplatePath)
+	defer fs.RenameWithFallback(ignoredTemplatePath, wrongTemplatePath)
 
 	linter := support.Linter{ChartDir: templateTestBasedir}
 	Templates(&linter, values, namespace, strict)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
* Use [ioutil.TempDir()](https://golang.org/pkg/io/ioutil/#TempDir) to pick temporary chart directory name
* Add test

Closes #5567, #8846 

**Special notes for your reviewer**:
* @gzur suggested this approach https://github.com/helm/helm/pull/8846#issuecomment-768479847
* @deathname wrote the test -- I tested by running w/o this patch and the test fails -- I tested with this patch and the test passes

I'm sorry for pushing this forward, we're hitting this and it's a small enough thing that I'd rather get it in than wait for someone else. Similarly, if any work that I propose anywhere gets stuck because I'm unavailable (which happens periodically), I'm more than happy for someone else to take my work and run with it.

We = consumers of argoproj/argo-cd#5107

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
