### PR TITLE
fix registry config flag was ignored

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -191,7 +191,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, err
 	}
 
-	cp, err := client.ChartPathOptions.LocateChart(chart, settings)
+	cp, err := client.LocateChart(chart, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -169,7 +169,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 		newCreateCmd(out),
 		newDependencyCmd(actionConfig, out),
 		newPullCmd(actionConfig, out),
-		newShowCmd(out),
+		newShowCmd(actionConfig, out),
 		newLintCmd(out),
 		newPackageCmd(out),
 		newRepoCmd(out),

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -56,8 +56,8 @@ This command inspects a chart (directory, file, or URL) and displays the content
 of the CustomResourceDefintion files
 `
 
-func newShowCmd(out io.Writer) *cobra.Command {
-	client := action.NewShow(action.ShowAll)
+func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	client := action.NewShow(action.ShowAll, cfg)
 
 	showCommand := &cobra.Command{
 		Use:               "show",
@@ -202,7 +202,7 @@ func runShow(args []string, client *action.Show) (string, error) {
 		return "", err
 	}
 
-	cp, err := client.ChartPathOptions.LocateChart(args[0], settings)
+	cp, err := client.LocateChart(args[0], settings)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -136,7 +136,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.Version = ">0.0.0-0"
 			}
 
-			chartPath, err := client.ChartPathOptions.LocateChart(args[1], settings)
+			chartPath, err := client.ChartPathOptions.LocateChart(args[1], settings, cfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -662,6 +662,10 @@ OUTER:
 	return nil
 }
 
+func (i *Install) LocateChart(name string, settings *cli.EnvSettings) (string, error) {
+	return i.ChartPathOptions.LocateChart(name, settings, i.cfg)
+}
+
 // LocateChart looks for a chart directory in known places, and returns either the full path or an error.
 //
 // This does not ensure that the chart is well-formed; only that the requested filename exists.
@@ -672,7 +676,7 @@ OUTER:
 // - URL
 //
 // If 'verify' was set on ChartPathOptions, this will attempt to also verify the chart.
-func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (string, error) {
+func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings, cfg *Configuration) (string, error) {
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 
@@ -709,7 +713,10 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		if version == "" {
 			return "", errors.New("version is explicitly required for OCI registries")
 		}
-		dl.Options = append(dl.Options, getter.WithTagName(version))
+		dl.Options = append(dl.Options,
+			getter.WithRegistryClient(cfg.RegistryClient),
+			getter.WithTagName(version),
+		)
 	}
 
 	if c.Verify {

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -28,6 +28,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
 )
 
 // ShowOutputFormat is the format of the output of `helm show`
@@ -56,6 +57,8 @@ func (o ShowOutputFormat) String() string {
 //
 // It provides the implementation of 'helm show' and its respective subcommands.
 type Show struct {
+	cfg *Configuration
+
 	ChartPathOptions
 	Devel            bool
 	OutputFormat     ShowOutputFormat
@@ -64,9 +67,10 @@ type Show struct {
 }
 
 // NewShow creates a new Show object with the given configuration.
-func NewShow(output ShowOutputFormat) *Show {
+func NewShow(output ShowOutputFormat, cfg *Configuration) *Show {
 	return &Show{
 		OutputFormat: output,
+		cfg:          cfg,
 	}
 }
 
@@ -130,6 +134,10 @@ func (s *Show) Run(chartpath string) (string, error) {
 		}
 	}
 	return out.String(), nil
+}
+
+func (s *Show) LocateChart(name string, settings *cli.EnvSettings) (string, error) {
+	return s.ChartPathOptions.LocateChart(name, settings, s.cfg)
 }
 
 func findReadme(files []*chart.File) (file *chart.File) {

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestShow(t *testing.T) {
-	client := NewShow(ShowAll)
+	client := NewShow(ShowAll, nil)
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*chart.File{
@@ -64,7 +64,7 @@ bar
 }
 
 func TestShowNoValues(t *testing.T) {
-	client := NewShow(ShowAll)
+	client := NewShow(ShowAll, nil)
 	client.chart = new(chart.Chart)
 
 	// Regression tests for missing values. See issue #1024.
@@ -80,7 +80,7 @@ func TestShowNoValues(t *testing.T) {
 }
 
 func TestShowValuesByJsonPathFormat(t *testing.T) {
-	client := NewShow(ShowValues)
+	client := NewShow(ShowValues, nil)
 	client.JSONPathTemplate = "{$.nestedKey.simpleKey}"
 	client.chart = buildChart(withSampleValues())
 	output, err := client.Run("")
@@ -94,7 +94,7 @@ func TestShowValuesByJsonPathFormat(t *testing.T) {
 }
 
 func TestShowCRDs(t *testing.T) {
-	client := NewShow(ShowCRDs)
+	client := NewShow(ShowCRDs, nil)
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*chart.File{
@@ -122,7 +122,7 @@ bar
 }
 
 func TestShowNoReadme(t *testing.T) {
-	client := NewShow(ShowAll)
+	client := NewShow(ShowAll, nil)
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*chart.File{


### PR DESCRIPTION
**What this PR does / why we need it**:

As already described in my previous PR #10211 , the registry client of the action config is not used everywhere (install, show, upgrade are missing). This PR adds the action config as a parameter to the `LocateChart` function. This fixes that the `--registry-config` flag was ignored for those commands.

@jdolitsky what do you think?

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
