### PR TITLE
test(linter): switch from golint to revive and fix lint errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
     environment:
       GOCACHE: "/tmp/go/cache"
-      GOLANGCI_LINT_VERSION: "1.36.0"
+      GOLANGCI_LINT_VERSION: "1.42.1"
 
     steps:
       - checkout

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,8 +21,8 @@ jobs:
           sudo mv golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64/golangci-lint /usr/local/bin/golangci-lint
           rm -rf golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64*
         env:
-          GOLANGCI_LINT_VERSION: '1.36.0'
-          GOLANGCI_LINT_SHA256: '9b8856b3a1c9bfbcf3a06b78e94611763b79abd9751c245246787cd3bf0e78a5'
+          GOLANGCI_LINT_VERSION: '1.42.1'
+          GOLANGCI_LINT_SHA256: '214b093c15863430c4b66dd39df677dab6e38fc873ded147e331740d50eea51f'
       - name: Test style
         run: make test-style
       - name: Run unit tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,12 @@ linters:
     - dupl
     - gofmt
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - structcheck
     - unused
     - varcheck

--- a/cmd/helm/completion_test.go
+++ b/cmd/helm/completion_test.go
@@ -47,10 +47,10 @@ func checkFileCompletion(t *testing.T, cmdName string, shouldBePerformed bool) {
 	}
 	if !strings.Contains(out, "ShellCompDirectiveNoFileComp") != shouldBePerformed {
 		if shouldBePerformed {
-			t.Error(fmt.Sprintf("Unexpected directive ShellCompDirectiveNoFileComp when completing '%s'", cmdName))
+			t.Errorf("Unexpected directive ShellCompDirectiveNoFileComp when completing '%s'", cmdName)
 		} else {
 
-			t.Error(fmt.Sprintf("Did not receive directive ShellCompDirectiveNoFileComp when completing '%s'", cmdName))
+			t.Errorf("Did not receive directive ShellCompDirectiveNoFileComp when completing '%s'", cmdName)
 		}
 		t.Log(out)
 	}

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -254,7 +254,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Handle SIGTERM
-	cSignal := make(chan os.Signal)
+	cSignal := make(chan os.Signal, 1)
 	signal.Notify(cSignal, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-cSignal

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -313,7 +313,7 @@ func loadFile(path string) (*pluginCommand, error) {
 	cmds := new(pluginCommand)
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return cmds, errors.New(fmt.Sprintf("File (%s) not provided by plugin. No plugin auto-completion possible.", path))
+		return cmds, fmt.Errorf("file (%s) not provided by plugin. No plugin auto-completion possible", path)
 	}
 
 	err = yaml.Unmarshal(b, cmds)

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -133,8 +133,8 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer, failOnRepoUpdate
 	wg.Wait()
 
 	if len(repoFailList) > 0 && failOnRepoUpdateFail {
-		return errors.New(fmt.Sprintf("Failed to update the following repositories: %s",
-			repoFailList))
+		return fmt.Errorf("Failed to update the following repositories: %s",
+			repoFailList)
 	}
 
 	fmt.Fprintln(out, "Update Complete. ⎈Happy Helming!⎈")

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -187,7 +187,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			ctx, cancel := context.WithCancel(ctx)
 
 			// Handle SIGTERM
-			cSignal := make(chan os.Signal)
+			cSignal := make(chan os.Signal, 1)
 			signal.Notify(cSignal, os.Interrupt, syscall.SIGTERM)
 			go func() {
 				<-cSignal

--- a/internal/experimental/registry/client.go
+++ b/internal/experimental/registry/client.go
@@ -240,9 +240,8 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 	}
 	numDescriptors := len(descriptors)
 	if numDescriptors < minNumDescriptors {
-		return nil, errors.New(
-			fmt.Sprintf("manifest does not contain minimum number of descriptors (%d), descriptors found: %d",
-				minNumDescriptors, numDescriptors))
+		return nil, fmt.Errorf("manifest does not contain minimum number of descriptors (%d), descriptors found: %d",
+			minNumDescriptors, numDescriptors)
 	}
 	var configDescriptor *ocispec.Descriptor
 	var chartDescriptor *ocispec.Descriptor
@@ -259,22 +258,17 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 		}
 	}
 	if configDescriptor == nil {
-		return nil, errors.New(
-			fmt.Sprintf("could not load config with mediatype %s", ConfigMediaType))
+		return nil, fmt.Errorf("could not load config with mediatype %s", ConfigMediaType)
 	}
 	if operation.withChart && chartDescriptor == nil {
-		return nil, errors.New(
-			fmt.Sprintf("manifest does not contain a layer with mediatype %s",
-				ChartLayerMediaType))
+		return nil, fmt.Errorf("manifest does not contain a layer with mediatype %s", ChartLayerMediaType)
 	}
 	var provMissing bool
 	if operation.withProv && provDescriptor == nil {
 		if operation.ignoreMissingProv {
 			provMissing = true
 		} else {
-			return nil, errors.New(
-				fmt.Sprintf("manifest does not contain a layer with mediatype %s",
-					ProvLayerMediaType))
+			return nil, fmt.Errorf("manifest does not contain a layer with mediatype %s", ProvLayerMediaType)
 		}
 	}
 	result := &PullResult{

--- a/internal/experimental/uploader/chart_uploader.go
+++ b/internal/experimental/uploader/chart_uploader.go
@@ -46,7 +46,7 @@ func (c *ChartUploader) UploadTo(ref, remote string) error {
 	}
 
 	if u.Scheme == "" {
-		return errors.New(fmt.Sprintf("scheme prefix missing from remote (e.g. \"%s://\")", registry.OCIScheme))
+		return fmt.Errorf("scheme prefix missing from remote (e.g. \"%s://\")", registry.OCIScheme)
 	}
 
 	p, err := c.Pushers.ByScheme(u.Scheme)

--- a/internal/third_party/dep/fs/rename.go
+++ b/internal/third_party/dep/fs/rename.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/internal/third_party/dep/fs/rename_windows.go
+++ b/internal/third_party/dep/fs/rename_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/chartutil/validate_name.go
+++ b/pkg/chartutil/validate_name.go
@@ -40,15 +40,15 @@ var (
 	errMissingName = errors.New("no name provided")
 
 	// errInvalidName indicates that an invalid release name was provided
-	errInvalidName = errors.New(fmt.Sprintf(
+	errInvalidName = fmt.Errorf(
 		"invalid release name, must match regex %s and the length must not be longer than 53",
-		validName.String()))
+		validName.String())
 
 	// errInvalidKubernetesName indicates that the name does not meet the Kubernetes
 	// restrictions on metadata names.
-	errInvalidKubernetesName = errors.New(fmt.Sprintf(
+	errInvalidKubernetesName = fmt.Errorf(
 		"invalid metadata name, must match regex %s and the length must not be longer than 253",
-		validName.String()))
+		validName.String())
 )
 
 const (

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -37,9 +37,9 @@ func TestEnvSettings(t *testing.T) {
 		ns, kcontext string
 		debug        bool
 		maxhistory   int
-		kAsUser      string
-		kAsGroups    []string
-		kCaFile      string
+		asUser       string
+		asGroups     []string
+		caFile       string
 	}{
 		{
 			name:       "defaults",
@@ -52,9 +52,9 @@ func TestEnvSettings(t *testing.T) {
 			ns:         "myns",
 			debug:      true,
 			maxhistory: defaultMaxHistory,
-			kAsUser:    "poro",
-			kAsGroups:  []string{"admins", "teatime", "snackeaters"},
-			kCaFile:    "/tmp/ca.crt",
+			asUser:     "poro",
+			asGroups:   []string{"admins", "teatime", "snackeaters"},
+			caFile:     "/tmp/ca.crt",
 		},
 		{
 			name:       "with envvars set",
@@ -62,9 +62,9 @@ func TestEnvSettings(t *testing.T) {
 			ns:         "yourns",
 			maxhistory: 5,
 			debug:      true,
-			kAsUser:    "pikachu",
-			kAsGroups:  []string{"operators", "snackeaters", "partyanimals"},
-			kCaFile:    "/tmp/ca.crt",
+			asUser:     "pikachu",
+			asGroups:   []string{"operators", "snackeaters", "partyanimals"},
+			caFile:     "/tmp/ca.crt",
 		},
 		{
 			name:       "with flags and envvars set",
@@ -73,9 +73,9 @@ func TestEnvSettings(t *testing.T) {
 			ns:         "myns",
 			debug:      true,
 			maxhistory: 5,
-			kAsUser:    "poro",
-			kAsGroups:  []string{"admins", "teatime", "snackeaters"},
-			kCaFile:    "/my/ca.crt",
+			asUser:     "poro",
+			asGroups:   []string{"admins", "teatime", "snackeaters"},
+			caFile:     "/my/ca.crt",
 		},
 	}
 
@@ -105,14 +105,14 @@ func TestEnvSettings(t *testing.T) {
 			if settings.MaxHistory != tt.maxhistory {
 				t.Errorf("expected maxHistory %d, got %d", tt.maxhistory, settings.MaxHistory)
 			}
-			if tt.kAsUser != settings.KubeAsUser {
-				t.Errorf("expected kAsUser %q, got %q", tt.kAsUser, settings.KubeAsUser)
+			if tt.asUser != settings.KubeAsUser {
+				t.Errorf("expected asUser %q, got %q", tt.asUser, settings.KubeAsUser)
 			}
-			if !reflect.DeepEqual(tt.kAsGroups, settings.KubeAsGroups) {
-				t.Errorf("expected kAsGroups %+v, got %+v", len(tt.kAsGroups), len(settings.KubeAsGroups))
+			if !reflect.DeepEqual(tt.asGroups, settings.KubeAsGroups) {
+				t.Errorf("expected asGroups %+v, got %+v", len(tt.asGroups), len(settings.KubeAsGroups))
 			}
-			if tt.kCaFile != settings.KubeCaFile {
-				t.Errorf("expected kCaFile %q, got %q", tt.kCaFile, settings.KubeCaFile)
+			if tt.caFile != settings.KubeCaFile {
+				t.Errorf("expected caFile %q, got %q", tt.caFile, settings.KubeCaFile)
 			}
 		})
 	}

--- a/pkg/helmpath/home_unix_test.go
+++ b/pkg/helmpath/home_unix_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package helmpath

--- a/pkg/helmpath/home_windows_test.go
+++ b/pkg/helmpath/home_windows_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package helmpath

--- a/pkg/helmpath/lazypath_darwin.go
+++ b/pkg/helmpath/lazypath_darwin.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
 // +build darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
 // +build darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_unix.go
+++ b/pkg/helmpath/lazypath_unix.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_unix_test.go
+++ b/pkg/helmpath/lazypath_unix_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_windows.go
+++ b/pkg/helmpath/lazypath_windows.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package helmpath

--- a/pkg/helmpath/lazypath_windows_test.go
+++ b/pkg/helmpath/lazypath_windows_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package helmpath


### PR DESCRIPTION
Signed-off-by: Martin Mulholland <mmulholl@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: 
It does 2 things:
- changes from the golint linter, which is deprecated, to the replacment revive
- fixes all of the linting errors including existing ones from gofmt, and govet, and new ones from revive

without these changes ```make test``` fails and does not run any tests. 

**Special notes for your reviewer**:

I fixed all of the gofmt errors by running ```gofmt -s -w <file>```, for example:
```gofmt -s -w cmd/helm/root_unix.go```

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #10205 
