### PR TITLE
feat(helm): add --password-stdin to `helm repo add`

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -146,7 +146,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 
 	if o.username != "" && o.password == "" {
 		if o.passwordFromStdinOpt {
-			passwordFromStdin, err := ioutil.ReadAll(os.Stdin)
+			passwordFromStdin, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -48,6 +48,7 @@ type repoAddOptions struct {
 	url                  string
 	username             string
 	password             string
+	passwordFromStdinOpt bool
 	passCredentialsAll   bool
 	forceUpdate          bool
 	allowDeprecatedRepos bool
@@ -85,6 +86,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&o.username, "username", "", "chart repository username")
 	f.StringVar(&o.password, "password", "", "chart repository password")
+	f.BoolVarP(&o.passwordFromStdinOpt, "password-stdin", "", false, "read chart repository password from stdin")
 	f.BoolVar(&o.forceUpdate, "force-update", false, "replace (overwrite) the repo if it already exists")
 	f.BoolVar(&o.deprecatedNoUpdate, "no-update", false, "Ignored. Formerly, it would disabled forced updates. It is deprecated by force-update.")
 	f.StringVar(&o.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
@@ -143,14 +145,24 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	if o.username != "" && o.password == "" {
-		fd := int(os.Stdin.Fd())
-		fmt.Fprint(out, "Password: ")
-		password, err := term.ReadPassword(fd)
-		fmt.Fprintln(out)
-		if err != nil {
-			return err
+		if o.passwordFromStdinOpt {
+			passwordFromStdin, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+			password := strings.TrimSuffix(string(passwordFromStdin), "\n")
+			password = strings.TrimSuffix(password, "\r")
+			o.password = password
+		} else {
+			fd := int(os.Stdin.Fd())
+			fmt.Fprint(out, "Password: ")
+			password, err := term.ReadPassword(fd)
+			fmt.Fprintln(out)
+			if err != nil {
+				return err
+			}
+			o.password = string(password)
 		}
-		o.password = string(password)
 	}
 
 	c := repo.Entry{

--- a/cmd/helm/testdata/password
+++ b/cmd/helm/testdata/password
@@ -1,0 +1,1 @@
+password

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package downloader
 
 import (
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -171,19 +170,7 @@ func TestIsTar(t *testing.T) {
 }
 
 func TestDownloadTo(t *testing.T) {
-	// Set up a fake repo with basic auth enabled
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	srv.Stop()
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv.WithMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if !ok || username != "username" || password != "password" {
-			t.Errorf("Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
-		}
-	}))
-	srv.Start()
+	srv := repotest.NewTempServerWithCleanupAndBasicAuth(t, "testdata/*.tgz*")
 	defer srv.Stop()
 	if err := srv.CreateIndex(); err != nil {
 		t.Fatal(err)

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -56,6 +56,23 @@ func NewTempServerWithCleanup(t *testing.T, glob string) (*Server, error) {
 	return srv, err
 }
 
+// Set up a fake repo with basic auth enabled
+func NewTempServerWithCleanupAndBasicAuth(t *testing.T, glob string) *Server {
+	srv, err := NewTempServerWithCleanup(t, glob)
+	srv.Stop()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.WithMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "username" || password != "password" {
+			t.Errorf("Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
+		}
+	}))
+	srv.Start()
+	return srv
+}
+
 type OCIServer struct {
 	*registry.Registry
 	RegistryURL  string


### PR DESCRIPTION
**What**

Without this commit, you can't pipe the password into `helm repo add`:

```
$ echo password | helm repo add repo-name https://repo-url --username username
Password:
Error: inappropriate ioctl for device
```

This commit introduces `--password-stdin`:

```
$ echo password | helm repo add repo-name https://repo-url --username username --password-stdin
"repo-name" has been added to your repositories
```

Fixes #10032

**Why**

There are two reasons I see for adding this:

* I personally would expect that it's possible to pipe the password into
  `helm repo add` but that's currently not the case. If I understand it
  correctly, you currently either need to pass the password via a cli
  parameter (`--password`) or use a expect/send mechanism.

* Subcommands like `helm registry login` already support
  `--password-stdin`. The cli interfaces should be consistent regarding
  which options they support.

**Notes**

* I basically just copy-pasted code from `cmd/helm/registry_login.go`.

* I don't know if this is the best approach to enable piping into the command. Maybe it would be sufficient to replace `term.ReadPassword(fd)` with something else that also supports piping/ doesn't yield `inappropriate ioctl for device`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
