### PR TITLE
feat: add --set-json flag to set json values.

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -47,6 +47,7 @@ func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 	f.StringArrayVar(&v.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.StringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.FileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
+	f.StringArrayVar(&v.JSONValues, "set-json", []string{}, "set JSON values on the command line (can specify multiple or separate values with commas: key1=jsonval1,key2=jsonval2)")
 }
 
 func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -51,7 +51,8 @@ To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line, to force
 a string value use '--set-string'. You can use '--set-file' to set individual
 values from a file when the value itself is too long for the command line
-or is dynamically generated.
+or is dynamically generated. You can also use '--set-json' to set json values
+(scalars/objects/arrays) from the command line.
 
     $ helm install -f myvalues.yaml myredis ./redis
 
@@ -67,6 +68,11 @@ or
 
     $ helm install --set-file my_script=dothings.sh myredis ./redis
 
+or
+
+    $ helm install --set-json 'master.sidecars=[{"name":"sidecar","image":"myImage","imagePullPolicy":"Always","ports":[{"name":"portname","containerPort":1234}]}]' myredis ./redis
+
+
 You can specify the '--values'/'-f' flag multiple times. The priority will be given to the
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml
 contained a key called 'Test', the value set in override.yaml would take precedence:
@@ -79,6 +85,13 @@ set for a key called 'foo', the 'newbar' value would take precedence:
 
     $ helm install --set foo=bar --set foo=newbar  myredis ./redis
 
+Similarly, in the following example 'foo' is set to '["four"]': 
+
+    $ helm install --set-json='foo=["one", "two", "three"]' --set-json='foo=["four"]' myredis ./redis
+
+And in the following example, 'foo' is set to '{"key1":"value1","key2":"bar"}':
+
+    $ helm install --set-json='foo={"key1":"value1","key2":"value2"}' --set-json='foo.key2="bar"' myredis ./redis
 
 To check the generated manifests of a release without installing the chart,
 the '--debug' and '--dry-run' flags can be combined.

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -51,7 +51,8 @@ To override values in a chart, use either the '--values' flag and pass in a file
 or use the '--set' flag and pass configuration from the command line, to force string
 values, use '--set-string'. You can use '--set-file' to set individual
 values from a file when the value itself is too long for the command line
-or is dynamically generated.
+or is dynamically generated. You can also use '--set-json' to set json values
+(scalars/objects/arrays) from the command line.
 
 You can specify the '--values'/'-f' flag multiple times. The priority will be given to the
 last (right-most) file specified. For example, if both myvalues.yaml and override.yaml

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -88,7 +88,7 @@ func compare(actual []byte, filename string) error {
 	}
 	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
-		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'\n", filename, expected, actual)
+		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
 	}
 	return nil
 }

--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	StringValues []string
 	Values       []string
 	FileValues   []string
+	JSONValues   []string
 }
 
 // MergeValues merges values from files specified via -f/--values and directly
@@ -55,6 +56,13 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		}
 		// Merge with the previous map
 		base = mergeMaps(base, currentMap)
+	}
+
+	// User specified a value via --set-json
+	for _, value := range opts.JSONValues {
+		if err := strvals.ParseJSON(value, base); err != nil {
+			return nil, errors.Errorf("failed parsing --set-json data %s", value)
+		}
 	}
 
 	// User specified a value via --set

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -17,10 +17,13 @@ package strvals
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -94,6 +97,18 @@ func ParseIntoString(s string, dest map[string]interface{}) error {
 	return t.parse()
 }
 
+// ParseJSON parses a string with format key1=val1, key2=val2, ...
+// where values are json strings (null, or scalars, or arrays, or objects).
+// An empty val is treated as null.
+//
+// If a key exists in dest, the new value overwrites the dest version.
+//
+func ParseJSON(s string, dest map[string]interface{}) error {
+	scanner := bytes.NewBufferString(s)
+	t := newJSONParser(scanner, dest)
+	return t.parse()
+}
+
 // ParseIntoFile parses a filevals line and merges the result into dest.
 //
 // This method always returns a string as the value.
@@ -113,9 +128,10 @@ type RunesValueReader func([]rune) (interface{}, error)
 // where sc is the source of the original data being parsed
 // where data is the final parsed data from the parses with correct types
 type parser struct {
-	sc     *bytes.Buffer
-	data   map[string]interface{}
-	reader RunesValueReader
+	sc        *bytes.Buffer
+	data      map[string]interface{}
+	reader    RunesValueReader
+	isjsonval bool
 }
 
 func newParser(sc *bytes.Buffer, data map[string]interface{}, stringBool bool) *parser {
@@ -123,6 +139,10 @@ func newParser(sc *bytes.Buffer, data map[string]interface{}, stringBool bool) *
 		return typedVal(rs, stringBool), nil
 	}
 	return &parser{sc: sc, data: data, reader: stringConverter}
