### PR TITLE
fix: improve logging & safety of statefulSetReady

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -391,6 +391,9 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 	}
 
 	if u.Wait {
+		u.cfg.Log(
+			"waiting for release %s resources (created: %d updated: %d  deleted: %d)",
+			upgradedRelease.Name, len(results.Created), len(results.Updated), len(results.Deleted))
 		if u.WaitForJobs {
 			if err := u.cfg.KubeClient.WaitWithJobs(target, u.Timeout); err != nil {
 				u.cfg.recordRelease(originalRelease)


### PR DESCRIPTION
**What this PR does / why we need it**:

Confirm that the current and updated revision numbers also match as part of the readiness check.

Also add additional logging around the sts transitions from non-ready to ready.

Fixes: #10163

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
