### PR TITLE
WIP: Render templates in parallel

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -123,7 +123,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 
 	// Add the 'include' function here so we can close over t.
 	funcMap["include"] = func(name string, data chartutil.Values) (string, error) {
-		processId:=goid()
+		processId := goid()
 		var includedNames_, ok = includedNamesPerProcess.Load(processId)
 		if !ok {
 			includedNames_ = make(map[string]int)
@@ -297,14 +297,14 @@ func (e Engine) renderWithReferencesInternal(tpls, referenceTpls map[string]rend
 		if toplevel {
 			go doRenderAsync(renderResults, filename, t, vals)
 		} else {
-			r,renderError := doRender(filename, t, vals)
+			r, renderError := doRender(filename, t, vals)
 			if renderError != nil {
 				return map[string]string{}, cleanupExecError(filename, renderError)
 			}
 			rendered[filename] = r
 		}
 	}
-	if renderResults !=nil {
+	if renderResults != nil {
 		for _, filename := range keys {
 			if strings.HasPrefix(path.Base(filename), "_") {
 				continue
@@ -318,17 +318,19 @@ func (e Engine) renderWithReferencesInternal(tpls, referenceTpls map[string]rend
 	}
 	return rendered, nil
 }
+
 type RenderResults struct {
 	filename string
 	rendered string
-	error error
+	error    error
 }
-func doRenderAsync(renderResults chan RenderResults, filename string, t* template.Template, vals chartutil.Values) {
+
+func doRenderAsync(renderResults chan RenderResults, filename string, t *template.Template, vals chartutil.Values) {
 	rendered, error := doRender(filename, t, vals)
 	renderResults <- RenderResults{filename: filename, rendered: rendered, error: error}
 }
 
-func doRender(filename string, t* template.Template, vals chartutil.Values) (string, error) {
+func doRender(filename string, t *template.Template, vals chartutil.Values) (string, error) {
 	var buf strings.Builder
 	if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
 		return "", cleanupExecError(filename, err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -123,11 +123,11 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 
 	// Add the 'include' function here so we can close over t.
 	funcMap["include"] = func(name string, data chartutil.Values) (string, error) {
-		processId := goid()
-		var existingIncludedNames, ok = includedNamesPerProcess.Load(processId)
+		processID := goid()
+		var existingIncludedNames, ok = includedNamesPerProcess.Load(processID)
 		if !ok {
 			existingIncludedNames = make(map[string]int)
-			includedNamesPerProcess.Store(processId, existingIncludedNames)
+			includedNamesPerProcess.Store(processID, existingIncludedNames)
 		}
 		includedNames := existingIncludedNames.(map[string]int)
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -124,12 +124,12 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 	// Add the 'include' function here so we can close over t.
 	funcMap["include"] = func(name string, data chartutil.Values) (string, error) {
 		processId := goid()
-		var includedNames_, ok = includedNamesPerProcess.Load(processId)
+		var existingIncludedNames, ok = includedNamesPerProcess.Load(processId)
 		if !ok {
-			includedNames_ = make(map[string]int)
-			includedNamesPerProcess.Store(processId, includedNames_)
+			existingIncludedNames = make(map[string]int)
+			includedNamesPerProcess.Store(processId, existingIncludedNames)
 		}
-		includedNames := includedNames_.(map[string]int)
+		includedNames := existingIncludedNames.(map[string]int)
 
 		var buf strings.Builder
 		if v, ok := includedNames[name]; ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR makes the template rendering process run in parallel to optimize the `helm template` and `helm install` operations when the chart contains lots of files to render.

**Special notes for your reviewer**:

We've been using this for a few months and haven't noticed any difference in the final output of the `template` step.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
