### PR TITLE
Implement show crds subcommand

### DIFF
--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -51,6 +51,11 @@ This command inspects a chart (directory, file, or URL) and displays the content
 of the README file
 `
 
+const showCRDsDesc = `
+This command inspects a chart (directory, file, or URL) and displays the contents
+of the CustomResourceDefintion files
+`
+
 func newShowCmd(out io.Writer) *cobra.Command {
 	client := action.NewShow(action.ShowAll)
 
@@ -139,7 +144,24 @@ func newShowCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmds := []*cobra.Command{all, readmeSubCmd, valuesSubCmd, chartSubCmd}
+	crdsSubCmd := &cobra.Command{
+		Use:               "crds [CHART]",
+		Short:             "show the chart's CRDs",
+		Long:              showCRDsDesc,
+		Args:              require.ExactArgs(1),
+		ValidArgsFunction: validArgsFunc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client.OutputFormat = action.ShowCRDs
+			output, err := runShow(args, client)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(out, output)
+			return nil
+		},
+	}
+
+	cmds := []*cobra.Command{all, readmeSubCmd, valuesSubCmd, chartSubCmd, crdsSubCmd}
 	for _, subCmd := range cmds {
 		addShowFlags(subCmd, client)
 		showCommand.AddCommand(subCmd)

--- a/cmd/helm/show_test.go
+++ b/cmd/helm/show_test.go
@@ -145,3 +145,7 @@ func TestShowReadmeFileCompletion(t *testing.T) {
 func TestShowValuesFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "show values", true)
 }
+
+func TestShowCRDsFileCompletion(t *testing.T) {
+	checkFileCompletion(t, "show crds", true)
+}

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -41,6 +42,8 @@ const (
 	ShowValues ShowOutputFormat = "values"
 	// ShowReadme is the format which only shows the chart's README
 	ShowReadme ShowOutputFormat = "readme"
+	// ShowCRDs is the format which only shows the chart's CRDs
+	ShowCRDs ShowOutputFormat = "crds"
 )
 
 var readmeFileNames = []string{"readme.md", "readme.txt", "readme"}
@@ -114,6 +117,18 @@ func (s *Show) Run(chartpath string) (string, error) {
 			return out.String(), nil
 		}
 		fmt.Fprintf(&out, "%s\n", readme.Data)
+	}
+
+	if s.OutputFormat == ShowCRDs || s.OutputFormat == ShowAll {
+		crds := s.chart.CRDObjects()
+		if len(crds) > 0 {
+			if s.OutputFormat == ShowAll && !bytes.HasPrefix(crds[0].File.Data, []byte("---")) {
+				fmt.Fprintln(&out, "---")
+			}
+			for _, crd := range crds {
+				fmt.Fprintf(&out, "%s\n", string(crd.File.Data))
+			}
+		}
 	}
 	return out.String(), nil
 }

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -28,6 +28,9 @@ func TestShow(t *testing.T) {
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*chart.File{
 			{Name: "README.md", Data: []byte("README\n")},
+			{Name: "crds/ignoreme.txt", Data: []byte("error")},
+			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
 		},
 		Raw: []*chart.File{
 			{Name: "values.yaml", Data: []byte("VALUES\n")},
@@ -47,6 +50,12 @@ VALUES
 
 ---
 README
+
+---
+foo
+
+---
+bar
 
 `
 	if output != expect {
@@ -79,6 +88,34 @@ func TestShowValuesByJsonPathFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 	expect := "simpleValue"
+	if output != expect {
+		t.Errorf("Expected\n%q\nGot\n%q\n", expect, output)
+	}
+}
+
+func TestShowCRDs(t *testing.T) {
+	client := NewShow(ShowCRDs)
+	client.chart = &chart.Chart{
+		Metadata: &chart.Metadata{Name: "alpine"},
+		Files: []*chart.File{
+			{Name: "crds/ignoreme.txt", Data: []byte("error")},
+			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
+		},
+	}
+
+	output, err := client.Run("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `---
+foo
+
+---
+bar
+
+`
 	if output != expect {
 		t.Errorf("Expected\n%q\nGot\n%q\n", expect, output)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This subcommand will display manifests under `crds/` if some exist. This also changes the behaviour of `show all` to include CRDs.

Suggested by @mattfarina to fix #9785

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
