### PR TITLE
Fix the url being set by WithURL on the getters

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/repo/repotest"
@@ -47,6 +48,8 @@ func TestInstall(t *testing.T) {
 	if err := srv.LinkIndices(); err != nil {
 		t.Fatal(err)
 	}
+
+	repoFile := filepath.Join(srv.Root(), "repositories.yaml")
 
 	tests := []cmdTestCase{
 		// Install, base case
@@ -242,6 +245,11 @@ func TestInstall(t *testing.T) {
 		{
 			name:   "basic install with credentials",
 			cmd:    "install aeneas reqtest --namespace default --repo " + srv2.URL + " --username username --password password --pass-credentials",
+			golden: "output/install.txt",
+		},
+		{
+			name:   "basic install with credentials and no repo",
+			cmd:    fmt.Sprintf("install aeneas test/reqtest --username username --password password --repository-config %s --repository-cache %s", repoFile, srv.Root()),
 			golden: "output/install.txt",
 		},
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -158,7 +158,6 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	if err != nil {
 		return nil, errors.Errorf("invalid chart URL format: %s", ref)
 	}
-	c.Options = append(c.Options, getter.WithURL(ref))
 
 	rf, err := loadRepoConfig(c.RepositoryConfig)
 	if err != nil {
@@ -177,6 +176,8 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 			// If there is no special config, return the default HTTP client and
 			// swallow the error.
 			if err == ErrNoOwnerRepo {
+				// Make sure to add the ref URL as the URL for the getter
+				c.Options = append(c.Options, getter.WithURL(ref))
 				return u, nil
 			}
 			return u, err
@@ -214,6 +215,10 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	if err != nil {
 		return u, err
 	}
+
+	// Now that we have the chart repository information we can use that URL
+	// to set the URL for the getter.
+	c.Options = append(c.Options, getter.WithURL(rc.URL))
 
 	r, err := repo.NewChartRepository(rc, c.Getters)
 	if err != nil {


### PR DESCRIPTION
The URL passed to the getter for WithURL needs to be a full URL
rather than a chart reference used at the CLI. For example,
bitnami/wordpress can point to the wordpress chart in the bitnami
repo where the bitnami repo is at https://charts.bitnami.com.
WithURL needs the full URL to the repo and not bitnami/wordpress.
This is important because getters use the full URL information.
In this case the http getter uses the host name for SNI handling.

Before this change WithURL was being set to the chart reference
instead of the URL. This was a silent bug.

This change sets WithURL using a URL after for the repo is
available when a reference is used instead of a full url.

Closes #9868

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
