### PR TITLE
Expose NewRootCmd

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -43,10 +43,6 @@ const FeatureGateOCI = gates.Gate("HELM_EXPERIMENTAL_OCI")
 
 var settings = cli.New()
 
-func init() {
-	log.SetFlags(log.Lshortfile)
-}
-
 func debug(format string, v ...interface{}) {
 	if settings.Debug {
 		format = fmt.Sprintf("[debug] %s\n", format)
@@ -60,6 +56,8 @@ func warning(format string, v ...interface{}) {
 }
 
 func main() {
+	log.SetFlags(log.Lshortfile)
+
 	// Setting the name of the app for managedFields in the Kubernetes client.
 	// It is set here to the full name of "helm" so that renaming of helm to
 	// another name (e.g., helm2 or helm3) does not change the name of the
@@ -67,7 +65,7 @@ func main() {
 	kube.ManagedFieldsManager = "helm"
 
 	actionConfig := new(action.Configuration)
-	cmd, err := newRootCmd(actionConfig, os.Stdout, os.Args[1:])
+	cmd, err := NewRootCmd(actionConfig, os.Stdout, os.Args[1:])
 	if err != nil {
 		warning("%+v", err)
 		os.Exit(1)

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -115,7 +115,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		Log:          func(format string, v ...interface{}) {},
 	}
 
-	root, err := newRootCmd(actionConfig, buf, args)
+	root, err := NewRootCmd(actionConfig, buf, args)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -83,7 +83,7 @@ By default, the default directories depend on the Operating System. The defaults
 | Windows          | %TEMP%\helm               | %APPDATA%\helm                 | %APPDATA%\helm          |
 `
 
-func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) (*cobra.Command, error) {
+func NewRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:          "helm",
 		Short:        "The Helm package manager for Kubernetes.",


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes the `newRootCmd` in `cmd/helm` as `NewRootCmd` so that it can be imported as a subcommand into other tools (mostly this would probably be kubernetes distributions that embed a bunch of tools). The functionality that was in `func init()` has been moved to `func main()` to avoid side-effects when importing the `github.com/helm/helm/cmd/helm`. 

There's still a lot happening in `main()` that need to be duplicated by the importer, but changing that will require a more significant refactoring of the command initialization.
