### PR TITLE
Remove verbose logging when updating chart repo index

### DIFF
--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -139,7 +139,7 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 		return "", err
 	}
 
-	indexFile, err := loadIndex(index, r.Config.URL)
+	indexFile, err := loadIndex(index)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -106,7 +106,7 @@ func LoadIndexFile(path string) (*IndexFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	i, err := loadIndex(b, path)
+	i, err := loadIndex(b)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error loading %s", path)
 	}
@@ -322,21 +322,19 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 
 // loadIndex loads an index file and does minimal validity checking.
 //
-// The source parameter is only used for logging.
 // This will fail if API Version is not set (ErrNoAPIVersion) or if the unmarshal fails.
-func loadIndex(data []byte, source string) (*IndexFile, error) {
+func loadIndex(data []byte) (*IndexFile, error) {
 	i := &IndexFile{}
 	if err := yaml.UnmarshalStrict(data, i); err != nil {
 		return i, err
 	}
 
-	for name, cvs := range i.Entries {
+	for _, cvs := range i.Entries {
 		for idx := len(cvs) - 1; idx >= 0; idx-- {
 			if cvs[idx].APIVersion == "" {
 				cvs[idx].APIVersion = chart.APIVersionV1
 			}
 			if err := cvs[idx].Validate(); err != nil {
-				log.Printf("skipping loading invalid entry for chart %q %q from %s: %s", name, cvs[idx].Version, source, err)
 				cvs = append(cvs[:idx], cvs[idx+1:]...)
 			}
 		}

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -147,7 +147,7 @@ func TestLoadIndex(t *testing.T) {
 
 // TestLoadIndex_Duplicates is a regression to make sure that we don't non-deterministically allow duplicate packages.
 func TestLoadIndex_Duplicates(t *testing.T) {
-	if _, err := loadIndex([]byte(indexWithDuplicates), "indexWithDuplicates"); err == nil {
+	if _, err := loadIndex([]byte(indexWithDuplicates)); err == nil {
 		t.Errorf("Expected an error when duplicate entries are present")
 	}
 }


### PR DESCRIPTION
This commit removes logs lines resulting from loading the index of a
chart repo containing many charts that don't adhere to semver.

Signed-off-by: Nathan Schmidt <nathan.schmidt@imc.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR removes logs lines resulting from loading the index of a
chart repo containing charts that don't adhere to semver.

Motivation behind this change is simple, there is little to no impact
from these log lines, and in most cases no action that the user could
reasonably expect to make.  In the authors case, this change reduces
the output of `helm repo up` from +100MB to <1KB.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
