### PR TITLE
Allow configuring install order of Custom Resources

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -162,7 +162,7 @@ func (c *Configuration) renderResources(ch *chart.Chart, values chartutil.Values
 	// Sort hooks, manifests, and partials. Only hooks and manifests are returned,
 	// as partials are not used after renderer.Render. Empty manifests are also
 	// removed here.
-	hs, manifests, err := releaseutil.SortManifests(files, caps.APIVersions, releaseutil.InstallOrder)
+	hs, manifests, err := releaseutil.SortManifests(files, caps.APIVersions, false)
 	if err != nil {
 		// By catching parse errors here, we can prevent bogus releases from going
 		// to Kubernetes.

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -181,7 +181,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 	}
 
 	manifests := releaseutil.SplitManifests(rel.Manifest)
-	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
+	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, true)
 	if err != nil {
 		// We could instead just delete everything in no particular order.
 		// FIXME: One way to delete at this point would be to try a label-based

--- a/pkg/releaseutil/kind_sorter_test.go
+++ b/pkg/releaseutil/kind_sorter_test.go
@@ -166,6 +166,21 @@ func TestKindSorter(t *testing.T) {
 			Name: "x",
 			Head: &SimpleHead{Kind: "HorizontalPodAutoscaler"},
 		},
+		{
+			Name:          "9",
+			Head:          &SimpleHead{Kind: "MyCustomResourceBeforeDeployment"},
+			InstallBefore: []string{"Deployment"},
+		},
+		{
+			Name:          "8",
+			Head:          &SimpleHead{Kind: "MyCustomResourceBeforeEverything"},
+			InstallBefore: InstallOrder,
+		},
+		{
+			Name:          "7",
+			Head:          &SimpleHead{Kind: "MyCustomResourceBeforeMultipleResources"},
+			InstallBefore: []string{"Deployment", "Service", "ServiceAccount"},
+		},
 	}
 
 	for _, test := range []struct {
@@ -173,8 +188,8 @@ func TestKindSorter(t *testing.T) {
 		uninstall   bool
 		expected    string
 	}{
-		{"install", false, "aAbcC3deEf1gh2iIjJkKlLmnopqrxstuvw!"},
-		{"uninstall", true, "wvmutsxrqponLlKkJjIi2hg1fEed3CcbAa!"},
+		{"install", false, "8aAbcC37deEf1gh2iIjJkKlLmnopq9rxstuvw!"},
+		{"uninstall", true, "wvmutsxr9qponLlKkJjIi2hg1fEed73CcbAa8!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {

--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 )
 
+// InstallOrderAnnotation the annotation that allows manipulating the install order of custom resources
+const InstallOrderAnnotation = "helm.sh/install-before"
+
 // SimpleHead defines what the structure of the head of a manifest file
 type SimpleHead struct {
 	Version  string `json:"apiVersion"`

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -257,13 +257,15 @@ func operateAnnotationValues(entry SimpleHead, annotation string, operate func(p
 	}
 }
 
-// isKnownKind returns true if the given kind exists in the InstallOrder or UninstallOrder
+// isKnownKind returns true if the given kind exists in the InstallOrder AND UninstallOrder
 func isKnownKind(kind string) bool {
-	knownKinds := append(InstallOrder, UninstallOrder...)
-
-	for _, kk := range knownKinds {
-		if kk == kind {
-			return true
+	for _, k := range InstallOrder {
+		if k == kind {
+			for _, kk := range UninstallOrder {
+				if kk == kind {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -164,11 +164,11 @@ func (file *manifestFile) sort(result *result) error {
 			var installBefore []string
 			for _, kind := range strings.Split(installBeforeKinds, ",") {
 				kind = strings.TrimSpace(kind)
-				if isKnownKind(kind) {
-					installBefore = append(installBefore, kind)
-				} else {
+				if !isKnownKind(kind) {
 					log.Printf("info: skipping unknown install-before kind: %q", kind)
+					continue
 				}
+				installBefore = append(installBefore, kind)
 			}
 
 			result.generic = append(result.generic, Manifest{

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -76,7 +76,7 @@ var events = map[string]release.HookEvent{
 //
 // Files that do not parse into the expected format are simply placed into a map and
 // returned.
-func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering KindSortOrder) ([]*release.Hook, []Manifest, error) {
+func SortManifests(files map[string]string, apis chartutil.VersionSet, uninstall bool) ([]*release.Hook, []Manifest, error) {
 	result := &result{}
 
 	var sortedFilePaths []string
@@ -109,7 +109,7 @@ func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering 
 		}
 	}
 
-	return sortHooksByKind(result.hooks, ordering), sortManifestsByKind(result.generic, ordering), nil
+	return sortHooksByKind(result.hooks, uninstall), sortManifestsByKind(result.generic, uninstall), nil
 }
 
 // sort takes a manifestFile object which may contain multiple resource definition

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -139,7 +139,7 @@ metadata:
 		manifests[o.path] = o.manifest
 	}
 
-	hs, generic, err := SortManifests(manifests, chartutil.VersionSet{"v1", "v1beta1"}, InstallOrder)
+	hs, generic, err := SortManifests(manifests, chartutil.VersionSet{"v1", "v1beta1"}, false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -219,7 +219,7 @@ metadata:
 		}
 	}
 
-	sorted = sortManifestsByKind(sorted, InstallOrder)
+	sorted = sortManifestsByKind(sorted, false)
 	for i, m := range generic {
 		if m.Content != sorted[i].Content {
 			t.Errorf("Expected %q, got %q", m.Content, sorted[i].Content)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

By default Helm installs Kubernetes Kinds that doesn't exist in the internal [kube_sorter.go](https://github.com/helm/helm/blob/d55c53df4e394fb62b0514a09c57bce235dd7877/pkg/releaseutil/kind_sorter.go#L31-L66) at the very end of a helm installation. This causes some serious issues with Custom Resources that need to be deployed before specific other resources.

This PR introduces a new Annotation called `helm.sh/install-before`. With this annotation user can specify in which order this Custom Resource is actually installed. For example `helm.sh/install-before="Deployment,Service"` means that this Resource will be installed **before** the Deployment resource as well as **before** the Service resource.

Here is a example resource with this Annotation:

```yaml
# Source: generic-service/templates/securitygrouppolicy.yaml
apiVersion: vpcresources.k8s.aws/v1beta1
kind: SecurityGroupPolicy
metadata:
  name: niklas-debug
  labels:
    helm.sh/chart: generic-service-0.5.0
    app.kubernetes.io/name: niklas-debug
    app.kubernetes.io/instance: niklas-debug
    app.kubernetes.io/version: "0.1.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    helm.sh/install-before: "Deployment,Statefulset,DaemonSet"
spec:
  podSelector: 
    matchLabels:
      app.kubernetes.io/name: niklas-debug
      app.kubernetes.io/instance: niklas-debug
  securityGroups:
    groupIds:
      - sg-xyz
```
In this case Helm with this PR would make sure that this SecurityGroupPolicy Resource is installed **before** any Deployment, Statefulset and DaemonSet Kinds. As well as Uninstalled **after** any Deployment, Statefulset and DaemonSet Kinds


* Fixes #8439 
* Fixes #8291
* Fixes #7072
* Fixes #6851
* Fixes #5916
* Fixes #5642
* Closes #8448



**Special notes for your reviewer**: I'm not a Golang developer, in fact this was the first time I wrote Golang code. So please feel free and improve stuff that doesn't look right.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
