### PR TITLE
feat(lint): Allow customization of APIVersions when using helm lint

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -120,6 +120,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&client.Strict, "strict", false, "fail on lint warnings")
 	f.BoolVar(&client.WithSubcharts, "with-subcharts", false, "lint dependent charts")
+	f.StringArrayVarP(&client.APIVersions, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
 	addValueOptionsFlags(f, valueOpts)
 
 	return cmd

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -33,6 +33,11 @@ func TestLintCmdWithSubchartsFlag(t *testing.T) {
 		cmd:       fmt.Sprintf("lint --with-subcharts %s", testChart),
 		golden:    "output/lint-chart-with-bad-subcharts-with-subcharts.txt",
 		wantError: true,
+	}, {
+		name:      "lint good chart using --api-versions flag",
+		cmd:       "lint --api-versions networking.k8s.io/v1 testdata/testcharts/chart-with-api-versions",
+		golden:    "output/lint-chart-with-api-versions.txt",
+		wantError: false,
 	}}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/lint-chart-with-api-versions.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-api-versions.txt
@@ -1,0 +1,5 @@
+==> Linting testdata/testcharts/chart-with-api-versions
+[INFO] Chart.yaml: icon is recommended
+[INFO] values.yaml: file does not exist
+
+1 chart(s) linted, 0 chart(s) failed

--- a/cmd/helm/testdata/testcharts/chart-with-api-versions/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/chart-with-api-versions/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://k8s.io/helm
+name: empty
+sources:
+- https://github.com/kubernetes/helm
+version: 0.1.0

--- a/cmd/helm/testdata/testcharts/chart-with-api-versions/templates/check-capabilities.tpl
+++ b/cmd/helm/testdata/testcharts/chart-with-api-versions/templates/check-capabilities.tpl
@@ -1,0 +1,3 @@
+{{- if not (.Capabilities.APIVersions.Has "networking.k8s.io/v1") }}
+  {{ fail "ERROR: APIVersion networking.k8s.io/v1 not found" }}
+{{- end -}}

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -36,6 +36,7 @@ type Lint struct {
 	Strict        bool
 	Namespace     string
 	WithSubcharts bool
+	APIVersions   []string
 }
 
 // LintResult is the result of Lint
@@ -58,7 +59,7 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	}
 	result := &LintResult{}
 	for _, path := range paths {
-		linter, err := lintChart(path, vals, l.Namespace, l.Strict)
+		linter, err := lintChart(path, vals, l.Namespace, l.Strict, l.APIVersions)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue
@@ -75,7 +76,7 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	return result
 }
 
