### PR TITLE
initialize registry client in oci getter

### DIFF
--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -58,10 +58,19 @@ func (g *OCIGetter) get(href string) (*bytes.Buffer, error) {
 }
 
 // NewOCIGetter constructs a valid http/https client as a Getter
-func NewOCIGetter(options ...Option) (Getter, error) {
-	var client OCIGetter
+func NewOCIGetter(ops ...Option) (Getter, error) {
+	registryClient, err := registry.NewClient()
+	if err != nil {
+		return nil, err
+	}
 
-	for _, opt := range options {
+	client := OCIGetter{
+		opts: options{
+			registryClient: registryClient,
+		},
+	}
+
+	for _, opt := range ops {
 		opt(&client.opts)
 	}
 

--- a/pkg/getter/ocigetter_test.go
+++ b/pkg/getter/ocigetter_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package getter
+
+import (
+	"testing"
+)
+
+func TestNewOCIGetter(t *testing.T) {
+	testfn := func(ops *options) {
+		if ops.registryClient == nil {
+			t.Fatalf("the OCIGetter's registryClient should not be null")
+		}
+	}
+
+	NewOCIGetter(testfn)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When trying to pull or use an image from my OCI-compliant registry, I get a nil pointer error.

```
➜ helm repo add localrepo oci://my-local-repo.com/my/chart/path:1.0.0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x22105e3]

goroutine 1 [running]:
helm.sh/helm/v3/internal/experimental/registry.(*Client).PullChart(0x0, 0xc000507380, 0xc000507380, 0x0, 0x0)
	/private/tmp/helm-20210204-28341-4m1iqg/internal/experimental/registry/client.go:156 +0x183
helm.sh/helm/v3/pkg/getter.(*OCIGetter).get(0xc0004f0aa0, 0xc0001807e0, 0x45, 0x20, 0x2589740, 0x268c701)
	/private/tmp/helm-20210204-28341-4m1iqg/pkg/getter/ocigetter.go:52 +0xc5
helm.sh/helm/v3/pkg/getter.(*OCIGetter).Get(0xc0004f0aa0, 0xc0001807e0, 0x45, 0xc000507300, 0x4, 0x4, 0xc00052af00, 0xc0001b1590, 0x50)
	/private/tmp/helm-20210204-28341-4m1iqg/pkg/getter/ocigetter.go:36 +0x77
helm.sh/helm/v3/pkg/repo.(*ChartRepository).DownloadIndexFile(0xc0001b1590, 0xc00052aec0, 0x2, 0x2, 0xc0001b1590)
	/private/tmp/helm-20210204-28341-4m1iqg/pkg/repo/chartrepo.go:127 +0x330
main.(*repoAddOptions).run(0xc00035e420, 0x2a4fcc0, 0xc0001a8008, 0x0, 0x0)
	/private/tmp/helm-20210204-28341-4m1iqg/cmd/helm/repo_add.go:183 +0x84b
main.newRepoAddCmd.func1(0xc0001de580, 0xc000433ee0, 0x2, 0x2, 0x0, 0x0)
	/private/tmp/helm-20210204-28341-4m1iqg/cmd/helm/repo_add.go:80 +0xf5
github.com/spf13/cobra.(*Command).execute(0xc0001de580, 0xc000433ea0, 0x2, 0x2, 0xc0001de580, 0xc000433ea0)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0xc00036eb00, 0xc0009ac3b0, 0x1, 0xc0005c1f60)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main()
	/private/tmp/helm-20210204-28341-4m1iqg/cmd/helm/helm.go:80 +0x24d
```

**Special notes for your reviewer**:

The issue was the `registryClient` in the `OCIGetter` was assumed to be initialized when `NewOCIGetter` was called. It was not. So this simply initializes it with `registry.NewClient()`.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
