### PR TITLE
Consider labels when querying releases

### DIFF
--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -189,6 +189,14 @@ func (mock *MockSecretsInterface) Init(t *testing.T, releases ...*rspb.Release) 
 		if err != nil {
 			t.Fatalf("Failed to create secret: %s", err)
 		}
+		//add release labels to secret
+		if rls.Labels != nil {
+			for k, v := range rls.Labels {
+				if _, ok := secret.ObjectMeta.Labels[k]; !ok {
+					secret.ObjectMeta.Labels[k] = v
+				}
+			}
+		}
 		mock.objects[objkey] = secret
 	}
 }

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -136,6 +136,9 @@ func (secrets *Secrets) Query(labels map[string]string) ([]*rspb.Release, error)
 			secrets.Log("query: failed to decode release: %s", err)
 			continue
 		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
 		results = append(results, rls)
 	}
 	return results, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Secret storage is not considering labels when querying release.

**Special notes for your reviewer**:
When using `List()` functions, labels are considered (https://github.com/helm/helm/blob/main/pkg/storage/driver/secrets.go#L101). It's probably not intended to ignore labels when using the `Query()` function.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
