### PR TITLE
add strict apiVersions, allowing templating without added versions from kube version

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -182,6 +182,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.IsUpgrade, "is-upgrade", false, "set .Release.IsUpgrade instead of .Release.IsInstall")
 	f.StringVar(&kubeVersion, "kube-version", "", "Kubernetes version used for Capabilities.KubeVersion")
 	f.StringArrayVarP(&extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
+	f.BoolVar(&client.StrictAPIVersions, "strict-api-versions", false, "set api versions to strict mode")
 	f.BoolVar(&client.UseReleaseName, "release-name", false, "use release name in the output-dir path.")
 	bindPostRenderFlag(cmd, &client.PostRenderer)
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -101,6 +101,8 @@ type Install struct {
 	// (for things like templating). These are ignored if ClientOnly is false
 	KubeVersion *chartutil.KubeVersion
 	APIVersions chartutil.VersionSet
+	// Used by helm template to limit API versions to the one specified in the --api-versions tag
+	StrictAPIVersions bool
 	// Used by helm template to render charts with .Release.IsUpgrade. Ignored if Dry-Run is false
 	IsUpgrade bool
 	// Used by helm template to add the release as part of OutputDir path
@@ -216,7 +218,11 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		if i.KubeVersion != nil {
 			i.cfg.Capabilities.KubeVersion = *i.KubeVersion
 		}
-		i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
+		if i.StrictAPIVersions && len(i.APIVersions) > 0 {
+			i.cfg.Capabilities.APIVersions = i.APIVersions
+		} else {
+			i.cfg.Capabilities.APIVersions = append(i.cfg.Capabilities.APIVersions, i.APIVersions...)
+		}
 		i.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
 
 		mem := driver.NewMemory()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

It would be nice to add an option to choose, when in offline mode / templating mode exactly which apiVersions you add. 

I'm thinking of an usage with ArgoCD for example: 

https://github.com/argoproj/argo-cd/issues/3594

References this issue : https://github.com/helm/helm/issues/10109
