### PR TITLE
Add deploy github actions workflows

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,3 +31,31 @@ jobs:
         run: make test-style
       - name: Run unit tests
         run: make test-coverage
+
+  canary-release:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      AZURE_STORAGE_CONNECTION_STRING: "${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}"
+      AZURE_STORAGE_CONTAINER_NAME: "${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}"
+      VERSION: canary
+    if: ${{ github.event }} == "push" && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - name: Build Helm Binaries
+        run: |
+          make build-cross
+          make dist checksum VERSION="${VERSION}"
+
+      - name: Azure CLI Action
+        uses: Azure/cli@1.0.4
+        with:
+          inlineScript: |
+            az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'helm-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -55,7 +55,7 @@ jobs:
           make dist checksum VERSION="${VERSION}"
 
       - name: Azure CLI Action
-        uses: Azure/cli@1.0.4
+        uses: Azure/cli@v1
         with:
           inlineScript: |
             az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'helm-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: release
+on:
+  create:
+    tags:
+      - v*
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      AZURE_STORAGE_CONNECTION_STRING: "${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}"
+      AZURE_STORAGE_CONTAINER_NAME: "${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - name: Set Version (tag event)
+        run: |
+          echo "::set-output name=VERSION::${GITHUB_REF##*/}"
+        if: github.event == "create"
+
+      - name: Set Version (dispatch event)
+        run: |
+          echo "::set-output name=VERSION::${{ github.event.inputs.version }}"
+        if: github.event == "workflow_dispatch"
+
+      - name: Build Helm Binaries
+        run: |
+          make build-cross
+          make dist checksum VERSION="${VERSION}"
+
+      - name: Azure CLI Action
+        uses: Azure/cli@1.0.4
+        with:
+          inlineScript: |
+            az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'helm-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
     tags:
       - v*
 
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Version
-        required: true
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -25,15 +19,9 @@ jobs:
         with:
           go-version: '1.16'
 
-      - name: Set Version (tag event)
+      - name: Set Version
         run: |
           echo "::set-output name=VERSION::${GITHUB_REF##*/}"
-        if: github.event == "create"
-
-      - name: Set Version (dispatch event)
-        run: |
-          echo "::set-output name=VERSION::${{ github.event.inputs.version }}"
-        if: github.event == "workflow_dispatch"
 
       - name: Build Helm Binaries
         run: |
@@ -41,7 +29,7 @@ jobs:
           make dist checksum VERSION="${VERSION}"
 
       - name: Azure CLI Action
-        uses: Azure/cli@1.0.4
+        uses: Azure/cli@v1
         with:
           inlineScript: |
             az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'helm-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>

refs #9921 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds the remaining required github actions workflows in order to complete the transition from CircleCI. Specifically the following will now happen:
- build-pr will now run when a PR is merged to the main branch
- deploy will now happen when:
  - a tag is pushed to the repository
  - the workflow is manually run from GitHub Actions with a provided version name (some questions here if this is desired)
  - on a push/merge to the main branch, a deploy happens with VERSION=canary

**Special notes for your reviewer**:
@bacongobbler This is about 99% complete. Just wanted to put this out as a draft for you to take a look at while I finish some final testing. One question I had is really around the release process. As I'm not familiar with the release process, I just copied what I saw in the `deploy.sh` script. So things like do something when a tag is specified, etc. However, after doing some work in other helm repositories (chart-release, chart-testing), I noticed those repo's also had a `workflow-dispatch` action that allow them to trigger the release manually via GHA. Is this something that would be desired here? I've stubbed out a majority of it in case you would be interested. But otherwise, let me know and I can pull it out.

This will require two secrets to be created inside of the repo in GitHub:
- AZURE_STORAGE_CONNECTION_STRING
- AZURE_STORAGE_CONTAINER_NAME

To take a look at the output of this, you can look at a successful run of the workflow here:
https://github.com/tylerauerbeck/helm/actions/runs/1099917788

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
