### PR TITLE
Make Chart's IsRoot available to templates

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -345,8 +345,13 @@ func allTemplates(c *chart.Chart, vals chartutil.Values) map[string]renderable {
 // As it recurses, it also sets the values to be appropriate for the template
 // scope.
 func recAllTpls(c *chart.Chart, templates map[string]renderable, vals chartutil.Values) {
+	chartMetaData := struct {
+		chart.Metadata
+		IsRoot bool
+	}{*c.Metadata, c.IsRoot()}
+
 	next := map[string]interface{}{
-		"Chart":        c.Metadata,
+		"Chart":        chartMetaData,
 		"Files":        newFiles(c.Files),
 		"Release":      vals["Release"],
 		"Capabilities": vals["Capabilities"],

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -346,6 +346,36 @@ func TestAllTemplates(t *testing.T) {
 	}
 }
 
+func TestChartValuesContainsIsRoot(t *testing.T) {
+	ch1 := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "parent"},
+		Templates: []*chart.File{
+			{Name: "templates/isroot", Data: []byte("{{.Chart.IsRoot}}")},
+		},
+	}
+	dep1 := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "child"},
+		Templates: []*chart.File{
+			{Name: "templates/isroot", Data: []byte("{{.Chart.IsRoot}}")},
+		},
+	}
+	ch1.AddDependency(dep1)
+
+	out, err := Render(ch1, chartutil.Values{})
+	if err != nil {
+		t.Fatalf("failed to render templates: %s", err)
+	}
+	expects := map[string]string{
+		"parent/charts/child/templates/isroot": "false",
+		"parent/templates/isroot":              "true",
+	}
+	for file, expect := range expects {
+		if out[file] != expect {
+			t.Errorf("Expected %q, got %q", expect, out[file])
+		}
+	}
+}
+
 func TestRenderDependency(t *testing.T) {
 	deptpl := `{{define "myblock"}}World{{end}}`
 	toptpl := `Hello {{template "myblock"}}`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR closes #9991 as it adds the information if the currently processed (templated) Chart is the root or not. This allows to have different behavior in case a Chart is installed on its own or included as part of another Chart. 

Templates can check this flag like so:

```
IsRoot: {{ .Chart.IsRoot }}
```

**Special notes for your reviewer**:
This is my first PR to Helm so please let me know if I'm missing something

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
