### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,11 +49,7 @@ func checkPermsStderr() (string, error) {
 }
 
 func TestCheckPerms(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "helmtest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 	tfile := filepath.Join(tdir, "testconfig")
 	fh, err := os.OpenFile(tfile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0440)
 	if err != nil {

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -25,18 +25,14 @@ import (
 )
 
 func TestAtomicWriteFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	testpath := filepath.Join(dir, "test")
 	stringContent := "Test content"
 	reader := bytes.NewReader([]byte(stringContent))
 	mode := os.FileMode(0644)
 
-	err = AtomicWriteFile(testpath, reader, mode)
+	err := AtomicWriteFile(testpath, reader, mode)
 	if err != nil {
 		t.Errorf("AtomicWriteFile error: %s", err)
 	}

--- a/internal/third_party/dep/fs/fs_test.go
+++ b/internal/third_party/dep/fs/fs_test.go
@@ -46,13 +46,9 @@ var (
 )
 
 func TestRenameWithFallback(t *testing.T) {
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	if err = RenameWithFallback(filepath.Join(dir, "does_not_exists"), filepath.Join(dir, "dst")); err == nil {
+	if err := RenameWithFallback(filepath.Join(dir, "does_not_exists"), filepath.Join(dir, "dst")); err == nil {
 		t.Fatal("expected an error for non existing file, but got nil")
 	}
 
@@ -64,31 +60,27 @@ func TestRenameWithFallback(t *testing.T) {
 		srcf.Close()
 	}
 
-	if err = RenameWithFallback(srcpath, filepath.Join(dir, "dst")); err != nil {
+	if err := RenameWithFallback(srcpath, filepath.Join(dir, "dst")); err != nil {
 		t.Fatal(err)
 	}
 
 	srcpath = filepath.Join(dir, "a")
-	if err = os.MkdirAll(srcpath, 0777); err != nil {
+	if err := os.MkdirAll(srcpath, 0777); err != nil {
 		t.Fatal(err)
 	}
 
 	dstpath := filepath.Join(dir, "b")
-	if err = os.MkdirAll(dstpath, 0777); err != nil {
+	if err := os.MkdirAll(dstpath, 0777); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = RenameWithFallback(srcpath, dstpath); err == nil {
+	if err := RenameWithFallback(srcpath, dstpath); err == nil {
 		t.Fatal("expected an error if dst is an existing directory, but got nil")
 	}
 }
 
 func TestCopyDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcdir := filepath.Join(dir, "src")
 	if err := os.MkdirAll(srcdir, 0755); err != nil {
@@ -108,7 +100,7 @@ func TestCopyDir(t *testing.T) {
 	for i, file := range files {
 		fn := filepath.Join(srcdir, file.path)
 		dn := filepath.Dir(fn)
-		if err = os.MkdirAll(dn, 0755); err != nil {
+		if err := os.MkdirAll(dn, 0755); err != nil {
 			t.Fatal(err)
 		}
 
@@ -189,14 +181,10 @@ func TestCopyDirFail_SrcInaccessible(t *testing.T) {
 	})
 	defer cleanup()
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dstdir = filepath.Join(dir, "dst")
-	if err = CopyDir(srcdir, dstdir); err == nil {
+	if err := CopyDir(srcdir, dstdir); err == nil {
 		t.Fatalf("expected error for CopyDir(%s, %s), got none", srcdir, dstdir)
 	}
 }
@@ -218,14 +206,10 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcdir = filepath.Join(dir, "src")
-	if err = os.MkdirAll(srcdir, 0755); err != nil {
+	if err := os.MkdirAll(srcdir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -242,12 +226,9 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 
 func TestCopyDirFail_SrcIsNotDir(t *testing.T) {
 	var srcdir, dstdir string
+	var err error
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcdir = filepath.Join(dir, "src")
 	if _, err = os.Create(srcdir); err != nil {
@@ -268,12 +249,9 @@ func TestCopyDirFail_SrcIsNotDir(t *testing.T) {
 
 func TestCopyDirFail_DstExists(t *testing.T) {
 	var srcdir, dstdir string
+	var err error
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcdir = filepath.Join(dir, "src")
 	if err = os.MkdirAll(srcdir, 0755); err != nil {
@@ -314,14 +292,10 @@ func TestCopyDirFailOpen(t *testing.T) {
 
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcdir = filepath.Join(dir, "src")
-	if err = os.MkdirAll(srcdir, 0755); err != nil {
+	if err := os.MkdirAll(srcdir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -345,11 +319,7 @@ func TestCopyDirFailOpen(t *testing.T) {
 }
 
 func TestCopyFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcf, err := os.Create(filepath.Join(dir, "srcfile"))
 	if err != nil {
@@ -405,13 +375,7 @@ func cleanUpDir(dir string) {
 }
 
 func TestCopyFileSymlink(t *testing.T) {
-	var tempdir, err = ioutil.TempDir("", "gotest")
-
-	if err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-
-	defer cleanUpDir(tempdir)
+	tempdir := t.TempDir()
 
 	testcases := map[string]string{
 		filepath.Join("./testdata/symlinks/file-symlink"):         filepath.Join(tempdir, "dst-file"),
@@ -477,11 +441,7 @@ func TestCopyFileFail(t *testing.T) {
 		t.Skip("Skipping for root user")
 	}
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	srcf, err := os.Create(filepath.Join(dir, "srcfile"))
 	if err != nil {
@@ -517,19 +477,12 @@ func TestCopyFileFail(t *testing.T) {
 // files this function creates. It is the caller's responsibility to call
 // this function before the test is done running, whether there's an error or not.
 func setupInaccessibleDir(t *testing.T, op func(dir string) error) func() {
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-		return nil // keep compiler happy
-	}
+	dir := t.TempDir()
 
 	subdir := filepath.Join(dir, "dir")
 
 	cleanup := func() {
 		if err := os.Chmod(subdir, 0777); err != nil {
-			t.Error(err)
-		}
-		if err := os.RemoveAll(dir); err != nil {
 			t.Error(err)
 		}
 	}
@@ -617,14 +570,10 @@ func TestIsSymlink(t *testing.T) {
 		t.Skip("Skipping for root user")
 	}
 
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dirPath := filepath.Join(dir, "directory")
-	if err = os.MkdirAll(dirPath, 0777); err != nil {
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -18,7 +18,6 @@ package action
 import (
 	"flag"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -37,13 +36,6 @@ var verbose = flag.Bool("test.log", false, "enable test logging")
 
 func actionConfigFixture(t *testing.T) *Configuration {
 	t.Helper()
-
-	tdir, err := ioutil.TempDir("", "helm-action-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() { os.RemoveAll(tdir) })
 
 	registryClient, err := registry.NewClient()
 	if err != nil {

--- a/pkg/action/dependency_test.go
+++ b/pkg/action/dependency_test.go
@@ -18,7 +18,6 @@ package action
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,11 +67,7 @@ func TestList(t *testing.T) {
 // chart names do not cause resolution problems.
 func TestDependencyStatus_Dashes(t *testing.T) {
 	// Make a temp dir
-	dir, err := ioutil.TempDir("", "helmtest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	chartpath := filepath.Join(dir, "charts")
 	if err := os.MkdirAll(chartpath, 0700); err != nil {
@@ -81,7 +76,7 @@ func TestDependencyStatus_Dashes(t *testing.T) {
 
 	// Add some fake charts
 	first := buildChart(withName("first-chart"))
-	_, err = chartutil.Save(first, chartpath)
+	_, err := chartutil.Save(first, chartpath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,11 +101,7 @@ func TestDependencyStatus_Dashes(t *testing.T) {
 
 func TestStatArchiveForStatus(t *testing.T) {
 	// Make a temp dir
-	dir, err := ioutil.TempDir("", "helmtest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	chartpath := filepath.Join(dir, "charts")
 	if err := os.MkdirAll(chartpath, 0700); err != nil {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -552,15 +551,11 @@ func TestInstallReleaseOutputDir(t *testing.T) {
 	instAction := installAction(t)
 	vals := map[string]interface{}{}
 
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	instAction.OutputDir = dir
 
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
+	_, err := instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
 	if err != nil {
 		t.Fatalf("Failed install: %s", err)
 	}
@@ -588,11 +583,7 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	instAction := installAction(t)
 	vals := map[string]interface{}{}
 
-	dir, err := ioutil.TempDir("", "output-dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	instAction.OutputDir = dir
 	instAction.UseReleaseName = true
@@ -600,7 +591,7 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 
 	newDir := filepath.Join(dir, instAction.ReleaseName)
 
-	_, err = instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
+	_, err := instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
 	if err != nil {
 		t.Fatalf("Failed install: %s", err)
 	}

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -403,11 +403,7 @@ func TestLoadV2WithReqs(t *testing.T) {
 }
 
 func TestLoadInvalidArchive(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "helm-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	writeTar := func(filename, internalPath string, body []byte) {
 		dest, err := os.Create(filename)
@@ -459,7 +455,7 @@ func TestLoadInvalidArchive(t *testing.T) {
 	} {
 		illegalChart := filepath.Join(tmpdir, tt.chartname)
 		writeTar(illegalChart, tt.internal, []byte("hello: world"))
-		_, err = Load(illegalChart)
+		_, err := Load(illegalChart)
 		if err == nil {
 			t.Fatal("expected error when unpacking illegal files")
 		}
@@ -471,7 +467,7 @@ func TestLoadInvalidArchive(t *testing.T) {
 	// Make sure that absolute path gets interpreted as relative
 	illegalChart := filepath.Join(tmpdir, "abs-path.tgz")
 	writeTar(illegalChart, "/Chart.yaml", []byte("hello: world"))
-	_, err = Load(illegalChart)
+	_, err := Load(illegalChart)
 	if err.Error() != "validation: chart.metadata.name is required" {
 		t.Error(err)
 	}

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -28,11 +28,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "helm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	c, err := Create("foo", tdir)
 	if err != nil {
@@ -70,11 +66,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateFrom(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "helm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	cf := &chart.Metadata{
 		APIVersion: chart.APIVersionV1,
@@ -120,11 +112,7 @@ func TestCreateFrom(t *testing.T) {
 
 // TestCreate_Overwrite is a regression test for making sure that files are overwritten.
 func TestCreate_Overwrite(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "helm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	var errlog bytes.Buffer
 

--- a/pkg/chartutil/expand_test.go
+++ b/pkg/chartutil/expand_test.go
@@ -17,18 +17,13 @@ limitations under the License.
 package chartutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestExpand(t *testing.T) {
-	dest, err := ioutil.TempDir("", "helm-testing-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	reader, err := os.Open("testdata/frobnitz-1.2.3.tgz")
 	if err != nil {
@@ -81,11 +76,7 @@ func TestExpand(t *testing.T) {
 }
 
 func TestExpandFile(t *testing.T) {
-	dest, err := ioutil.TempDir("", "helm-testing-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	if err := ExpandFile(dest, "testdata/frobnitz-1.2.3.tgz"); err != nil {
 		t.Fatal(err)

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -129,11 +128,7 @@ func TestSavePreservesTimestamps(t *testing.T) {
 	// written timestamp for the files.
 	initialCreateTime := time.Now().Add(-1 * time.Second)
 
-	tmp, err := ioutil.TempDir("", "helm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -203,11 +198,7 @@ func retrieveAllHeadersFromTar(path string) ([]*tar.Header, error) {
 }
 
 func TestSaveDir(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "helm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -17,7 +17,6 @@ package downloader
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -218,11 +217,7 @@ func TestGetRepoNames(t *testing.T) {
 }
 
 func TestDownloadAll(t *testing.T) {
-	chartPath, err := ioutil.TempDir("", "test-downloadall")
-	if err != nil {
-		t.Fatalf("could not create tempdir: %v", err)
-	}
-	defer os.RemoveAll(chartPath)
+	chartPath := t.TempDir()
 	m := &Manager{
 		Out:              new(bytes.Buffer),
 		RepositoryConfig: repoConfig,

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package lint
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -120,11 +118,7 @@ func TestGoodChart(t *testing.T) {
 //
 // See https://github.com/helm/helm/issues/7923
 func TestHelmCreateChart(t *testing.T) {
-	dir, err := ioutil.TempDir("", "-helm-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	createdChart, err := chartutil.Create("testhelmcreatepasseslint", dir)
 	if err != nil {

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -209,11 +208,7 @@ func TestHTTPInstallerUpdate(t *testing.T) {
 func TestExtract(t *testing.T) {
 	source := "https://repo.localdomain/plugins/fake-plugin-0.0.1.tar.gz"
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Set the umask to default open permissions so we can actually test
 	oldmask := syscall.Umask(0000)

--- a/pkg/plugin/installer/local_installer_test.go
+++ b/pkg/plugin/installer/local_installer_test.go
@@ -28,11 +28,7 @@ var _ Installer = new(LocalInstaller)
 
 func TestLocalInstaller(t *testing.T) {
 	// Make a temp dir
-	tdir, err := ioutil.TempDir("", "helm-installer-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 	if err := ioutil.WriteFile(filepath.Join(tdir, "plugin.yaml"), []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -513,11 +513,7 @@ func TestIndexWrite(t *testing.T) {
 	if err := i.MustAdd(&chart.Metadata{APIVersion: "v2", Name: "clipper", Version: "0.1.0"}, "clipper-0.1.0.tgz", "http://example.com/charts", "sha256:1234567890"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	dir, err := ioutil.TempDir("", "helm-tmp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	testpath := filepath.Join(dir, "test")
 	i.WriteFile(testpath, 0600)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. `T.TempDir` also does error handling under the hood.

Reference: https://pkg.go.dev/testing#T.TempDir

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
