### PR TITLE
Fix subcharts dependencies processing

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -106,6 +106,15 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 		md := *c.Metadata
 		out.Metadata = &md
 
+		if md.Dependencies != nil {
+			dependencies := make([]*chart.Dependency, len(md.Dependencies))
+			for i := range md.Dependencies {
+				d := *md.Dependencies[i]
+				dependencies[i] = &d
+			}
+			md.Dependencies = dependencies
+		}
+
 		if dep.Alias != "" {
 			md.Name = dep.Alias
 		}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -312,20 +312,34 @@ func TestDependentChartAliases(t *testing.T) {
 	c := loadChart(t, "testdata/dependent-chart-alias")
 	req := c.Metadata.Dependencies
 
-	if len(c.Dependencies()) != 2 {
-		t.Fatalf("expected 2 dependencies for this chart, but got %d", len(c.Dependencies()))
+	if len(c.Dependencies()) != 3 {
+		t.Fatalf("expected 3 dependencies for this chart, but got %d", len(c.Dependencies()))
 	}
 
 	if err := processDependencyEnabled(c, c.Values, ""); err != nil {
 		t.Fatalf("expected no errors but got %q", err)
 	}
 
-	if len(c.Dependencies()) != 3 {
+	if len(c.Dependencies()) != 5 {
 		t.Fatal("expected alias dependencies to be added")
 	}
 
 	if len(c.Dependencies()) != len(c.Metadata.Dependencies) {
 		t.Fatalf("expected number of chart dependencies %d, but got %d", len(c.Metadata.Dependencies), len(c.Dependencies()))
+	}
+
+	for _, dep := range c.Dependencies() {
+		if len(dep.Metadata.Dependencies) == 0 {
+			continue
+		}
+		if len(dep.Dependencies()) != len(dep.Metadata.Dependencies) {
+			t.Fatalf("subchart %s: expected number of dependencies %d, but got %d", dep.Name(), len(dep.Metadata.Dependencies), len(dep.Dependencies()))
+		}
+		for i := range dep.Dependencies() {
+			if dep.Metadata.Dependencies[i].Name != dep.Dependencies()[i].Name() {
+				t.Fatalf("subchart %s: expected name %s, but got %s", dep.Name(), dep.Metadata.Dependencies[i].Name, dep.Dependencies()[i].Name())
+			}
+		}
 	}
 
 	aliasChart := getAliasDependency(c.Dependencies(), req[2])

--- a/pkg/chartutil/testdata/dependent-chart-alias/Chart.yaml
+++ b/pkg/chartutil/testdata/dependent-chart-alias/Chart.yaml
@@ -27,3 +27,11 @@ dependencies:
     version: "4.3.2"
     repository: https://example.com/charts
     alias: mariners1
+  - name: gizmo
+    version: "0.1.0"
+    repository: https://example.com/charts
+    alias: gizmo1
+  - name: gizmo
+    version: "0.1.0"
+    repository: https://example.com/charts
+    alias: gizmo2

--- a/pkg/chartutil/testdata/dependent-chart-alias/charts/gizmo/Chart.yaml
+++ b/pkg/chartutil/testdata/dependent-chart-alias/charts/gizmo/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: gizmo
+description: Deploy a basic Alpine Linux pod
+version: 0.1.0
+home: https://helm.sh/helm
+dependencies:
+  - name: frobule
+    version: 0.1.0
+    alias: frobozz1
+  - name: frobule
+    version: 0.1.0
+    alias: frobozz2

--- a/pkg/chartutil/testdata/dependent-chart-alias/charts/gizmo/charts/frobule/Chart.yaml
+++ b/pkg/chartutil/testdata/dependent-chart-alias/charts/gizmo/charts/frobule/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: frobule
+description: Deploy a basic Alpine Linux pod
+version: 0.1.0
+home: https://helm.sh/helm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

There is an issue when you use a subchart more than once with alias and that this subchart also have a subchart.

In pkg/chartutil/dependencies.go, getAliasDependency() return a partial copy of the passed chart keeping the same slice for metadata.Dependencies. This results in metadata.Dependencies been shared by multiple Charts objects.
At some point processDependencyEnabled() changes the name of each dependencies by their alias. This impact others dependencies generated by getAliasDependency() and leads to processDependencyEnabled() to not correctly handles their dependencies (as it use the name to do so and the name is now the alias).

This patch make a copy of all the dependencies in a new slice to avoid this issue.

fix #10160

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
