### PR TITLE
fix(typo): fix typo of storage doc

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -55,8 +55,8 @@ func (s *Storage) Get(name string, version int) (*rspb.Release, error) {
 }
 
 // Create creates a new storage entry holding the release. An
-// error is returned if the storage driver failed to store the
-// release, or a release with identical an key already exists.
+// error is returned if the storage driver fails to store the
+// release, or a release with an identical key already exists.
 func (s *Storage) Create(rls *rspb.Release) error {
 	s.Log("creating release %q", makeKey(rls.Name, rls.Version))
 	if s.MaxHistory > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix method document typo of `storage.go`.

**Special notes for your reviewer**:

No.