### PR TITLE
Correctly handle repository data file paths that contain a component with the same suffix as the data file

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -119,7 +119,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	repoFileExt := filepath.Ext(o.repoFile)
 	var lockPath string
 	if len(repoFileExt) > 0 && len(repoFileExt) < len(o.repoFile) {
-		lockPath = strings.Replace(o.repoFile, repoFileExt, ".lock", 1)
+		lockPath = strings.TrimSuffix(o.repoFile, repoFileExt) + ".lock"
 	} else {
 		lockPath = o.repoFile + ".lock"
 	}

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -48,7 +48,11 @@ func TestRepoAddCmd(t *testing.T) {
 	}
 	defer srv2.Stop()
 
-	tmpdir := ensure.TempDir(t)
+	tmpdir := filepath.Join(ensure.TempDir(t), "path-component/data")
+	err = os.MkdirAll(tmpdir, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
 	repoFile := filepath.Join(tmpdir, "repositories.yaml")
 
 	tests := []cmdTestCase{

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -48,7 +48,7 @@ func TestRepoAddCmd(t *testing.T) {
 	}
 	defer srv2.Stop()
 
-	tmpdir := filepath.Join(ensure.TempDir(t), "path-component/data")
+	tmpdir := filepath.Join(ensure.TempDir(t), "path-component.yaml/data")
 	err = os.MkdirAll(tmpdir, 0777)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #10661; description from that issue:

When generating a lockfile name for `repository.yaml`, if part of the path _already_ contains `.yaml` then the current code will replace that part of the path instead of the suffix.  For example, given the following (already existing in the filesystem) path to repository.yaml:

```
generated-path-including.yaml-suffix/tmp/helm/config/repository.yaml
```

...the current code will generate a lockfile called:

```
generated-path-including.lock-suffix/tmp/helm/config/repository.yaml
```

...which will then cause an error when trying to create the lockfile because the rest of the path does not exist.

This hits us in https://github.com/datastax/fallout because we run multiple helm instances with separate autogenerated config dirs:

https://github.com/datastax/fallout/blob/41c8f0f7a0dea653cdcd7f9458d68ee9e5a33739/src/main/java/com/datastax/fallout/components/kubernetes/AbstractKubernetesProvisioner.java#L100-L105

...where the scratch space includes user-submitted data (often a test definition name, which can contain `.yaml`).

**Special notes for your reviewer**:

I modified the existing `repo_add_test.go` to make it use a problematic path for the config, validated that it failed, then fixed the error.  Each of these steps is in a separate commit; I'm happy to squash on merge or earlier.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
