### PR TITLE
Fix helm install --create-namespace flag RBAC issue

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -309,7 +309,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		if err != nil {
 			return nil, err
 		}
-		if _, err := i.cfg.KubeClient.Create(resourceList); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := i.cfg.KubeClient.CreateIfNotExists(resourceList); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -47,6 +47,11 @@ func (p *PrintingKubeClient) Create(resources kube.ResourceList) (*kube.Result, 
 	return &kube.Result{Created: resources}, nil
 }
 
+// Create prints the values of what would be created with a real KubeClient.
+func (p *PrintingKubeClient) CreateIfNotExists(resources kube.ResourceList) (*kube.Result, error) {
+	return p.Create(resources)
+}
+
 func (p *PrintingKubeClient) Wait(resources kube.ResourceList, _ time.Duration) error {
 	_, err := io.Copy(p.Out, bufferize(resources))
 	return err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -29,6 +29,8 @@ import (
 type Interface interface {
 	// Create creates one or more resources.
 	Create(resources ResourceList) (*Result, error)
+	// Create creates one or more resources with resource existance check.
+	CreateIfNotExists(resources ResourceList) (*Result, error)
 
 	Wait(resources ResourceList, timeout time.Duration) error
 


### PR DESCRIPTION
Allow case when namespace already exists in the cluster and user does not have a permission to create namespaces. `helm install --create-namespace` would not try to create namespace (and receive an unnecessary failure) in such case.

This change makes `--create-namespace` flag behaviour more idempotent.