### PR TITLE
Improve URL credential handling

### DIFF
--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -71,3 +71,11 @@ func ExtractHostname(addr string) (string, error) {
 	}
 	return u.Hostname(), nil
 }
+
+// SchemeHostAndPortMatches returns if the scheme, port and hostname of the given url matches
+func SchemeHostAndPortMatches(u1, u2 *url.URL) bool {
+	// Host on URL (returned from url.Parse) contains the port if present.
+	// This check ensures credentials are not passed between different
+	// services on different ports.
+	return u1.Scheme == u2.Scheme && u1.Host == u2.Host
+}

--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -77,5 +77,19 @@ func SchemeHostAndPortMatches(u1, u2 *url.URL) bool {
 	// Host on URL (returned from url.Parse) contains the port if present.
 	// This check ensures credentials are not passed between different
 	// services on different ports.
-	return u1.Scheme == u2.Scheme && u1.Host == u2.Host
+	getPort := func(url *url.URL) string {
+		if url.Port() == "" {
+			if url.Scheme == "https" { // is always lower case
+				return "443"
+			}
+
+			if url.Scheme == "http" {
+				return "80"
+			}
+		}
+		return url.Port()
+	}
+	u1Port := getPort(u1)
+	u2Port := getPort(u2)
+	return u1.Scheme == u2.Scheme && u1.Hostname() == u2.Hostname() && u1Port == u2Port
 }

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package urlutil
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
 func TestURLJoin(t *testing.T) {
 	tests := []struct {
@@ -35,6 +38,33 @@ func TestURLJoin(t *testing.T) {
 			t.Errorf("%s: error %q", tt.name, err)
 		} else if got != tt.expect {
 			t.Errorf("%s: expected %q, got %q", tt.name, tt.expect, got)
+		}
+	}
+}
+
+func TestSchemeHostAndPortMatches(t *testing.T) {
+	for _, tt := range []struct {
+		a, b  string
+		match bool
+	}{
+		{"http://example.com", "http://example.com", true},
+		{"https://example.com", "https://example.com", true},
+		{"http://example.com", "https://example.com", false},
+		{"https://example.com", "http://example.com", false},
+		{"http://example.com:80", "http://example.com:80", true},
+		{"https://example.com:443", "https://example.com:443", true},
+		{"http://example.com:1234", "http://example.com:5678", false},
+		{"https://example.com:1234", "https://example.com:5678", false},
+		// The following lines are subject of change, currently only there
+		// to ensure that the existing logic works as expected and the
+		// upcoming fix / improvement works as wanted
+		{"http://example.com:80", "http://example.com", false},
+		{"https://example.com:443", "https://example.com", false},
+	} {
+		u1, _ := url.Parse(tt.a)
+		u2, _ := url.Parse(tt.b)
+		if tt.match != SchemeHostAndPortMatches(u1, u2) {
+			t.Errorf("Expected %q==%q to be %t", tt.a, tt.b, tt.match)
 		}
 	}
 }

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -55,11 +55,12 @@ func TestSchemeHostAndPortMatches(t *testing.T) {
 		{"https://example.com:443", "https://example.com:443", true},
 		{"http://example.com:1234", "http://example.com:5678", false},
 		{"https://example.com:1234", "https://example.com:5678", false},
-		// The following lines are subject of change, currently only there
-		// to ensure that the existing logic works as expected and the
-		// upcoming fix / improvement works as wanted
-		{"http://example.com:80", "http://example.com", false},
-		{"https://example.com:443", "https://example.com", false},
+		{"http://example.com:80", "http://example.com", true},
+		{"https://example.com:443", "https://example.com", true},
+		{"http://example.com:80", "https://example.com", false},
+		{"https://example.com:443", "http://example.com", false},
+		{"http://example.com:1234", "http://example.com", false},
+		{"https://example.com:1234", "https://example.com", false},
 	} {
 		u1, _ := url.Parse(tt.a)
 		u2, _ := url.Parse(tt.b)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/yaml"
 
+	"helm.sh/helm/v3/internal/urlutil"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
@@ -730,10 +731,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 			return "", err
 		}
 
-		// Host on URL (returned from url.Parse) contains the port if present.
-		// This check ensures credentials are not passed between different
-		// services on different ports.
-		if c.PassCredentialsAll || (u1.Scheme == u2.Scheme && u1.Host == u2.Host) {
+		if c.PassCredentialsAll || urlutil.SchemeHostAndPortMatches(u1, u2) {
 			dl.Options = append(dl.Options, getter.WithBasicAuth(c.Username, c.Password))
 		} else {
 			dl.Options = append(dl.Options, getter.WithBasicAuth("", ""))

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -66,10 +66,7 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 		return nil, errors.Wrap(err, "Unable to parse URL getting from")
 	}
 
-	// Host on URL (returned from url.Parse) contains the port if present.
-	// This check ensures credentials are not passed between different
-	// services on different ports.
-	if g.opts.passCredentialsAll || (u1.Scheme == u2.Scheme && u1.Host == u2.Host) {
+	if g.opts.passCredentialsAll || urlutil.SchemeHostAndPortMatches(u1, u2) {
 		if g.opts.username != "" && g.opts.password != "" {
 			req.SetBasicAuth(g.opts.username, g.opts.password)
 		}

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -208,8 +208,8 @@ func TestDownload(t *testing.T) {
 	// test with Get URL differing from withURL
 	crossAuthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
-		if ok || username == "username" || password == "password" {
-			t.Errorf("Expected request to not include but got '%v', '%s', '%s'", ok, username, password)
+		if ok {
+			t.Errorf("Expected no basic auth in request but got user '%s' and password '%s'", username, password)
 		}
 		fmt.Fprint(w, expect)
 	}))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently, if the index.yaml of a helm repo contains entries, pointing to the same repo but with explicit port declaration of port 80 for http or 443 for https, the helm client needs the flag `--pass-credentials` to work, because it thinks that http://foo.com:80 is not the same location as http://foo.com. In fact, for https and http we can always say, that the default port is 443/80.

There are big helm repository managers like jfrog artifactory 6, which show that behavior (adding the port to the index.yaml for https / http). There it's then necessary to add the `--pass-credentials` flag which is really dangerous, because it can lead to accidentially forwarded secrets to external registries - as it happened in the company I am working for.

This pull request mitigates this issue and implements that the http(s) urls with and without default port declaration matches, so that in the case just described, the helm client doesn't nee the `--pass-credentials` anymore.

**Special notes for your reviewer**:
This merge request consists of 3 commits. First ist just a tiny cleanup of a unit test (eliminate dead code), just a warmup.

Because integration testing with port 80 / 443 is not simply possible, because it would require root access / special permissions on the dev machine, I decided to extract the check logic the urlutil in the second commit, keeping the exact same logic to make sure that I don't break anything and guard the logic with a unit test.

The third commit then introduces the change which contains the special handling for http(s) schemes when no port is declared explicitly.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
