### PR TITLE
Set go version to 1.17 to match CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module helm.sh/helm/v3
 
-go 1.16
+go 1.17
 
 require (
 	github.com/BurntSushi/toml v0.4.1


### PR DESCRIPTION
Closes #10580 

**What this PR does / why we need it**:

Bump go version to 1.17 to match CI. It's needed because building with 1.16 is broken and because the CI uses 1.17.