### PR TITLE
Add --jsonpath to helm show chart

### DIFF
--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -174,9 +174,10 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 	f := subCmd.Flags()
 
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
-	if subCmd.Name() == "values" {
+	if subCmd.Name() == "chart" || subCmd.Name() == "values" {
 		f.StringVar(&client.JSONPathTemplate, "jsonpath", "", "supply a JSONPath expression to filter the output")
 	}
+
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 
 	err := subCmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -86,7 +86,15 @@ func (s *Show) Run(chartpath string) (string, error) {
 
 	var out strings.Builder
 	if s.OutputFormat == ShowChart || s.OutputFormat == ShowAll {
-		fmt.Fprintf(&out, "%s\n", cf)
+		if s.JSONPathTemplate != "" {
+			printer, err := printers.NewJSONPathPrinter(s.JSONPathTemplate)
+			if err != nil {
+				return "", errors.Wrapf(err, "error parsing jsonpath %s", s.JSONPathTemplate)
+			}
+			printer.Execute(&out, s.chart.Metadata)
+		} else {
+			fmt.Fprintf(&out, "%s\n", cf)
+		}
 	}
 
 	if (s.OutputFormat == ShowValues || s.OutputFormat == ShowAll) && s.chart.Values != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
In some CI pipelines, we want to get some fields of `Chart.yaml` and JSONpath templates are the best way to achieve this. Since `helm` right now prints the chart metadata as YAML, it's not really easy.

**Special notes for your reviewer**:
- `--jsonpath` is already a flag in `helm show values`, and it uses the same approach.
- I couldn't find any unit tests of `--jsonpath` for `helm show values` and have decided not to add any