### PR TITLE
Fix User-Agent header in requests made by Helm

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 
+	"helm.sh/helm/v3/internal/version"
 	"helm.sh/helm/v3/pkg/helmpath"
 )
 
@@ -226,5 +227,9 @@ func (s *EnvSettings) SetNamespace(namespace string) {
 
 // RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
+	s.config.WrapConfigFn = func(c *rest.Config) *rest.Config {
+		c.UserAgent = version.GetUserAgent()
+		return c
+	}
 	return s.config
 }

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+
+	"helm.sh/helm/v3/internal/version"
 )
 
 func TestSetNamespace(t *testing.T) {
@@ -228,6 +230,21 @@ func TestEnvOrBool(t *testing.T) {
 				t.Errorf("expected result %t, got %t", tt.expected, actual)
 			}
 		})
+	}
+}
+
+func TestUserAgentHEaderInK8sRESTClientConfig(t *testing.T) {
+	defer resetEnv()()
+
+	settings := New()
+	restConfig, err := settings.RESTClientGetter().ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedUserAgent := version.GetUserAgent()
+	if restConfig.UserAgent != expectedUserAgent {
+		t.Errorf("expected User-Agent header %q in K8s REST client config, got %q", expectedUserAgent, restConfig.UserAgent)
 	}
 }
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -310,14 +310,13 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 		repoURL.Path = strings.TrimSuffix(repoURL.Path, "/") + "/"
 		u = repoURL.ResolveReference(u)
 		u.RawQuery = q.Encode()
-		// TODO add user-agent
+
 		if _, err := getter.NewHTTPGetter(getter.WithURL(rc.URL)); err != nil {
 			return repoURL, err
 		}
 		return u, err
 	}
 
-	// TODO add user-agent
 	return u, nil
 }
 

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -155,9 +155,8 @@ func TestHTTPGetter(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	expect := "Call me Ishmael"
-	expectedUserAgent := "I am Groot"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defaultUserAgent := "Helm/" + strings.TrimPrefix(version.GetVersion(), "v")
+		defaultUserAgent := version.GetUserAgent()
 		if r.UserAgent() != defaultUserAgent {
 			t.Errorf("Expected '%s', got '%s'", defaultUserAgent, r.UserAgent())
 		}
@@ -179,6 +178,7 @@ func TestDownload(t *testing.T) {
 	}
 
 	// test with http server
+	const expectedUserAgent = "I am Groot"
 	basicAuthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok || username != "username" || password != "password" {

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -124,7 +124,6 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 	parsedURL.Path = path.Join(parsedURL.Path, "index.yaml")
 
 	indexURL := parsedURL.String()
-	// TODO add user-agent
 	resp, err := r.Client.Get(indexURL,
 		getter.WithURL(r.Config.URL),
 		getter.WithInsecureSkipVerifyTLS(r.Config.InsecureSkipTLSverify),


### PR DESCRIPTION
Current Helm v3.8.1 installed from package manager or build from main branch when makes requests to K8s API (with use of K8s SDK), e.g. executing the command

```
helm history test
```
does not have the proper value set in `User-Agent` header. It looks like that on macOS Monterey with Apple Silicon.
```yaml
User-Agent: Go-http-client/1.1
```
This PR fixes it and makes it consistent with `User-Agent` set when requests are made to chart repositories (it works as expected). So now it always looks like that
```yaml
User-Agent: Helm/3.8+unreleased
```
or
```yaml
User-Agent: Helm/3.8
```

Hence I removed those comments too from the code
```
// TODO add user-agent
```
because it's been already done and works as expected for interaction with chart repos and etc. Here is the line which provides it https://github.com/helm/helm/blob/0d9ebc7885e427373fbdaa95f461b349fb0b1ac1/pkg/getter/httpgetter.go#L53
