### PR TITLE
Package signing without bundling

### DIFF
--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -112,7 +112,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&client.Sign, "sign", false, "use a PGP private key to sign this package")
-	f.StringVar(&client.Key, "key", "", "name of the key to use when signing. Used if --sign is true")
+	f.StringVar(&client.Key, "key", "", "name of the key to use when signing. Used if --sign, or --sign-tgz, is true")
 	f.StringVar(&client.Keyring, "keyring", defaultKeyring(), "location of a public keyring")
 	f.StringVar(&client.PassphraseFile, "passphrase-file", "", `location of a file which contains the passphrase for the signing key. Use "-" in order to read from stdin.`)
 	f.StringVar(&client.Version, "version", "", "set the version on the chart to this semver version")

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -104,7 +104,11 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(out, "Successfully packaged chart and saved it to: %s\n", p)
+				signedComment := ""
+				if client.Sign {
+					signedComment = "+signed"
+				}
+				fmt.Fprintf(out, "Successfully packaged%s chart, and saved it to: %s\n", signedComment, p)
 			}
 			return nil
 		},

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/Masterminds/semver/v3"
@@ -56,45 +58,51 @@ func NewPackage() *Package {
 
 // Run executes 'helm package' against the given chart and returns the path to the packaged chart.
 func (p *Package) Run(path string, vals map[string]interface{}) (string, error) {
-	ch, err := loader.LoadDir(path)
+	err := validatePackage(path)
+	var name string
 	if err != nil {
-		return "", err
-	}
-
-	// If version is set, modify the version.
-	if p.Version != "" {
-		ch.Metadata.Version = p.Version
-	}
-
-	if err := validateVersion(ch.Metadata.Version); err != nil {
-		return "", err
-	}
-
-	if p.AppVersion != "" {
-		ch.Metadata.AppVersion = p.AppVersion
-	}
-
-	if reqs := ch.Metadata.Dependencies; reqs != nil {
-		if err := CheckDependencies(ch, reqs); err != nil {
-			return "", err
-		}
-	}
-
-	var dest string
-	if p.Destination == "." {
-		// Save to the current working directory.
-		dest, err = os.Getwd()
+		ch, err := loader.LoadDir(path)
 		if err != nil {
 			return "", err
 		}
-	} else {
-		// Otherwise save to set destination
-		dest = p.Destination
-	}
 
-	name, err := chartutil.Save(ch, dest)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to save")
+		// If version is set, modify the version.
+		if p.Version != "" {
+			ch.Metadata.Version = p.Version
+		}
+
+		if err := validateVersion(ch.Metadata.Version); err != nil {
+			return "", err
+		}
+
+		if p.AppVersion != "" {
+			ch.Metadata.AppVersion = p.AppVersion
+		}
+
+		if reqs := ch.Metadata.Dependencies; reqs != nil {
+			if err := CheckDependencies(ch, reqs); err != nil {
+				return "", err
+			}
+		}
+
+		var dest string
+		if p.Destination == "." {
+			// Save to the current working directory.
+			dest, err = os.Getwd()
+			if err != nil {
+				return "", err
+			}
+		} else {
+			// Otherwise save to set destination
+			dest = p.Destination
+		}
+
+		name, err = chartutil.Save(ch, dest)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to save")
+		}
+	} else {
+		name = path
 	}
 
 	if p.Sign {
@@ -102,6 +110,18 @@ func (p *Package) Run(path string, vals map[string]interface{}) (string, error) 
 	}
 
 	return name, err
