### PR TITLE
Add descriptions to repo completions

### DIFF
--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -131,7 +132,7 @@ func compListRepos(prefix string, ignoredRepoNames []string) []string {
 		filteredRepos := filterRepos(f.Repositories, ignoredRepoNames)
 		for _, repo := range filteredRepos {
 			if strings.HasPrefix(repo.Name, prefix) {
-				rNames = append(rNames, repo.Name)
+				rNames = append(rNames, fmt.Sprintf("%s\t%s", repo.Name, repo.URL))
 			}
 		}
 	}

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,6 +159,51 @@ func testCacheFiles(t *testing.T, cacheIndexFile string, cacheChartsFile string,
 	}
 	if _, err := os.Stat(cacheChartsFile); err == nil {
 		t.Errorf("Error cache chart file was not removed for repository %s", repoName)
+	}
+}
+
+func TestRepoRemoveCompletion(t *testing.T) {
+	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	rootDir := ensure.TempDir(t)
+	repoFile := filepath.Join(rootDir, "repositories.yaml")
+	repoCache := filepath.Join(rootDir, "cache/")
+
+	var testRepoNames = []string{"foo", "bar", "baz"}
+
+	// Add test repos
+	for _, repoName := range testRepoNames {
+		o := &repoAddOptions{
+			name:     repoName,
+			url:      ts.URL(),
+			repoFile: repoFile,
+		}
+
+		if err := o.run(os.Stderr); err != nil {
+			t.Error(err)
+		}
+	}
+
+	repoSetup := fmt.Sprintf("--repository-config %s --repository-cache %s", repoFile, repoCache)
+
+	// In the following tests, we turn off descriptions for completions by using __completeNoDesc.
+	// We have to do this because the description will contain the port used by the webserver,
+	// and that port changes each time we run the test.
+	tests := []cmdTestCase{{
+		name:   "completion for repo remove",
+		cmd:    fmt.Sprintf("%s __completeNoDesc repo remove ''", repoSetup),
+		golden: "output/repo_list_comp.txt",
+	}, {
+		name:   "completion for repo remove repetition",
+		cmd:    fmt.Sprintf("%s __completeNoDesc repo remove foo ''", repoSetup),
+		golden: "output/repo_repeat_comp.txt",
+	}}
+	for _, test := range tests {
+		runTestCmd(t, []cmdTestCase{test})
 	}
 }
 

--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -302,7 +302,14 @@ func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.Shell
 
 	// First check completions for repos
 	repos := compListRepos("", nil)
-	for _, repo := range repos {
+	for _, repoInfo := range repos {
+		// Split name from description
+		repoInfo := strings.Split(repoInfo, "\t")
+		repo := repoInfo[0]
+		repoDesc := ""
+		if len(repoInfo) > 1 {
+			repoDesc = repoInfo[1]
+		}
 		repoWithSlash := fmt.Sprintf("%s/", repo)
 		if strings.HasPrefix(toComplete, repoWithSlash) {
 			// Must complete with charts within the specified repo
@@ -310,15 +317,15 @@ func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.Shell
 			noSpace = false
 			break
 		} else if strings.HasPrefix(repo, toComplete) {
-			// Must complete the repo name
-			completions = append(completions, repoWithSlash)
+			// Must complete the repo name with the slash, followed by the description
+			completions = append(completions, fmt.Sprintf("%s\t%s", repoWithSlash, repoDesc))
 			noSpace = true
 		}
 	}
 	cobra.CompDebugln(fmt.Sprintf("Completions after repos: %v", completions), settings.Debug)
 
 	// Now handle completions for url prefixes
-	for _, url := range []string{"https://", "http://", "file://"} {
+	for _, url := range []string{"https://\tChart URL prefix", "http://\tChart URL prefix", "file://\tChart local URL prefix"} {
 		if strings.HasPrefix(toComplete, url) {
 			// The user already put in the full url prefix; we don't have
 			// anything to add, but make sure the shell does not default
@@ -355,7 +362,7 @@ func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.Shell
 	// If the user didn't provide any input to completion,
 	// we provide a hint that a path can also be used
 	if includeFiles && len(toComplete) == 0 {
-		completions = append(completions, "./", "/")
+		completions = append(completions, "./\tRelative path prefix to local chart", "/\tAbsolute path prefix to local chart")
 	}
 	cobra.CompDebugln(fmt.Sprintf("Completions after checking empty input: %v", completions), settings.Debug)
 

--- a/cmd/helm/testdata/output/repo_list_comp.txt
+++ b/cmd/helm/testdata/output/repo_list_comp.txt
@@ -1,0 +1,5 @@
+foo
+bar
+baz
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/repo_repeat_comp.txt
+++ b/cmd/helm/testdata/output/repo_repeat_comp.txt
@@ -1,0 +1,4 @@
+bar
+baz
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is part 2 of the implementation of HIP 008: https://github.com/helm/community/blob/master/hips/hip-0008.md
It is a follow-up to #9243

This PR adds descriptions to Helm's custom completions for repository names.  Note that with #9990 these descriptions are available for every shell.
For example:
```
$ helm repo remove <TAB>
bitnami  -- https://charts.bitnami.com/bitnami
center   -- https://repo.chartcenter.io
stable   -- https://kubernetes-charts.storage.googleapis.com

$ helm install myrelease <TAB>
./                     -- Relative path prefix to local chart
/                      -- Absolute path prefix to local chart
bitnami/               -- https://charts.bitnami.com/bitnami
center/                -- https://repo.chartcenter.io
file://                -- Chart local URL prefix
grafana/               -- https://grafana.github.io/helm-charts
https://    http://    -- Chart URL prefix
oteemocharts/          -- https://oteemo.github.io/charts
stable/                -- https://charts.helm.sh/stable

$ helm show all <TAB>
bitnami  -- https://charts.bitnami.com/bitnami
center   -- https://repo.chartcenter.io
stable   -- https://kubernetes-charts.storage.googleapis.com
```

**Special notes for your reviewer**:

The remaining aspects of HIP 0008 are:

- chart names - completion for chart names uses the special `<repo>-charts.txt` file, which currently does not contain enough information to provide a description for chart names
- helm environment variables - will be done in its own PR as it is more complex

**If applicable**:
- [x] this PR contains unit tests
