### PR TITLE
error eturn instead of panic for pkg/action.Configuration#Init() method

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -408,7 +408,7 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 		store = storage.Init(d)
 	default:
 		// Not sure what to do here.
-		errors.Errorf("Unknown driver in HELM_DRIVER: %s", helmDriver)
+		return errors.Errorf("Unknown driver in HELM_DRIVER: %s", helmDriver)
 	}
 
 	c.RESTClientGetter = getter

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -403,12 +403,12 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 			namespace,
 		)
 		if err != nil {
-			panic(fmt.Sprintf("Unable to instantiate SQL driver: %v", err))
+			return errors.Wrap(err, "Unable to instantiate SQL driver")
 		}
 		store = storage.Init(d)
 	default:
 		// Not sure what to do here.
-		panic("Unknown driver in HELM_DRIVER: " + helmDriver)
+		errors.Errorf("Unknown driver in HELM_DRIVER: %s", helmDriver)
 	}
 
 	c.RESTClientGetter = getter

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	dockerauth "github.com/deislabs/oras/pkg/auth/docker"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"helm.sh/helm/v3/internal/experimental/registry"
@@ -35,7 +36,6 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"helm.sh/helm/v3/pkg/time"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 var verbose = flag.Bool("test.log", false, "enable test logging")

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -383,7 +383,7 @@ func TestConfiguration_Init(t *testing.T) {
 			true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.configuration


### PR DESCRIPTION

Signed-off-by: wuhuizuo <wuhuizuo@126.com>


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: fix issue #9698 

**What I did**: error eturn instead of panic for pkg/action.Configuration#Init() method
**Why**: since the method have a error type return value, it should not panic in method body.

**Special notes for your reviewer**:

**If applicable**:

- [x] this PR has been tested for backwards compatibility
