### PR TITLE
Fix SIGSEGV by adding OCI RegistryClient args

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -122,7 +122,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			rel, err := runInstall(args, client, valueOpts, out)
+			rel, err := runInstall(args, client, cfg, valueOpts, out)
 			if err != nil {
 				return errors.Wrap(err, "INSTALLATION FAILED")
 			}
@@ -174,7 +174,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	}
 }
 
-func runInstall(args []string, client *action.Install, valueOpts *values.Options, out io.Writer) (*release.Release, error) {
+func runInstall(args []string, client *action.Install, cfg *action.Configuration, valueOpts *values.Options, out io.Writer) (*release.Release, error) {
 	debug("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		debug("setting version to >0.0.0-0")
@@ -227,6 +227,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 					Keyring:          client.ChartPathOptions.Keyring,
 					SkipUpdate:       false,
 					Getters:          p,
+					RegistryClient:   cfg.RegistryClient,
 					RepositoryConfig: settings.RepositoryConfig,
 					RepositoryCache:  settings.RepositoryCache,
 					Debug:            settings.Debug,

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -79,7 +79,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.ClientOnly = !validate
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			client.IncludeCRDs = includeCrds
-			rel, err := runInstall(args, client, valueOpts, out)
+			rel, err := runInstall(args, client, cfg, valueOpts, out)
 
 			if err != nil && !settings.Debug {
 				if rel != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -118,7 +118,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.Description = client.Description
 					instClient.DependencyUpdate = client.DependencyUpdate
 
-					rel, err := runInstall(args, instClient, valueOpts, out)
+					rel, err := runInstall(args, instClient, cfg, valueOpts, out)
 					if err != nil {
 						return err
 					}
@@ -159,6 +159,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							Keyring:          client.ChartPathOptions.Keyring,
 							SkipUpdate:       false,
 							Getters:          p,
+							RegistryClient:   cfg.RegistryClient,
 							RepositoryConfig: settings.RepositoryConfig,
 							RepositoryCache:  settings.RepositoryCache,
 							Debug:            settings.Debug,


### PR DESCRIPTION
Fixes #10246

WIP: Need to add unit tests, need to add args to newPackage in
cmd/helm/package_test.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes a sigsegv occurring on Helm 3.7.1 and Helm 3.8.0 when running `helm package` or `helm install` or `helm upgrade` when the Helm chart has an OCI dependency. Occurs if the dependencies have not previously been downloaded either via `helm dependency update` or `helm template` (the latter of which already has the proper code to handle up the OCI repos, which is how I figured out what was missing).

**Special notes for your reviewer**:

Per discussion in #10246, this PR is currently missing tests, since adding tests for this seems to require adding a lot of test infrastructure which I'm not sure what your team wants, especially with respect to simulating external OCI dependencies. I want some help to get this properly unit tested (or unit tests waived) and merged.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
