### PR TITLE
Actually skip unverifiable files when downloading dependencies

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -446,7 +446,8 @@ func (m *Manager) safeMoveDeps(deps []*chart.Dependency, source, dest string) er
 			fname := filepath.Join(dest, file.Name())
 			ch, err := loader.LoadFile(fname)
 			if err != nil {
-				fmt.Fprintf(m.Out, "Could not verify %s for deletion: %s (Skipping)", fname, err)
+				fmt.Fprintf(m.Out, "Could not verify %s for deletion: %s (Skipping)\n", fname, err)
+				continue
 			}
 			// local dependency - skip
 			if isLocalDependency[ch.Name()] {


### PR DESCRIPTION
Signed-off-by: Fabian Jucker <fabianju@gmx.ch>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Basically closes #10162 in the simplest way possible. 

**Special notes for your reviewer**:
I took a look at how the `existsInSourceDirectory` map is populated as suggested by @bacongobbler. But my understanding is, that the idea behind the refactoring in 4b23d0a25b15f990e5de9bc2e1e8cbd80de9243c was basically to have all dependencies downloaded to a temporary directory and compare/copy from there. Existing files in the `charts` directory are not considered anywhere in the setup of the temporary directory and I assume @bacongobbler intended to skip such files in the `safeMoveDeps` but simply forgot the `continue` statement (because not skipping after a loader error makes no sense).

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
