### PR TITLE
feat: plugin.yaml support platformHooks (closes #7117)

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -50,6 +50,12 @@ type PlatformCommand struct {
 	Command         string `json:"command"`
 }
 
+type PlatformHook struct {
+	OperatingSystem string `json:"os"`
+	Architecture    string `json:"arch"`
+	Hooks           Hooks  `json:"hooks"`
+}
+
 // Metadata describes a plugin.
 //
 // This is the plugin equivalent of a chart.Metadata.
@@ -92,7 +98,8 @@ type Metadata struct {
 	IgnoreFlags bool `json:"ignoreFlags"`
 
 	// Hooks are commands that will run on events.
-	Hooks Hooks
+	PlatformHook []PlatformHook `json:"platformHook"`
+	Hooks        Hooks
 
 	// Downloaders field is used if the plugin supply downloader mechanism
 	// for special protocols.
@@ -164,6 +171,51 @@ func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string, error) {
 		baseArgs = append(baseArgs, extraArgs...)
 	}
 	return main, baseArgs, nil
+}
+
+// The following rules will apply to processing the Plugin.PlatformHook.Hooks:
+// If hook name exists in platformHook, do the following:
+// - If both OS and Arch match the current platform, search will stop and the command will be prepared for execution
+// - If OS matches and there is no more specific match, the hook will be prepared for execution
+// - If no OS/Arch match is found, return nil
+func getPlatformHook(platformHooks []PlatformHook, event string) []string {
+	var hookCommand []string
+	eq := strings.EqualFold
+	for _, p := range platformHooks {
+		if hook, ok := p.Hooks[event]; ok {
+			if eq(p.OperatingSystem, runtime.GOOS) {
+				hookCommand = strings.Split(os.ExpandEnv(hook), " ")
+			}
+			if eq(p.OperatingSystem, runtime.GOOS) && eq(p.Architecture, runtime.GOARCH) {
+				return strings.Split(os.ExpandEnv(hook), " ")
+			}
+		}
+	}
+	return hookCommand
+}
+
+// PrepareHook takes a Plugin.PlatformHook.Hooks, a Plugin.Hooks and an event and will apply the following processing:
+// - If platformHook is present, it will be searched first
+// - If both OS and Arch match the current platform, search for required hook name. If exists, search will stop and the hook will be prepared for execution
+// - If OS matches and there is no more specific match, the hook will be prepared for execution
+// - If no OS/Arch match is found, the default hook will be prepared for execution
+// - If no hook is present and no matches are found in platformHook, will exit with an error
+//
+// The result is suitable to pass to exec.Command.
+func (p *Plugin) PrepareHook(event string) ([]string, error) {
+	var parts []string
+	platCmdLen := len(p.Metadata.PlatformHook)
+	if platCmdLen > 0 {
+		parts = getPlatformHook(p.Metadata.PlatformHook, event)
+	}
+	if platCmdLen == 0 || parts == nil {
+		parts = strings.Split(os.ExpandEnv(p.Metadata.Hooks[event]), " ")
+	}
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, fmt.Errorf("no plugin hook is applicable")
+	}
+
+	return parts, nil
 }
 
 // validPluginName is a regular expression that validates plugin names.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This pr adds `platformHook` behavior for plugin installations. This is mainly to support plugin installation for windows, since at this point, helm plugins are not able to run on windows.
Usage is very similar to current `platformCommand`. The user can specify specific os to run hooks on, and if missing, default to root `hooks` key in plugin yaml

closes #7117

**Special notes for your reviewer**:
For env vars, there was an issue with using built-in `os.ExpandEnv` function on windows. 
Hence, there's no support for `$var` in windows scripts. What is working though is windows env var syntax `%VAR%` - mainly used for `%HELM_PLUGIN_DIR%`

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility