### PR TITLE
Improve description for version flag.

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -47,7 +47,7 @@ func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 }
 
 func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
-	f.StringVar(&c.Version, "version", "", "specify the exact chart version to use. If this is not specified, the latest version is used")
+	f.StringVar(&c.Version, "version", "", "specify a version constraint for the chart version to use. This constraint can be a specific tag (e.g. 1.1.1) or it may reference a valid range (e.g. ^2.0.0). If this is not specified, the latest version is used")
 	f.BoolVar(&c.Verify, "verify", false, "verify the package before using it")
 	f.StringVar(&c.Keyring, "keyring", defaultKeyring(), "location of public keys used for verification")
 	f.StringVar(&c.RepoURL, "repo", "", "chart repository url where to locate the requested chart")


### PR DESCRIPTION
This PR tries to improve the description for the `version` flag: With the `version` flag one cannot just specify the exact version number. It is possible to specify whole version constraints. This is not immediately obvious with the current description. The PR closes #9495.