### PR TITLE
fix(helm): Add WARNING when --repo parameter is ignored

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -418,3 +418,8 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 
 	return nil
 }
+
+func warning(format string, v ...interface{}) {
+	format = fmt.Sprintf("WARNING: %s\n", format)
+	fmt.Fprintf(os.Stderr, format, v...)
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -643,6 +643,11 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 				return "", err
 			}
 		}
+		if c.RepoURL != "" {
+			warning("Chart found at local path '%v'. Ignoring Repository URL '%v.'",
+				abs,
+				c.RepoURL)
+		}
 		return abs, nil
 	}
 	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {


### PR DESCRIPTION
When helm finds a chart under a local (relative) path, it will
always use that chart. Thus, helm will ignore the --repo parameter.
Issue a warning message to make users aware of this behavior.

Closes #9731

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
