### PR TITLE
Fixing issue where helm show all fails to show crds when no readme

### DIFF
--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -109,14 +109,13 @@ func (s *Show) Run(chartpath string) (string, error) {
 	}
 
 	if s.OutputFormat == ShowReadme || s.OutputFormat == ShowAll {
-		if s.OutputFormat == ShowAll {
-			fmt.Fprintln(&out, "---")
-		}
 		readme := findReadme(s.chart.Files)
-		if readme == nil {
-			return out.String(), nil
+		if readme != nil {
+			if s.OutputFormat == ShowAll {
+				fmt.Fprintln(&out, "---")
+			}
+			fmt.Fprintf(&out, "%s\n", readme.Data)
 		}
-		fmt.Fprintf(&out, "%s\n", readme.Data)
 	}
 
 	if s.OutputFormat == ShowCRDs || s.OutputFormat == ShowAll {

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -120,3 +120,33 @@ bar
 		t.Errorf("Expected\n%q\nGot\n%q\n", expect, output)
 	}
 }
+
+func TestShowNoReadme(t *testing.T) {
+	client := NewShow(ShowAll)
+	client.chart = &chart.Chart{
+		Metadata: &chart.Metadata{Name: "alpine"},
+		Files: []*chart.File{
+			{Name: "crds/ignoreme.txt", Data: []byte("error")},
+			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
+		},
+	}
+
+	output, err := client.Run("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `name: alpine
+
+---
+foo
+
+---
+bar
+
+`
+	if output != expect {
+		t.Errorf("Expected\n%q\nGot\n%q\n", expect, output)
+	}
+}


### PR DESCRIPTION
Closes #10058

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When a chart has no README.md file but has CRDs and you try to use `helm show all` on it.... the CRDs will not be displayed.

More detail can be found on #10058

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
