### PR TITLE
Add alternative template delimiter

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -164,6 +164,12 @@ func TestInstall(t *testing.T) {
 			name: "install chart with library chart dependency",
 			cmd:  "install withlibchartp testdata/testcharts/chart-with-lib-dep",
 		},
+		// Install, chart with alternative delimiter
+		{
+			name:   "install with alternative delimiter",
+			cmd:    "install alt-delim testdata/testcharts/chart-with-alt-delim",
+			golden: "output/install-chart-with-alt-delim.txt",
+		},
 		// Install, library chart
 		{
 			name:      "install library chart",

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -131,6 +131,11 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf(`template '%s' --skip-tests`, chartPath),
 			golden: "output/template-skip-tests.txt",
 		},
+		{
+			name:   "template chart-with-alt-delim",
+			cmd:    "template alt-delim testdata/testcharts/chart-with-alt-delim",
+			golden: "output/template-chart-with-alt-delim.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
+++ b/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
@@ -1,0 +1,18 @@
+---
+# Source: chart-with-alt-delim/templates/alt-configmap.yaml
+# helm: delim=[[,]]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alt-delim-chart-with-alt-delim-alt
+data:
+  myvalue: "Hello {{world}}"
+---
+# Source: chart-with-alt-delim/templates/normal-configmap.yaml
+# helm: delim=[[,]]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alt-delim-chart-with-alt-delim-normal
+data:
+  myvalue: "Hello world"

--- a/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
+++ b/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
@@ -1,17 +1,6 @@
----
-# Source: chart-with-alt-delim/templates/alt-configmap.yaml
-# helm: delim=[,]
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: alt-delim-chart-with-alt-delim-alt
-data:
-  myvalue: "Hello {{world}}"
----
-# Source: chart-with-alt-delim/templates/normal-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: alt-delim-chart-with-alt-delim-normal
-data:
-  myvalue: "Hello world"
+NAME: alt-delim
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None

--- a/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
+++ b/cmd/helm/testdata/output/install-chart-with-alt-delim.txt
@@ -1,6 +1,6 @@
 ---
 # Source: chart-with-alt-delim/templates/alt-configmap.yaml
-# helm: delim=[[,]]
+# helm: delim=[,]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +9,6 @@ data:
   myvalue: "Hello {{world}}"
 ---
 # Source: chart-with-alt-delim/templates/normal-configmap.yaml
-# helm: delim=[[,]]
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/helm/testdata/output/template-chart-with-alt-delim.txt
+++ b/cmd/helm/testdata/output/template-chart-with-alt-delim.txt
@@ -1,0 +1,17 @@
+---
+# Source: chart-with-alt-delim/templates/alt-configmap.yaml
+# helm: delim=[,]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alt-delim-chart-with-alt-delim-alt
+data:
+  myvalue: "Hello {{world}}"
+---
+# Source: chart-with-alt-delim/templates/normal-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alt-delim-chart-with-alt-delim-normal
+data:
+  myvalue: "Hello world"

--- a/cmd/helm/testdata/output/template-chart-with-alt-delim.txt
+++ b/cmd/helm/testdata/output/template-chart-with-alt-delim.txt
@@ -1,6 +1,6 @@
 ---
 # Source: chart-with-alt-delim/templates/alt-configmap.yaml
-# helm: delim=[,]
+# helm: delimiters=[[,]]
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/.helmignore
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: chart-with-alt-delim
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/README.md
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/README.md
@@ -1,0 +1,5 @@
+# Chart with alternative delimiter
+
+This chart tests the ability to switch the template delimiter in specific files
+
+This is very useful when rendering templates of tools that use `{{ }}` templating macros (i.e. prometheus, argo, ...)

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/_helpers.tpl
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart-with-alt-delim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart-with-alt-delim.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart-with-alt-delim.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart-with-alt-delim.labels" -}}
+helm.sh/chart: {{ include "chart-with-alt-delim.chart" . }}
+{{ include "chart-with-alt-delim.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart-with-alt-delim.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart-with-alt-delim.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart-with-alt-delim.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart-with-alt-delim.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
@@ -1,4 +1,4 @@
-# helm: delim=[,]
+# helm: delimiters=[[,]]
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
@@ -1,0 +1,7 @@
+# helm: delim=[[,]]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: [[ template "chart-with-alt-delim.fullname" . ]]-alt
+data:
+  myvalue: "Hello {{world}}"

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/alt-configmap.yaml
@@ -1,4 +1,4 @@
-# helm: delim=[[,]]
+# helm: delim=[,]
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/normal-configmap.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/normal-configmap.yaml
@@ -1,4 +1,3 @@
-# helm: delim=[[,]]
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/normal-configmap.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/templates/normal-configmap.yaml
@@ -1,0 +1,7 @@
+# helm: delim=[[,]]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "chart-with-alt-delim.fullname" . }}-normal
+data:
+  myvalue: "Hello world"

--- a/cmd/helm/testdata/testcharts/chart-with-alt-delim/values.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-alt-delim/values.yaml
@@ -1,0 +1,82 @@
+# Default values for chart-with-alt-delim.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -391,7 +391,7 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, vals chartutil.
 		templates[path.Join(newParentID, t.Name)] = renderable{
 			tpl:      string(t.Data),
 			vals:     next,
-			opts: 	  readTemplateMagicComments(string(t.Data)),
+			opts:     readTemplateMagicComments(string(t.Data)),
 			basePath: path.Join(newParentID, "templates"),
 		}
 	}
@@ -416,7 +416,7 @@ func readTemplateMagicComments(templateBody string) templateOpts {
 	templateOpts := templateOpts{}
 	matches := magicCommentsRegexp.FindAllSubmatch([]byte(templateBody), -1)
 	for _, match := range matches {
-		if (strings.EqualFold(string(match[1]), "delim")) {
+		if strings.EqualFold(string(match[1]), "delim") {
 			delim := strings.SplitN(string(match[2]), ",", 2)
 			templateOpts.delimL = strings.Repeat(delim[0], 2)
 			templateOpts.delimR = strings.Repeat(delim[1], 2)
@@ -424,4 +424,4 @@ func readTemplateMagicComments(templateBody string) templateOpts {
 	}
 
 	return templateOpts
- }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some popular kubernetes components (prometheus,  argo-workflows, ...) use templating with `{{...}}` syntax.
This makes it hard for helm users to template the resources for these workloads (see links below).
The current workarounds render the templates hard to read and hard to maintain.

This PR addresses this by allowing a specific template to change its template delimiters.
The delimiter change is set using "magic comments" which is a wide spread trick used to carry more metadata inlined in a file (see examples below).

To change the template delimiter, a helm user would add a `# helm: delim=[,]` comment to the head of the template file:

```yaml
# helm: delimiters=[[,]]
apiVersion: v1
kind: ConfigMap
metadata:
  name: [[ template "chart-with-alt-delim.fullname" . ]]-alt
data:
  myvalue: "Hello {{world}}"
```

This will only effect the specific template and so compatibility with other charts and templates is not impacted.

Examples of magic comments in our ecosystems:
- [vim](https://vim.fandom.com/wiki/Modeline_magic)
- [go-lang](https://github.com/xaionaro-go/hackery)
- [Ruby](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/comments_rdoc.html#label-Magic+Comments)
- [Webpack](https://webpack.js.org/api/module-methods/#magic-comments)

refs #4789
refs #2931
https://stackoverflow.com/questions/64802290/how-can-i-use-argo-workflows-templates-in-helm
https://stackoverflow.com/questions/56341558/how-to-escape-and-in-argo-workflow
https://tempered.works/posts/2020-05-21-helm-argo/


**Special notes for your reviewer**:
Added a unit test to verify rendering of a normal template as well as a template with alternative delimiter side by side.
I'd be happy to add documentation if this is merged.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

**TODO**:
- [x] Open HIP
- [x] Scan lines in template only up to the first line that does not start with `#`
