### PR TITLE
Download manager improvements

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -899,13 +899,13 @@ func key(name string) (string, error) {
 
 // removeDuplicates remove entries with the same name or unique key
 func removeDuplicates(re []*repo.Entry) []*repo.Entry {
-	m := make(map[string]struct{})
-	uniq := make([]*repo.Entry, 0)
+	m := map[string]bool{}
+	uniq := []*repo.Entry{}
 	for _, r := range re {
-		if _, ok := m[r.Name]; ok {
+		if m[r.Name] {
 			continue
 		}
-		m[r.Name] = struct{}{}
+		m[r.Name] = true
 		uniq = append(uniq, r)
 	}
 

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -580,11 +580,6 @@ func (m *Manager) resolveRepoNames(deps []*chart.Dependency) (map[string]string,
 			continue
 		}
 
-		if strings.HasPrefix(dd.Repository, "oci://") {
-			reposMap[dd.Name] = dd.Repository
-			continue
-		}
-
 		found := false
 
 		for _, repo := range repos {

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -531,8 +531,8 @@ func (m *Manager) ensureMissingRepos(repoNames map[string]string, deps []*chart.
 	// is not configured.
 	if !m.SkipUpdate && len(ru) > 0 {
 
-		// Some dependencies might have a diferent names but point to the same repository
-		// after creating a unique key we should remove duplicated entries to avoid unecessary work
+		// Some dependencies might have a different names but point to the same repository
+		// after creating a unique key we should remove duplicated entries to avoid unnecessary work
 		ru = removeDuplicates(ru)
 
 		fmt.Fprintln(m.Out, "Getting updates for unmanaged Helm repositories...")

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
 	"helm.sh/helm/v3/pkg/repo/repotest"
 )
 
@@ -520,4 +521,45 @@ func TestKey(t *testing.T) {
 			t.Errorf("wrong key name generated for %q, expected %q but got %q", tt.name, tt.expect, o)
 		}
 	}
+}
+
+func TestRemoveDuplicates(t *testing.T) {
+	entries := []*repo.Entry{
+		{Name: "helm-manager-sha123"},
+		{Name: "helm-manager-sha456"},
+		{Name: "helm-manager-sha123"},
+	}
+
+	tests := []struct {
+		input  []*repo.Entry
+		expect []*repo.Entry
+	}{
+		{
+			input:  entries,
+			expect: entries[:2],
+		},
+		{
+			input:  entries[1:],
+			expect: entries[1:],
+		},
+	}
+
+	for _, tt := range tests {
+		output := removeDuplicates(tt.input)
+
+		outSize := len(output)
+		expectedSize := len(tt.expect)
+
+		if outSize != expectedSize {
+			t.Fatalf("duplication removal failed, expected %d but got %d", expectedSize, outSize)
+		}
+
+		for i, o := range output {
+			if o != tt.expect[i] {
+				t.Errorf("duplication removal failed, expected %q but got %q", tt.expect[i], o)
+			}
+
+		}
+	}
+
 }


### PR DESCRIPTION
When updating local charts directory, while ensuring the missing repositories the check only looks for the Name, but sometimes the repository address might be the same, leading to unnecessary fetch of duplicate index files.

This change will ensure no duplicates entries exists before fetching and remove a duplicate check for `oci://` prefix.

Solves #9878 
