### PR TITLE
Remove runTestActionCmd and use runTestCmd instead

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -71,27 +71,6 @@ func runTestCmd(t *testing.T, tests []cmdTestCase) {
 	}
 }
 
-func runTestActionCmd(t *testing.T, tests []cmdTestCase) {
-	t.Helper()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer resetEnv()()
-
-			store := storageFixture()
-			for _, rel := range tt.rels {
-				store.Create(rel)
-			}
-			_, out, err := executeActionCommandC(store, tt.cmd)
-			if (err != nil) != tt.wantError {
-				t.Errorf("expected error, got '%v'", err)
-			}
-			if tt.golden != "" {
-				test.AssertGoldenString(t, out, tt.golden)
-			}
-		})
-	}
-}
-
 func storageFixture() *storage.Storage {
 	return storage.Init(driver.NewMemory())
 }

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -254,7 +254,7 @@ func TestInstall(t *testing.T) {
 		},
 	}
 
-	runTestActionCmd(t, tests)
+	runTestCmd(t, tests)
 }
 
 func TestInstallOutputCompletion(t *testing.T) {


### PR DESCRIPTION
`runTestCmd` is identical to `runTestActionCmd` except that it

  * runs the command multiple times if the `repeat` property is greater
    than zero,
  * calls its storage `storage` instead of `store`,
  * fails if the `Create` method returns an error, and
  * logs a "running cmd" message.

This is most easily demonstrated by copying the functions to their own
files and diffing the files with this command:

    git diff --no-index --ignore-space-change --color-words=. runTestActionCmd.go runTestCmd.go

Also, `runTestCmd` is used 32 times; `runTestActionCmd` only 1.

Signed-off-by: Simon Alling <alling.simon@gmail.com>