### PR TITLE
Improve time display

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -29,6 +29,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 var listHelp = `
@@ -156,20 +157,11 @@ func newReleaseListWriter(releases []*release.Release, timeFormat string) *relea
 			Name:       r.Name,
 			Namespace:  r.Namespace,
 			Revision:   strconv.Itoa(r.Version),
+			Updated:    time.Display(r.Info.LastDeployed, timeFormat),
 			Status:     r.Info.Status.String(),
 			Chart:      fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version),
 			AppVersion: r.Chart.Metadata.AppVersion,
 		}
-
-		t := "-"
-		if tspb := r.Info.LastDeployed; !tspb.IsZero() {
-			if timeFormat != "" {
-				t = tspb.Format(timeFormat)
-			} else {
-				t = tspb.String()
-			}
-		}
-		element.Updated = t
 
 		elements = append(elements, element)
 	}

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -30,6 +29,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 // NOTE: Keep the list of statuses up-to-date with pkg/release/status.go.
@@ -114,9 +114,7 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		return nil
 	}
 	fmt.Fprintf(out, "NAME: %s\n", s.release.Name)
-	if !s.release.Info.LastDeployed.IsZero() {
-		fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Format(time.ANSIC))
-	}
+	fmt.Fprintf(out, "LAST DEPLOYED: %s\n", time.Display(s.release.Info.LastDeployed, time.UnixDate))
 	fmt.Fprintf(out, "NAMESPACE: %s\n", s.release.Namespace)
 	fmt.Fprintf(out, "STATUS: %s\n", s.release.Info.Status.String())
 	fmt.Fprintf(out, "REVISION: %d\n", s.release.Version)
@@ -135,8 +133,8 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 			}
 			fmt.Fprintf(out, "TEST SUITE:     %s\n%s\n%s\n%s\n",
 				h.Name,
-				fmt.Sprintf("Last Started:   %s", h.LastRun.StartedAt.Format(time.ANSIC)),
-				fmt.Sprintf("Last Completed: %s", h.LastRun.CompletedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Last Started:   %s", time.Display(h.LastRun.StartedAt, time.UnixDate)),
+				fmt.Sprintf("Last Completed: %s", time.Display(h.LastRun.CompletedAt, time.UnixDate)),
 				fmt.Sprintf("Phase:          %s", h.LastRun.Phase),
 			)
 		}

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -26,6 +26,24 @@ import (
 	"time"
 )
 
+const (
+	ANSIC       = time.ANSIC
+	UnixDate    = time.UnixDate
+	RubyDate    = time.RubyDate
+	RFC822      = time.RFC822
+	RFC822Z     = time.RFC822Z
+	RFC850      = time.RFC850
+	RFC1123     = time.RFC1123
+	RFC1123Z    = time.RFC1123Z
+	RFC3339     = time.RFC3339
+	RFC3339Nano = time.RFC3339Nano
+	Kitchen     = time.Kitchen
+	Stamp       = time.Stamp
+	StampMilli  = time.StampMilli
+	StampMicro  = time.StampMicro
+	StampNano   = time.StampNano
+)
+
 // emptyString contains an empty JSON string value to be used as output
 var emptyString = `""`
 
@@ -89,3 +107,15 @@ func (t Time) Round(d time.Duration) Time    { return Time{Time: t.Time.Round(d)
 func (t Time) Sub(u Time) time.Duration      { return t.Time.Sub(u.Time) }
 func (t Time) Truncate(d time.Duration) Time { return Time{Time: t.Time.Truncate(d)} }
 func (t Time) UTC() Time                     { return Time{Time: t.Time.UTC()} }
+
+func Display(t Time, timeFormat string) string {
+	d := "-"
+	if !t.IsZero() {
+		if timeFormat != "" {
+			d = t.Local().Format(timeFormat)
+		} else {
+			d = t.Local().String()
+		}
+	}
+	return d
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/master/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

1. If you install in different time zones, you cannot know the exact time without timezone information.

`helm list`
```
REVISION     UPDATED
3            2021-03-19 10:42:30.538764449 +0900 KST
2            2021-03-25 09:27:23.247807185 +0000 UTC
```

`helm list --time-format="2006-01-02T15:04:05.999999-07:00"`
```
 REVISION     UPDATED
 3            2021-03-19T10:42:30.538764+09:00
 2            2021-03-25T09:27:23.247807+00:00
```
 **When displaying time information, I suggest displaying it based on the time zone of the client.** 

2. The time is not known exactly because the time zone is not displayed.

`helm history or helm status`
```
 REVISION        UPDATED
 1               Thu Feb 18 11:37:32 2021
 2               Thu Feb 18 11:40:33 2021
```
**I suggest changing the Time Format from ANSIC to UnixDate to include the time zone by default.**

3. The time format is not the same for table output and json/yaml output.
``` helm history```   ```helm history -o json```
```
UPDATED                 
Thu Feb 18 11:37:32 2021
```
```
{..."updated":"2021-02-18T11:37:32.900442129+09:00",...}
```
**Modify the TIme display format to be the same.**

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
