### PR TITLE
Fixing issue with non-existant .Template when using tpl function

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -260,7 +260,6 @@ func (e Engine) renderWithReferences(tpls, referenceTpls map[string]renderable) 
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
 			return map[string]string{}, cleanupExecError(filename, err)
 		}
-		delete(vals, "Template")
 
 		// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 		// is set. Since missing=error will never get here, we do not need to handle


### PR DESCRIPTION
This is a regression accidently introduced in #9957.

A delete call had been used on the Template key of vals. This caused
a condition where Template was not available when rendering via tpl.
The delete happened after ExecuteTemplate so the issue is surpsising.
It may possibly be a race condition. Existing tests did not catch it.
I tried to create a test that directly tested the issue and was
unable to replicate the error seen with real charts. This leads me
to believe it is a race condition in the underlying Go template
package.

The delete call was not there before #9957. It should be safe to
remove and keep that information.

Closes #10082

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

A regression was accidentally introduced. This fixes the regression.

**Special notes for your reviewer**:

The lack of tests is because this is difficult to test. Existing tests should have caught the issue and new tests failed to catch it. My current best guess is that this is due to a race condition somewhere in the Go template package.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
