### PR TITLE
feat(linter): check for nested resource-policy annotations

### DIFF
--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -424,3 +424,41 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 		t.Fatalf("Expected 0 lint errors, got %d", l)
 	}
 }
+func TestValidateListAnnotations(t *testing.T) {
+	md := &K8sYamlStruct{
+		APIVersion: "v1",
+		Kind:       "List",
+		Metadata: k8sYamlMetadata{
+			Name: "list",
+		},
+	}
+	manifest := `
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+`
+
+	if err := validateListAnnotations(md, manifest); err == nil {
+		t.Fatal("expected list with nested keep annotations to fail")
+	}
+
+	manifest = `
+apiVersion: v1
+kind: List
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+`
+
+	if err := validateListAnnotations(md, manifest); err != nil {
+		t.Fatalf("List objects keep annotations should pass. got: %s", err)
+	}
+}


### PR DESCRIPTION
The 'helm.sh/resource-policy' annotation is only supported on top level
objects.  The annotation is ignored if given on a nested object within a
list.

Ref #9829