### PR TITLE
Adding Scott Rigby as helm/helm maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ maintainers:
   - marckhouzam
   - mattfarina
   - prydonius
+  - scottrigby
   - SlickNik
   - technosophos
 emeritus:


### PR DESCRIPTION
As mentioned during today's helm developer call, @scottrigby has been voted in as a helm/helm maintainer.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
