### PR TITLE
Added s390x support to get script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -60,7 +60,7 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="darwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nwindows-amd64"
+  local supported="darwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to https://github.com/helm/helm"


### PR DESCRIPTION
Signed-off-by: Ajay Victor <ajvictor@in.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add s390x support to get installer script

**Special notes for your reviewer**:
Similar PR: https://github.com/helm/helm/pull/8177
Results:
```
[VM scripts]# ./get
Helm v2.17.0 is available. Changing from version v2.12.0.
Downloading https://get.helm.sh/helm-v2.17.0-linux-s390x.tar.gz
Preparing to install helm and tiller into /usr/local/bin
helm installed into /usr/local/bin/helm
tiller installed into /usr/local/bin/tiller
Run 'helm init' to configure helm.
[VM scripts]#
```
Check:
```
[VM scripts]# helm --help
The Kubernetes package manager

To begin working with Helm, run the 'helm init' command:

        $ helm init

This will install Tiller to your running Kubernetes cluster.
It will also set up any necessary local configuration.

Common actions from this point include:

- helm search:    Search for charts
- helm fetch:     Download a chart to your local directory to view
- helm install:   Upload the chart to Kubernetes
- helm list:      List releases of charts

Environment:

- $HELM_HOME:           Set an alternative location for Helm files. By default, these are stored in ~/.helm
- $HELM_HOST:           Set an alternative Tiller host. The format is host:port
- $HELM_NO_PLUGINS:     Disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
- $TILLER_NAMESPACE:    Set an alternative Tiller namespace (default "kube-system")
- $KUBECONFIG:          Set an alternative Kubernetes configuration file (default "~/.kube/config")
- $HELM_TLS_CA_CERT:    Path to TLS CA certificate used to verify the Helm client and Tiller server certificates (default "$HELM_HOME/ca.pem")
- $HELM_TLS_CERT:       Path to TLS client certificate file for authenticating to Tiller (default "$HELM_HOME/cert.pem")
- $HELM_TLS_KEY:        Path to TLS client key file for authenticating to Tiller (default "$HELM_HOME/key.pem")
- $HELM_TLS_ENABLE:     Enable TLS connection between Helm and Tiller (default "false")
- $HELM_TLS_VERIFY:     Enable TLS connection between Helm and Tiller and verify Tiller server certificate (default "false")
- $HELM_TLS_HOSTNAME:   The hostname or IP address used to verify the Tiller server certificate (default "127.0.0.1")
- $HELM_KEY_PASSPHRASE: Set HELM_KEY_PASSPHRASE to the passphrase of your PGP private key. If set, you will not be prompted for the passphrase while signing helm charts

Usage:
  helm [command]

Available Commands:
  completion  Generate autocompletions script for the specified shell (bash or zsh)
  create      Create a new chart with the given name
  delete      Given a release name, delete the release from Kubernetes
  dependency  Manage a chart's dependencies
  fetch       Download a chart from a repository and (optionally) unpack it in local directory
  get         Download a named release
  help        Help about any command
  history     Fetch release history
  home        Displays the location of HELM_HOME
  init        Initialize Helm on both client and server
  inspect     Inspect a chart
  install     Install a chart archive
  lint        Examines a chart for possible issues
  list        List releases
  package     Package a chart directory into a chart archive
  plugin      Add, list, or remove Helm plugins
  repo        Add, list, remove, update, and index chart repositories
  reset       Uninstalls Tiller from a cluster
  rollback    Rollback a release to a previous revision
  search      Search for a keyword in charts
  serve       Start a local http web server
  status      Displays the status of the named release
  template    Locally render templates
  test        Test a release
  upgrade     Upgrade a release
  verify      Verify that a chart at the given path has been signed and is valid
  version     Print the client/server version information

Flags:
      --debug                           Enable verbose output
  -h, --help                            help for helm
      --home string                     Location of your Helm config. Overrides $HELM_HOME (default "/root/.helm")
      --host string                     Address of Tiller. Overrides $HELM_HOST
      --kube-context string             Name of the kubeconfig context to use
      --kubeconfig string               Absolute path of the kubeconfig file to be used
      --tiller-connection-timeout int   The duration (in seconds) Helm will wait to establish a connection to Tiller (default 300)
      --tiller-namespace string         Namespace of Tiller (default "kube-system")

Use "helm [command] --help" for more information about a command.
```
**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
