### PR TITLE
fea(#10511): add --post-renderer-args to support assign args to PostR…

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -117,7 +117,7 @@ func (o *outputValue) Set(s string) error {
 func bindPostRenderFlag(cmd *cobra.Command, varRef *postrender.PostRenderer) {
 	p := &postRendererOptions{varRef, "", []string{}}
 	cmd.Flags().Var(&postRendererString{p}, postRenderFlag, "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
-	cmd.Flags().Var(&postRendererArgsSlice{p}, postRenderArgsFlag, "the args to an executable to be used for post rendering.  (can specify multiple)")
+	cmd.Flags().Var(&postRendererArgsSlice{p}, postRenderArgsFlag, "an argument to the post-renderer (can specify multiple)")
 }
 
 type postRendererOptions struct {
@@ -164,10 +164,15 @@ func (p *postRendererArgsSlice) Type() string {
 }
 
 func (p *postRendererArgsSlice) Set(val string) error {
-	if val == "" || p.options.binaryPath == "" {
+	if val == "" {
 		return nil
 	}
+
 	p.options.args = append(p.options.args, val)
+
+	if p.options.binaryPath == "" {
+		return nil
+	}
 	// overwrite if already create PostRenderer by `post-renderer` flags
 	pr, err := postrender.NewExec(p.options.binaryPath, p.options.args...)
 	if err != nil {

--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -164,10 +164,8 @@ func (p *postRendererArgsSlice) Type() string {
 }
 
 func (p *postRendererArgsSlice) Set(val string) error {
-	if val == "" {
-		return nil
-	}
 
+	// a post-renderer defined by a user may accept empty arguments
 	p.options.args = append(p.options.args, val)
 
 	if p.options.binaryPath == "" {

--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -143,7 +143,7 @@ func (p postRendererExecFlag) Set(s string) error {
 		return nil
 	}
 	p.options.binaryPath = s
-	pr, err := postrender.NewExec(p.options.binaryPath, p.options.args)
+	pr, err := postrender.NewExecWithArgs(p.options.binaryPath, p.options.args)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (p postRendererArgsFlag) Set(s string) error {
 		return nil
 	}
 	// update if already create PostRenderer
-	pr, err := postrender.NewExec(p.options.binaryPath, p.options.args)
+	pr, err := postrender.NewExecWithArgs(p.options.binaryPath, p.options.args)
 	if err != nil {
 		return err
 	}

--- a/pkg/postrender/exec.go
+++ b/pkg/postrender/exec.go
@@ -34,7 +34,15 @@ type execRender struct {
 // It returns an error if the binary cannot be found. If the path does not
 // contain any separators, it will search in $PATH, otherwise it will resolve
 // any relative paths to a fully qualified path
-func NewExec(binaryPath string, args []string) (PostRenderer, error) {
+func NewExec(binaryPath string) (PostRenderer, error) {
+	fullPath, err := getFullPath(binaryPath)
+	if err != nil {
+		return nil, err
+	}
+	return &execRender{fullPath, []string{}}, nil
+}
+
+func NewExecWithArgs(binaryPath string, args []string) (PostRenderer, error) {
 	fullPath, err := getFullPath(binaryPath)
 	if err != nil {
 		return nil, err

--- a/pkg/postrender/exec.go
+++ b/pkg/postrender/exec.go
@@ -34,15 +34,7 @@ type execRender struct {
 // It returns an error if the binary cannot be found. If the path does not
 // contain any separators, it will search in $PATH, otherwise it will resolve
 // any relative paths to a fully qualified path
-func NewExec(binaryPath string) (PostRenderer, error) {
-	fullPath, err := getFullPath(binaryPath)
-	if err != nil {
-		return nil, err
-	}
-	return &execRender{fullPath, []string{}}, nil
-}
-
-func NewExecWithArgs(binaryPath string, args []string) (PostRenderer, error) {
+func NewExec(binaryPath string, args ...string) (PostRenderer, error) {
 	fullPath, err := getFullPath(binaryPath)
 	if err != nil {
 		return nil, err

--- a/pkg/postrender/exec.go
+++ b/pkg/postrender/exec.go
@@ -27,23 +27,24 @@ import (
 
 type execRender struct {
 	binaryPath string
+	args       []string
 }
 
 // NewExec returns a PostRenderer implementation that calls the provided binary.
 // It returns an error if the binary cannot be found. If the path does not
 // contain any separators, it will search in $PATH, otherwise it will resolve
 // any relative paths to a fully qualified path
-func NewExec(binaryPath string) (PostRenderer, error) {
+func NewExec(binaryPath string, args []string) (PostRenderer, error) {
 	fullPath, err := getFullPath(binaryPath)
 	if err != nil {
 		return nil, err
 	}
-	return &execRender{fullPath}, nil
+	return &execRender{fullPath, args}, nil
 }
 
 // Run the configured binary for the post render
 func (p *execRender) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
-	cmd := exec.Command(p.binaryPath)
+	cmd := exec.Command(p.binaryPath, p.args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/pkg/postrender/exec_test.go
+++ b/pkg/postrender/exec_test.go
@@ -116,7 +116,24 @@ func TestExecRun(t *testing.T) {
 	testpath, cleanup := setupTestingScript(t)
 	defer cleanup()
 
-	renderer, err := NewExec(testpath, []string{})
+	renderer, err := NewExec(testpath)
+	require.NoError(t, err)
+
+	output, err := renderer.Run(bytes.NewBufferString("FOOTEST"))
+	is.NoError(err)
+	is.Contains(output.String(), "BARTEST")
+}
+
+func TestNewExecWithArgsRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// the actual Run test uses a basic sed example, so skip this test on windows
+		t.Skip("skipping on windows")
+	}
+	is := assert.New(t)
+	testpath, cleanup := setupTestingScript(t)
+	defer cleanup()
+
+	renderer, err := NewExecWithArgs(testpath, []string{})
 	require.NoError(t, err)
 
 	output, err := renderer.Run(bytes.NewBufferString("FOOTEST"))

--- a/pkg/postrender/exec_test.go
+++ b/pkg/postrender/exec_test.go
@@ -116,7 +116,7 @@ func TestExecRun(t *testing.T) {
 	testpath, cleanup := setupTestingScript(t)
 	defer cleanup()
 
-	renderer, err := NewExec(testpath)
+	renderer, err := NewExec(testpath, []string{})
 	require.NoError(t, err)
 
 	output, err := renderer.Run(bytes.NewBufferString("FOOTEST"))

--- a/pkg/postrender/exec_test.go
+++ b/pkg/postrender/exec_test.go
@@ -34,7 +34,7 @@ const testingScript = `#!/bin/sh
 if [ $# -eq 0 ]; then
 sed s/FOOTEST/BARTEST/g <&0
 else
-sed s/FOOTEST/BARTEST$#/g <&0
+sed s/FOOTEST/"$*"/g <&0
 fi
 `
 
@@ -137,12 +137,12 @@ func TestNewExecWithOneArgsRun(t *testing.T) {
 	testpath, cleanup := setupTestingScript(t)
 	defer cleanup()
 
-	renderer, err := NewExec(testpath, "FOOTEST")
+	renderer, err := NewExec(testpath, "ARG1")
 	require.NoError(t, err)
 
 	output, err := renderer.Run(bytes.NewBufferString("FOOTEST"))
 	is.NoError(err)
-	is.Contains(output.String(), "BARTEST1")
+	is.Contains(output.String(), "ARG1")
 }
 
 func TestNewExecWithTwoArgsRun(t *testing.T) {
@@ -154,12 +154,12 @@ func TestNewExecWithTwoArgsRun(t *testing.T) {
 	testpath, cleanup := setupTestingScript(t)
 	defer cleanup()
 
-	renderer, err := NewExec(testpath, "FOOTEST", "FOOTEST")
+	renderer, err := NewExec(testpath, "ARG1", "ARG2")
 	require.NoError(t, err)
 
 	output, err := renderer.Run(bytes.NewBufferString("FOOTEST"))
 	is.NoError(err)
-	is.Contains(output.String(), "BARTEST2")
+	is.Contains(output.String(), "ARG1 ARG2")
 }
 
 func setupTestingScript(t *testing.T) (filepath string, cleanup func()) {


### PR DESCRIPTION
…enderer exec


closes #10511 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Now helm  `--post-renderer` only accept  the `executable` in `PATH`;  

but it is very  necessary that  the `post-renderer-executable`   worked with some args ,for example change the docker.io registry into private docker registry when deploy the chart without internet access.

can helm can add `args` to assign the args in to  `post-renderer-executable` such as ` --post-renderer-args` 
```
helm install mychart stable/wordpress --post-renderer ./path/to/render_executable --post-renderer-args "--args_1_to_render_executable" --post-renderer-args "--args_2_to_render_executable"
````

**Special notes for your reviewer**:
this implement to make the less change of the helm code.  it is  more compatibility than  #9047.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
