### PR TITLE
Add support for installing on Windows via Cygwin

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -51,7 +51,7 @@ initOS() {
 
   case "$OS" in
     # Minimalist GNU for Windows
-    mingw*) OS='windows';;
+    mingw*|cygwin*) OS='windows';;
   esac
 }
 


### PR DESCRIPTION
Add support for installing helm precompiled binary on Windows via Cygwin

Signed-off-by: Ioan Indreias <indreias@gmail.com>