### PR TITLE
feat: helm pull --repo to use repo creds from helm repos file

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -73,6 +73,8 @@ func (p *Pull) SetRegistryClient(client *registry.Client) {
 func (p *Pull) Run(chartRef string) (string, error) {
 	var out strings.Builder
 
+	p.loadMissingCredentials()
+
 	c := downloader.ChartDownloader{
 		Out:     &out,
 		Keyring: p.Keyring,
@@ -172,4 +174,20 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		return out.String(), chartutil.ExpandFile(ud, saved)
 	}
 	return out.String(), nil
+}
+
+// loadMissingCredentials checks if the repository credentials are already stored in helm's repository config, if the
+// repository URL is set via CLI (--repo), but neither a username nor password are set for a pull request.
+func (p *Pull) loadMissingCredentials() {
+	if p.RepoURL != "" && p.Username == "" && p.Password == "" {
+		f, err := repo.LoadFile(p.Settings.RepositoryConfig)
+		if err != nil {
+			return
+		}
+		if repoEntry := f.GetByURL(p.RepoURL); repoEntry != nil {
+			p.cfg.Logger().Debug("Using credentials from repository config")
+			p.Username = repoEntry.Username
+			p.Password = repoEntry.Password
+		}
+	}
 }

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -558,3 +558,67 @@ func TestPullOCIWithTagAndDigest(t *testing.T) {
 		}
 	}
 }
+
+func TestPullWithCredentialsFromExistingRepository(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz"),
+		repotest.WithMiddleware(repotest.BasicAuthMiddleware(t)),
+	)
+	defer srv.Stop()
+
+	if err := srv.LinkIndices(); err != nil {
+		t.Fatal(err)
+	}
+
+	// all flags will get "-d outdir" appended.
+	tests := []struct {
+		name       string
+		args       string
+		expectFile string
+	}{
+		{
+			name:       "Chart fetch using repo URL with username and password",
+			expectFile: "./signtest-0.1.0.tgz",
+			args:       "signtest --repo " + srv.URL() + " --username username --password password",
+		},
+		{
+			name:       "Chart fetch using repo URL with stored credentials",
+			expectFile: "./signtest-0.1.0.tgz",
+			args:       "signtest --repo " + srv.URL(),
+		},
+	}
+
+	outdir := t.TempDir()
+	repositoryConfig := filepath.Join(outdir, "repositories.yaml")
+	repositoryCache := outdir
+	registryConfig := filepath.Join(outdir, "config.json")
+	cmd := fmt.Sprintf("repo add test_repository %s --username %s --password %s "+
+		"--repository-config %s --repository-cache %s --registry-config %s",
+		srv.URL(), "username", "password", repositoryConfig, repositoryCache, registryConfig,
+	)
+	if _, _, err := executeActionCommand(cmd); err != nil {
+		t.Fatalf("got error in setup, error: %q", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := fmt.Sprintf("pull %s -d '%s' --repository-config %s --repository-cache %s --registry-config %s",
+				tt.args,
+				outdir,
+				repositoryConfig,
+				repositoryCache,
+				registryConfig,
+			)
+			_, _, err := executeActionCommand(cmd)
+			if err != nil {
+				t.Fatalf("%q reported error: %s", tt.name, err)
+			}
+
+			ef := filepath.Join(outdir, tt.expectFile)
+			if _, err := os.Stat(ef); err != nil {
+				t.Errorf("%q: expected a file at %s. %s", tt.name, ef, err)
+			}
+		})
+	}
+}

