### PR TITLE
Fix potential data races in chartutil

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -111,7 +111,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	actionConfig := &action.Configuration{
 		Releases:     store,
 		KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
-		Capabilities: chartutil.DefaultCapabilities,
+		Capabilities: chartutil.DefaultCapabilities(),
 		Log:          func(format string, v ...interface{}) {},
 	}
 

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -10,7 +10,6 @@ metadata:
     kube-version/major: "1"
     kube-version/minor: "20"
     kube-version/version: "v1.20.0"
-    kube-api-version/test: v1
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-one.txt
+++ b/cmd/helm/testdata/output/template-show-only-one.txt
@@ -10,7 +10,6 @@ metadata:
     kube-version/major: "1"
     kube-version/minor: "20"
     kube-version/version: "v1.20.0"
-    kube-api-version/test: v1
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-skip-tests.txt
+++ b/cmd/helm/testdata/output/template-skip-tests.txt
@@ -74,7 +74,6 @@ metadata:
     kube-version/major: "1"
     kube-version/minor: "20"
     kube-version/version: "v1.20.0"
-    kube-api-version/test: v1
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -91,7 +91,6 @@ metadata:
     kube-version/major: "1"
     kube-version/minor: "20"
     kube-version/version: "v1.20.0"
-    kube-api-version/test: v1
 spec:
   type: ClusterIP
   ports:

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -310,7 +310,7 @@ func (c *Configuration) releaseContent(name string, version int) (*release.Relea
 func GetVersionSet(client discovery.ServerResourcesInterface) (chartutil.VersionSet, error) {
 	groups, resources, err := client.ServerGroupsAndResources()
 	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
-		return chartutil.DefaultVersionSet, errors.Wrap(err, "could not get apiVersions from Kubernetes")
+		return chartutil.DefaultVersionSet(), errors.Wrap(err, "could not get apiVersions from Kubernetes")
 	}
 
 	// FIXME: The Kubernetes test fixture for cli appears to always return nil
@@ -318,7 +318,7 @@ func GetVersionSet(client discovery.ServerResourcesInterface) (chartutil.Version
 	// return the default API list. This is also a safe value to return in any
 	// other odd-ball case.
 	if len(groups) == 0 && len(resources) == 0 {
-		return chartutil.DefaultVersionSet, nil
+		return chartutil.DefaultVersionSet(), nil
 	}
 
 	versionMap := make(map[string]interface{})

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -83,7 +83,7 @@ func actionConfigFixture(t *testing.T) *Configuration {
 	return &Configuration{
 		Releases:       storage.Init(driver.NewMemory()),
 		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
-		Capabilities:   chartutil.DefaultCapabilities,
+		Capabilities:   chartutil.DefaultCapabilities(),
 		RegistryClient: registryClient,
 		Log: func(format string, v ...interface{}) {
 			t.Helper()

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -196,7 +196,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	if i.ClientOnly {
 		// Add mock objects in here so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
-		i.cfg.Capabilities = chartutil.DefaultCapabilities
+		i.cfg.Capabilities = chartutil.DefaultCapabilities()
 		i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
 		i.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -118,7 +118,7 @@ func TestInstallReleaseClientOnly(t *testing.T) {
 	instAction.ClientOnly = true
 	instAction.Run(buildChart(), nil) // disregard output
 
-	is.Equal(instAction.cfg.Capabilities, chartutil.DefaultCapabilities)
+	is.Equal(instAction.cfg.Capabilities, chartutil.DefaultCapabilities())
 	is.Equal(instAction.cfg.KubeClient, &kubefake.PrintingKubeClient{Out: ioutil.Discard})
 }
 

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -32,22 +32,6 @@ const (
 	k8sVersionMinor = 20
 )
 
-var (
-	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
-	DefaultVersionSet = allKnownVersions()
-
-	// DefaultCapabilities is the default set of capabilities.
-	DefaultCapabilities = &Capabilities{
-		KubeVersion: KubeVersion{
-			Version: fmt.Sprintf("v%d.%d.0", k8sVersionMajor, k8sVersionMinor),
-			Major:   strconv.Itoa(k8sVersionMajor),
-			Minor:   strconv.Itoa(k8sVersionMinor),
-		},
-		APIVersions: DefaultVersionSet,
-		HelmVersion: helmversion.Get(),
-	}
-)
-
 // Capabilities describes the capabilities of the Kubernetes cluster.
 type Capabilities struct {
 	// KubeVersion is the Kubernetes version.
@@ -101,4 +85,21 @@ func allKnownVersions() VersionSet {
 		vs = append(vs, gv.String())
 	}
 	return vs
+}
+
+// DefaultCapabilities returns the default set of capabilities.
+func DefaultCapabilities() *Capabilities {
+	return &Capabilities{KubeVersion: KubeVersion{
+		Version: fmt.Sprintf("v%d.%d.0", k8sVersionMajor, k8sVersionMinor),
+		Major:   strconv.Itoa(k8sVersionMajor),
+		Minor:   strconv.Itoa(k8sVersionMinor),
+	},
+		APIVersions: DefaultVersionSet(),
+		HelmVersion: helmversion.Get(),
+	}
+}
+
+// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
+func DefaultVersionSet() VersionSet {
+	return allKnownVersions()
 }

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -35,13 +35,13 @@ func TestVersionSet(t *testing.T) {
 }
 
 func TestDefaultVersionSet(t *testing.T) {
-	if !DefaultVersionSet.Has("v1") {
+	if !DefaultVersionSet().Has("v1") {
 		t.Error("Expected core v1 version set")
 	}
 }
 
 func TestDefaultCapabilities(t *testing.T) {
-	kv := DefaultCapabilities.KubeVersion
+	kv := DefaultCapabilities().KubeVersion
 	if kv.String() != "v1.20.0" {
 		t.Errorf("Expected default KubeVersion.String() to be v1.20.0, got %q", kv.String())
 	}
@@ -60,7 +60,7 @@ func TestDefaultCapabilities(t *testing.T) {
 }
 
 func TestDefaultCapabilitiesHelmVersion(t *testing.T) {
-	hv := DefaultCapabilities.HelmVersion
+	hv := DefaultCapabilities().HelmVersion
 
 	if hv.Version != "v3.5" {
 		t.Errorf("Expected default HelmVersion to be v3.5, got %q", hv.Version)

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -136,7 +136,7 @@ type ReleaseOptions struct {
 // This takes both ReleaseOptions and Capabilities to merge into the render values.
 func ToRenderValues(chrt *chart.Chart, chrtVals map[string]interface{}, options ReleaseOptions, caps *Capabilities) (Values, error) {
 	if caps == nil {
-		caps = DefaultCapabilities
+		caps = DefaultCapabilities()
 	}
 	top := map[string]interface{}{
 		"Chart":        chrt.Metadata,


### PR DESCRIPTION
Hello!

This PR attempts to fix the data race issues raised in https://github.com/helm/helm/issues/9618.
The code in this PR is also demonstrated here https://github.com/devzx/helm-data-race under the fix/vendor folder

The main changes are:
- Replaced package level variables used as defaults in the chartutil package that were susceptible to data races with functions and replaced all references with the new functions
- Updated incorrect golden files that had been generated as a result of using the aforementioned package level variables which contained `kubernetes-api-version` data that was persisted from previous tests.
-  Fixed more data races within the `allKnownVersions()` function which was using a package level variable from kubernetes scheme pacakge, now we create and manage our own instance of it per call.