### PR TITLE
feat: implement export-values

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -198,7 +198,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		return nil, err
 	}
 
-	if err := chartutil.ProcessDependencies(chrt, vals); err != nil {
+	if err := chartutil.ProcessDependencies(chrt, &vals); err != nil {
 		return nil, err
 	}
 
@@ -349,7 +349,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	go i.performInstall(rChan, rel, toBeAdopted, resources)
 	go i.handleContext(ctx, rChan, doneChan, rel)
 	result := <-rChan
-	//start preformInstall go routine
+	// start preformInstall go routine
 	return result.r, result.e
 }
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -207,7 +207,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	if err := chartutil.ProcessDependencies(chart, vals); err != nil {
+	if err := chartutil.ProcessDependencies(chart, &vals); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -45,6 +45,9 @@ type Dependency struct {
 	// ImportValues holds the mapping of source values to parent key to be imported. Each item can be a
 	// string or pair of child/parent sublist items.
 	ImportValues []interface{} `json:"import-values,omitempty"`
+	// ExportValues holds the mapping of parent values to child key to be exported. Each item can be a
+	// string or pair of parent/child sublist items.
+	ExportValues []interface{} `json:"export-values,omitempty"`
 	// Alias usable alias to be used for the chart
 	Alias string `json:"alias,omitempty"`
 }

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -318,7 +318,7 @@ func TestProcessDependencyExportValues(t *testing.T) {
 	for kk, vv := range e {
 		pv, err := cc.PathValue(kk)
 		if err != nil {
-			t.Fatalf("retrieving export values table %v %v", kk, err)
+			t.Errorf("retrieving export values table %v %v", kk, err)
 		}
 
 		switch pv := pv.(type) {

--- a/pkg/chartutil/testdata/subpop/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/Chart.yaml
@@ -25,6 +25,16 @@ dependencies:
         parent: .
       - SCBexported2
       - SC1exported1
+    export-values:
+      - parent: exported-parent
+        child: exported-parent
+      - parent: exported-overridden-parent
+        child: exported-overridden-parent
+      - parent: exported-single-value-parent
+        child: exported-single-value-parent
+      - parent: exported-passthrough
+        child: subcharta.exported-passthrough
+      - exported-short-parent
 
   - name: subchart2
     repository: http://localhost:10191

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/Chart.yaml
@@ -17,6 +17,10 @@ dependencies:
         parent: overridden-chartA
       - child: SCAdata
         parent: imported-chartA-B
+    export-values:
+      - parent: exported-overridden-chart1
+        child: exported-overridden-chart1
+      - exported-short-chart1
 
   - name: subchartb
     repository: http://localhost:10191

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/charts/subchartA/values.yaml
@@ -15,3 +15,15 @@ SCAdata:
   SCAnested1:
     SCAnested2: true
 
+exported-overridden-chart1:
+  SCAbool: true
+  SCAfloat: 33.3
+  SCAint: 333
+  SCAstring: "exported-from-chart1"
+  SPExtra15: "should-be-unchanged"
+
+exported-passthrough:
+  SPExtra18: "should-be-unchanged"
+
+exported-short-chart1:
+  SPExtra16: "should-be-unchanged"

--- a/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart1/values.yaml
@@ -29,6 +29,26 @@ overridden-chartA:
 imported-chartA-B:
   SC1extra5: "tiller"
 
+exported-parent:
+  SPExtra10: "should-be-unchanged"
+
+exported-overridden-parent:
+  SC1bool: false
+  SC1float: 11.1
+  SC1int: 111
+  SC1string: "should-be-overridden"
+  SPExtra11: "should-be-unchanged"
+
+exported-short-parent:
+  SPExtra12: "should-be-unchanged"
+
+exported-overridden-chart1:
+  SCAbool: true
+  SCAfloat: 33.3
+  SCAint: 333
+  SCAstring: "exported-from-chart1"
+  SPExtra13: "exported-from-chart1-n2"
+
 overridden-chartA-B:
   SCAbool: true
   SCAfloat: 3.33
@@ -53,3 +73,6 @@ exports:
       SC1exported2:
         all:
           SC1exported3: "SC1expstr"
+  exported-short-chart1:
+    exported-short-chart1:
+      SPExtra14: "exported-from-chart1-n3"

--- a/pkg/chartutil/testdata/subpop/charts/subchart2/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart2/values.yaml
@@ -18,4 +18,3 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-

--- a/pkg/chartutil/testdata/subpop/values.yaml
+++ b/pkg/chartutil/testdata/subpop/values.yaml
@@ -35,6 +35,28 @@ overridden-chartA-B:
   SCBstring: "jango"
   SPextra6: 111
 
+exported-parent:
+  SPExtra7: "exported-from-parent"
+  SPNested1:
+    SPExtra19: "exported-from-parent-n6"
+
+exported-overridden-parent:
+  SC1bool: true
+  SC1float: 22.2
+  SC1int: 222
+  SC1string: "exported-from-parent-n2"
+  SPExtra8: "exported-from-parent-n3"
+
+exported-single-value-parent: "exported-from-parent-n7"
+
+exported-passthrough:
+  SPExtra17: "exported-from-parent-n5"
+
+exports:
+  exported-short-parent:
+    exported-short-parent:
+      SPExtra9: "exported-from-parent-n4"
+
 tags:
   front-end: true
   back-end: false

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -72,7 +72,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 
 	// lint ignores import-values
 	// See https://github.com/helm/helm/issues/9658
-	if err := chartutil.ProcessDependencies(chart, values); err != nil {
+	if err := chartutil.ProcessDependencies(chart, &values); err != nil {
 		return
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR implements `export-values` directive which is similar to the [import-values](https://helm.sh/docs/topics/charts/#importing-child-values-via-dependencies) directive, but instead of importing the values of the subchart into the current chart it exports the values of the current chart into subchart.

Initially the change was discussed here #3242. There were several attempts to implement this: #7477, #3243.

## Usage:
In the full form of `export-values` you specify which value tree to export (with `parent:`) and where it should be exported in the subchart (with `child:`).

In the short form of `export-values` you only specify a relative path inside of the `exports:` key of the parent chart values: specified values will be exported to the root of the subchart values (same as with the `import-values`). This allows to export/import values defined in `exports:` both to the parent chart or to the child chart depending on the directive used (`import-values` or `export-values`).

Unlike `import-values`, `export-values` can export not only the trees of values (maps), but other types of values too (strings, ints, etc).

Example:
```yaml
# values.yaml
parent-map:
  key1: parent-value1
  key2: parent-value2
  
exports:
  parent-map:
    key3: parent-value3
  
subchart1:
  subchart-map:
    key1: subchart-value1
```

```yaml
# Chart.yaml:
dependencies:
  - name: subchart1
    version: 1.0.0
    export-values:
    - parent: "parent-map"
      child: "subchart-map"
    - "parent-map.key3"
```

```yaml      
# charts/subchart1/dump-values-in-subchart.yaml
dump-values-in-subchart: {{ .Values | toYaml | nindent 2 }}
```

Result of `helm template`:
```yaml
# charts/subchart1/dump-values-in-subchart.yaml
dump-values-in-subchart:
  subchart-map:
    key1: parent-value1
    key2: parent-value2
    key3: parent-value3
```

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility