### PR TITLE
Add WithTransport to enable reuse of TCP connections

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -18,6 +18,7 @@ package getter
 
 import (
 	"bytes"
+	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -43,6 +44,7 @@ type options struct {
 	version               string
 	registryClient        *registry.Client
 	timeout               time.Duration
+	transport             *http.Transport
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -116,6 +118,12 @@ func WithRegistryClient(client *registry.Client) Option {
 func WithUntar() Option {
 	return func(opts *options) {
 		opts.unTar = true
+	}
+}
+
+func WithTransport(transport *http.Transport) Option {
+	return func(opts *options) {
+		opts.transport = transport
 	}
 }
 

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -106,10 +106,17 @@ func NewHTTPGetter(options ...Option) (Getter, error) {
 }
 
 func (g *HTTPGetter) httpClient() (*http.Client, error) {
-	transport := &http.Transport{
-		DisableCompression: true,
-		Proxy:              http.ProxyFromEnvironment,
+	var transport *http.Transport
+
+	if g.opts.transport == nil {
+		transport = &http.Transport{
+			DisableCompression: true,
+			Proxy:              http.ProxyFromEnvironment,
+		}
+	} else {
+		transport = g.opts.transport
 	}
+
 	if (g.opts.certFile != "" && g.opts.keyFile != "") || g.opts.caFile != "" {
 		tlsConf, err := tlsutil.NewClientTLS(g.opts.certFile, g.opts.keyFile, g.opts.caFile)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Enables the reuse of TCP connections as explained in the issue this PR closes.
Currently the httpgetter creates a new transport on every request, which is not aligned with the  official [golang documentation](https://go.dev/src/net/http/transport.go) of its use:

> Transports should be reused instead of created as needed.
> Transports are safe for concurrent use by multiple goroutines.

closes #10667


**Special notes for your reviewer**:

The issue provides an example on how to reproduce the problem and the improvement once this PR has been applied.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
