### PR TITLE
Add flag trimpath in the go build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.exe
+*.swp
 .DS_Store
 .coverage/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
+	GO111MODULE=on go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
 
 # ------------------------------------------------------------------------------
 #  install
@@ -165,7 +165,7 @@ $(GOIMPORTS):
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GOX)
-	GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GOFLAGS="-trimpath" GO111MODULE=on CGO_ENABLED=0 $(GOX) -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/$(BINNAME)" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds the flag `-trimpath` in the `make build` and `make build-cross`. 

##### make build-cross
Helm uses [gox](https://github.com/mitchellh/gox) to cross compile but `gox` does not support the `-trimpath` flag.  To add the flag, I've used `GOFLAGS="-trimpath"` env in the `gox` command.

##### make build
The flag has been directly added in the `go` `build` command.

This way the directory path, `/home/circlei`, is trimmed, for example, 
###### with Helm v3.5.2
```bash
$ ./helm version
version.BuildInfo{Version:"v3.5.2", GitCommit:"167aac70832d3a384f65f9745335e9fb40169dc2", GitTreeState:"dirty", GoVersion:"go1.15.7"}
$ ./helm install abc . --dry-run --debug
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /home/waterbottle/Code/linux-amd64

Error: Chart.yaml file is missing
helm.go:81: [debug] Chart.yaml file is missing
helm.sh/helm/v3/pkg/chart/loader.LoadFiles
        /home/circleci/helm.sh/helm/pkg/chart/loader/load.go:158
helm.sh/helm/v3/pkg/chart/loader.LoadDir
        /home/circleci/helm.sh/helm/pkg/chart/loader/directory.go:119
helm.sh/helm/v3/pkg/chart/loader.DirLoader.Load
        /home/circleci/helm.sh/helm/pkg/chart/loader/directory.go:41
helm.sh/helm/v3/pkg/chart/loader.Load
        /home/circleci/helm.sh/helm/pkg/chart/loader/load.go:62
main.runInstall
        /home/circleci/helm.sh/helm/cmd/helm/install.go:199
main.newInstallCmd.func2
        /home/circleci/helm.sh/helm/cmd/helm/install.go:120
github.com/spf13/cobra.(*Command).execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main
        /home/circleci/helm.sh/helm/cmd/helm/helm.go:80
runtime.main
        /usr/local/go/src/runtime/proc.go:204
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1374
```
###### with this change:
```bash
$ ./helm install abc . --dry-run --debug
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /home/waterbottle/Code/helm-pallav/_dist/linux-amd64

Error: Chart.yaml file is missing
helm.go:81: [debug] Chart.yaml file is missing
helm.sh/helm/v3/pkg/chart/loader.LoadFiles
        helm.sh/helm/v3/pkg/chart/loader/load.go:158
helm.sh/helm/v3/pkg/chart/loader.LoadDir
        helm.sh/helm/v3/pkg/chart/loader/directory.go:119
helm.sh/helm/v3/pkg/chart/loader.DirLoader.Load
        helm.sh/helm/v3/pkg/chart/loader/directory.go:41
helm.sh/helm/v3/pkg/chart/loader.Load
        helm.sh/helm/v3/pkg/chart/loader/load.go:62
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:199
main.newInstallCmd.func2
        helm.sh/helm/v3/cmd/helm/install.go:120
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.1.1/command.go:895
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:80
runtime.main
        runtime/proc.go:204
runtime.goexit
        runtime/asm_amd64.s:1374
```



**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
