### PR TITLE
Fix install use URL base authentication

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -688,6 +688,10 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		// Host on URL (returned from url.Parse) contains the port if present.
 		// This check ensures credentials are not passed between different
 		// services on different ports.
+		if password, ok := u1.User.Password(); ok {
+			c.Username = u1.User.Username()
+			c.Password = password
+		}
 		if c.PassCredentialsAll || (u1.Scheme == u2.Scheme && u1.Host == u2.Host) {
 			dl.Options = append(dl.Options, getter.WithBasicAuth(c.Username, c.Password))
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

When I use `helm install wepack wepack-testing --repo https://username:password@coding-public-helm.pkg.coding.net/wepack/wepack`, return:

```
Error: failed to download "https://coding-public-helm.pkg.coding.net/wepack/wepack/wepack-testing/wepack-testing-0.0.0-release.tgz" at version "0.0.0-release" (hint: running `helm repo update` may help)
```

It seem that `FindChartInAuthAndTLSAndPassRepoURL` can download index file `index.yaml`.

![image](https://user-images.githubusercontent.com/8142348/123902793-09f55580-d9a0-11eb-844a-0edf9b9c244f.png)

but next to `getter.WithBasicAuth`, It set empty username and password in `dl.Options`.

![image](https://user-images.githubusercontent.com/8142348/123903246-eaaaf800-d9a0-11eb-9ac6-d704fa35ee65.png)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
