### PR TITLE
Add name validation rules for different object kinds

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -65,7 +65,7 @@ var (
 // ValidName is a regular expression for resource names.
 //
 // DEPRECATED: This will be removed in Helm 4, and is no longer used here. See
-// pkg/chartutil.ValidateName for the replacement.
+// pkg/lint/rules.validateMetadataNameFunc for the replacement.
 //
 // According to the Kubernetes help text, the regular expression it uses is:
 //

--- a/pkg/chartutil/validate_name.go
+++ b/pkg/chartutil/validate_name.go
@@ -96,6 +96,9 @@ func ValidateReleaseName(name string) error {
 //
 // The Kubernetes documentation is here, though it is not entirely correct:
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+//
+// Deprecated: remove in Helm 4.  Name validation now uses rules defined in
+// pkg/lint/rules.validateMetadataNameFunc()
 func ValidateMetadataName(name string) error {
 	if name == "" || len(name) > maxMetadataNameLen || !validName.MatchString(name) {
 		return errInvalidKubernetesName

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -215,7 +215,7 @@ func validateMetadataName(obj *K8sYamlStruct) error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), obj.Metadata.Name, msg))
 	}
 	if len(allErrs) > 0 {
-		return fmt.Errorf("object name does not conform to Kubernetes naming requirements: %q (%s)", obj.Metadata.Name, allErrs.ToAggregate().Error())
+		return errors.Wrapf(allErrs.ToAggregate(), "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
 	}
 	return nil
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/validation"
+	apipath "k8s.io/apimachinery/pkg/api/validation/path"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -202,16 +205,68 @@ func validateYamlContent(err error) error {
 	return errors.Wrap(err, "unable to parse YAML")
 }
 
+// validateMetadataName uses the correct validation function for the object
+// Kind, or if not set, defaults to the standard definition of a subdomain in
+// DNS (RFC 1123), used by most resources.
 func validateMetadataName(obj *K8sYamlStruct) error {
-	if len(obj.Metadata.Name) == 0 || len(obj.Metadata.Name) > 253 {
-		return fmt.Errorf("object name must be between 0 and 253 characters: %q", obj.Metadata.Name)
+	fn := validateMetadataNameFunc(obj)
+	if fn == nil {
+		fn = validation.NameIsDNSSubdomain
 	}
-	// This will return an error if the characters do not abide by the standard OR if the
-	// name is left empty.
-	if err := chartutil.ValidateMetadataName(obj.Metadata.Name); err != nil {
-		return errors.Wrapf(err, "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+
+	allErrs := field.ErrorList{}
+	for _, msg := range fn(obj.Metadata.Name, false) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), obj.Metadata.Name, msg))
+	}
+	if len(allErrs) > 0 {
+		return fmt.Errorf("object name does not conform to Kubernetes naming requirements: %q (%s)", obj.Metadata.Name, allErrs.ToAggregate().Error())
 	}
 	return nil
+}
+
+// validateMetadataNameFunc will return a name validation function for the
+// object kind, if defined below.
+//
+// Rules should match those set in the various api validations:
+// https://github.com/kubernetes/kubernetes/blob/v1.20.0/pkg/apis/core/validation/validation.go#L205-L274
+// https://github.com/kubernetes/kubernetes/blob/v1.20.0/pkg/apis/apps/validation/validation.go#L39
+// ...
+//
+// Implementing here to avoid importing k/k.
+//
+// If no mapping is defined, returns nil.
+func validateMetadataNameFunc(obj *K8sYamlStruct) validation.ValidateNameFunc {
+	switch strings.ToLower(obj.Kind) {
+	case "pod", "node", "secret", "endpoints", "resourcequota", // core
+		"controllerrevision", "daemonset", "deployment", "replicaset", "statefulset", // apps
+		"autoscaler",     // autoscaler
+		"cronjob", "job", // batch
+		"lease",                    // coordination
+		"endpointslice",            // discovery
+		"networkpolicy", "ingress", // networking
+		"podsecuritypolicy",                           // policy
+		"priorityclass",                               // scheduling
+		"podpreset",                                   // settings
+		"storageclass", "volumeattachment", "csinode": // storage
+		return validation.NameIsDNSSubdomain
+	case "service":
+		return validation.NameIsDNS1035Label
+	case "namespace":
+		return validation.ValidateNamespaceName
+	case "serviceaccount":
+		return validation.ValidateServiceAccountName
+	case "certificatesigningrequest":
+		// No validation.
+		// https://github.com/kubernetes/kubernetes/blob/v1.20.0/pkg/apis/certificates/validation/validation.go#L137-L140
+		return func(name string, prefix bool) []string { return nil }
+	case "role", "clusterrole", "rolebinding", "clusterrolebinding":
+		// https://github.com/kubernetes/kubernetes/blob/v1.20.0/pkg/apis/rbac/validation/validation.go#L32-L34
+		return func(name string, prefix bool) []string {
+			return apipath.IsValidPathSegmentName(name)
+		}
+	default:
+		return nil
+	}
 }
 
 func validateNoCRDHooks(manifest []byte) error {

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -210,10 +210,6 @@ func validateYamlContent(err error) error {
 // DNS (RFC 1123), used by most resources.
 func validateMetadataName(obj *K8sYamlStruct) error {
 	fn := validateMetadataNameFunc(obj)
-	if fn == nil {
-		fn = validation.NameIsDNSSubdomain
-	}
-
 	allErrs := field.ErrorList{}
 	for _, msg := range fn(obj.Metadata.Name, false) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), obj.Metadata.Name, msg))
