### PR TITLE
Bringing over an edit from the helm-www repo

### DIFF
--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -53,7 +53,7 @@ of the README file
 
 const showCRDsDesc = `
 This command inspects a chart (directory, file, or URL) and displays the contents
-of the CustomResourceDefintion files
+of the CustomResourceDefinition files
 `
 
 func newShowCmd(out io.Writer) *cobra.Command {


### PR DESCRIPTION
This typo was fixed by @hs0210 in https://github.com/helm/helm-www/pull/1229 (thank you!) but we incorrectly merged it into the generated output in the www repo. Adding the change to the correct location so it's not overwritten.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
