### PR TITLE
add SetNamespace method for EnvSettings, in order to set namespace in helm sdk

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -180,6 +180,11 @@ func (s *EnvSettings) Namespace() string {
 	return "default"
 }
 
+// SetNamespace sets the namespace in the configuration
+func (s *EnvSettings) SetNamespace(namespace string) {
+	s.namespace = namespace
+}
+
 // RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	return s.config

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -25,6 +25,20 @@ import (
 	"github.com/spf13/pflag"
 )
 
+func TestSetNamespace(t *testing.T) {
+	settings := New()
+
+	if settings.namespace != "" {
+		t.Errorf("Expected empty namespace, got %s", settings.namespace)
+	}
+
+	settings.SetNamespace("testns")
+	if settings.namespace != "testns" {
+		t.Errorf("Expected namespace testns, got %s", settings.namespace)
+	}
+
+}
+
 func TestEnvSettings(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
add SetNamespace method for EnvSettings, in order to set namespace in helm sdk

Signed-off-by: yxxhero <aiopsclub@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
fix https://github.com/helm/helm/issues/10215
**Special notes for your reviewer**:
add SetNamespace method for EnvSettings, in order to set namespace in helm sdk
**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
