### PR TITLE
allow ldflags to overwrite k8s version

### DIFF
--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -28,12 +28,10 @@ import (
 	helmversion "helm.sh/helm/v3/internal/version"
 )
 
-const (
+var (
 	k8sVersionMajor = 1
 	k8sVersionMinor = 20
-)
 
-var (
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()
 

--- a/pkg/lint/rules/deprecations.go
+++ b/pkg/lint/rules/deprecations.go
@@ -25,7 +25,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-const (
+var (
 	// This should be set in the Makefile based on the version of client-go being imported.
 	// These constants will be overwritten with LDFLAGS
 	k8sVersionMajor = 1


### PR DESCRIPTION
Signed-off-by: Sverre Boschman <1142569+sboschman@users.noreply.github.com>

**What this PR does / why we need it**:
Allow ldflags to overwrite the k8s version as intented. Hopefully fixes #10324 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
