### PR TITLE
fix(repo): make IndexFile.Has() match exact version

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -154,8 +154,12 @@ func (i IndexFile) Add(md *chart.Metadata, filename, baseURL, digest string) {
 
 // Has returns true if the index has an entry for a chart with the given name and exact version.
 func (i IndexFile) Has(name, version string) bool {
-	_, err := i.Get(name, version)
-	return err == nil
+	for _, ver := range i.Entries[name] {
+		if version == ver.Version {
+			return true
+		}
+	}
+	return false
 }
 
 // SortEntries sorts the entries by version in descending order.


### PR DESCRIPTION
Change Has() function to check against the exact version (as described
in the docstring comment) instead of falling back to the semver
constraints business.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes index merge in cases where version numbers
are similar enough (but not identical), causing previous entries to be
inadvertently overwritten.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
