### PR TITLE
Modernize `helm create` Ingress Template

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -211,7 +211,6 @@ const defaultIgnore = `# Patterns to ignore when building packages.
 `
 
 const defaultIngress = `{{- if .Values.ingress.enabled -}}
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion -}}
@@ -268,7 +267,7 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- end }}
+{{- end }}
 `
 
 const defaultDeployment = `apiVersion: apps/v1


### PR DESCRIPTION

> This pull request and idea is open for discussion
> It's based on this discussion: https://github.com/helm/helm/issues/9462

- fix non-working values in `helm create` template
- introduce support for Ingress v1
- support ingressClass support of K8s 1.18 
- remove support for Kubernetes 1.13 and below

TODO (as soon of a community acceptance):
- adjust unit tests & test data
- adjust documentation
- test on older clusters