+}
+
+func validatePackage(filename string) error {
+	switch fi, err := os.Stat(filename); {
+	case err != nil:
+		return err
+	case fi.IsDir():
+		return errors.New("filename is a folder")
+	case strings.EqualFold(filepath.Ext(filename), ".tgz"):
+		return nil
+	}
+	return errors.New("chart must be a tgz file")
 }
 
 // validateVersion Verify that version is a Version, and error out if it is not.

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -61,6 +61,8 @@ func (p *Package) Run(path string, vals map[string]interface{}) (string, error) 
 	err := validatePackage(path)
 	var name string
 	if err != nil {
+		// ugly err reset
+		err = nil
 		ch, err := loader.LoadDir(path)
 		if err != nil {
 			return "", err

--- a/pkg/action/package_test.go
+++ b/pkg/action/package_test.go
@@ -150,7 +150,7 @@ func TestValidatePackage(t *testing.T) {
 		{
 			"path is a folder",
 			"testdata/charts/",
-			errors.New("chart must be a tgz file"),
+			errors.New("filename is a folder"),
 		},
 		{
 			"path is a file",
@@ -161,7 +161,7 @@ func TestValidatePackage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validatePackage(tt.path); err != nil {
-				if err != tt.wantErr {
+				if err.Error() != tt.wantErr.Error() {
 					t.Errorf("Expected {%v}, got {%v}", tt.wantErr, err)
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
When consuming packages that are not signed by an external entity, it is useful to pull an existing package and sign it yourself  for validation within your own deployment

**Special notes for your reviewer**:
This leverages the existing package signing feature, as well as the chart downloader logic for package recognition. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Unit tests
```
$ go test -v ./.../action -run TestValidatePackage
?       helm.sh/helm/v3/internal/experimental/action    [no test files]
=== RUN   TestValidatePackage
=== RUN   TestValidatePackage/normal_package
=== RUN   TestValidatePackage/invalid_archived_path
=== RUN   TestValidatePackage/non-helm_created_package
=== RUN   TestValidatePackage/path_is_a_folder
=== RUN   TestValidatePackage/path_is_a_file
--- PASS: TestValidatePackage (0.00s)
    --- PASS: TestValidatePackage/normal_package (0.00s)
    --- PASS: TestValidatePackage/invalid_archived_path (0.00s)
    --- PASS: TestValidatePackage/non-helm_created_package (0.00s)
    --- PASS: TestValidatePackage/path_is_a_folder (0.00s)
    --- PASS: TestValidatePackage/path_is_a_file (0.00s)
PASS
ok      helm.sh/helm/v3/pkg/action      1.710s
```

How this works
```
$  helm version
version.BuildInfo{Version:"v3.7+unreleased", GitCommit:"c2c472c9244368279778e14c1e47d20d9f443f91", GitTreeState:"clean", GoVersion:"go1.17"}
$ helm create foo
$ helm package --sign --key helm-sign --keyring /go/.gnupg/secring.gpg --passphrase-file passphrase foo
Successfully packaged+signed chart, and saved it to: /tmp/tmp.YEurNOmbot/foo-0.1.0.tgz
$ helm verify --keyring /go/.gnupg/secring.gpg foo-0.1.0.tgz
Signed by: helm-sign <helm@sign>
Using Key With Fingerprint: 8B413F2114299D7FD1814B197C3C65643AE6F555
Chart Hash Verified: sha256:bbae468295a9f01c4db16179d859e8648f7c0a88715e05ac6681a0fe70cab4e3


### backup PROV file created during packaging and sign the package


$ mv foo-0.1.0.tgz.prov foo-0.1.0.tgz.TMP.prov
$ helm package --sign --key helm-sign --keyring /go/.gnupg/secring.gpg --passphrase-file passphrase foo-0.1.0.tgz
Successfully packaged+signed chart, and saved it to: /tmp/tmp.YEurNOmbot/foo-0.1.0.tgz
$ diff foo-0.1.0.tgz.prov foo-0.1.0.tgz.TMP.prov
16,25c16,25
< wsDcBAEBCgAQBQJhTlJOCRB8PGVkOub1VQAAEpgMABM898fXPkylZKrydvcCQNs3
< NgN7XDkV/f4S/qkRIiTCrvsuZXecDmZyoFY8eicJVU7oXuM34dEkf795gCMFyhwZ
< NfzJ8gINWLdKaCBipwSazBi9FKNUuaxY6jmPssWg/c6DqqvjtvP0fS6wZXESBD43
< qjeMEYacBp/6f9Rs1Zl1nIi/FzV+KuhBIefKZm6e/L+Ca7RcKqqP6af/Sjhwzkha
< pbcL9+SC63Z0VoDrze8rdBvgJCXh6HfnwJ4jtQRam8uyxLjv0weSwIoK/o/DwNfY
< to439grDa+3FREvl2CX7m/XwSzlkqerV57R6DdUpVqc9ErHgXLKfwpZ1RLQjgT48
< 3QWOqemsPdaeD7qThgjXjlaEEkMOQDG9UgaSgG86PVbVg7pmhRNYis7CbQGMVRyz
< WSsQ580oBnT7UxPaIL3djE7nEhgju322TK4W8pgTn+QCmkkpAkHWHSzg0zpaKJg5
< z2l97zqT7ArP85kP1XkVKX0nZhT54APFXSSi1AB+pA==
< =h4MM
---
> wsDcBAEBCgAQBQJhTlILCRB8PGVkOub1VQAABlYMAGyU4ccLkVqm3hx0riUnnqqo
> QL6v7Y5Cy1Edy4dqCvv4NKAtdW6sQBGbGsA3LkgwG0eqSLRp9C8eTnYZob+MoJnn
> GbSHq2wBTWhOFHd7B0X6OtL3If7t9sAhnHP7rocXXLUDONCttZq+pEj7hyerQoVx
> zAwCo01CpgFGDe5LeVoQlA9pkZQGYQyUyIRLVHMpVtoSRBMAPnBz3Pl8i3xmgfj2
> lBOAN25v640kjghvFCr2YRJi7LNFbrDcJr3vxerE9xD2F/aWiwDsyOu3mxeBRzi2
> whU7VFUiNqkmrJKLRwbD5yWZYJObAyEKLdmi1HAK1My+cvXf8Sd2KTWSjc3wBiAL
> Q5zov/enVTi6E0dEClTbIxAwNIOPEH93hheXgQyCu7XawBc0WqH59O75TrG5SY32
> x/7dP9ssd5k7aISh8Rrc6GORhw3MaYiEudB+MbXJ640JQhyFxWwdvRahVpulKMor
> tqwx7pFuxnCdnETY+bMZxDpdcZGgavPoaDaQrurWmQ==
> =RbUs
$ helm verify --keyring /go/.gnupg/secring.gpg foo-0.1.0.tgz
Signed by: helm-sign <helm@sign>
Using Key With Fingerprint: 8B413F2114299D7FD1814B197C3C65643AE6F555
Chart Hash Verified: sha256:bbae468295a9f01c4db16179d859e8648f7c0a88715e05ac6681a0fe70cab4e3
```