### PR TITLE
Use the chartutil package to validate release names in linter

### DIFF
--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
@@ -5,7 +5,7 @@
 	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 
 ==> Linting testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart
-[ERROR] Chart.yaml: name is required
+[ERROR] Chart.yaml: no name provided
 [ERROR] Chart.yaml: apiVersion is required. The value must be either "v1" or "v2"
 [ERROR] Chart.yaml: version is required
 [INFO] Chart.yaml: icon is recommended

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -104,8 +104,9 @@ func validateChartYamlFormat(chartFileError error) error {
 }
 
 func validateChartName(cf *chart.Metadata) error {
-	if cf.Name == "" {
-		return errors.New("name is required")
+	err := chartutil.ValidateReleaseName(cf.Name)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -196,7 +196,7 @@ func TestChartfile(t *testing.T) {
 			return
 		}
 
-		if !strings.Contains(msgs[0].Err.Error(), "name is required") {
+		if !strings.Contains(msgs[0].Err.Error(), "no name provided") {
 			t.Errorf("Unexpected message 0: %s", msgs[0].Err)
 		}
 
@@ -225,22 +225,26 @@ func TestChartfile(t *testing.T) {
 		linter := support.Linter{ChartDir: anotherBadChartDir}
 		Chartfile(&linter)
 		msgs := linter.Messages
-		expectedNumberOfErrorMessages := 3
+		expectedNumberOfErrorMessages := 4
 
 		if len(msgs) != expectedNumberOfErrorMessages {
 			t.Errorf("Expected %d errors, got %d", expectedNumberOfErrorMessages, len(msgs))
 			return
 		}
 
-		if !strings.Contains(msgs[0].Err.Error(), "version should be of type string") {
+		if !strings.Contains(msgs[0].Err.Error(), "invalid release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53") {
 			t.Errorf("Unexpected message 0: %s", msgs[0].Err)
 		}
 
-		if !strings.Contains(msgs[1].Err.Error(), "version '7.2445e+06' is not a valid SemVer") {
+		if !strings.Contains(msgs[1].Err.Error(), "version should be of type string") {
+			t.Errorf("Unexpected message 0: %s", msgs[0].Err)
+		}
+
+		if !strings.Contains(msgs[2].Err.Error(), "version '7.2445e+06' is not a valid SemVer") {
 			t.Errorf("Unexpected message 1: %s", msgs[1].Err)
 		}
 
-		if !strings.Contains(msgs[2].Err.Error(), "appVersion should be of type string") {
+		if !strings.Contains(msgs[3].Err.Error(), "appVersion should be of type string") {
 			t.Errorf("Unexpected message 2: %s", msgs[2].Err)
 		}
 	})

--- a/pkg/lint/rules/testdata/anotherbadchartfile/Chart.yaml
+++ b/pkg/lint/rules/testdata/anotherbadchartfile/Chart.yaml
@@ -1,4 +1,4 @@
-name: "some-chart"
+name: InvalidName
 apiVersion: v2
 description: A Helm chart for Kubernetes
 version: 72445e2


### PR DESCRIPTION
closes #10537

**What this PR does / why we need it**:

The chartutil package has a `ValidateReleaseName` function. This PR allows the linter to use it in order to improve validation of chart's name.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
