### PR TITLE
Fix: Tweak scripts/get to fetch latest v2 tag from releases

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -77,12 +77,12 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local release_url="https://github.com/helm/helm/releases"
+    local release_url="https://api.github.com/repos/helm/helm/tags?per_page=100"
     if type "curl" > /dev/null; then
 
-      TAG=$(curl -Ls $release_url | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(curl -Ls $release_url | grep name | awk '{print $2}' | grep 'v2.[0-9]*.[0-9]*\"' | head -n 1 | cut -d '"' -f 2)
     elif type "wget" > /dev/null; then
-      TAG=$(wget $release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v2.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(wget $release_url -O - 2>&1 | grep name | awk '{print $2}' | grep 'v2.[0-9]*.[0-9]*\"' | head -n 1 | cut -d '"' -f 2)
     fi
   else
     TAG=$DESIRED_VERSION


### PR DESCRIPTION
## Motivation

Fixes #9714

The script [helm/scripts/get](https://github.com/helm/helm/blob/main/scripts/get) to install latest version of helm2 errors out like so.

```bash
<SNIPPED>
Downloading https://get.helm.sh/helm--linux-amd64.tar.gz
SHA sum of /tmp/helm-installer-sWGDPd/helm--linux-amd64.tar.gz does not match. Aborting.
<SNIPPED>
```

The script finds the latest release of `v2.x` by checking the GitHub releases page. However, as new releases are added,  v2.x got pushed to second page which fails the script. 

## Fix

Instead of using the GitHub release url, use GitHub API with `per_page=100`. This gives a JSON output of the last 100 releases.
