### PR TITLE
Honor --dependency-update flag in upgrade command

### DIFF
--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -120,6 +120,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 					instClient.SubNotes = client.SubNotes
 					instClient.Description = client.Description
+					instClient.DependencyUpdate = client.DependencyUpdate
 
 					rel, err := runInstall(args, instClient, valueOpts, out)
 					if err != nil {


### PR DESCRIPTION
When installing a new chart via the `upgrade` subcommand, the `--dependency-update` flag is ignored. The changes introduced here resolves this deficiency