+}
+
+func newJSONParser(sc *bytes.Buffer, data map[string]interface{}) *parser {
+	return &parser{sc: sc, data: data, reader: nil, isjsonval: true}
 }
 
 func newFileParser(sc *bytes.Buffer, data map[string]interface{}, reader RunesValueReader) *parser {
@@ -184,6 +204,33 @@ func (t *parser) key(data map[string]interface{}) (reterr error) {
 			set(data, kk, list)
 			return err
 		case last == '=':
+			if t.isjsonval {
+				empval, err := t.emptyVal()
+				if err != nil {
+					return err
+				}
+				if empval {
+					set(data, string(k), nil)
+					return nil
+				}
+				// parse jsonvals by using Go’s JSON standard library
+				// Decode is preferred to Unmarshal in order to parse just the json parts of the list key1=jsonval1,key2=jsonval2,...
+				// Since Decode has its own buffer that consumes more characters (from underlying t.sc) than the ones actually decoded,
+				// we invoke Decode on a separate reader built with a copy of what is left in t.sc. After Decode is executed, we
+				// discard in t.sc the chars of the decoded json value (the number of those characters is returned by InputOffset).
+				var jsonval interface{}
+				dec := json.NewDecoder(strings.NewReader(t.sc.String()))
+				if err = dec.Decode(&jsonval); err != nil {
+					return err
+				}
+				set(data, string(k), jsonval)
+				if _, err = io.CopyN(ioutil.Discard, t.sc, dec.InputOffset()); err != nil {
+					return err
+				}
+				// skip possible blanks and comma
+				_, err = t.emptyVal()
+				return err
+			}
 			//End of key. Consume =, Get value.
 			// FIXME: Get value list first
 			vl, e := t.valList()
@@ -205,7 +252,6 @@ func (t *parser) key(data map[string]interface{}) (reterr error) {
 			default:
 				return e
 			}
-
 		case last == ',':
 			// No value given. Set the value to empty string. Return error.
 			set(data, string(k), "")
@@ -280,6 +326,34 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 	case err != nil:
 		return list, err
 	case last == '=':
+		if t.isjsonval {
+			empval, err := t.emptyVal()
+			if err != nil {
+				return list, err
+			}
+			if empval {
+				return setIndex(list, i, nil)
+			}
+			// parse jsonvals by using Go’s JSON standard library
+			// Decode is preferred to Unmarshal in order to parse just the json parts of the list key1=jsonval1,key2=jsonval2,...
+			// Since Decode has its own buffer that consumes more characters (from underlying t.sc) than the ones actually decoded,
+			// we invoke Decode on a separate reader built with a copy of what is left in t.sc. After Decode is executed, we
+			// discard in t.sc the chars of the decoded json value (the number of those characters is returned by InputOffset).
+			var jsonval interface{}
+			dec := json.NewDecoder(strings.NewReader(t.sc.String()))
+			if err = dec.Decode(&jsonval); err != nil {
+				return list, err
+			}
+			if list, err = setIndex(list, i, jsonval); err != nil {
+				return list, err
+			}
+			if _, err = io.CopyN(ioutil.Discard, t.sc, dec.InputOffset()); err != nil {
+				return list, err
+			}
+			// skip possible blanks and comma
+			_, err = t.emptyVal()
+			return list, err
+		}
 		vl, e := t.valList()
 		switch e {
 		case nil:
@@ -340,6 +414,28 @@ func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) {
 		return setIndex(list, i, inner)
 	default:
 		return nil, errors.Errorf("parse error: unexpected token %v", last)
+	}
+}
+
+// check for an empty value
+// read and consume optional spaces until comma or EOF (empty val) or any other char (not empty val)
+// comma and spaces are consumed, while any other char is not cosumed
+func (t *parser) emptyVal() (bool, error) {
+	for {
+		r, _, e := t.sc.ReadRune()
+		if e == io.EOF {
+			return true, nil
+		}
+		if e != nil {
+			return false, e
+		}
+		if r == ',' {
+			return true, nil
+		}
+		if !unicode.IsSpace(r) {
+			t.sc.UnreadRune()
+			return false, nil
+		}
 	}
 }
 


### PR DESCRIPTION
When used with helm install, helm template, helm upgrade, it enables
to set json values (scalars/objects/arrays) from the command line.

Closes #10428

Signed-off-by: Luca Di Rocco <lucadirocco@gmail.com>

**What this PR does / why we need it**:
This PR allows to set any key of the exposed values (scalars, objects, arrays) of a chart, by using a json value on the command line.
It become easier and more concise to update entire portions of the exposed values, as json data structures on command line, rather than setting the value of each individual leaf attribute of the data structure (#10428 provides an example) 

**Special notes for your reviewer**:
The implementation has tried to reuse as much as possible the existing code and the standard libraries, and is quite straightforward.
There are some obvious changes in cmd/helm/flags.go and pkg/cli/values/options.go in order to include the new option flag (--set-json)
The parser logic from pkg/strvals/parser.go is reused, with an extra field in the parser struct (isjsonval bool, true only for --set-json) and some extra code in the following two functions, to parse a json value when a "=" char is met:
func (t *parser) key(data map[string]interface{}) (reterr error)
func (t *parser) listItem(list []interface{}, i int) ([]interface{}, error) 

**If applicable**:
- [X] this PR contains documentation  
        Little updates in the description constants of cmd/helm/install.go and cmd/helm/upgrade.go to.
        Together with the info from cmd/helm/flags.go, this should update the documentation when "helm docs --type markdown --generate-headers" is executed.
- [X] this PR contains unit tests
        Some extra unit tests with function TestParseJSON in pkg/strvals/parser_test.go
- [X] this PR has been tested for backwards compatibility
        All unit test run, I don't know if something else is required. Being this a new feature, there are no changes in existing functionalities.
        Please note that I had also to remove the ending new line '\n' from an errors.Errorf statement in the  
func compare(actual []byte, filename string) error, in file ./internal/test/test.go, because go lint was failing and also tests were not running.
