### PR TITLE
fix: fixed broken 3 way merge when previous release was failed

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -181,20 +181,15 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, errPending
 	}
 
-	var currentRelease *release.Release
-	if lastRelease.Info.Status == release.StatusDeployed {
-		// no need to retrieve the last deployed release from storage as the last release is deployed
-		currentRelease = lastRelease
-	} else {
-		// finds the deployed release with the given name
-		currentRelease, err = u.cfg.Releases.Deployed(name)
-		if err != nil {
-			if errors.Is(err, driver.ErrNoDeployedReleases) &&
-				(lastRelease.Info.Status == release.StatusFailed || lastRelease.Info.Status == release.StatusSuperseded) {
-				currentRelease = lastRelease
-			} else {
-				return nil, nil, err
-			}
+	isUpgrade := true
+	currentRelease := lastRelease
+	_, err = u.cfg.Releases.Deployed(name)
+	if err != nil {
+		if errors.Is(err, driver.ErrNoDeployedReleases) &&
+			(lastRelease.Info.Status == release.StatusFailed || lastRelease.Info.Status == release.StatusSuperseded || lastRelease.Info.Status == release.StatusPendingInstall || lastRelease.Info.Status == release.StatusPendingUpgrade || lastRelease.Info.Status == release.StatusPendingRollback) {
+			isUpgrade = false
+		} else {
+			return nil, nil, err
 		}
 	}
 
@@ -216,7 +211,8 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		Name:      name,
 		Namespace: currentRelease.Namespace,
 		Revision:  revision,
-		IsUpgrade: true,
+		IsInstall: !isUpgrade,
+		IsUpgrade: isUpgrade,
 	}
 
 	caps, err := u.cfg.getCapabilities()


### PR DESCRIPTION
Create a patch from previous release revision no matter succeeded it was or failed, rather than always creating a patch from the previous succeeded release revision.

This change solves cases proveded in the issue: https://github.com/helm/helm/issues/10363.