--- a/pkg/repo/v1/repo.go
+++ b/pkg/repo/v1/repo.go
@@ -18,8 +18,11 @@ package repo // import "helm.sh/helm/v4/pkg/repo/v1"
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -88,6 +91,45 @@ func (r *File) Has(name string) bool {
 func (r *File) Get(name string) *Entry {
 	for _, entry := range r.Repositories {
 		if entry.Name == name {
+			return entry
+		}
+	}
+	return nil
+}
+
+// compareURLs returns true if url1 and url2 can each be parsed, have the exact
+// same scheme and host and the same cleaned path.
+func compareURLs(url1, url2 string) bool {
+	parsed1, err := url.Parse(url1)
+	if err != nil {
+		return false
+	}
+	parsed2, err := url.Parse(url2)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(parsed1.Scheme, parsed2.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(parsed1.Host, parsed2.Host) {
+		return false
+	}
+	return path.Clean(normalizePath(parsed1.Path)) == path.Clean(normalizePath(parsed2.Path))
+}
+
+func normalizePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+// GetByURL returns the first entry with the given URL if one exists, otherwise
+// returns nil. For comparison, GetByURL tries to sanitize/standardize the URLs
+// as much as possible.
+func (r *File) GetByURL(url string) *Entry {
+	for _, entry := range r.Repositories {
+		if compareURLs(entry.URL, url) {
 			return entry
 		}
 	}

--- a/pkg/repo/v1/repo_test.go
+++ b/pkg/repo/v1/repo_test.go
@@ -128,6 +128,49 @@ func TestRepoFile_Get(t *testing.T) {
 	}
 }
 
+func TestRepoFileGetByURL(t *testing.T) {
+	repo := NewFile()
+	repo.Add(
+		&Entry{
+			Name: "first",
+			URL:  "https://example.com/first",
+		},
+		&Entry{
+			Name: "second1",
+			URL:  "https://example.comm/second",
+		},
+		&Entry{
+			Name: "second2",
+			URL:  "http://example.com/second",
+		},
+		&Entry{
+			Name: "second3",
+			URL:  "https://example.com/second/////////",
+		},
+		&Entry{
+			Name: "third",
+			URL:  "https://example.com/third",
+		},
+	)
+
+	url := "https://example.com/second"
+
+	entry := repo.GetByURL(url)
+	if entry == nil {
+		t.Fatalf("Expected repo entry %q to be found", url)
+	}
+
+	expected := "second3"
+	if entry.Name != expected {
+		t.Errorf("Expected repo Name to be %q but got %q", expected, entry.Name)
+	}
+
+	entry = repo.GetByURL("http://nonexistent.example.com/nonexistent")
+	if entry != nil {
+		t.Errorf("Got unexpected entry %+v", entry)
+	}
+}
+
 func TestRemoveRepository(t *testing.T) {
 	sampleRepository := NewFile()
 	sampleRepository.Add(


### PR DESCRIPTION
Up to this point, helm pull --repo required --username and --password
even if the repository had already been added via helm repo add.
    
From now on, check repositories in the repositories file and if the URL
matches, pull the chart with the username and password from the entry.

Fixes #9599

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

**What this PR does / why we need it**:

Set up the following reproducer - set up the following directory structure for httpd:
```
yum install httpd -y
mkdir cd /var/www/html/charts
cd /var/www/html/charts
helm repo add brigade https://brigadecore.github.io/charts
helm pull brigade/brigade
helm pull brigade/kashti
helm repo index . --url http://127.0.0.1/charts
htpasswd -c .htpasswd testuser   # --> "password"
cat <<'EOF' > .htaccess
AuthType Basic
AuthName "Restricted Access"
AuthUserFile /var/www/html/charts/.htpasswd
Require valid-user
EOF
restorecon -R .

vi /etc/httpd/conf/httpd.conf
# <Directory "/var/www/html/charts"> 
#    AllowOverride AuthConfig
# </Directory>
```

Now, the repo should be password protected:
```
curl -u testuser:password  http://127.0.0.1/charts/index.yaml
```

```
# helm repo add localhost http://127.0.0.1/charts/ --username testuser --password password
# helm search repo localhost
NAME             	CHART VERSION	APP VERSION	DESCRIPTION                                       
localhost/brigade	1.10.0       	v1.5.0     	Brigade provides event-driven scripting of Kube...
localhost/kashti 	0.7.0        	v0.4.0     	A Helm chart for Kubernetes
# helm pull localhost/brigade
# ll | grep brigade
-rw-r--r--. 1 root root 14278 Feb 10 15:01 brigade-1.10.0.tgz
```

However, with --repo, this won't work:
```
# helm pull --repo http://127.0.0.1/charts/ brigade
Error: failed to fetch http://127.0.0.1/charts/brigade-1.10.0.tgz : 401 Unauthorized
```

The username and password must be provided:
```
# helm pull --repo http://127.0.0.1/charts/ brigade
Error: looks like "http://127.0.0.1/charts/" is not a valid chart repository or cannot be reached: failed to fetch http://127.0.0.1/charts/index.yaml : 401 Unauthorized
```

After applying the fix:
```
[root@fedora1 helm]# /home/akaris/development/helm/bin/helm pull --repo http://127.0.0.1/charts/ brigade; if [ -f brigade-1.10.0.tgz ]; then echo ok; rm -f brigade-1.10.0.tgz;fi
ok
[root@fedora1 helm]# /home/akaris/development/helm/bin/helm pull --repo http://127.0.0.1/charts brigade; if [ -f brigade-1.10.0.tgz ]; then echo ok; rm -f brigade-1.10.0.tgz;fi
ok
[root@fedora1 helm]# /home/akaris/development/helm/bin/helm pull --repo http://127.0.0.1/charts//// brigade; if [ -f brigade-1.10.0.tgz ]; then echo ok; rm -f brigade-1.10.0.tgz;fi
ok
[root@fedora1 helm]# /home/akaris/development/helm/bin/helm pull --repo http://127.0.0.1///charts//// brigade; if [ -f brigade-1.10.0.tgz ]; then echo ok; rm -f brigade-1.10.0.tgz;fi
ok
[root@fedora1 helm]# /home/akaris/development/helm/bin/helm pull --repo http://127.0.0.1/charts/a//// brigade; if [ -f brigade-1.10.0.tgz ]; then echo ok; rm -f brigade-1.10.0.tgz;fi
Error: looks like "http://127.0.0.1/charts/a////" is not a valid chart repository or cannot be reached: failed to fetch http://127.0.0.1/charts/a////index.yaml : 401 Unauthorized
```



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
