### PR TITLE
Fix install scripts, hardcode latest/last v2 release

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -76,14 +76,8 @@ verifySupported() {
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
-    # Get tag from release URL
-    local release_url="https://github.com/helm/helm/releases"
-    if type "curl" > /dev/null; then
-
-      TAG=$(curl -Ls $release_url | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    elif type "wget" > /dev/null; then
-      TAG=$(wget $release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
-    fi
+    # Pinning tag to v2.17.0 as per https://github.com/helm/helm/issues/9607
+    TAG=v2.17.0
   else
     TAG=$DESIRED_VERSION
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm's install script, `get`, is currently broken due to no recent v2 release. When attempting to get the latest tag, no tag is found as there has not been a recent v2 release. I recognize that v2 has EOL'ed, I figured I'd make this PR anyways since its more readable/maintainable (not relying on http parsing).  


**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
