### PR TITLE
fix(helm): process  dependencies import-values

### DIFF
--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -35,6 +35,7 @@ const badChartDir = "rules/testdata/badchartfile"
 const badValuesFileDir = "rules/testdata/badvaluesfile"
 const badYamlFileDir = "rules/testdata/albatross"
 const goodChartDir = "rules/testdata/goodone"
+const subChartValuesDir = "rules/testdata/withsubchart"
 
 func TestBadChart(t *testing.T) {
 	m := All(badChartDir, values, namespace, strict).Messages
@@ -142,5 +143,17 @@ func TestHelmCreateChart(t *testing.T) {
 		}
 	} else if msg := m[0].Err.Error(); !strings.Contains(msg, "icon is recommended") {
 		t.Errorf("Unexpected lint error: %s", msg)
+	}
+}
+
+// lint ignores import-values
+// See https://github.com/helm/helm/issues/9658
+func TestSubChartValuesChart(t *testing.T) {
+	m := All(subChartValuesDir, values, namespace, strict).Messages
+	if len(m) != 0 {
+		t.Error("All returned linter messages when it shouldn't have")
+		for i, msg := range m {
+			t.Logf("Message %d: %s", i, msg)
+		}
 	}
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -70,6 +70,12 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 		Namespace: namespace,
 	}
 
+	// lint ignores import-values
+	// See https://github.com/helm/helm/issues/9658
+	if err := chartutil.ProcessDependencies(chart, values); err != nil {
+		return
+	}
+
 	cvals, err := chartutil.CoalesceValues(chart, values)
 	if err != nil {
 		return

--- a/pkg/lint/rules/testdata/withsubchart/Chart.yaml
+++ b/pkg/lint/rules/testdata/withsubchart/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: withsubchart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+icon: http://riverrun.io
+
+dependencies:
+  - name: subchart
+    version: 0.1.16
+    repository: "file://../subchart"
+    import-values:
+      - child: subchart
+        parent: subchart
+

--- a/pkg/lint/rules/testdata/withsubchart/charts/subchart/Chart.yaml
+++ b/pkg/lint/rules/testdata/withsubchart/charts/subchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: subchart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/lint/rules/testdata/withsubchart/charts/subchart/templates/subchart.yaml
+++ b/pkg/lint/rules/testdata/withsubchart/charts/subchart/templates/subchart.yaml
@@ -1,0 +1,2 @@
+metadata:
+  name: {{ .Values.subchart.name | lower }}

--- a/pkg/lint/rules/testdata/withsubchart/charts/subchart/values.yaml
+++ b/pkg/lint/rules/testdata/withsubchart/charts/subchart/values.yaml
@@ -1,0 +1,2 @@
+subchart:
+  name: subchart

--- a/pkg/lint/rules/testdata/withsubchart/templates/mainchart.yaml
+++ b/pkg/lint/rules/testdata/withsubchart/templates/mainchart.yaml
@@ -1,0 +1,2 @@
+metadata:
+  name: {{ .Values.subchart.name | lower }}


### PR DESCRIPTION
When running helm lint, import-values for dependencies are ignored,
also added test for linting chart with import-values

Closes #9658

Signed-off-by: Stuart Drennan <stuart.drennan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When running helm lint, import-values for dependencies are ignored this fixes that by processing dependencies as part of template rule, also added test for linting chart with import-values

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
