### PR TITLE
fix tarFromLocalDir saving file dependencies in dest path

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -302,7 +302,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			if m.Debug {
 				fmt.Fprintf(m.Out, "Archiving %s from repo %s\n", dep.Name, dep.Repository)
 			}
-			ver, err := tarFromLocalDir(m.ChartPath, dep.Name, dep.Repository, dep.Version)
+			ver, err := tarFromLocalDir(m.ChartPath, dep.Name, dep.Repository, dep.Version, tmpPath)
 			if err != nil {
 				saveError = err
 				break
@@ -852,10 +852,8 @@ func writeLock(chartpath string, lock *chart.Lock, legacyLockfile bool) error {
 	return ioutil.WriteFile(dest, data, 0644)
 }
 
-// archive a dep chart from local directory and save it into charts/
-func tarFromLocalDir(chartpath, name, repo, version string) (string, error) {
-	destPath := filepath.Join(chartpath, "charts")
-
+// archive a dep chart from local directory and save it into destPath
+func tarFromLocalDir(chartpath, name, repo, version, destPath string) (string, error) {
 	if !strings.HasPrefix(repo, "file://") {
 		return "", errors.Errorf("wrong format: chart %s repository %s", name, repo)
 	}

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -263,6 +263,10 @@ func TestDownloadAll(t *testing.T) {
 	if err := m.downloadAll([]*chart.Dependency{signDep, localDep}); err != nil {
 		t.Error(err)
 	}
+
+	if _, err := os.Stat(filepath.Join(chartPath, "charts", "signtest-0.1.0.tgz")); os.IsNotExist(err) {
+		t.Error(err)
+	}
 }
 
 func TestUpdateBeforeBuild(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

**What this PR does / why we need it**: `tarFromLocalDir` used to save dependencies in the destination folder, `charts`. With the refactor to `downloadAll` in #9889, all dependencies during `helm dependency update` must be saved to `tmpcharts` so that a safe update can occur.

Our test cases verified that `downloadAll` succeeded, but it didn't test whether the dependency was saved to the directory. I added a test to verify the fix.

closes #10112.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
