### PR TITLE
fix(doc): fix kube client interface doc.

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -100,7 +100,7 @@ func (c *Client) getKubeClient() (*kubernetes.Clientset, error) {
 	return c.kubeClient, err
 }
 
-// IsReachable tests connectivity to the cluster
+// IsReachable tests connectivity to the cluster.
 func (c *Client) IsReachable() error {
 	client, err := c.getKubeClient()
 	if err == genericclioptions.ErrEmptyConfig {
@@ -126,7 +126,7 @@ func (c *Client) Create(resources ResourceList) (*Result, error) {
 	return &Result{Created: resources}, nil
 }
 
-// Wait up to the given timeout for the specified resources to be ready
+// Wait waits up to the given timeout for the specified resources to be ready.
 func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	cs, err := c.getKubeClient()
 	if err != nil {
@@ -324,7 +324,7 @@ func (c *Client) watchTimeout(t time.Duration) func(*resource.Info) error {
 
 // WatchUntilReady watches the resources given and waits until it is ready.
 //
-// This function is mainly for hook implementations. It watches for a resource to
+// This method is mainly for hook implementations. It watches for a resource to
 // hit a particular milestone. The milestone depends on the Kind.
 //
 // For most kinds, it checks to see if the resource is marked as Added or Modified

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -30,14 +30,19 @@ type Interface interface {
 	// Create creates one or more resources.
 	Create(resources ResourceList) (*Result, error)
 
+	// Wait waits up to the given timeout for the specified resources to be ready.
 	Wait(resources ResourceList, timeout time.Duration) error
 
+	// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
 	WaitWithJobs(resources ResourceList, timeout time.Duration) error
 
 	// Delete destroys one or more resources.
 	Delete(resources ResourceList) (*Result, []error)
 
-	// Watch the resource in reader until it is "ready". This method
+	// WatchUntilReady watches the resources given and waits until it is ready.
+	//
+	// This method is mainly for hook implementations. It watches for a resource to
+	// hit a particular milestone. The milestone depends on the Kind.
 	//
 	// For Jobs, "ready" means the Job ran to completion (exited without error).
 	// For Pods, "ready" means the Pod phase is marked "succeeded".
@@ -49,9 +54,9 @@ type Interface interface {
 	// if it doesn't exist.
 	Update(original, target ResourceList, force bool) (*Result, error)
 
-	// Build creates a resource list from a Reader
+	// Build creates a resource list from a Reader.
 	//
-	// reader must contain a YAML stream (one or more YAML documents separated
+	// Reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n")
 	//
 	// Validates against OpenAPI schema if validate is true.
@@ -61,7 +66,7 @@ type Interface interface {
 	// and returns said phase (PodSucceeded or PodFailed qualify).
 	WaitAndGetCompletedPodPhase(name string, timeout time.Duration) (v1.PodPhase, error)
 
-	// isReachable checks whether the client is able to connect to the cluster
+	// IsReachable checks whether the client is able to connect to the cluster.
 	IsReachable() error
 }
 


### PR DESCRIPTION
For the interface at `pkg/kube/interface.go`:

- add missing interface methods doc.
- fix some wrong english grammar.

**What this PR does / why we need it**:

Fix kube client interface doc.

**If applicable**:
- [x] this PR has been tested for backwards compatibility
