### PR TITLE
remove least recent releases from the history even if there are no deployed releases

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -177,7 +177,7 @@ func (s *Storage) removeLeastRecent(name string, max int) error {
 	relutil.SortByRevision(h)
 
 	lastDeployed, err := s.Deployed(name)
-	if err != nil {
+	if err != nil && !errors.Is(err, driver.ErrNoDeployedReleases) {
 		return err
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #10550 

**What this PR does / why we need it**:
This PR modifies the behavior of creating releases in the history.
Currently, if the history has reached max capacity and none of the releases are in `deployed` status, it returns a NoDeployedReleases error.
This PR allows purging the least recent records from the history even if no releases are in `deployed` status.

**Special notes for your reviewer**:
#10550 is not yet confirmed as a bug

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
