### PR TITLE
Fix coalesce globals to prevent subchart globals to leak upstream

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -127,9 +127,10 @@ func coalesceGlobals(dest, src map[string]interface{}) {
 			// It's not clear if this condition can actually ever trigger.
 			log.Printf("key %s is table. Skipping", key)
 			continue
+		} else {
+			// TODO: Do we need to do any additional checking on the value?
+			dg[key] = val
 		}
-		// TODO: Do we need to do any additional checking on the value?
-		dg[key] = val
 	}
 	dest[GlobalKey] = dg
 }

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -87,6 +87,9 @@ func TestCoalesceValues(t *testing.T) {
 			&chart.Chart{
 				Metadata: &chart.Metadata{Name: "ahab"},
 				Values: map[string]interface{}{
+					"global": map[string]interface{}{
+						"nested": map[string]interface{}{"foo": "bar"},
+					},
 					"scope":  "ahab",
 					"name":   "ahab",
 					"boat":   true,
@@ -135,9 +138,11 @@ func TestCoalesceValues(t *testing.T) {
 		{"{{.pequod.ahab.scope}}", "whale"},
 		{"{{.pequod.ahab.nested.foo}}", "true"},
 		{"{{.pequod.ahab.global.name}}", "Ishmael"},
+		{"{{.pequod.ahab.global.nested.foo}}", "bar"},
 		{"{{.pequod.ahab.global.subject}}", "Queequeg"},
 		{"{{.pequod.ahab.global.harpooner}}", "Tashtego"},
 		{"{{.pequod.global.name}}", "Ishmael"},
+		{"{{.pequod.global.nested.foo}}", "<no value>"},
 		{"{{.pequod.global.subject}}", "Queequeg"},
 		{"{{.spouter.global.name}}", "Ishmael"},
 		{"{{.spouter.global.harpooner}}", "<no value>"},


### PR DESCRIPTION
Signed-off-by: Giacomo Margaria <giacomo.margaria@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
fixes: #9749
Make sure tables are copied *by value* and NOT *by reference* within `coalesceGlobals`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
