### PR TITLE
Fixes a SIGSEGV similar to issue 1347

### DIFF
--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -157,8 +157,8 @@ func newReleaseListWriter(releases []*release.Release, timeFormat string) *relea
 			Namespace:  r.Namespace,
 			Revision:   strconv.Itoa(r.Version),
 			Status:     r.Info.Status.String(),
-			Chart:      fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version),
-			AppVersion: r.Chart.Metadata.AppVersion,
+			Chart:      formatChartname(r.Chart),
+			AppVersion: formatAppVersion(r.Chart),
 		}
 
 		t := "-"


### PR DESCRIPTION
**What this PR does / why we need it**:

The `helm list` command is producing a `SIGSEGV` on some of our Kubernetes Clusters:

```
$ helm list --all-namespaces
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x575b044]

goroutine 1 [running]:
main.newReleaseListWriter(0xc103132000, 0x100, 0x400, 0x0, 0x0, 0x0)
	helm.sh/helm/v3/cmd/helm/list.go:160 +0x124
main.newListCmd.func1(0xc000892500, 0xc0003d6ae0, 0x0, 0x3, 0x0, 0x0)
	helm.sh/helm/v3/cmd/helm/list.go:111 +0x4ed
github.com/spf13/cobra.(*Command).execute(0xc000892500, 0xc000308400, 0x3, 0x4, 0xc000892500, 0xc000308400)
	github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc0006faf00, 0xc0002061c8, 0x1, 0xc0008b5f60)
	github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.1.3/command.go:897
```

It looks like a fix was made for `helm history` in the past related to Issue https://github.com/helm/helm/issues/1347 but the fix did not address `helm list`.  This change leverages the same utility functions that fix utilized in PR https://github.com/helm/helm/pull/1349 to resolve the issue.

**Special notes for your reviewer**:

No special notes.  I have tested the update on our infrastructure and am happy to report `helm list` works.  🚀 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
