### PR TITLE
Not possible to pass values to second instance of sub sub chart with alias

### DIFF
--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -47,6 +47,23 @@ type Dependency struct {
 	ImportValues []interface{} `json:"import-values,omitempty"`
 	// Alias usable alias to be used for the chart
 	Alias string `json:"alias,omitempty"`
+
+	originalName string
+}
+
+// SetNameFromAlias sets originalName if empty, so can be called multiple times.
+// This assumes that the first time SetNameFromAlias is called, d.Name is the name as
+// specified in the dependency's Chart.yaml
+func (d *Dependency) SetNameFromAlias() {
+	if d.originalName == "" {
+		d.originalName = d.Name
+	}
+	d.Name = d.Alias
+}
+
+// EqualName returns true if the dependency's name or originalName is equal to the given name.
+func (d *Dependency) EqualName(name string) bool {
+	return d.Name == name || d.originalName == name
 }
 
 // Validate checks for common problems with the dependency datastructure in

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -95,7 +95,7 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 		if c == nil {
 			continue
 		}
-		if c.Name() != dep.Name {
+		if !dep.EqualName(c.Name()) {
 			continue
 		}
 		if !IsCompatibleRange(dep.Version, c.Metadata.Version) {
@@ -129,7 +129,7 @@ func processDependencyEnabled(c *chart.Chart, v map[string]interface{}, path str
 Loop:
 	for _, existing := range c.Dependencies() {
 		for _, req := range c.Metadata.Dependencies {
-			if existing.Name() == req.Name && IsCompatibleRange(req.Version, existing.Metadata.Version) {
+			if req.EqualName(existing.Name()) && IsCompatibleRange(req.Version, existing.Metadata.Version) {
 				continue Loop
 			}
 		}
@@ -141,7 +141,7 @@ Loop:
 			chartDependencies = append(chartDependencies, chartDependency)
 		}
 		if req.Alias != "" {
-			req.Name = req.Alias
+			req.SetNameFromAlias()
 		}
 	}
 	c.SetDependencies(chartDependencies...)

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -424,3 +424,48 @@ func TestDependentChartsWithSomeSubchartsSpecifiedInDependency(t *testing.T) {
 		t.Fatalf("expected 1 dependency specified in Chart.yaml, got %d", len(c.Metadata.Dependencies))
 	}
 }
+
+func TestAliasOfSubSubChartWithMultipleInstances(t *testing.T) {
+	c := loadChart(t, "testdata/subsubalias")
+
+	if len(c.Dependencies()) != 1 {
+		t.Fatalf("expected 1 dependencies for this chart, but got %d", len(c.Dependencies()))
+	}
+
+	if err := processDependencyEnabled(c, c.Values, ""); err != nil {
+		t.Fatalf("expected no errors but got %q", err)
+	}
+
+	req := c.Metadata.Dependencies
+
+	if len(req) == 0 {
+		t.Fatalf("there are no dependencies to test")
+	}
+
+	sub1 := c.Dependencies()[0]
+	sub1subReq := sub1.Metadata.Dependencies[0]
+	sub1subAlias := getAliasDependency(sub1.Dependencies(), sub1subReq)
+	if len(sub1.Dependencies()) != 1 {
+		t.Fatalf("expected 1 dependencies for this chart, but got %d", len(c.Dependencies()))
+	}
+	if sub1subAlias == nil {
+		t.Fatalf("expected sub1subAlias to not be nil")
+	}
+	if sub1subAlias.Name() != "sub-sub1" {
+		t.Fatalf("expected name to be sub-sub1")
+	}
+
+	sub2 := c.Dependencies()[1]
+	sub2subReq := sub2.Metadata.Dependencies[0]
+	sub2subAlias := getAliasDependency(sub2.Dependencies(), sub2subReq)
+	if len(sub2.Dependencies()) != 1 {
+		t.Fatalf("expected 1 dependencies for this chart, but got %d", len(c.Dependencies()))
+	}
+	if sub2subAlias == nil {
+		t.Fatalf("expected sub2subAlias to not be nil")
+	}
+	if sub2subAlias.Name() != "sub-sub1" {
+		t.Fatalf("expected name to be sub-sub1")
+	}
+
+}

--- a/pkg/chartutil/testdata/subsubalias/Chart.yaml
+++ b/pkg/chartutil/testdata/subsubalias/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: parent
+description: parent
+type: application
+version: 0.0.1
+dependencies:
+- name: sub-chart
+  version: 0.0.1
+  alias: sub1
+- name: sub-chart
+  version: 0.0.1
+  alias: sub2

--- a/pkg/chartutil/testdata/subsubalias/charts/sub-chart/Chart.yaml
+++ b/pkg/chartutil/testdata/subsubalias/charts/sub-chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: sub-chart
+description: sub-chart
+type: application
+version: 0.0.1
+dependencies:
+- name: sub-sub-chart
+  version: 0.0.1
+  alias: sub-sub1

--- a/pkg/chartutil/testdata/subsubalias/charts/sub-chart/charts/sub-sub-chart/Chart.yaml
+++ b/pkg/chartutil/testdata/subsubalias/charts/sub-chart/charts/sub-sub-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: sub-sub-chart
+description: sub-sub-chart
+type: application
+version: 0.0.1

--- a/pkg/chartutil/testdata/subsubalias/charts/sub-chart/charts/sub-sub-chart/templates/test.yaml
+++ b/pkg/chartutil/testdata/subsubalias/charts/sub-chart/charts/sub-sub-chart/templates/test.yaml
@@ -1,0 +1,1 @@
+name: {{ required "name is required" .Values.name }}

--- a/pkg/chartutil/testdata/subsubalias/values.yaml
+++ b/pkg/chartutil/testdata/subsubalias/values.yaml
@@ -1,0 +1,6 @@
+sub1:
+  sub-sub1:
+    name: foo
+sub2:
+  sub-sub1:
+    name: baz


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Resolves https://github.com/helm/helm/issues/10407

**What this PR does / why we need it**:
I came across this bug when trying to create multiple instances of a chart that in turn had multiple instances of a sub chart and was using aliases. Don't think this is a very common use case, but I thought it would be good/educational to try and fix it.

From my limited understanding of the code base, it seems the bug comes from the fact that a requirement with an alias has its name overwritten to the alias value at some point. And if that requirement is used again it cannot be matched against an existing chart by name.

This was reproducible with a test case and a minimal chart example.

I did also fix the bug by introducing a new field called `orignalName` and a method `equalName` on `Dependency` that should be used to match requirements and charts.

Since I am not super well versed in the code base I don't know if the proposed solution is good enough and if there are any issues with backwards compat and so on. So happy change/drop it according to any feedback given.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
