### PR TITLE
Include external path to chart

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -63,6 +63,11 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 	f.BoolVar(&c.PassCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
 }
 
+// addExternalPathsFlags adds flags to the given command
+func addExternalPathsFlags(f *pflag.FlagSet, v *[]string) {
+	f.StringArrayVar(v, "include-path", []string{}, "paths to local directories to add during chart installation")
+}
+
 // bindOutputFlag will add the output flag to the given command and bind the
 // value to the given format pointer
 func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -80,6 +80,11 @@ func main() {
 		}
 	})
 
+	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+		debug("%+v", err)
+		os.Exit(1)
+	}
+
 	if err := cmd.Execute(); err != nil {
 		debug("%+v", err)
 		switch e := err.(type) {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -157,6 +157,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
+	addExternalPathsFlags(f, &client.ExternalPaths)
 
 	err := cmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		requiredArgs := 2

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -77,6 +77,18 @@ func TestInstall(t *testing.T) {
 			cmd:    "install virgil testdata/testcharts/alpine -f testdata/testcharts/alpine/extra_values.yaml",
 			golden: "output/install-with-values-file.txt",
 		},
+		// Install, external dir
+		{
+			name:   "install with external dir",
+			cmd:    "install virgil testdata/testcharts/external --set glob.enabled=true --include-path testdata/files/",
+			golden: "output/install-with-external-files.txt",
+		},
+		// Install, external dir with alias
+		{
+			name:   "chart with template with external dir and alias",
+			cmd:    "install virgil testdata/testcharts/externalAlias --set glob.enabled=true --include-path vol1@testdata/files/",
+			golden: "output/install-with-external-files.txt",
+		},
 		// Install, no hooks
 		{
 			name:   "install without hooks",

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -131,6 +131,16 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf(`template '%s' --skip-tests`, chartPath),
 			golden: "output/template-skip-tests.txt",
 		},
+		{
+			name:   "chart with template with external dir",
+			cmd:    fmt.Sprintf("template '%s' --set glob.enabled=true --include-path testdata/files/", "testdata/testcharts/external"),
+			golden: "output/template-with-external-dir.txt",
+		},
+		{
+			name:   "chart with template with external dir and alias",
+			cmd:    fmt.Sprintf("template '%s' --set glob.enabled=true --include-path vol1@testdata/files/", "testdata/testcharts/externalAlias"),
+			golden: "output/template-with-external-dir-and-alias.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/files/external.1.conf
+++ b/cmd/helm/testdata/files/external.1.conf
@@ -1,0 +1,1 @@
+external-1

--- a/cmd/helm/testdata/files/external.2.conf
+++ b/cmd/helm/testdata/files/external.2.conf
@@ -1,0 +1,1 @@
+external-2

--- a/cmd/helm/testdata/files/external.txt
+++ b/cmd/helm/testdata/files/external.txt
@@ -1,0 +1,1 @@
+out-of-chart-dir

--- a/cmd/helm/testdata/output/install-with-external-files.txt
+++ b/cmd/helm/testdata/output/install-with-external-files.txt
@@ -1,0 +1,6 @@
+NAME: virgil
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None

--- a/cmd/helm/testdata/output/template-with-external-dir-and-alias.txt
+++ b/cmd/helm/testdata/output/template-with-external-dir-and-alias.txt
@@ -1,0 +1,25 @@
+---
+# Source: configmap/templates/config-map.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "release-name-"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: "Helm"
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: "release-name"
+    app.kubernetes.io/version: 1.0
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "configmap-0.1.0"
+data:
+  external.1.conf: |
+    external-1
+  external.2.conf: |
+    external-2
+  external.txt: |
+    out-of-chart-dir

--- a/cmd/helm/testdata/output/template-with-external-dir.txt
+++ b/cmd/helm/testdata/output/template-with-external-dir.txt
@@ -1,0 +1,25 @@
+---
+# Source: configmap/templates/config-map.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "release-name-"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: "Helm"
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: "release-name"
+    app.kubernetes.io/version: 1.0
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "configmap-0.1.0"
+data:
+  external.1.conf: |
+    external-1
+  external.2.conf: |
+    external-2
+  external.txt: |
+    out-of-chart-dir

--- a/cmd/helm/testdata/output/template-with-external-file.txt
+++ b/cmd/helm/testdata/output/template-with-external-file.txt
@@ -1,0 +1,21 @@
+---
+# Source: configmap/templates/config-map.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "RELEASE-NAME-"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: "Helm"
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: "RELEASE-NAME"
+    app.kubernetes.io/version: 1.0
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "configmap-0.1.0"
+data:
+  external.txt: |
+    out-of-chart-dir

--- a/cmd/helm/testdata/testcharts/external/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/external/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Deploy a basic Config Map from an external file
+home: https://helm.sh/helm
+name: configmap
+sources:
+- https://github.com/helm/helm
+version: 0.1.0

--- a/cmd/helm/testdata/testcharts/external/external.txt
+++ b/cmd/helm/testdata/testcharts/external/external.txt
@@ -1,0 +1,1 @@
+in-chart

--- a/cmd/helm/testdata/testcharts/external/templates/config-map.yaml
+++ b/cmd/helm/testdata/testcharts/external/templates/config-map.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{.Release.Name}}-{{.Values.Name}}"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+data:
+{{- if .Values.external }}
+{{ (.Files.Glob .Values.external).AsConfig | indent 2 }}
+{{- end }}
+{{- if .Values.glob.enabled }}
+{{ (.Files.Glob .Values.glob.path).AsConfig | indent 2 }}
+{{- end }}

--- a/cmd/helm/testdata/testcharts/external/values.yaml
+++ b/cmd/helm/testdata/testcharts/external/values.yaml
@@ -1,0 +1,4 @@
+external: false
+glob:
+  enabled: false
+  path: "*"

--- a/cmd/helm/testdata/testcharts/externalAlias/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/externalAlias/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Deploy a basic Config Map from an external file
+home: https://helm.sh/helm
+name: configmap
+sources:
+- https://github.com/helm/helm
+version: 0.1.0

--- a/cmd/helm/testdata/testcharts/externalAlias/external.txt
+++ b/cmd/helm/testdata/testcharts/externalAlias/external.txt
@@ -1,0 +1,1 @@
+in-chart

--- a/cmd/helm/testdata/testcharts/externalAlias/templates/config-map.yaml
+++ b/cmd/helm/testdata/testcharts/externalAlias/templates/config-map.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{.Release.Name}}-{{.Values.Name}}"
+  labels:
+    # The "app.kubernetes.io/managed-by" label is used to track which tool
+    # deployed a given chart. It is useful for admins who want to see what
+    # releases a particular tool is responsible for.
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    # The "app.kubernetes.io/instance" convention makes it easy to tie a release
+    # to all of the Kubernetes resources that were created as part of that
+    # release.
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    # This makes it easy to audit chart usage.
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+data:
+{{- if .Values.external }}
+{{ (.Files.Glob .Values.external).AsConfig | indent 2 }}
+{{- end }}
+{{- if .Values.glob.enabled }}
+{{ (.Files.Glob .Values.glob.path).AsConfig | indent 2 }}
+{{- end }}

--- a/cmd/helm/testdata/testcharts/externalAlias/values.yaml
+++ b/cmd/helm/testdata/testcharts/externalAlias/values.yaml
@@ -1,0 +1,4 @@
+external: false
+glob:
+  enabled: false
+  path: "vol1/*"

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -115,6 +115,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.PostRenderer = client.PostRenderer
 					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 					instClient.SubNotes = client.SubNotes
+					instClient.ExternalPaths = client.ExternalPaths
 					instClient.Description = client.Description
 
 					rel, err := runInstall(args, instClient, valueOpts, out)
@@ -233,6 +234,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)
 	bindPostRenderFlag(cmd, &client.PostRenderer)
