### PR TITLE
Adding Joe Julian as triage maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ maintainers:
   - SlickNik
   - technosophos
 triage:
+  - joejulian
   - yxxhero
   - zonggen
 emeritus:


### PR DESCRIPTION
Per @marckhouzam, @joejulian has been voted in as a triage maintainer: https://lists.cncf.io/g/cncf-helm/message/436

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
