### PR TITLE
Fix dependency build when use repository with basic authentication

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -720,6 +720,10 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
+	if urlUsername, urlPassword, ok := getBasicAuth(repoURL); ok {
+		username = urlUsername
+		password = urlPassword
+	}
 	url, err = repo.FindChartInRepoURL(repoURL, name, version, certFile, keyFile, caFile, m.Getters)
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
@@ -785,6 +789,18 @@ func normalizeURL(baseURL, urlOrPath string) (string, error) {
 
 	u2.Path = path.Join(u2.Path, urlOrPath)
 	return u2.String(), nil
+}
+
+func getBasicAuth(baseURL string) (string, string, bool) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", "", false
+	}
+	if _, ok := u.User.Password(); !ok {
+		return "", "", false
+	}
+	password, _ := u.User.Password()
+	return u.User.Username(), password, true
 }
 
 // loadChartRepositories reads the repositories.yaml, and then builds a map of


### PR DESCRIPTION
**What this PR does / why we need it**:
helm dependency build now is not support dependencies repository URL with basic authentication.

here I have helm chart in Git Repo: https://codingcorp.coding.net/public/wangwei_test_cd/bookinfo/git.

Chart.yaml:

```
apiVersion: v1
appVersion: "1.3"
description: Nocalhost Bookinfo Helm chart for Kubernetes
name: nocalhost-bookinfo
version: 1.2.2

dependencies:
  - name: nocalhost-rattings
    version: 1.2.2
    repository: "https://helm-1624626656778:c7df48d7408f1b692ca85f26ff1d98946f7fc7dd@codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm"
```

when I use `helm dependency build`, get error:

```
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://helm-1624626656778:c7df48d7408f1b692ca85f26ff1d98946f7fc7dd@codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm" chart repository
Saving 1 charts
Downloading nocalhost-rattings from repo https://helm-1624626656778:c7df48d7408f1b692ca85f26ff1d98946f7fc7dd@codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm
Save error occurred:  could not download https://codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm/nocalhost-rattings/nocalhost-rattings-1.2.2.tgz: failed to fetch https://codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm/nocalhost-rattings/nocalhost-rattings-1.2.2.tgz : 401 Unauthorized
Deleting newly downloaded charts, restoring pre-update state
Error: could not download https://codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm/nocalhost-rattings/nocalhost-rattings-1.2.2.tgz: failed to fetch https://codingcorp-helm.pkg.coding.net/wangwei_test_cd/helm/nocalhost-rattings/nocalhost-rattings-1.2.2.tgz : 401 Unauthorized
```

so this PR will fix this error. It will use repository URL with username and password for download chart, **without 401 Unauthorized error**

**Special notes for your reviewer**:

empty 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
