### PR TITLE
fix(install/upgrade): Use buffered channel for signal notification to avoid signal loss

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,8 +21,8 @@ jobs:
           sudo mv golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64/golangci-lint /usr/local/bin/golangci-lint
           rm -rf golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64*
         env:
-          GOLANGCI_LINT_VERSION: '1.36.0'
-          GOLANGCI_LINT_SHA256: '9b8856b3a1c9bfbcf3a06b78e94611763b79abd9751c245246787cd3bf0e78a5'
+          GOLANGCI_LINT_VERSION: '1.43.0'
+          GOLANGCI_LINT_SHA256: 'f3515cebec926257da703ba0a2b169e4a322c11dc31a8b4656b50a43e48877f4'
       - name: Test style
         run: make test-style
       - name: Run unit tests

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -253,8 +253,10 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 
-	// Handle SIGTERM
-	cSignal := make(chan os.Signal)
+	// Set up channel on which to send signal notifications.
+	// We must use a buffered channel or risk missing the signal
+	// if we're not ready to receive when the signal is sent.
+	cSignal := make(chan os.Signal, 2)
 	signal.Notify(cSignal, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-cSignal

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -186,8 +186,10 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)
 
-			// Handle SIGTERM
-			cSignal := make(chan os.Signal)
+			// Set up channel on which to send signal notifications.
+			// We must use a buffered channel or risk missing the signal
+			// if we're not ready to receive when the signal is sent.
+			cSignal := make(chan os.Signal, 2)
 			signal.Notify(cSignal, os.Interrupt, syscall.SIGTERM)
 			go func() {
 				<-cSignal

--- a/pkg/helmpath/home_unix_test.go
+++ b/pkg/helmpath/home_unix_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package helmpath

--- a/pkg/helmpath/lazypath_darwin.go
+++ b/pkg/helmpath/lazypath_darwin.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
 // +build darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
 // +build darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_unix.go
+++ b/pkg/helmpath/lazypath_unix.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 package helmpath

--- a/pkg/helmpath/lazypath_unix_test.go
+++ b/pkg/helmpath/lazypath_unix_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 package helmpath


### PR DESCRIPTION
**What this PR does / why we need it**:
System signal calls can be lost when using an unbuffered channel. This means that signal hanging may not pickup signals from time to time like interrupts to install and upgrades. 

Refer to https://pkg.go.dev/os/signal#Notify for more details.

Closes #10348 

Related #9180 
 
**Special notes for your reviewer**:
Some background in:

- https://pkg.go.dev/os/signal#Notify
- https://github.com/golang/go/issues/45043

This PR also includes updating `golangci-lint` to latest version to pick up warning like this in CI. This required some updates to additional files as a consequence.

This is related to #10206. Missed this when checking before I pushed the PR. I think it is best to merge this PR first before introducing 'revive'.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
