### PR TITLE
fix(pkg/kube): statefulSetReady: handle partition cases correctly

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -377,7 +377,7 @@ func (c *ReadyChecker) statefulSetReady(sts *appsv1.StatefulSet) bool {
 	expectedReplicas := replicas - partition
 
 	// Make sure all the updated pods have been scheduled
-	if int(sts.Status.UpdatedReplicas) != expectedReplicas {
+	if int(sts.Status.UpdatedReplicas) < expectedReplicas {
 		c.log("StatefulSet is not ready: %s/%s. %d out of %d expected pods have been scheduled", sts.Namespace, sts.Name, sts.Status.UpdatedReplicas, expectedReplicas)
 		return false
 	}

--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -157,9 +157,23 @@ func Test_ReadyChecker_statefulSetReady(t *testing.T) {
 		{
 			name: "statefulset is not ready when partition is set",
 			args: args{
-				sts: newStatefulSet("foo", 1, 1, 1, 1),
+				sts: newStatefulSet("foo", 2, 1, 1, 0),
 			},
 			want: false,
+		},
+		{
+			name: "statefulset is ready when partition is set and no change in template",
+			args: args{
+				sts: newStatefulSet("foo", 2, 1, 2, 2),
+			},
+			want: true,
+		},
+		{
+			name: "statefulset is ready when partition is greater than replicas",
+			args: args{
+				sts: newStatefulSet("foo", 1, 2, 1, 1),
+			},
+			want: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
The partition value can be greater than number of replicas, in that case no pods are rolled out. The expectedReplicas becomes a negative number. https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions

In the cases where the update does not change anything in the pod template, the updatedReplicas value from StatefulSet status remains unchanged. Such updates can still set some partition value, and UpdatedReplicas is always greater than expectedReplicas. Basically, the StatefulSet is ready / rolled-out.

In both the above scenarios, providing `--wait` flag causes it to timeout waiting indefinitely. Because updatedReplicas can never be negative, or be equal to the expectedReplicas for the second case.

This commit handles both the above scenarios by checking if UpdatedReplicas is smaller than expectedReplicas. If it is, then the StatefulSet is not ready yet.

**Special notes for your reviewer**:
I have done the following manual testing for this change, in all the cases the update succeeds as expected, and the wait flag waits till the pods are rolled-out.

1. Download and install a chart where partitioning + StatefulSets are used.  
   Partition: 0, Replicas: 3

   <details>
   <summary>Commands</summary>
   <pre>
   curl -O https://charts.yugabyte.com/yugabyte-2.11.0.tgz
   ~/src/helm/bin/helm install yb ./yugabyte-2.11.0.tgz \
     --namespace helm-test --create-namespace \
     --set resource.master.requests.cpu=0.25 \
     --set resource.master.requests.memory=0.35Gi \
     --set resource.tserver.requests.cpu=0.25 \
     --set resource.tserver.requests.memory=0.35Gi \
     --set storage.ephemeral=true \
     --wait
   </pre>
   </details>

2. Do a partitioned update where there is a change in the template.  
   expectedReplicas: 2, updatedReplicas: 2, partition: 1

   <details>
   <summary>Commands</summary>
   <pre>
   ~/src/helm/bin/helm upgrade yb ./yugabyte-2.11.0.tgz \
     --namespace helm-test --create-namespace \
     --set resource.master.requests.cpu=0.25 \
     --set resource.master.requests.memory=0.35Gi \
     --set resource.tserver.requests.cpu=0.25 \
     --set resource.tserver.requests.memory=0.35Gi \
     --set storage.ephemeral=true \
     --set gflags.master.default_memory_limit_to_ram_ratio=0.87 \
     --set partition.master=1 \
     --wait
   </pre>
   </details>

3. Complete the partitioned update. (All three replicas are updated)  
   expectedReplicas: 1, updatedReplicas: 1, partition: 0

   <details>
   <summary>Commands</summary>
   <pre>
   ~/src/helm/bin/helm upgrade yb ./yugabyte-2.11.0.tgz \
     --namespace helm-test --create-namespace \
     --set resource.master.requests.cpu=0.25 \
     --set resource.master.requests.memory=0.35Gi \
     --set resource.tserver.requests.cpu=0.25 \
     --set resource.tserver.requests.memory=0.35Gi \
     --set storage.ephemeral=true \
     --set gflags.master.default_memory_limit_to_ram_ratio=0.87 \
     --set partition.master=0 \
     --wait
   </pre>
   </details>

4. Do a no-op update with partition value.  
   expectedReplicas: 2, updatedReplicas: 3 (because nothing has changed), partition: 1

   <details>
   <summary>Commands</summary>
   <pre>
   ~/src/helm/bin/helm upgrade yb ./yugabyte-2.11.0.tgz \
     --namespace helm-test --create-namespace \
     --set resource.master.requests.cpu=0.25 \
     --set resource.master.requests.memory=0.35Gi \
     --set resource.tserver.requests.cpu=0.25 \
     --set resource.tserver.requests.memory=0.35Gi \
     --set storage.ephemeral=true \
     --set gflags.master.default_memory_limit_to_ram_ratio=0.87 \
     --set partition.master=1 \
     --wait
   </pre>
   </details>

5. Change in the pod template with partition value greater than replicas.  
   expectedReplicas: -2, updatedReplicas: 3 (no pods will change), partition: 5

   <details>
   <summary>Commands</summary>
   <pre>
   ~/src/helm/bin/helm upgrade yb ./yugabyte-2.11.0.tgz \
     --namespace helm-test --create-namespace \
     --set resource.master.requests.cpu=0.25 \
     --set resource.master.requests.memory=0.35Gi \
     --set resource.tserver.requests.cpu=0.25 \
     --set resource.tserver.requests.memory=0.35Gi \
     --set storage.ephemeral=true \
     --set gflags.master.default_memory_limit_to_ram_ratio=0.85 \
     --set partition.master=5 \
     --wait
   </pre>
   </details>

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Based on the code from kubectl rollout:
https://github.com/kubernetes/kubectl/blob/a450ebd59c1e8917df23d37c6f05d8e16c3746aa/pkg/polymorphichelpers/rollout_status.go#L138-L141

Closes #8674