### PR TITLE
fix(helm): ignore file-not-found error for `helm repo list -o json`

### DIFF
--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -38,8 +38,8 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 		Args:              require.NoArgs,
 		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			f, err := repo.LoadFile(settings.RepositoryConfig)
-			if isNotExist(err) || (len(f.Repositories) == 0 && !(outfmt == output.JSON || outfmt == output.YAML)) {
+			f, _ := repo.LoadFile(settings.RepositoryConfig)
+			if len(f.Repositories) == 0 && !(outfmt == output.JSON || outfmt == output.YAML) {
 				return errors.New("no repositories to show")
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Currently, `helm repo list -o json` returns (either `[]` or an english "no repositories" error message, depending on whether `$HELM_CONFIG_HOME/repositories.yaml` exists). This PR aligns the two cases so that it always returns `[]`.

This makes Helm more predictable to interact with for external scripts.

This is extracted from https://github.com/helm/helm/pull/10091#discussion_r778070678.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility