### PR TITLE
Fix helm repo index with encoded URLs

### DIFF
--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -33,10 +33,19 @@ func URLJoin(baseURL string, paths ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if u.RawPath == "" {
+		u.RawPath = u.Path
+	}
 	// We want path instead of filepath because path always uses /.
-	all := []string{u.Path}
+	all := []string{u.RawPath}
 	all = append(all, paths...)
-	u.Path = path.Join(all...)
+	u.RawPath = path.Join(all...)
+
+	u.Path, err = url.PathUnescape(u.RawPath)
+	if err != nil {
+		return "", err
+	}
+
 	return u.String(), nil
 }
 

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -28,6 +28,9 @@ func TestURLJoin(t *testing.T) {
 		{name: "URL, two paths", url: "http://example.com", paths: []string{"hello", "world"}, expect: "http://example.com/hello/world"},
 		{name: "URL, no paths", url: "http://example.com", paths: []string{}, expect: "http://example.com"},
 		{name: "basepath, two paths", url: "../example.com", paths: []string{"hello", "world"}, expect: "../example.com/hello/world"},
+		{name: "encoded parts", url: "../example.com", paths: []string{"hello", "world"}, expect: "../example.com/hello/world"},
+		{name: "Long URL with encoded path, non-encoded paths", url: "http://example.com/but%2ffirst", paths: []string{"part-1", "part-2"}, expect: "http://example.com/but%2ffirst/part-1/part-2"},
+		{name: "Long URL with encoded path, encoded paths", url: "http://example.com/but%2ffirst", paths: []string{"part%25-1", "part%25-2"}, expect: "http://example.com/but%2ffirst/part%25-1/part%25-2"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

While fixing #9764, and #9821, I found another usage of `url.Path` without `url.RawPath`.

I have not (yet) an end-user case, but the code is only used for `helm repo index`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
