### PR TITLE
Allow for helm install script to work on Windows

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -22,7 +22,7 @@
 : ${DEBUG:="false"}
 : ${VERIFY_CHECKSUM:="true"}
 : ${VERIFY_SIGNATURES:="false"}
-: ${HELM_INSTALL_DIR:="/usr/local/bin"}
+: ${HELM_INSTALL_DIR:="${GOPATH}/bin"}
 : ${GPG_PUBRING:="pubring.kbx"}
 
 HAS_CURL="$(type "curl" &> /dev/null && echo true || echo false)"


### PR DESCRIPTION
**What this PR does / why we need it**:
This installs to the GOPATH bin folder which will work cross platform and will likely be setup on the user's path. Previously it used a standard unix path which is non-existent on Windows. As currently written it requires the user to have go installed. Since that may not be the case for all Windows users we may want to make this a fallback option. If this path is desired and will be approved I'd be happy to make that update.

To run on windows you then just need to pass the --no-sudo flag.

**Special notes for your reviewer**:
You're awesome!

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
