### PR TITLE
Add a destination option to `helm create`

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -52,6 +52,7 @@ will be overwritten, but other files will be left alone.
 
 type createOptions struct {
 	starter    string // --starter
+	directory  string // --directory
 	name       string
 	starterDir string
 }
@@ -81,6 +82,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
+	cmd.Flags().StringVarP(&o.directory, "directory", "d", "", "the location of the created chart")
 	return cmd
 }
 
@@ -97,6 +99,11 @@ func (o *createOptions) run(out io.Writer) error {
 		APIVersion:  chart.APIVersionV2,
 	}
 
+	destination := o.directory
+	if destination == "" {
+		destination = o.name
+	}
+
 	if o.starter != "" {
 		// Create from the starter
 		lstarter := filepath.Join(o.starterDir, o.starter)
@@ -104,10 +111,10 @@ func (o *createOptions) run(out io.Writer) error {
 		if filepath.IsAbs(o.starter) {
 			lstarter = o.starter
 		}
-		return chartutil.CreateFrom(cfile, filepath.Dir(o.name), lstarter)
+		return chartutil.CreateFrom(cfile, destination, lstarter)
 	}
 
 	chartutil.Stderr = out
-	_, err := chartutil.Create(chartname, filepath.Dir(o.name))
+	_, err := chartutil.Create(chartname, destination)
 	return err
 }

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -71,12 +71,13 @@ func TestCreateStarterCmd(t *testing.T) {
 	// Create a starter.
 	starterchart := helmpath.DataPath("starters")
 	os.MkdirAll(starterchart, 0755)
-	if dest, err := chartutil.Create("starterchart", starterchart); err != nil {
+	destination := filepath.Join(starterchart, "starterchart")
+	if dest, err := chartutil.Create("starterchart", destination); err != nil {
 		t.Fatalf("Could not create chart: %s", err)
 	} else {
 		t.Logf("Created %s", dest)
 	}
-	tplpath := filepath.Join(starterchart, "starterchart", "templates", "foo.tpl")
+	tplpath := filepath.Join(destination, "templates", "foo.tpl")
 	if err := ioutil.WriteFile(tplpath, []byte("test"), 0644); err != nil {
 		t.Fatalf("Could not write template: %s", err)
 	}
@@ -134,12 +135,13 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 	// Create a starter.
 	starterchart := helmpath.DataPath("starters")
 	os.MkdirAll(starterchart, 0755)
-	if dest, err := chartutil.Create("starterchart", starterchart); err != nil {
+	destination := filepath.Join(starterchart, "starterchart")
+	if dest, err := chartutil.Create("starterchart", destination); err != nil {
 		t.Fatalf("Could not create chart: %s", err)
 	} else {
 		t.Logf("Created %s", dest)
 	}
-	tplpath := filepath.Join(starterchart, "starterchart", "templates", "foo.tpl")
+	tplpath := filepath.Join(destination, "templates", "foo.tpl")
 	if err := ioutil.WriteFile(tplpath, []byte("test"), 0644); err != nil {
 		t.Fatalf("Could not write template: %s", err)
 	}
@@ -147,10 +149,8 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 	os.MkdirAll(helmpath.CachePath(), 0755)
 	defer testChdir(t, helmpath.CachePath())()
 
-	starterChartPath := filepath.Join(starterchart, "starterchart")
-
 	// Run a create
-	if _, _, err := executeActionCommand(fmt.Sprintf("create --starter=%s %s", starterChartPath, cname)); err != nil {
+	if _, _, err := executeActionCommand(fmt.Sprintf("create --starter=%s %s", destination, cname)); err != nil {
 		t.Errorf("Failed to run create: %s", err)
 		return
 	}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -570,12 +570,12 @@ func Create(name, dir string) (string, error) {
 		return "", err
 	}
 
-	path, err := filepath.Abs(dir)
+	cdir, err := filepath.Abs(dir)
 	if err != nil {
-		return path, err
+		return cdir, err
 	}
 
-	parentPath := filepath.Dir(path)
+	parentPath := filepath.Dir(cdir)
 	if fi, err := os.Stat(parentPath); err != nil {
 		return parentPath, err
 	} else if !fi.IsDir() {
@@ -588,57 +588,57 @@ func Create(name, dir string) (string, error) {
 	}{
 		{
 			// Chart.yaml
-			path:    filepath.Join(path, ChartfileName),
+			path:    filepath.Join(cdir, ChartfileName),
 			content: []byte(fmt.Sprintf(defaultChartfile, name)),
 		},
 		{
 			// values.yaml
-			path:    filepath.Join(path, ValuesfileName),
+			path:    filepath.Join(cdir, ValuesfileName),
 			content: []byte(fmt.Sprintf(defaultValues, name)),
 		},
 		{
 			// .helmignore
-			path:    filepath.Join(path, IgnorefileName),
+			path:    filepath.Join(cdir, IgnorefileName),
 			content: []byte(defaultIgnore),
 		},
 		{
 			// ingress.yaml
-			path:    filepath.Join(path, IngressFileName),
+			path:    filepath.Join(cdir, IngressFileName),
 			content: transform(defaultIngress, name),
 		},
 		{
 			// deployment.yaml
-			path:    filepath.Join(path, DeploymentName),
+			path:    filepath.Join(cdir, DeploymentName),
 			content: transform(defaultDeployment, name),
 		},
 		{
 			// service.yaml
-			path:    filepath.Join(path, ServiceName),
+			path:    filepath.Join(cdir, ServiceName),
 			content: transform(defaultService, name),
 		},
 		{
 			// serviceaccount.yaml
-			path:    filepath.Join(path, ServiceAccountName),
+			path:    filepath.Join(cdir, ServiceAccountName),
 			content: transform(defaultServiceAccount, name),
 		},
 		{
 			// hpa.yaml
-			path:    filepath.Join(path, HorizontalPodAutoscalerName),
+			path:    filepath.Join(cdir, HorizontalPodAutoscalerName),
 			content: transform(defaultHorizontalPodAutoscaler, name),
 		},
 		{
 			// NOTES.txt
-			path:    filepath.Join(path, NotesName),
+			path:    filepath.Join(cdir, NotesName),
 			content: transform(defaultNotes, name),
 		},
 		{
 			// _helpers.tpl
-			path:    filepath.Join(path, HelpersName),
+			path:    filepath.Join(cdir, HelpersName),
 			content: transform(defaultHelpers, name),
 		},
 		{
 			// test-connection.yaml
-			path:    filepath.Join(path, TestConnectionName),
+			path:    filepath.Join(cdir, TestConnectionName),
 			content: transform(defaultTestConnection, name),
 		},
 	}
@@ -649,14 +649,14 @@ func Create(name, dir string) (string, error) {
 			fmt.Fprintf(Stderr, "WARNING: File %q already exists. Overwriting.\n", file.path)
 		}
 		if err := writeFile(file.path, file.content); err != nil {
-			return path, err
+			return cdir, err
 		}
 	}
 	// Need to add the ChartsDir explicitly as it does not contain any file OOTB
-	if err := os.MkdirAll(filepath.Join(path, ChartsDir), 0755); err != nil {
-		return path, err
+	if err := os.MkdirAll(filepath.Join(cdir, ChartsDir), 0755); err != nil {
+		return cdir, err
 	}
-	return path, nil
+	return cdir, nil
 }
 
 // transform performs a string replacement of the specified source for

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -34,12 +34,11 @@ func TestCreate(t *testing.T) {
 	}
 	defer os.RemoveAll(tdir)
 
-	c, err := Create("foo", tdir)
+	destination := filepath.Join(tdir, "foo")
+	c, err := Create("foo", destination)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	dir := filepath.Join(tdir, "foo")
 
 	mychart, err := loader.LoadDir(c)
 	if err != nil {
@@ -63,7 +62,7 @@ func TestCreate(t *testing.T) {
 		TestConnectionName,
 		ValuesfileName,
 	} {
-		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+		if _, err := os.Stat(filepath.Join(destination, f)); err != nil {
 			t.Errorf("Expected %s file: %s", f, err)
 		}
 	}
@@ -83,15 +82,14 @@ func TestCreateFrom(t *testing.T) {
 	}
 	srcdir := "./testdata/frobnitz/charts/mariner"
 
-	if err := CreateFrom(cf, tdir, srcdir); err != nil {
+	destination := filepath.Join(tdir, cf.Name)
+	if err := CreateFrom(cf, destination, srcdir); err != nil {
 		t.Fatal(err)
 	}
 
-	dir := filepath.Join(tdir, "foo")
-	c := filepath.Join(tdir, cf.Name)
-	mychart, err := loader.LoadDir(c)
+	mychart, err := loader.LoadDir(destination)
 	if err != nil {
-		t.Fatalf("Failed to load newly created chart %q: %s", c, err)
+		t.Fatalf("Failed to load newly created chart %q: %s", destination, err)
 	}
 
 	if mychart.Name() != "foo" {
@@ -103,12 +101,12 @@ func TestCreateFrom(t *testing.T) {
 		ValuesfileName,
 		filepath.Join(TemplatesDir, "placeholder.tpl"),
 	} {
-		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+		if _, err := os.Stat(filepath.Join(destination, f)); err != nil {
 			t.Errorf("Expected %s file: %s", f, err)
 		}
 
 		// Check each file to make sure <CHARTNAME> has been replaced
-		b, err := ioutil.ReadFile(filepath.Join(dir, f))
+		b, err := ioutil.ReadFile(filepath.Join(destination, f))
 		if err != nil {
 			t.Errorf("Unable to read file %s: %s", f, err)
 		}
@@ -128,18 +126,17 @@ func TestCreate_Overwrite(t *testing.T) {
 
 	var errlog bytes.Buffer
 
-	if _, err := Create("foo", tdir); err != nil {
+	destination := filepath.Join(tdir, "foo")
+	if _, err := Create("foo", destination); err != nil {
 		t.Fatal(err)
 	}
 
-	dir := filepath.Join(tdir, "foo")
-
-	tplname := filepath.Join(dir, "templates/hpa.yaml")
+	tplname := filepath.Join(destination, "templates/hpa.yaml")
 	writeFile(tplname, []byte("FOO"))
 
 	// Now re-run the create
 	Stderr = &errlog
-	if _, err := Create("foo", tdir); err != nil {
+	if _, err := Create("foo", destination); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -40,6 +40,14 @@ var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
 func SaveDir(c *chart.Chart, dest string) error {
 	// Create the chart directory
 	outdir := filepath.Join(dest, c.Name())
+	return SaveDirCustom(c, outdir)
+}
+
+// SaveDirCustom saves a chart as files in a custom directory.
+//
+// This takes the chart name and the output directory, writing the chart's contents
+// to that directory.
+func SaveDirCustom(c *chart.Chart, outdir string) error {
 	if fi, err := os.Stat(outdir); err == nil && !fi.IsDir() {
 		return errors.Errorf("file %s already exists and is not a directory", outdir)
 	}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -19,6 +19,7 @@ package lint
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -125,7 +126,8 @@ func TestHelmCreateChart(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	createdChart, err := chartutil.Create("testhelmcreatepasseslint", dir)
+	destination := filepath.Join(dir, "testhelmcreatepasseslint")
+	createdChart, err := chartutil.Create("testhelmcreatepasseslint", destination)
 	if err != nil {
 		t.Error(err)
 		// Fatal is bad because of the defer.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Related to #10048.

This PR adds a new option to `helm create`: `--directory` (shorthand `-d`). Here's an example:
```bash
$ helm create coolapp -d coolapp-helm
Creating coolapp

$ ls ./coolapp-helm
Chart.yaml  charts      templates   values.yaml
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
