### PR TITLE
[bugfix] Fix inconsistency in release name for template rendering during lint

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -66,7 +66,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	}
 
 	options := chartutil.ReleaseOptions{
-		Name:      "test-release",
+		Name:      "RELEASE-NAME",
 		Namespace: namespace,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, we have some Helm charts that include a little template function to validate that a resource name (being the result of several different computed values from different places) looks like we expect it to.

Recently, we found out that if that resource name contains `$.Release.Name`, then when our template tries to validate it during a `helm lint` run, it always fails no matter what we set our expected name to. A simplified example follows

Our template looks like this:
```
{{- $name = printf "%s-%s-%s" $.Release.Name $.Values.thing $.Values.stuff -}}
{{- if ne $name $.Values.expectedName -}}
  {{- fail (printf "expected name: %s; got: %s" $.Values.expectedName $name) -}}
{{- end -}}
```

Our values file looks like this:
```
thing: brandon
stuff: willett
expectedName: test-release-brandon-willett
```

Then a call to `helm lint` always fails with this error:
```
fail: expected name: test-release-brandon-willett; got: RELEASE-NAME-brandon-willett
```

But then when we change `expectedName` to `RELEASE-NAME` in the values file, it flips and still errors:
```
fail: expected name: RELEASE-NAME-brandon-willett; got: test-release-brandon-willett
```

Hunted around in your code for a bit and it seems to stem from an inconsistency between these two template renderings:

https://github.com/helm/helm/blob/main/pkg/lint/rules/template.go#L69
https://github.com/helm/helm/blob/main/cmd/helm/template.go#L68

So, this PR tries to patch the inconsistency. Let me know if this is an acceptable fix, thanks!

**Special notes for your reviewer**:

(none)
