### PR TITLE
Fix memory leak in upgrade action

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -325,15 +325,13 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 	doneChan := make(chan interface{})
 	go u.releasingUpgrade(rChan, upgradedRelease, current, target, originalRelease)
 	go u.handleContext(ctx, doneChan, ctxChan, upgradedRelease)
-	var result resultMessage
 	select {
-	case result = <-rChan:
+	case result := <-rChan:
 		doneChan <- true
-	case result = <-ctxChan:
-		close(rChan)
+		return result.r, result.e
+	case result := <-ctxChan:
+		return result.r, result.e
 	}
-
-	return result.r, result.e
 }
 
 // Function used to lock the Mutex, this is important for the case when the atomic flag is set.

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -321,9 +321,17 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		return nil, err
 	}
 	rChan := make(chan resultMessage)
+	ctxChan := make(chan resultMessage)
+	doneChan := make(chan interface{})
 	go u.releasingUpgrade(rChan, upgradedRelease, current, target, originalRelease)
-	go u.handleContext(ctx, rChan, upgradedRelease)
-	result := <-rChan
+	go u.handleContext(ctx, doneChan, ctxChan, upgradedRelease)
+	var result resultMessage
+	select {
+	case result = <-rChan:
+		doneChan <- true
+	case result = <-ctxChan:
+		close(rChan)
+	}
 
 	return result.r, result.e
 }
@@ -341,13 +349,17 @@ func (u *Upgrade) reportToPerformUpgrade(c chan<- resultMessage, rel *release.Re
 }
 
 // Setup listener for SIGINT and SIGTERM
-func (u *Upgrade) handleContext(ctx context.Context, c chan<- resultMessage, upgradedRelease *release.Release) {
-
+func (u *Upgrade) handleContext(ctx context.Context, done chan interface{}, c chan<- resultMessage, upgradedRelease *release.Release) {
 	go func() {
-		<-ctx.Done()
-		err := ctx.Err()
-		// when the atomic flag is set the ongoing release finish first and doesn't give time for the rollback happens.
-		u.reportToPerformUpgrade(c, upgradedRelease, kube.ResourceList{}, err)
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+
+			// when the atomic flag is set the ongoing release finish first and doesn't give time for the rollback happens.
+			u.reportToPerformUpgrade(c, upgradedRelease, kube.ResourceList{}, err)
+		case <-done:
+			return
+		}
 	}()
 }
 func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *release.Release, current kube.ResourceList, target kube.ResourceList, originalRelease *release.Release) {


### PR DESCRIPTION
This PR fixes the memory leak in the upgrade action when helm is used as library.

fixes helm/helm#10439