@@ -234,7 +230,9 @@ func validateMetadataName(obj *K8sYamlStruct) error {
 //
 // Implementing here to avoid importing k/k.
 //
-// If no mapping is defined, returns nil.
+// If no mapping is defined, returns NameIsDNSSubdomain.  This is used by object
+// kinds that don't have special requirements, so is the most likely to work if
+// new kinds are added.
 func validateMetadataNameFunc(obj *K8sYamlStruct) validation.ValidateNameFunc {
 	switch strings.ToLower(obj.Kind) {
 	case "pod", "node", "secret", "endpoints", "resourcequota", // core
@@ -265,7 +263,7 @@ func validateMetadataNameFunc(obj *K8sYamlStruct) validation.ValidateNameFunc {
 			return apipath.IsValidPathSegmentName(name)
 		}
 	default:
-		return nil
+		return validation.NameIsDNSSubdomain
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
fix #9197 and #9203

**Special notes for your reviewer**:
ref
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
https://github.com/kubernetes/kubernetes/blob/585fc57cc7aaf73baf6aef84bf6dab65bde0ef9e/pkg/apis/rbac/validation/validation.go#L32

This is an alternative to https://github.com/helm/helm/pull/9218 which has some feedback but appears to have stalled.  Please feel free to reject this if you prefer to pursue that instead.

The name validation change that went into https://github.com/helm/helm/releases/tag/v3.3.0 in https://github.com/helm/helm/pull/8011 doesn't take into account the different validation rules used by the different apis.

For us, the linter is failing on the RBAC rules but I can see other Kinds are also affected.

I had a good look and I can't find any way to use a higher-level api-machinery or equivalent function to validate in a generic way - even [ValidateObjectMeta](https://pkg.go.dev/k8s.io/apimachinery@v0.20.2/pkg/api/validation#ValidateObjectMeta) needs to be passed the validation function to use.  I can't find any way to set these without comparing the object's Kind. I've not used ValidateObjectMeta directly as it checks other things besides the name.

Personally, I feel this approach is brittle but I'd like to do my part to push this closer to a resolution.  I'm not aware of the motivation behind the original PR but my vote would be to revert it.  This is the best I could come up with that matches the intended behaviour.

I've left the old validation function in the utils package as it is public.  I can remove it if requested - no Helm code is using it.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
