### PR TITLE
feat(comp): Move to Cobra's bash completion V2

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -88,16 +88,16 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 	}
 
 	bash := &cobra.Command{
-		Use:                   "bash",
-		Short:                 "generate autocompletion script for bash",
-		Long:                  bashCompDesc,
-		Args:                  require.NoArgs,
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     noCompletions,
+		Use:               "bash",
+		Short:             "generate autocompletion script for bash",
+		Long:              bashCompDesc,
+		Args:              require.NoArgs,
+		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletionBash(out, cmd)
 		},
 	}
+	bash.Flags().BoolVar(&disableCompDescriptions, noDescFlagName, false, noDescFlagText)
 
 	zsh := &cobra.Command{
 		Use:               "zsh",
@@ -129,7 +129,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 }
 
 func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
-	err := cmd.Root().GenBashCompletion(out)
+	err := cmd.Root().GenBashCompletionV2(out, !disableCompDescriptions)
 
 	// In case the user renamed the helm binary (e.g., to be able to run
 	// both helm2 and helm3), we hook the new binary name to the completion function


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This change moves to use Cobra's new Bash Completion V2.
The V2 version has the following benefits:
- provides completion descriptions as for the other shells
- aligned with the completion logic for the other shells
- uses a 300-line shell script (versus 4K lines for V1)

Here are some examples of descriptions enabled for bash:
```
$ bin/helm s<TAB><TAB>
search  (search for a keyword in charts)           status  (display the status of the named release)
show    (show information of a chart)
```

**Special notes for your reviewer**:

Backwards-compatibility has been tested with the acceptance-testing repo using PR https://github.com/helm/acceptance-testing/pull/93

**If applicable**:
- [x] this PR has been tested for backwards compatibility
