### PR TITLE
fix (Issue #10685): Do not panic on invalid value locations

### DIFF
--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -117,5 +117,8 @@ func readFile(filePath string, p getter.Providers) ([]byte, error) {
 		return ioutil.ReadFile(filePath)
 	}
 	data, err := g.Get(filePath, getter.WithURL(filePath))
+	if err != nil {
+		return nil, err
+	}
 	return data.Bytes(), err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR closes #10685. Ultimately this fix displays the actual error message instead of panicking.

Previously, the following commands:
```
helm create examples
helm template examples -f "http://a.b"
```
made the program to panic; while now the same commands produce the following error message:
```
Error: Get "http://a.b": dial tcp: lookup a.b: no such host
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
