### PR TITLE
Add support for importing single values from dependencies

### DIFF
--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -206,6 +206,11 @@ func TestProcessDependencyImportValues(t *testing.T) {
 	e["overridden-chartA-B.SCBextra1"] = "13"
 	e["overridden-chartA-B.SC1extra6"] = "77"
 
+	e["imported-chart1-SC1bool"] = "true"
+	e["imported-chart1-SC1float"] = "3.14"
+	e["imported-chart1-SC1int"] = "100"
+	e["imported-chart1-SC1string"] = "dollywood"
+
 	// `exports` style
 	e["SCBexported1B"] = "1965"
 	e["SC1extra7"] = "true"

--- a/pkg/chartutil/testdata/subpop/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/Chart.yaml
@@ -25,6 +25,14 @@ dependencies:
         parent: .
       - SCBexported2
       - SC1exported1
+      - child: SC1data.SC1bool
+        parent: imported-chart1-SC1bool
+      - child: SC1data.SC1float
+        parent: imported-chart1-SC1float
+      - child: SC1data.SC1int
+        parent: imported-chart1-SC1int
+      - child: SC1data.SC1string
+        parent: imported-chart1-SC1string
 
   - name: subchart2
     repository: http://localhost:10191

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -187,8 +187,7 @@ func (v Values) PathValue(path string) (interface{}, error) {
 
 func (v Values) pathValue(path []string) (interface{}, error) {
 	if len(path) == 1 {
-		// if exists must be root key not table
-		if _, ok := v[path[0]]; ok && !istable(v[path[0]]) {
+		if _, ok := v[path[0]]; ok {
 			return v[path[0]], nil
 		}
 		return nil, ErrNoValue{path[0]}
@@ -200,8 +199,8 @@ func (v Values) pathValue(path []string) (interface{}, error) {
 	if err != nil {
 		return nil, ErrNoValue{key}
 	}
-	// check table for key and ensure value is not a table
-	if k, ok := t[key]; ok && !istable(k) {
+	// check table for key
+	if k, ok := t[key]; ok {
 		return k, nil
 	}
 	return nil, ErrNoValue{key}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for importing single values ​​from dependencies. This keeps the value file clean, especially when using subcharts with different clean code practices. It closes #2746

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
