### PR TITLE
fix: added resource info into the validation error

### DIFF
--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -51,7 +51,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
-			return errors.Wrap(err, "could not get information about the resource")
+			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
 		}
 
 		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.


### PR DESCRIPTION
This fix adds resource kind, name and namespace into the validation error to help user to find out the original reason of the error.