### PR TITLE
feat: add optional boolean '--wait' flag to 'uninstall' command.

### DIFF
--- a/cmd/helm/testdata/output/uninstall-wait.txt
+++ b/cmd/helm/testdata/output/uninstall-wait.txt
@@ -1,0 +1,1 @@
+release "aeneas" uninstalled

--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -71,6 +71,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate a uninstall")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation")
 	f.BoolVar(&client.KeepHistory, "keep-history", false, "remove all associated resources and mark the release as deleted, but retain the release history")
+	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 

--- a/cmd/helm/uninstall_test.go
+++ b/cmd/helm/uninstall_test.go
@@ -58,6 +58,12 @@ func TestUninstall(t *testing.T) {
 			rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "aeneas"})},
 		},
 		{
+			name:   "wait",
+			cmd:    "uninstall aeneas --wait",
+			golden: "output/uninstall-wait.txt",
+			rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "aeneas"})},
+		},
+		{
 			name:      "uninstall without release",
 			cmd:       "uninstall",
 			golden:    "output/uninstall-no-args.txt",

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -120,8 +120,10 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	res.Info = kept
 
 	if u.Wait {
-		if err := u.cfg.KubeClient.WaitForDelete(deletedResources, u.Timeout); err != nil {
-			errs = append(errs, err)
+		if kubeClient, ok := u.cfg.KubeClient.(kube.ClientInterface); ok {
+			if err := kubeClient.WaitForDelete(deletedResources, u.Timeout); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -120,7 +120,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	res.Info = kept
 
 	if u.Wait {
-		if kubeClient, ok := u.cfg.KubeClient.(kube.ClientInterface); ok {
+		if kubeClient, ok := u.cfg.KubeClient.(kube.InterfaceExt); ok {
 			if err := kubeClient.WaitForDelete(deletedResources, u.Timeout); err != nil {
 				errs = append(errs, err)
 			}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	helmtime "helm.sh/helm/v3/pkg/time"
@@ -37,6 +38,7 @@ type Uninstall struct {
 	DisableHooks bool
 	DryRun       bool
 	KeepHistory  bool
+	Wait         bool
 	Timeout      time.Duration
 	Description  string
 }
@@ -110,12 +112,18 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 		u.cfg.Log("uninstall: Failed to store updated release: %s", err)
 	}
 
-	kept, errs := u.deleteRelease(rel)
+	deletedResources, kept, errs := u.deleteRelease(rel)
 
 	if kept != "" {
 		kept = "These resources were kept due to the resource policy:\n" + kept
 	}
 	res.Info = kept
+
+	if u.Wait {
+		if err := u.cfg.KubeClient.WaitForDelete(deletedResources, u.Timeout); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
 	if !u.DisableHooks {
 		if err := u.cfg.execHook(rel, release.HookPostDelete, u.Timeout); err != nil {
@@ -172,12 +180,12 @@ func joinErrors(errs []error) string {
 	return strings.Join(es, "; ")
 }
 
-// deleteRelease deletes the release and returns manifests that were kept in the deletion process
-func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
+// deleteRelease deletes the release and returns list of delete resources and manifests that were kept in the deletion process
+func (u *Uninstall) deleteRelease(rel *release.Release) (kube.ResourceList, string, []error) {
 	var errs []error
 	caps, err := u.cfg.getCapabilities()
 	if err != nil {
-		return rel.Manifest, []error{errors.Wrap(err, "could not get apiVersions from Kubernetes")}
+		return nil, rel.Manifest, []error{errors.Wrap(err, "could not get apiVersions from Kubernetes")}
 	}
 
 	manifests := releaseutil.SplitManifests(rel.Manifest)
@@ -187,7 +195,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 		// FIXME: One way to delete at this point would be to try a label-based
 		// deletion. The problem with this is that we could get a false positive
 		// and delete something that was not legitimately part of this release.
-		return rel.Manifest, []error{errors.Wrap(err, "corrupted release record. You must manually delete the resources")}
+		return nil, rel.Manifest, []error{errors.Wrap(err, "corrupted release record. You must manually delete the resources")}
 	}
 
 	filesToKeep, filesToDelete := filterManifestsToKeep(files)
@@ -203,10 +211,10 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (string, []error) {
 
 	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), false)
 	if err != nil {
-		return "", []error{errors.Wrap(err, "unable to build kubernetes objects for delete")}
+		return nil, "", []error{errors.Wrap(err, "unable to build kubernetes objects for delete")}
 	}
 	if len(resources) > 0 {
 		_, errs = u.cfg.KubeClient.Delete(resources)
 	}
-	return kept, errs
+	return resources, kept, errs
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -162,7 +162,7 @@ func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) err
 	return w.waitForResources(resources)
 }
 
-// Wait up to the given timeout for the specified resources to be deleted
+// WaitForDelete wait up to the given timeout for the specified resources to be deleted.
 func (c *Client) WaitForDelete(resources ResourceList, timeout time.Duration) error {
 	w := waiter{
 		log:     c.Log,

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -162,6 +162,15 @@ func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) err
 	return w.waitForResources(resources)
 }
 
+// Wait up to the given timeout for the specified resources to be deleted
+func (c *Client) WaitForDelete(resources ResourceList, timeout time.Duration) error {
+	w := waiter{
+		log:     c.Log,
+		timeout: timeout,
+	}
+	return w.waitForDeletedResources(resources)
+}
+
 func (c *Client) namespace() string {
 	if c.Namespace != "" {
 		return c.Namespace

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -63,7 +63,15 @@ func (f *FailingKubeClient) WaitWithJobs(resources kube.ResourceList, d time.Dur
 	if f.WaitError != nil {
 		return f.WaitError
 	}
-	return f.PrintingKubeClient.Wait(resources, d)
+	return f.PrintingKubeClient.WaitWithJobs(resources, d)
+}
+
+// WaitForDelete returns the configured error if set or prints
+func (f *FailingKubeClient) WaitForDelete(resources kube.ResourceList, d time.Duration) error {
+	if f.WaitError != nil {
+		return f.WaitError
+	}
+	return f.PrintingKubeClient.WaitForDelete(resources, d)
 }
 
 // Delete returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -57,6 +57,11 @@ func (p *PrintingKubeClient) WaitWithJobs(resources kube.ResourceList, _ time.Du
 	return err
 }
 
+func (p *PrintingKubeClient) WaitForDelete(resources kube.ResourceList, _ time.Duration) error {
+	_, err := io.Copy(p.Out, bufferize(resources))
+	return err
+}
+
 // Delete implements KubeClient delete.
 //
 // It only prints out the content to be deleted.

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -70,13 +70,13 @@ type Interface interface {
 	IsReachable() error
 }
 
-// ClientInterface is introduced to avoid breaking backwards compatibility for Interface implementers.
+// InterfaceExt is introduced to avoid breaking backwards compatibility for Interface implementers.
 //
-// TODO Helm 4: Remove ClientInterface and integrate its method(s) into the Interface.
-type ClientInterface interface {
+// TODO Helm 4: Remove InterfaceExt and integrate its method(s) into the Interface.
+type InterfaceExt interface {
 	// WaitForDelete wait up to the given timeout for the specified resources to be deleted.
 	WaitForDelete(resources ResourceList, timeout time.Duration) error
 }
 
 var _ Interface = (*Client)(nil)
-var _ ClientInterface = (*Client)(nil)
+var _ InterfaceExt = (*Client)(nil)

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -36,6 +36,8 @@ type Interface interface {
 	// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
 	WaitWithJobs(resources ResourceList, timeout time.Duration) error
 
+	WaitForDelete(resources ResourceList, timeout time.Duration) error
+
 	// Delete destroys one or more resources.
 	Delete(resources ResourceList) (*Result, []error)
 

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -36,8 +36,6 @@ type Interface interface {
 	// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
 	WaitWithJobs(resources ResourceList, timeout time.Duration) error
 
-	WaitForDelete(resources ResourceList, timeout time.Duration) error
-
 	// Delete destroys one or more resources.
 	Delete(resources ResourceList) (*Result, []error)
 
@@ -72,4 +70,13 @@ type Interface interface {
 	IsReachable() error
 }
 
+// ClientInterface is introduced to avoid breaking backwards compatibility for Interface implementers.
+//
+// TODO Helm 4: Remove ClientInterface and integrate its method(s) into the Interface.
+type ClientInterface interface {
+	// WaitForDelete wait up to the given timeout for the specified resources to be deleted.
+	WaitForDelete(resources ResourceList, timeout time.Duration) error
+}
+
 var _ Interface = (*Client)(nil)
+var _ ClientInterface = (*Client)(nil)


### PR DESCRIPTION
add optional boolean '--wait' flag to 'uninstall' command. If set 'uninstall' command will wait until all the resources are deleted before returning. It will wait for as long as --timeout

Signed-off-by: Mike Ng <ming@redhat.com>

closes #2378

**What this PR does / why we need it**:
The helm uninstall `--wait` flag has been heavily requested by the community, see #2378 . 
This is my hacking attempt at implementing this flag.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
