### PR TITLE
Fix panic with OCI for install, upgrade, and show

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -165,7 +165,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 		newCreateCmd(out),
 		newDependencyCmd(actionConfig, out),
 		newPullCmd(actionConfig, out),
-		newShowCmd(out),
+		newShowCmd(actionConfig, out),
 		newLintCmd(out),
 		newPackageCmd(out),
 		newRepoCmd(out),

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -56,8 +56,8 @@ This command inspects a chart (directory, file, or URL) and displays the content
 of the CustomResourceDefinition files
 `
 
-func newShowCmd(out io.Writer) *cobra.Command {
-	client := action.NewShow(action.ShowAll)
+func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	client := action.NewShowWithConfig(action.ShowAll, cfg)
 
 	showCommand := &cobra.Command{
 		Use:               "show",

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -64,10 +64,22 @@ type Show struct {
 }
 
 // NewShow creates a new Show object with the given configuration.
+// Deprecated: Use NewShowWithConfig
+// TODO Helm 4: Fold NewShowWithConfig back into NewShow
 func NewShow(output ShowOutputFormat) *Show {
 	return &Show{
 		OutputFormat: output,
 	}
+}
+
+// NewShowWithConfig creates a new Show object with the given configuration.
+func NewShowWithConfig(output ShowOutputFormat, cfg *Configuration) *Show {
+	sh := &Show{
+		OutputFormat: output,
+	}
+	sh.ChartPathOptions.registryClient = cfg.RegistryClient
+
+	return sh
 }
 
 // Run executes 'helm show' against the given release.

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 func TestShow(t *testing.T) {
-	client := NewShow(ShowAll)
+	config := actionConfigFixture(t)
+	client := NewShowWithConfig(ShowAll, config)
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*chart.File{

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -112,9 +112,12 @@ type resultMessage struct {
 
 // NewUpgrade creates a new Upgrade object with the given configuration.
 func NewUpgrade(cfg *Configuration) *Upgrade {
-	return &Upgrade{
+	up := &Upgrade{
 		cfg: cfg,
 	}
+	up.ChartPathOptions.registryClient = cfg.RegistryClient
+
+	return up
 }
 
 // Run executes the upgrade on the given release.


### PR DESCRIPTION
When range support for OCI went in via #10527 it created a situation
where some lookups for a chart could cause a panic. This change
makes sure the registry client is available to lookup OCI charts

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
