### PR TITLE
Export namespace in cli.EnvSettings

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -39,9 +39,10 @@ const defaultMaxHistory = 10
 
 // EnvSettings describes all of the environment settings.
 type EnvSettings struct {
-	namespace string
-	config    *genericclioptions.ConfigFlags
+	config *genericclioptions.ConfigFlags
 
+	// KubeNamespace is the namespace to use for the Kubernetes client.
+	KubeNamespace string
 	// KubeConfig is the path to the kubeconfig file
 	KubeConfig string
 	// KubeContext is the name of the kubeconfig context.
@@ -72,7 +73,7 @@ type EnvSettings struct {
 
 func New() *EnvSettings {
 	env := &EnvSettings{
-		namespace:        os.Getenv("HELM_NAMESPACE"),
+		KubeNamespace:    os.Getenv("HELM_NAMESPACE"),
 		MaxHistory:       envIntOr("HELM_MAX_HISTORY", defaultMaxHistory),
 		KubeContext:      os.Getenv("HELM_KUBECONTEXT"),
 		KubeToken:        os.Getenv("HELM_KUBETOKEN"),
@@ -89,7 +90,7 @@ func New() *EnvSettings {
 
 	// bind to kubernetes config flags
 	env.config = &genericclioptions.ConfigFlags{
-		Namespace:        &env.namespace,
+		Namespace:        &env.KubeNamespace,
 		Context:          &env.KubeContext,
 		BearerToken:      &env.KubeToken,
 		APIServer:        &env.KubeAPIServer,
@@ -103,7 +104,7 @@ func New() *EnvSettings {
 
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace scope for this request")
+	fs.StringVarP(&s.KubeNamespace, "KubeNamespace", "n", s.KubeNamespace, "KubeNamespace scope for this request")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", "", "path to the kubeconfig file")
 	fs.StringVar(&s.KubeContext, "kube-context", s.KubeContext, "name of the kubeconfig context to use")
 	fs.StringVar(&s.KubeToken, "kube-token", s.KubeToken, "bearer token used for authentication")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Changes `EnvSettings.namespace` to `EnvSettings.KubeNamespace` so it's exported.

This is useful for applications that use the Go SDK and need to set the
namespace without relying on the HELM_NAMESPACE environment variable. Example here: https://github.com/hashicorp/consul-k8s/blob/main/cli/cmd/install/install.go#L191-L198

The action.Configuration Init function initializes a kube client using the namespace in cli.EnvSettings, and the only way we'd be able to currently set it is by using the HELM_NAMESPACE environment variable. For the helm CLI itself, it can rely on the flags to update this value, but other applications using the Go SDK can't use this. 

**Special notes for your reviewer**:
I changed `namespace` to `KubeNamespace` rather than `Namespace` to not conflict with the function name.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
