### PR TITLE
feat(plugin): Allow plugins to receive empty arg

### DIFF
--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -170,7 +170,9 @@ func manuallyProcessArgs(args []string) ([]string, []string) {
 				return v
 			}
 		}
-		return ""
+		// Return something different than what we received by adding a random prefix.
+		// We cannot simply return an empty string as v could be an empty string itself.
+		return fmt.Sprintf("x%s", v)
 	}
 
 	for i := 0; i < len(args); i++ {

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -116,6 +116,8 @@ func TestLoadPlugins(t *testing.T) {
 		{"env", "env stuff", "show the env", "env\n", []string{}, 0},
 		{"exitwith", "exitwith code", "This exits with the specified exit code", "", []string{"2"}, 2},
 		{"fullenv", "show env vars", "show all env vars", envs + "\n", []string{}, 0},
+		// Test that empty arguments are passed to the plugin
+		{"numargs", "echo num args", "echo number of arguments received", "3\n", []string{"-a", "", "-b"}, 0},
 	}
 
 	plugins := cmd.Commands()
@@ -196,6 +198,7 @@ func TestLoadPluginsForCompletion(t *testing.T) {
 				{"more", []string{"one", "two"}, []string{"b", "ball"}, []staticCompletionDetails{}},
 			}},
 		}},
+		{"numargs", []string{}, []string{}, []staticCompletionDetails{}},
 	}
 	checkCommand(t, cmd.Commands(), tests)
 }

--- a/cmd/helm/testdata/helmhome/helm/plugins/numargs/numargs.sh
+++ b/cmd/helm/testdata/helmhome/helm/plugins/numargs/numargs.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo $#

--- a/cmd/helm/testdata/helmhome/helm/plugins/numargs/plugin.yaml
+++ b/cmd/helm/testdata/helmhome/helm/plugins/numargs/plugin.yaml
@@ -1,0 +1,4 @@
+name: numargs
+usage: "echo num args"
+description: "echo number of arguments received"
+command: "$HELM_PLUGIN_DIR/numargs.sh"

--- a/cmd/helm/testdata/output/plugin_list_comp.txt
+++ b/cmd/helm/testdata/output/plugin_list_comp.txt
@@ -3,5 +3,6 @@ echo	echo stuff
 env	env stuff
 exitwith	exitwith code
 fullenv	show env vars
+numargs	echo num args
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/plugin_repeat_comp.txt
+++ b/cmd/helm/testdata/output/plugin_repeat_comp.txt
@@ -2,5 +2,6 @@ echo	echo stuff
 env	env stuff
 exitwith	exitwith code
 fullenv	show env vars
+numargs	echo num args
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #10654

This small fix allows empty arguments to be properly passed to plugins.

**Special notes for your reviewer**:

To compare before and after:
```
> helm 2to3 __complete ''
Error: requires at least 1 arg(s), only received 0
Error: plugin "2to3" exited with error

> bin/helm 2to3 __complete '' 
cleanup	cleanup Helm v2 configuration, release data and Tiller deployment
convert	migrate Helm v2 release in-place to Helm v3
help	Help about any command
move	migrate Helm v2 configuration in-place to Helm v3
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

**If applicable**:
- [x] this PR contains unit tests
