### PR TITLE
fix(cmd): Show that flags can be used for zsh/fish

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -92,12 +92,11 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 	}
 
 	zsh := &cobra.Command{
-		Use:                   "zsh",
-		Short:                 "generate autocompletion script for zsh",
-		Long:                  zshCompDesc,
-		Args:                  require.NoArgs,
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     noCompletions,
+		Use:               "zsh",
+		Short:             "generate autocompletion script for zsh",
+		Long:              zshCompDesc,
+		Args:              require.NoArgs,
+		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletionZsh(out, cmd)
 		},
@@ -105,12 +104,11 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 	zsh.Flags().BoolVar(&disableCompDescriptions, noDescFlagName, false, noDescFlagText)
 
 	fish := &cobra.Command{
-		Use:                   "fish",
-		Short:                 "generate autocompletion script for fish",
-		Long:                  fishCompDesc,
-		Args:                  require.NoArgs,
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     noCompletions,
+		Use:               "fish",
+		Short:             "generate autocompletion script for fish",
+		Long:              fishCompDesc,
+		Args:              require.NoArgs,
+		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletionFish(out, cmd)
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Tiny little tweak to the help message.
The "helm completion zsh" and "helm completion fish" commands accept the "--no-descriptions" flag, therefore we should not disable the addition of "[flags]" to the usage line when printing the help.