-func lintChart(path string, vals map[string]interface{}, namespace string, strict bool) (support.Linter, error) {
+func lintChart(path string, vals map[string]interface{}, namespace string, strict bool, apiVersions []string) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
 
@@ -114,5 +115,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, stric
 		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
-	return lint.All(chartPath, vals, namespace, strict), nil
+	return lint.All(chartPath, vals, namespace, strict, apiVersions), nil
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -78,7 +78,7 @@ func TestLintChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, strict)
+			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, strict, nil)
 			switch {
 			case err != nil && !tt.err:
 				t.Errorf("%s", err)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -24,14 +24,14 @@ import (
 )
 
 // All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, strict bool) support.Linter {
+func All(basedir string, values map[string]interface{}, namespace string, strict bool, apiVersions []string) support.Linter {
 	// Using abs path to get directory context
 	chartDir, _ := filepath.Abs(basedir)
 
 	linter := support.Linter{ChartDir: chartDir}
 	rules.Chartfile(&linter)
 	rules.ValuesWithOverrides(&linter, values)
-	rules.Templates(&linter, values, namespace, strict)
+	rules.Templates(&linter, values, namespace, strict, apiVersions)
 	rules.Dependencies(&linter)
 	return linter
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -87,7 +87,7 @@ func TestBadChart(t *testing.T) {
 }
 
 func TestInvalidYaml(t *testing.T) {
-	m := All(badYamlFileDir, values, namespace, strict).Messages
+	m := All(badYamlFileDir, values, namespace, strict, nil).Messages
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -97,7 +97,7 @@ func TestInvalidYaml(t *testing.T) {
 }
 
 func TestBadValues(t *testing.T) {
-	m := All(badValuesFileDir, values, namespace, strict).Messages
+	m := All(badValuesFileDir, values, namespace, strict, nil).Messages
 	if len(m) < 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -107,7 +107,7 @@ func TestBadValues(t *testing.T) {
 }
 
 func TestGoodChart(t *testing.T) {
-	m := All(goodChartDir, values, namespace, strict).Messages
+	m := All(goodChartDir, values, namespace, strict, nil).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {
@@ -135,7 +135,7 @@ func TestHelmCreateChart(t *testing.T) {
 
 	// Note: we test with strict=true here, even though others have
 	// strict = false.
-	m := All(createdChart, values, namespace, true).Messages
+	m := All(createdChart, values, namespace, true, nil).Messages
 	if ll := len(m); ll != 1 {
 		t.Errorf("All should have had exactly 1 error. Got %d", ll)
 		for i, msg := range m {
@@ -149,7 +149,7 @@ func TestHelmCreateChart(t *testing.T) {
 // lint ignores import-values
 // See https://github.com/helm/helm/issues/9658
 func TestSubChartValuesChart(t *testing.T) {
-	m := All(subChartValuesDir, values, namespace, strict).Messages
+	m := All(subChartValuesDir, values, namespace, strict, nil).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -38,7 +38,7 @@ const goodChartDir = "rules/testdata/goodone"
 const subChartValuesDir = "rules/testdata/withsubchart"
 
 func TestBadChart(t *testing.T) {
-	m := All(badChartDir, values, namespace, strict).Messages
+	m := All(badChartDir, values, namespace, strict, nil).Messages
 	if len(m) != 8 {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -45,7 +45,7 @@ var (
 )
 
 // Templates lints the templates in the Linter.
-func Templates(linter *support.Linter, values map[string]interface{}, namespace string, strict bool) {
+func Templates(linter *support.Linter, values map[string]interface{}, namespace string, strict bool, apiVersions []string) {
 	fpath := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
@@ -80,7 +80,10 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	if err != nil {
 		return
 	}
-	valuesToRender, err := chartutil.ToRenderValues(chart, cvals, options, nil)
+
+	caps := chartutil.DefaultCapabilities
+	caps.APIVersions = chartutil.VersionSet(apiVersions)
+	valuesToRender, err := chartutil.ToRenderValues(chart, cvals, options, caps)
 	if err != nil {
 		linter.RunLinterRule(support.ErrorSev, fpath, err)
 		return

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -55,7 +55,7 @@ const strict = false
 
 func TestTemplateParsing(t *testing.T) {
 	linter := support.Linter{ChartDir: templateTestBasedir}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	res := linter.Messages
 
 	if len(res) != 1 {
@@ -78,7 +78,7 @@ func TestTemplateIntegrationHappyPath(t *testing.T) {
 	defer os.Rename(ignoredTemplatePath, wrongTemplatePath)
 
 	linter := support.Linter{ChartDir: templateTestBasedir}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	res := linter.Messages
 
 	if len(res) != 0 {
@@ -88,7 +88,7 @@ func TestTemplateIntegrationHappyPath(t *testing.T) {
 
 func TestV3Fail(t *testing.T) {
 	linter := support.Linter{ChartDir: "./testdata/v3-fail"}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	res := linter.Messages
 
 	if len(res) != 3 {
@@ -108,7 +108,7 @@ func TestV3Fail(t *testing.T) {
 
 func TestMultiTemplateFail(t *testing.T) {
 	linter := support.Linter{ChartDir: "./testdata/multi-template-fail"}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	res := linter.Messages
 
 	if len(res) != 1 {
@@ -229,7 +229,7 @@ func TestDeprecatedAPIFails(t *testing.T) {
 	}
 
 	linter := support.Linter{ChartDir: filepath.Join(tmpdir, mychart.Name())}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	if l := len(linter.Messages); l != 1 {
 		for i, msg := range linter.Messages {
 			t.Logf("Message %d: %s", i, msg)
@@ -286,7 +286,7 @@ func TestStrictTemplateParsingMapError(t *testing.T) {
 	linter := &support.Linter{
 		ChartDir: filepath.Join(dir, ch.Metadata.Name),
 	}
-	Templates(linter, ch.Values, namespace, strict)
+	Templates(linter, ch.Values, namespace, strict, nil)
 	if len(linter.Messages) != 0 {
 		t.Errorf("expected zero messages, got %d", len(linter.Messages))
 		for i, msg := range linter.Messages {
@@ -416,7 +416,7 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 	}
 
 	linter := support.Linter{ChartDir: filepath.Join(tmpdir, mychart.Name())}
-	Templates(&linter, values, namespace, strict)
+	Templates(&linter, values, namespace, strict, nil)
 	if l := len(linter.Messages); l > 0 {
 		for i, msg := range linter.Messages {
 			t.Logf("Message %d: %s", i, msg)


### PR DESCRIPTION
Usage: `helm lint --api-versions []string`

closes #10190

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Adds `--api-versions` support for `helm lint`

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
