### PR TITLE
Fix default registry config path of oci protocol provider

### DIFF
--- a/internal/experimental/registry/client.go
+++ b/internal/experimental/registry/client.go
@@ -62,7 +62,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		option(client)
 	}
 	if client.credentialsFile == "" {
-		client.credentialsFile = helmpath.CachePath("registry", CredentialsFileBasename)
+		client.credentialsFile = helmpath.ConfigPath(CredentialsFileBasename)
 	}
 	if client.authorizer == nil {
 		authClient, err := dockerauth.NewClient(client.credentialsFile)

--- a/internal/experimental/registry/constants.go
+++ b/internal/experimental/registry/constants.go
@@ -21,7 +21,7 @@ const (
 	OCIScheme = "oci"
 
 	// CredentialsFileBasename is the filename for auth credentials file
-	CredentialsFileBasename = "config.json"
+	CredentialsFileBasename = "registry.json"
 
 	// ConfigMediaType is the reserved media type for the Helm chart manifest config
 	ConfigMediaType = "application/vnd.cncf.helm.config.v1+json"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes #10122 by changing the default registry config path to the one also used in `EnvSettings` as it is currently not set properly here (https://github.com/helm/helm/blob/main/pkg/action/install.go#L712) opposed for the pull command which does it here (https://github.com/helm/helm/blob/main/pkg/action/pull.go#L100). I think a nicer solution would be to actually use the registry client that is created as part of the action configuration (`actionConfig.RegistryClient`) in `root.go` (https://github.com/helm/helm/blob/main/cmd/helm/root.go#L156) or at least also somehow pass through the registry config env file to the backend but I'm too unfamiliar with the Helm architecture.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
