### PR TITLE
Add the ability to output the computed values using the template sub-command

### DIFF
--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -131,6 +131,21 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf(`template '%s' --skip-tests`, chartPath),
 			golden: "output/template-skip-tests.txt",
 		},
+		{
+			name:   "template compute-values",
+			cmd:    fmt.Sprintf(`template '%s' --computed-values`, chartPath),
+			golden: "output/template-compute-values.txt",
+		},
+		{
+			name:   "template compute-values-overrides",
+			cmd:    fmt.Sprintf(`template '%s' --computed-values --set service.name=apache`, chartPath),
+			golden: "output/template-compute-values-overrides.txt",
+		},
+		{
+			name:   "template compute-values-subchart-with-overrides",
+			cmd:    fmt.Sprintf(`template '%s' --computed-values --set subcharta.service.name=nginx`, chartPath),
+			golden: "output/template-compute-values-subchart-overrides.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/template-compute-values-overrides.txt
+++ b/cmd/helm/testdata/output/template-compute-values-overrides.txt
@@ -1,0 +1,107 @@
+SC1data:
+  SC1bool: true
+  SC1extra1: 11
+  SC1float: 3.14
+  SC1int: 100
+  SC1string: dollywood
+SCBexported1A:
+  SC1extra7: true
+  SCBexported1B: 1965
+exports:
+  SC1exported1:
+    global:
+      SC1exported2:
+        all:
+          SC1exported3: SC1expstr
+  SCBexported2:
+    SCBexported2A: blaster
+imported-chartA:
+  SC1extra2: 1.337
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+imported-chartA-B:
+  SC1extra5: tiller
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+imported-chartB:
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+overridden-chartA:
+  SC1extra3: true
+  SCAbool: true
+  SCAfloat: 3.14
+  SCAint: 100
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabbathehut
+overridden-chartA-B:
+  SC1extra6: 77
+  SCAbool: true
+  SCAextra1: 23
+  SCAfloat: 3.33
+  SCAint: 555
+  SCAstring: wormwood
+  SCBbool: true
+  SCBextra1: 13
+  SCBfloat: 0.25
+  SCBint: 98
+  SCBstring: murkwood
+service:
+  externalPort: 80
+  internalPort: 80
+  name: apache
+  type: ClusterIP
+subcharta:
+  SCAdata:
+    SCAbool: false
+    SCAfloat: 3.1
+    SCAint: 55
+    SCAnested1:
+      SCAnested2: true
+    SCAstring: jabba
+  global: {}
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: apache
+    type: ClusterIP
+subchartb:
+  SCBdata:
+    SCBbool: true
+    SCBfloat: 7.77
+    SCBint: 33
+    SCBstring: boba
+  exports:
+    SCBexported1:
+      SCBexported1A:
+        SCBexported1B: 1965
+    SCBexported2:
+      SCBexported2A: blaster
+  global:
+    kolla:
+      nova:
+        api:
+          all:
+            port: 8774
+        metadata:
+          all:
+            port: 8775
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: nginx
+    type: ClusterIP

--- a/cmd/helm/testdata/output/template-compute-values-subchart-overrides.txt
+++ b/cmd/helm/testdata/output/template-compute-values-subchart-overrides.txt
@@ -1,0 +1,107 @@
+SC1data:
+  SC1bool: true
+  SC1extra1: 11
+  SC1float: 3.14
+  SC1int: 100
+  SC1string: dollywood
+SCBexported1A:
+  SC1extra7: true
+  SCBexported1B: 1965
+exports:
+  SC1exported1:
+    global:
+      SC1exported2:
+        all:
+          SC1exported3: SC1expstr
+  SCBexported2:
+    SCBexported2A: blaster
+imported-chartA:
+  SC1extra2: 1.337
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+imported-chartA-B:
+  SC1extra5: tiller
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+imported-chartB:
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+overridden-chartA:
+  SC1extra3: true
+  SCAbool: true
+  SCAfloat: 3.14
+  SCAint: 100
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabbathehut
+overridden-chartA-B:
+  SC1extra6: 77
+  SCAbool: true
+  SCAextra1: 23
+  SCAfloat: 3.33
+  SCAint: 555
+  SCAstring: wormwood
+  SCBbool: true
+  SCBextra1: 13
+  SCBfloat: 0.25
+  SCBint: 98
+  SCBstring: murkwood
+service:
+  externalPort: 80
+  internalPort: 80
+  name: nginx
+  type: ClusterIP
+subcharta:
+  SCAdata:
+    SCAbool: false
+    SCAfloat: 3.1
+    SCAint: 55
+    SCAnested1:
+      SCAnested2: true
+    SCAstring: jabba
+  global: {}
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: nginx
+    type: ClusterIP
+subchartb:
+  SCBdata:
+    SCBbool: true
+    SCBfloat: 7.77
+    SCBint: 33
+    SCBstring: boba
+  exports:
+    SCBexported1:
+      SCBexported1A:
+        SCBexported1B: 1965
+    SCBexported2:
+      SCBexported2A: blaster
+  global:
+    kolla:
+      nova:
+        api:
+          all:
+            port: 8774
+        metadata:
+          all:
+            port: 8775
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: nginx
+    type: ClusterIP

--- a/cmd/helm/testdata/output/template-compute-values.txt
+++ b/cmd/helm/testdata/output/template-compute-values.txt
@@ -1,0 +1,107 @@
+SC1data:
+  SC1bool: true
+  SC1extra1: 11
+  SC1float: 3.14
+  SC1int: 100
+  SC1string: dollywood
+SCBexported1A:
+  SC1extra7: true
+  SCBexported1B: 1965
+exports:
+  SC1exported1:
+    global:
+      SC1exported2:
+        all:
+          SC1exported3: SC1expstr
+  SCBexported2:
+    SCBexported2A: blaster
+imported-chartA:
+  SC1extra2: 1.337
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+imported-chartA-B:
+  SC1extra5: tiller
+  SCAbool: false
+  SCAfloat: 3.1
+  SCAint: 55
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabba
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+imported-chartB:
+  SCBbool: true
+  SCBfloat: 7.77
+  SCBint: 33
+  SCBstring: boba
+overridden-chartA:
+  SC1extra3: true
+  SCAbool: true
+  SCAfloat: 3.14
+  SCAint: 100
+  SCAnested1:
+    SCAnested2: true
+  SCAstring: jabbathehut
+overridden-chartA-B:
+  SC1extra6: 77
+  SCAbool: true
+  SCAextra1: 23
+  SCAfloat: 3.33
+  SCAint: 555
+  SCAstring: wormwood
+  SCBbool: true
+  SCBextra1: 13
+  SCBfloat: 0.25
+  SCBint: 98
+  SCBstring: murkwood
+service:
+  externalPort: 80
+  internalPort: 80
+  name: nginx
+  type: ClusterIP
+subcharta:
+  SCAdata:
+    SCAbool: false
+    SCAfloat: 3.1
+    SCAint: 55
+    SCAnested1:
+      SCAnested2: true
+    SCAstring: jabba
+  global: {}
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: apache
+    type: ClusterIP
+subchartb:
+  SCBdata:
+    SCBbool: true
+    SCBfloat: 7.77
+    SCBint: 33
+    SCBstring: boba
+  exports:
+    SCBexported1:
+      SCBexported1A:
+        SCBexported1B: 1965
+    SCBexported2:
+      SCBexported2A: blaster
+  global:
+    kolla:
+      nova:
+        api:
+          all:
+            port: 8774
+        metadata:
+          all:
+            port: 8775
+  service:
+    externalPort: 80
+    internalPort: 80
+    name: nginx
+    type: ClusterIP


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the ability to template the resolved values files (all the values including the chart defaults). This is equivalent to the output seen in the `--dry-run` `COMPUTED VALUES:` section.

The default behaviour of template is untouched and only changed when you use the `--computed-values` flag, which will output 
 the computed values _instead_ of the fully rendered manifest.

**example:**
```
# Display the computed values of the chart in its default state
helm template ./chart/name --computed-values
# Display the computed values of the chart after overrides have been applied
helm template ./chart/name --computed-values -f overrides.yaml
```

will output the values _after_ they have been resolved by the helm parsers.

This is useful in simple CI situations where a particular value is expected especially when traversing multiple environments, it is also useful as an input for other parsers or templating tools to provide customised output based on the values passed into the chart.

- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
