### PR TITLE
Update install.go

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -355,6 +355,11 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 				return i.failRelease(rel, err)
 			}
 		}
+		for _, r := range resources {
+			if err := r.Get(); err != nil {
+				return i.failRelease(rel, err)
+			}
+		}
 	}
 
 	if !i.DisableHooks {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -355,10 +355,10 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 				return i.failRelease(rel, err)
 			}
 		}
-		for _, r := range resources {
-			if err := r.Get(); err != nil {
-				return i.failRelease(rel, err)
-			}
+	}
+	for _, r := range resources {
+		if err := r.Get(); err != nil {
+			return i.failRelease(rel, err)
 		}
 	}
 


### PR DESCRIPTION
issue: Install a chart with same name After delete the release. The CR resources may be not created, because the info is a deleted infos.
