### PR TITLE
HTTPGetter: Reuse http transport

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -121,6 +121,7 @@ func WithUntar() Option {
 	}
 }
 
+// WithTransport sets the http.Transport to allow overwriting the HTTPGetter default.
 func WithTransport(transport *http.Transport) Option {
 	return func(opts *options) {
 		opts.transport = transport

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -18,6 +18,7 @@ package getter
 
 import (
 	"bytes"
+	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -43,6 +44,7 @@ type options struct {
 	version               string
 	registryClient        *registry.Client
 	timeout               time.Duration
+	transport             *http.Transport
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -116,6 +118,12 @@ func WithRegistryClient(client *registry.Client) Option {
 func WithUntar() Option {
 	return func(opts *options) {
 		opts.unTar = true
+	}
+}
+
+func WithTransport(transport *http.Transport) Option {
+	return func(opts *options) {
+		opts.transport = transport
 	}
 }
 

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -109,20 +109,19 @@ func NewHTTPGetter(options ...Option) (Getter, error) {
 }
 
 func (g *HTTPGetter) httpClient() (*http.Client, error) {
-	var transport *http.Transport
-
 	if g.opts.transport != nil {
-		transport = g.opts.transport
-	} else {
-		g.once.Do(func() {
-			g.transport = &http.Transport{
-				DisableCompression: true,
-				Proxy:              http.ProxyFromEnvironment,
-			}
-		})
-
-		transport = g.transport
+		return &http.Client{
+			Transport: g.opts.transport,
+			Timeout:   g.opts.timeout,
+		}, nil
 	}
+
+	g.once.Do(func() {
+		g.transport = &http.Transport{
+			DisableCompression: true,
+			Proxy:              http.ProxyFromEnvironment,
+		}
+	})
 
 	if (g.opts.certFile != "" && g.opts.keyFile != "") || g.opts.caFile != "" {
 		tlsConf, err := tlsutil.NewClientTLS(g.opts.certFile, g.opts.keyFile, g.opts.caFile)
@@ -137,21 +136,21 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 		}
 		tlsConf.ServerName = sni
 
-		transport.TLSClientConfig = tlsConf
+		g.transport.TLSClientConfig = tlsConf
 	}
 
 	if g.opts.insecureSkipVerifyTLS {
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{
+		if g.transport.TLSClientConfig == nil {
+			g.transport.TLSClientConfig = &tls.Config{
 				InsecureSkipVerify: true,
 			}
 		} else {
-			transport.TLSClientConfig.InsecureSkipVerify = true
+			g.transport.TLSClientConfig.InsecureSkipVerify = true
 		}
 	}
 
 	client := &http.Client{
-		Transport: transport,
+		Transport: g.transport,
 		Timeout:   g.opts.timeout,
 	}
 

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -518,4 +518,15 @@ func TestHTTPTransportOption(t *testing.T) {
 	if transport1 != transport2 {
 		t.Fatalf("Expected applied transport to be reused")
 	}
+
+	g = HTTPGetter{}
+	g.opts.url = "https://localhost"
+	g.opts.certFile = "testdata/client.crt"
+	g.opts.keyFile = "testdata/client.key"
+	g.opts.insecureSkipVerifyTLS = true
+	g.opts.transport = transport
+	usedTransport := verifyInsecureSkipVerify(t, &g, "HTTPGetter with 2 way ssl", false)
+	if usedTransport.TLSClientConfig != nil {
+		t.Fatal("transport.TLSClientConfig should not be set")
+	}
 }

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -402,24 +402,24 @@ func TestHTTPGetterTarDownload(t *testing.T) {
 func TestHttpClientInsecureSkipVerify(t *testing.T) {
 	g := HTTPGetter{}
 	g.opts.url = "https://localhost"
-	verifyInsecureSkipVerify(t, g, "Blank HTTPGetter", false)
+	verifyInsecureSkipVerify(t, &g, "Blank HTTPGetter", false)
 
 	g = HTTPGetter{}
 	g.opts.url = "https://localhost"
 	g.opts.caFile = "testdata/ca.crt"
-	verifyInsecureSkipVerify(t, g, "HTTPGetter with ca file", false)
+	verifyInsecureSkipVerify(t, &g, "HTTPGetter with ca file", false)
 
 	g = HTTPGetter{}
 	g.opts.url = "https://localhost"
 	g.opts.insecureSkipVerifyTLS = true
-	verifyInsecureSkipVerify(t, g, "HTTPGetter with skip cert verification only", true)
+	verifyInsecureSkipVerify(t, &g, "HTTPGetter with skip cert verification only", true)
 
 	g = HTTPGetter{}
 	g.opts.url = "https://localhost"
 	g.opts.certFile = "testdata/client.crt"
 	g.opts.keyFile = "testdata/client.key"
 	g.opts.insecureSkipVerifyTLS = true
-	transport := verifyInsecureSkipVerify(t, g, "HTTPGetter with 2 way ssl", true)
+	transport := verifyInsecureSkipVerify(t, &g, "HTTPGetter with 2 way ssl", true)
 	if len(transport.TLSClientConfig.Certificates) <= 0 {
 		t.Fatal("transport.TLSClientConfig.Certificates is not present")
 	}
@@ -428,7 +428,7 @@ func TestHttpClientInsecureSkipVerify(t *testing.T) {
 	}
 }
 
-func verifyInsecureSkipVerify(t *testing.T, g HTTPGetter, caseName string, expectedValue bool) *http.Transport {
+func verifyInsecureSkipVerify(t *testing.T, g *HTTPGetter, caseName string, expectedValue bool) *http.Transport {
 	returnVal, err := g.httpClient()
 
 	if err != nil {


### PR DESCRIPTION
The `HTTPGetter` makes a new instance of the `http.Transport` on each HTTP request, which according to the docs should be avoided.

From the go docs (https://github.com/golang/go/blob/master/src/net/http/client.go#L32 and https://github.com/golang/go/blob/master/src/net/http/transport.go#L68)
```
The Client's Transport typically has internal state (cached TCP connections)
...
Transports should be reused instead of created as needed.
```

In polling clients which make use of this `HTTPGetter` like https://github.com/fluxcd/source-controller this can cause problems as for every request a new TCP connection is created and never closed, which in our case went to thousands of open TCP connections from this polling client.

This PR makes a single transport per `HTTPGetter` client and reuses it for future requests.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
