### PR TITLE
[helmignore] Support for '!' as a special leading sequence

### DIFF
--- a/internal/ignore/doc.go
+++ b/internal/ignore/doc.go
@@ -62,6 +62,5 @@ Notable differences from .gitignore:
 	- The globbing library is Go's 'filepath.Match', not fnmatch(3)
 	- Trailing spaces are always ignored (there is no supported escape sequence)
 	- The evaluation of escape sequences has not been tested for compatibility
-	- There is no support for '\!' as a special leading sequence.
 */
 package ignore // import "helm.sh/helm/v3/internal/ignore"


### PR DESCRIPTION
.helmignore has "supported" negative matches uselessly for a long time, reported as an open ticket (https://github.com/helm/helm/issues/3622) as early as 2018. This revision implements negative matching correctly and usefully for the first time.

Closes #3622.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
