### PR TITLE
Fix specifying of Kubernetes version from build scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
       - run:
           name: test
           command: make test-coverage
+      - run:
+          name: test build
+          command: make
       - deploy:
           name: deploy
           command: .circleci/deploy.sh

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	k8sVersionMajor = 1
-	k8sVersionMinor = 20
+	// The Kubernetes version can be set by LDFLAGS. In order to do that the value
+	// must be a string.
+	k8sVersionMajor = "1"
+	k8sVersionMinor = "20"
 
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()
@@ -38,9 +40,9 @@ var (
 	// DefaultCapabilities is the default set of capabilities.
 	DefaultCapabilities = &Capabilities{
 		KubeVersion: KubeVersion{
-			Version: fmt.Sprintf("v%d.%d.0", k8sVersionMajor, k8sVersionMinor),
-			Major:   strconv.Itoa(k8sVersionMajor),
-			Minor:   strconv.Itoa(k8sVersionMinor),
+			Version: fmt.Sprintf("v%s.%s.0", k8sVersionMajor, k8sVersionMinor),
+			Major:   k8sVersionMajor,
+			Minor:   k8sVersionMinor,
 		},
 		APIVersions: DefaultVersionSet,
 		HelmVersion: helmversion.Get(),

--- a/pkg/lint/rules/deprecations.go
+++ b/pkg/lint/rules/deprecations.go
@@ -18,6 +18,7 @@ package rules // import "helm.sh/helm/v3/pkg/lint/rules"
 
 import (
 	"fmt"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,9 +28,10 @@ import (
 
 var (
 	// This should be set in the Makefile based on the version of client-go being imported.
-	// These constants will be overwritten with LDFLAGS
-	k8sVersionMajor = 1
-	k8sVersionMinor = 20
+	// These constants will be overwritten with LDFLAGS. The version components must be
+	// strings in order for LDFLAGS to set them.
+	k8sVersionMajor = "1"
+	k8sVersionMinor = "20"
 )
 
 // deprecatedAPIError indicates than an API is deprecated in Kubernetes
@@ -60,7 +62,16 @@ func validateNoDeprecations(resource *K8sYamlStruct) error {
 		}
 		return err
 	}
-	if !deprecation.IsDeprecated(runtimeObject, k8sVersionMajor, k8sVersionMinor) {
+	maj, err := strconv.Atoi(k8sVersionMajor)
+	if err != nil {
+		return err
+	}
+	min, err := strconv.Atoi(k8sVersionMinor)
+	if err != nil {
+		return err
+	}
+
+	if !deprecation.IsDeprecated(runtimeObject, maj, min) {
 		return nil
 	}
 	gvk := fmt.Sprintf("%s %s", resource.APIVersion, resource.Kind)


### PR DESCRIPTION
This bug came about because of three issues that this change
corrects:
- The CI scripts run on a pull request did not test building
  Helm. This means that a failure to set a variable using LDFLAGS
  had no opportunity to be caught.
- #8608 provided a means to match the k8s version used in linting
  and chartutil with the version of the package we pull in. With
  one problem. It attempts to set a const as if it were a string.
  This is ignored and everyone missed it.
- #10325 moved those constants to vars so it could be set. This
  looked good and passed tests but missed that you can't set an
  int as if it were a string. See first bullet.

This change fixes this by moved the internal representation to
be a string. These are internal variables not exposed in the public
API which makes this change non-breaking to the API.

Closes #10367

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: It fixes Helm on main being unable to be built right now.

**Special notes for your reviewer**: N/A

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
