### PR TITLE
Fix URL with encoded path support for ChartDownloader

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -307,6 +307,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		}
 		q := repoURL.Query()
 		// We need a trailing slash for ResolveReference to work, but make sure there isn't already one
+		repoURL.RawPath = strings.TrimSuffix(repoURL.RawPath, "/") + "/"
 		repoURL.Path = strings.TrimSuffix(repoURL.Path, "/") + "/"
 		u = repoURL.ResolveReference(u)
 		u.RawQuery = q.Encode()

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -48,6 +48,7 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "reference, testing-relative repo", ref: "testing-relative/bar", expect: "http://example.com/helm/bar-1.2.3.tgz"},
 		{name: "reference, testing-relative-trailing-slash repo", ref: "testing-relative-trailing-slash/foo", expect: "http://example.com/helm/charts/foo-1.2.3.tgz"},
 		{name: "reference, testing-relative-trailing-slash repo", ref: "testing-relative-trailing-slash/bar", expect: "http://example.com/helm/bar-1.2.3.tgz"},
+		{name: "encoded URL", ref: "encoded-url/foobar", expect: "http://example.com/with%2Fslash/charts/foobar-4.2.1.tgz"},
 		{name: "full URL, HTTPS, irrelevant version", ref: "https://example.com/foo-1.2.3.tgz", version: "0.1.0", expect: "https://example.com/foo-1.2.3.tgz", fail: true},
 		{name: "full URL, file", ref: "file:///foo-1.2.3.tgz", fail: true},
 		{name: "invalid", ref: "invalid-1.2.3", fail: true},

--- a/pkg/downloader/testdata/repositories.yaml
+++ b/pkg/downloader/testdata/repositories.yaml
@@ -24,3 +24,5 @@ repositories:
   - name: testing-https-insecureskip-tls-verify
     url: "https://example-https-insecureskiptlsverify.com"
     insecure_skip_tls_verify: true
+  - name: encoded-url
+    url: "http://example.com/with%2Fslash"

--- a/pkg/downloader/testdata/repository/encoded-url-index.yaml
+++ b/pkg/downloader/testdata/repository/encoded-url-index.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+entries:
+  foobar:
+    - name: foobar
+      description: Foo Chart With Encoded URL
+      home: https://helm.sh/helm
+      keywords: []
+      maintainers: []
+      sources:
+        - https://github.com/helm/charts
+      urls:
+        - charts/foobar-4.2.1.tgz
+      version: 4.2.1
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      apiVersion: v2


### PR DESCRIPTION
**What this PR does / why we need it**:

When the repo url contains URL-encoded parts, and doesn't end with `/`, relative downloads are not properly resolved.

Example, with  current main (3d1bc72827e4edef273fb3d8d8ded2a25fa6f39d):

```shell
$ bin/helm repo add kubitus-ingress-operator https://gitlab.com/api/v4/projects/kubitus-project%2Fkubitus-ingress-operator/packages/helm/stable
"kubitus-ingress-operator" has been added to your repositories

$ show.go:173: [debug] Original chart version: ""
Error: failed to fetch https://gitlab.com/api/v4/projects/kubitus-project/kubitus-ingress-operator/packages/helm/stable/charts/kubitus-ingress-operator-v0.2.0.tgz : 404 Not Found
helm.go:81: [debug] failed to fetch https://gitlab.com/api/v4/projects/kubitus-project/kubitus-ingress-operator/packages/helm/stable/charts/kubitus-ingress-operator-v0.2.0.tgz : 404 Not Found
helm.sh/helm/v3/pkg/getter.(*HTTPGetter).get
        /home/circleci/helm.sh/helm/pkg/getter/httpgetter.go:73
helm.sh/helm/v3/pkg/getter.(*HTTPGetter).Get
        /home/circleci/helm.sh/helm/pkg/getter/httpgetter.go:41
helm.sh/helm/v3/pkg/downloader.(*ChartDownloader).DownloadTo
        /home/circleci/helm.sh/helm/pkg/downloader/chart_downloader.go:99
helm.sh/helm/v3/pkg/action.(*ChartPathOptions).LocateChart
        /home/circleci/helm.sh/helm/pkg/action/install.go:675
main.runShow
        /home/circleci/helm.sh/helm/cmd/helm/show.go:179
main.newShowCmd.func4
        /home/circleci/helm.sh/helm/cmd/helm/show.go:116
github.com/spf13/cobra.(*Command).execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main
        /home/circleci/helm.sh/helm/cmd/helm/helm.go:80
runtime.main
        /usr/local/go/src/runtime/proc.go:204
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1374
```

As you can see, `%2F` was replaced by `/` which leads to `404 Not found`.


We this patch applied, it works:

```
$ bin/helm show chart  kubitus-ingress-operator/kubitus-ingress-operator --debug
show.go:195: [debug] Original chart version: ""
apiVersion: v2
appVersion: main
dependencies:
- condition: metacontroller.enabled
  name: metacontroller
  repository: ""
description: Kubitus Ingress Operator
home: https://gitlab.com/kubitus-project/kubitus-ingress-operator
name: kubitus-ingress-operator
sources:
- https://gitlab.com/kubitus-project/kubitus-ingress-operator
type: application
version: v0.2.0
```
**Special notes for your reviewer**:

Fixes: #9977.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