+	addExternalPathsFlags(f, &client.ExternalPaths)
 
 	err := cmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 2 {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -88,7 +88,7 @@ func compare(actual []byte, filename string) error {
 	}
 	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
-		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'\n", filename, expected, actual)
+		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
 	}
 	return nil
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -17,6 +17,7 @@ package action
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -214,6 +215,15 @@ func withSampleIncludingIncorrectTemplates() chartOption {
 			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
+func withExternalFileTemplate(externalPath string) chartOption {
+	return func(opts *chartOptions) {
+		externalFilesTemplates := []*chart.File{
+			{Name: "templates/with-external-paths", Data: []byte(fmt.Sprintf(`data: {{ .Files.Get "%s" }}`, externalPath))},
+		}
+		opts.Templates = append(opts.Templates, externalFilesTemplates...)
 	}
 }
 

--- a/pkg/action/rollback_test.go
+++ b/pkg/action/rollback_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func rollbackAction(t *testing.T) *Rollback {
+	config := actionConfigFixture(t)
+	rollbackAction := NewRollback(config)
+
+	return rollbackAction
+}
+
+func TestRollbackToReleaseWithExternalFile(t *testing.T) {
+	is := assert.New(t)
+	vals := map[string]interface{}{}
+
+	chartVersion1 := buildChart(withExternalFileTemplate(ExternalFileName))
+	chartVersion2 := buildChart()
+
+	instAction := installAction(t)
+	instAction.ExternalPaths = append(instAction.ExternalPaths, ExternalFileRelPath)
+	relVersion1, err := instAction.Run(chartVersion1, vals)
+	is.Contains(relVersion1.Manifest, "out-of-chart-dir")
+	is.NoError(err)
+
+	upAction := upgradeAction(t)
+	err = upAction.cfg.Releases.Create(relVersion1)
+	is.NoError(err)
+	relVersion2, err := upAction.Run(relVersion1.Name, chartVersion2, vals)
+	is.NotContains(relVersion2.Manifest, "out-out-chart-dir")
+	is.NoError(err)
+
+	rollAction := rollbackAction(t)
+	err = rollAction.cfg.Releases.Create(relVersion1)
+	is.NoError(err)
+	err = rollAction.cfg.Releases.Create(relVersion2)
+	is.NoError(err)
+	currentRelease, targetRelease, err := rollAction.prepareRollback(relVersion2.Name)
+	is.NoError(err)
+	relVersion3, err := rollAction.performRollback(currentRelease, targetRelease)
+	is.NoError(err)
+
+	is.Contains(relVersion3.Manifest, "out-of-chart-dir")
+}

--- a/pkg/action/testdata/files/external.txt
+++ b/pkg/action/testdata/files/external.txt
@@ -1,0 +1,1 @@
+out-of-chart-dir

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -101,8 +101,10 @@ type Upgrade struct {
 	DisableOpenAPIValidation bool
 	// Get missing dependencies
 	DependencyUpdate bool
-	// Lock to control raceconditions when the process receives a SIGTERM
+	// Lock to control race conditions when the process receives a SIGTERM
 	Lock sync.Mutex
+	// ExternalPaths is list of included files in configuration
+	ExternalPaths []string
 }
 
 type resultMessage struct {
@@ -176,6 +178,10 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			return nil, nil, driver.NewErrNoDeployedReleases(name)
 		}
+		return nil, nil, err
+	}
+
+	if err := loadExternalPaths(chart, u.ExternalPaths); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/chart/loader/local.go
+++ b/pkg/chart/loader/local.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ExpandFilePath expands a local file, dir or glob path to a list of files
+func ExpandFilePath(path string) ([]string, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() {
+			files = append(files, filepath.ToSlash(path))
+		}
+		return nil
+	})
+
+	return files, nil
+}

