### PR TITLE
Helm test logs filter fix

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -93,6 +94,8 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 	if len(executingHooks) == 0 {
 		executingHooks = rel.Hooks
 	}
+
+	sort.Stable(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
 		for _, e := range h.Events {


### PR DESCRIPTION
**What this PR does / why we need it**:
Issue #10018 describes how the `--filter` and `--logs` flags don't work together when performing `helm test`. This is because the function that gets the logs doesn't take the filtering into account. 

This PR takes both filtering and hook weights into account when retrieving logs. Hope this helps.

closes #10018

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
