### PR TITLE
Add yxxhero as triage maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,8 @@ maintainers:
   - scottrigby
   - SlickNik
   - technosophos
+triage:
+  - yxxhero
 emeritus:
   - fibonacci1729
   - jascott1


### PR DESCRIPTION
**What this PR does / why we need it**:

As agreed by lazy consensus, we will include triage maintainers in the OWNERS file.

https://lists.cncf.io/g/cncf-helm-core-maintainers/message/334
https://lists.cncf.io/g/cncf-helm-core-maintainers/message/337

@yxxhero an official welcome 😄 