### PR TITLE
Add hint to missing dependency message

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -214,6 +214,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		// As of Helm 2.4.0, this is treated as a stopping condition:
 		// https://github.com/helm/helm/issues/2209
 		if err := action.CheckDependencies(chartRequested, req); err != nil {
+			err = errors.Wrap(err, "An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies")
 			if client.DependencyUpdate {
 				man := &downloader.Manager{
 					Out:              out,

--- a/cmd/helm/testdata/output/upgrade-with-missing-dependencies.txt
+++ b/cmd/helm/testdata/output/upgrade-with-missing-dependencies.txt
@@ -1,1 +1,1 @@
-Error: found in Chart.yaml, but missing in charts/ directory: reqsubchart2
+Error: An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: reqsubchart2

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -146,6 +146,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			}
 			if req := ch.Metadata.Dependencies; req != nil {
 				if err := action.CheckDependencies(ch, req); err != nil {
+					err = errors.Wrap(err, "An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies")
 					if client.DependencyUpdate {
 						man := &downloader.Manager{
 							Out:              out,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds a hint on how to resolve the situation to the 'missing dependency' error message.
Since switching to a shared library, this is the single biggest cause for confusion for developers in my team which could be solved by adding the  _"You may need to run `helm dependency build` to fetch missing dependencies."_ message at the end.

**Special notes for your reviewer**:

n/a

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
