### PR TITLE
fix: rollback failure after update error

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -256,13 +256,6 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 		return nil
 	})
 
-	switch {
-	case err != nil:
-		return res, err
-	case len(updateErrors) != 0:
-		return res, errors.Errorf(strings.Join(updateErrors, " && "))
-	}
-
 	for _, info := range original.Difference(target) {
 		c.Log("Deleting %q in %s...", info.Name, info.Namespace)
 
@@ -283,6 +276,13 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 			continue
 		}
 		res.Deleted = append(res.Deleted, info)
+	}
+
+	switch {
+	case err != nil:
+		return res, err
+	case len(updateErrors) != 0:
+		return res, errors.Errorf(strings.Join(updateErrors, " && "))
 	}
 	return res, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

closes #10219

Helm update stops after processing changes if there was an error, this as the effect the deletes are skipped. Now when rollback is requested it can fails because the delete was not done.

The fix moves the logic to process errors from after processing changes to after processing changes and deletes.


**Special notes for your reviewer**:

I ran the go test against the fix and everything passed. Was not sure how to add a test for this scenario - if a test os required please provide some guidance on how best to do this.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
