### PR TITLE
Hooks with the same Weight but different Kind should not be compared by Name

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -38,7 +38,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 	}
 
-	// hooke are pre-ordered by kind, so keep order stable
+	// hooks are pre-ordered by kind, so keep order stable
 	sort.Stable(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
@@ -113,7 +113,7 @@ type hookByWeight []*release.Hook
 func (x hookByWeight) Len() int      { return len(x) }
 func (x hookByWeight) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x hookByWeight) Less(i, j int) bool {
-	if x[i].Weight == x[j].Weight {
+	if x[i].Weight == x[j].Weight && x[i].Kind == x[j].Kind {
 		return x[i].Name < x[j].Name
 	}
 	return x[i].Weight < x[j].Weight


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #10006 

**What this PR does / why we need it**:
When hooks are being sorted, hooks resources with the same `Weight` but different `Kind`s should not be compared based on their `Name`s since that could result the loss of resource creation precedence.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
