### PR TITLE
WIP Fix dependency condition is always true when it's checking a value that doesn't exist

### DIFF
--- a/cmd/helm/testdata/testcharts/subchart/values.yaml
+++ b/cmd/helm/testdata/testcharts/subchart/values.yaml
@@ -53,3 +53,9 @@ exports:
       SC1exported2:
         all:
           SC1exported3: "SC1expstr"
+
+subcharta:
+  enabled: true
+
+subchartb:
+  enabled: true

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -51,6 +51,8 @@ func processDependencyConditions(reqs []*chart.Dependency, cvals Values, cpath s
 				} else if _, ok := err.(ErrNoValue); !ok {
 					// this is a real error
 					log.Printf("Warning: PathValue returned error %v", err)
+				} else {
+					r.Enabled = false
 				}
 			}
 		}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -111,6 +111,10 @@ func TestDependencyEnabled(t *testing.T) {
 		"subcharts with alias also respect conditions",
 		M{"subchart1": M{"enabled": false}, "subchart2alias": M{"enabled": true, "subchartb": M{"enabled": true}}},
 		[]string{"parentchart", "parentchart.subchart2alias", "parentchart.subchart2alias.subchartb"},
+	}, {
+		"subcharts with alias also respect conditions on a non-existent value",
+		M{"subchart1": M{"enabled": false}, "subchart2alias2": M{}},
+		[]string{"parentchart"},
 	}}
 
 	for _, tc := range tests {

--- a/pkg/chartutil/testdata/subpop/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/Chart.yaml
@@ -39,3 +39,9 @@ dependencies:
     repository: http://localhost:10191
     version: 0.1.0
     condition: subchart2alias.enabled
+
+  - name: subchart2
+    alias: subchart2alias2
+    repository: http://localhost:10191
+    version: 0.1.0
+    condition: subchart2alias2.nonexistent.enabled


### PR DESCRIPTION
Signed-off-by: Chao <oleooo@126.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
For each dependency in `Chart.yml`, the condition will be considered as `true` if it is checking a value that doesn't exist.

For this example:
```
...

dependencies:
  - name: subchart
    repository: http://localhost:10191
    version: 0.1.0
    condition: subchart.enabled

...
```
If `subchart.enabled` is missing in `values.yml`, the `subchart` will be enabled by default which is considered as an unexpected behavior.

This PR fixes the issue, closes #10296

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