--- a/pkg/chart/loader/local_test.go
+++ b/pkg/chart/loader/local_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandFilePath(t *testing.T) {
+	req := require.New(t)
+
+	dir, err := ExpandFilePath("testdata/albatross/")
+	req.NoError(err)
+	req.Contains(dir, "testdata/albatross/Chart.yaml")
+	req.Contains(dir, "testdata/albatross/values.yaml")
+
+	file, err := ExpandFilePath("testdata/albatross/Chart.yaml")
+	req.NoError(err)
+	req.Contains(file, "testdata/albatross/Chart.yaml")
+}

--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"encoding/base64"
+	"fmt"
 	"path"
 	"strings"
 
@@ -50,6 +51,7 @@ func (f files) GetBytes(name string) []byte {
 	if v, ok := f[name]; ok {
 		return v
 	}
+	fmt.Printf("file %s not included", name)
 	return []byte{}
 }
 
@@ -60,7 +62,8 @@ func (f files) GetBytes(name string) []byte {
 //
 //	{{.Files.Get "foo"}}
 func (f files) Get(name string) string {
-	return string(f.GetBytes(name))
+	content := f.GetBytes(name)
+	return string(content)
 }
 
 // Glob takes a glob pattern and returns another files object only containing
@@ -102,7 +105,8 @@ func (f files) Glob(pattern string) files {
 //   data:
 // {{ .Files.Glob("config/**").AsConfig() | indent 4 }}
 func (f files) AsConfig() string {
-	if f == nil {
+	if f == nil || len(f) == 0 {
+		fmt.Println("must pass path")
 		return ""
 	}
 
@@ -131,7 +135,8 @@ func (f files) AsConfig() string {
 //   data:
 // {{ .Files.Glob("secrets/*").AsSecrets() }}
 func (f files) AsSecrets() string {
-	if f == nil {
+	if f == nil || len(f) == 0 {
+		fmt.Println("must pass files")
 		return ""
 	}
 
@@ -153,7 +158,8 @@ func (f files) AsSecrets() string {
 // {{ . }}{{ end }}
 func (f files) Lines(path string) []string {
 	if f == nil || f[path] == nil {
-		return []string{}
+		fmt.Println("must pass files")
+		return nil
 	}
 
 	return strings.Split(string(f[path]), "\n")


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds the flag --include-path which allows you to include external paths in the install, upgrade and template commands.


**EXAMPLE 1** (Included only one path without alias):

Given the configmap:
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: {{ .Release.Name }}-test
data: {{ (.Files.Glob "tmp/externals/**").AsConfig | nindent 2 }}
```
And the directory structure:
```
├── /tmp/externals
│   ├── external1.txt
│   └── external2.txt
|   └── externals2
│       ├── external3.txt
│       └── external4.txt
```
Running  ``` helm template test_chart --include-path /tmp/externals ``` will generate the manifest:

Source: test_chart/templates/test.configmap.yaml
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: RELEASE-NAME-test
data:
  external1.txt: |
    External file 1
  external2.txt: |
    External file 2
  external3.txt: |
    External file 3
  external4.txt: |
    External file 4
```
In in chart.Files structure is:
```
external1.txt
external2.txt
externals2
    ├── external3.txt
    └── external4.txt
```

**EXAMPLE 2** (Included only one path with alias):
You can define a named alias using the ```@``` identifier. Once defined, you can use the named alias inside your templates.

Given the configmap:
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: {{ .Release.Name }}-test
data: {{ (.Files.Glob "vol1/**").AsConfig | nindent 2 }}
```
And the directory structure:
```
├── /tmp/externals
│   ├── external1.txt
│   └── external2.txt
|   └── externals2
│       ├── external3.txt
│       └── external4.txt
```
Running ```helm template test_chart --include-path vol1@/tmp/externals``` will generate the manifest:

Source: test_chart/templates/test.configmap.yaml
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: RELEASE-NAME-test
data:
  external1.txt: |
    External file 1
  external2.txt: |
    External file 2
  external3.txt: |
    External file 3
  external4.txt: |
    External file 4
```
The resulting chart.Files structure is:
```
vol1
├──external1.txt
├──external2.txt
└──externals2
    ├── external3.txt
    └── external4.txt
```

**EXAMPLE 3** (Included more path with/without alias):
You can define a named alias using the  ```@``` separator. If you don't need an alias and include multiple paths Helm will generate numeric alias starting with 0. In the example below, one path has an alias and one doesn't. 

Given the configmaps:
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: {{ .Release.Name }}-test1
data: {{ (.Files.Glob "vol1/**").AsConfig | nindent 2 }}
```
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: {{ .Release.Name }}-test2
data: {{ (.Files.Glob "1/**").AsConfig | nindent 2 }}
```
And the directory structure:
```
├── /tmp/externals1
│   ├── external1.txt
│   └── external2.txt
|
├── /tmp/externals2
│   ├── external3.txt
│   └── external4.txt
```
Running helm ```template test_chart --include-path vol1@/tmp/externals1 --include-path /tmp/externals2``` will generate the manifest:

Source: test_chart/templates/test.configmap.yaml
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: RELEASE-NAME-test1
data:
  external1.txt: |
    External file 1
  external2.txt: |
    External file 2
```
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: RELEASE-NAME-test2
data:
  external3.txt: |
    External file 3
  external4.txt: |
    External file 4
```
The resulting chart.Files structure is:
```
├───vol1
│   ├──external1.txt
│   └──external2.txt
│
├────1
│   ├──external3.txt
│   └──external4.txt
```

If the ```--include-path``` is not passed, the output will be like this:

```Error: template: test_chart/templates/test.configmap.yaml:6:41: executing "test_chart/templates/test.configmap.yaml" at <(.Files.Glob "/tmp/externals/*").AsConfig>: error calling AsConfig: must pass path```

Use ```--debug``` flag to render out invalid YAML
Special notes for your reviewer:
This PR continues the work that @itaispiegel started in his PR: #10077.

This is my first contribution to Helm, and my first time working with Go. I continued the work from #10077 but restricted my PR only two paths so there is no file or glob support for the ```--include-path``` flag.

close #10077

Thanks in advance! :)