### PR TITLE
Moving prydonius to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ maintainers:
   - jdolitsky
   - marckhouzam
   - mattfarina
-  - prydonius
   - scottrigby
   - SlickNik
   - technosophos
@@ -18,6 +17,7 @@ emeritus:
   - michelleN
   - migmartri
   - nebril
+  - prydonius
   - rimusz
   - seh
   - thomastaylor312


### PR DESCRIPTION
Thanks, @prydonius! Moving you to emeritus per @technosophos.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
