### PR TITLE
Print pods status when --debug flag is enabled

### DIFF
--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -69,7 +69,7 @@ func Test_ReadyChecker_deploymentReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
-			if got := c.deploymentReady(tt.args.rs, tt.args.dep); got != tt.want {
+			if got := c.deploymentReady(context.TODO(), tt.args.rs, tt.args.dep); got != tt.want {
 				t.Errorf("deploymentReady() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Insted of only printing what pods are not ready, let's include a bit more detailed
information on why that is. This makes it much easier to debug errors when running
helm upgrade or install with debug enabled

It will now produce the following output:
```
wait.go:48: [debug] beginning wait for 5 resources with timeout of 5m0s
ready.go:283: [debug] Deployment is not ready: default/smo-test-1. 0 out of 1 expected pods are ready
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-9p54c PodInitializing
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-sbzvm PodInitializing
ready.go:283: [debug] Deployment is not ready: default/smo-test-1. 0 out of 1 expected pods are ready
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-9p54c PodInitializing
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-sbzvm PodInitializing
ready.go:283: [debug] Deployment is not ready: default/smo-test-1. 0 out of 1 expected pods are ready
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-9p54c Running
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-sbzvm Running
ready.go:283: [debug] Deployment is not ready: default/smo-test-1. 0 out of 1 expected pods are ready
ready.go:226: [debug] Pod is not ready: default/smo-test-1-7b5fc4cbf6-9p54c CrashLoopBackOff (waiting: back-off 10s restarting failed container=smo-test-1 pod=smo-test-1-7b5fc4cbf6-9p54c_default(398f03f0-1a1e-4fa2-b435-6df6d869a2e8))
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This improves the debugging experience in CI pipelines, by indicating what actually could be wrong.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
