### PR TITLE
Add flag to exit with 1 if no results found

### DIFF
--- a/cmd/helm/search_repo_test.go
+++ b/cmd/helm/search_repo_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -90,4 +93,51 @@ func TestSearchRepoOutputCompletion(t *testing.T) {
 
 func TestSearchRepoFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "search repo", true) // File completion may be useful when inputting a keyword
+}
+
+func TestSearchRepositoriesCmdExitCode(t *testing.T) {
+	if os.Getenv("RUN_MAIN_FOR_TESTING") == "1" {
+		os.Args = []string{"helm", "search", "repo", "syzygy", "--fail-if-no-results-found"}
+
+		// We DO call helm's main() here. So this looks like a normal `helm` process.
+		main()
+
+		// As main calls os.Exit, we never reach this line.
+		// But the test called this block of code catches and verifies the exit code.
+		return
+	}
+
+	// Do a second run of this specific test(TestPluginExitCode) with RUN_MAIN_FOR_TESTING=1 set,
+	// So that the second run is able to run main() and this first run can verify the exit status returned by that.
+	//
+	// This technique originates from https://talks.golang.org/2014/testing.slide#23.
+	cmd := exec.Command(os.Args[0], "-test.run=TestSearchRepositoriesCmdExitCode")
+	cmd.Env = append(
+		os.Environ(),
+		"RUN_MAIN_FOR_TESTING=1",
+	)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	exiterr, ok := err.(*exec.ExitError)
+
+	if !ok {
+		t.Fatalf("Unexpected error returned by os.Exit: %T", err)
+	}
+
+	expectedStdout := "No results found\n"
+	if stdout.String() != expectedStdout {
+		t.Errorf("Expected %q written to stdout: Got %q", expectedStdout, stdout.String())
+	}
+
+	if stderr.String() != "" {
+		t.Errorf("Expected no writes to stderr: Got %q", stderr.String())
+	}
+
+	if exiterr.ExitCode() != 1 {
+		t.Errorf("Expected exit code 1: Got %d", exiterr.ExitCode())
+	}
+
 }


### PR DESCRIPTION
The `--fail-if-no-results-found` flag exit with status code 1 if no
search results found during `helm search repo` and `helm search hub`
commands.  This is useful for automation scripts.

closes #7197

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
