### PR TITLE
Fixing issue where OCI handling early causes a bad message

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -578,8 +578,7 @@ func (m *Manager) resolveRepoNames(deps []*chart.Dependency) (map[string]string,
 	missing := []string{}
 	for _, dd := range deps {
 		// Don't map the repository, we don't need to download chart from charts directory
-		// When OCI is used there is no Helm repository
-		if dd.Repository == "" || registry.IsOCI(dd.Repository) {
+		if dd.Repository == "" {
 			continue
 		}
 		// if dep chart is from local path, verify the path is valid


### PR DESCRIPTION
Note, there is OCI handling later in the funtion that should
handle the situation instead.

Closes #10534

**What this PR does / why we need it**:

See the issue. A bad output message.

**Special notes for your reviewer**:

Look no further for the blame of this bug than the author of the fix.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
