### PR TITLE
fix: improve logging & safety of statefulSetReady

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -380,6 +380,9 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 	}
 
 	if u.Wait {
+		u.cfg.Log(
+			"waiting for release %s resources (created=%d, updated=%d, deleted=%d)",
+			upgradedRelease.Name, len(results.Created), len(results.Updated), len(results.Deleted))
 		if u.WaitForJobs {
 			if err := u.cfg.KubeClient.WaitWithJobs(target, u.Timeout); err != nil {
 				u.cfg.recordRelease(originalRelease)


### PR DESCRIPTION
**What this PR does / why we need it**:

This isn't necessarily a fix, but the additional logging may help us in
determining what the underlying issue is and it seems sensible to
confirm that the current and updated revision numbers also match as part
of the readiness check.

Contributes-to: #10163
