### PR TITLE
fix: dep up when exists tmpcharts

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -385,15 +385,9 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		fmt.Fprintln(m.Out, "Save error occurred: ", saveError)
 		fmt.Fprintln(m.Out, "Deleting newly downloaded charts, restoring pre-update state")
 		for _, dep := range deps {
-			if err := m.safeDeleteDep(dep.Name, destPath); err != nil {
+			if err := m.safeDeleteDep(dep.Name, tmpPath); err != nil {
 				return err
 			}
-		}
-		if err := os.RemoveAll(destPath); err != nil {
-			return errors.Wrapf(err, "failed to remove %v", destPath)
-		}
-		if err := fs.RenameWithFallback(tmpPath, destPath); err != nil {
-			return errors.Wrap(err, "unable to move current charts to tmp dir")
 		}
 		return saveError
 	}

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/getter"


### PR DESCRIPTION
Closes: #5567

Signed-off-by: jorgevillaverde <jorge.villaverde@toucansoft.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: If the process is killed when running `helm dep up` and the folder `tmpcharts` was created and not delete before the process was kill, the next time the user ties to run `helm dep up` will result on the error

```
Error: Unable to move current charts to tmp dir: rename /mychart/charts /mychart/tmpcharts: file exists
```

This PR adds a check to see if `tmpcharts` exists, and delete it before [RenameWithFallback](https://github.com/helm/helm/blob/main/pkg/downloader/manager.go#L261). This prevents the error from happening.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
