### PR TITLE
Support --wait with helm status #10750

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -91,6 +91,9 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 	bindOutputFlag(cmd, &outfmt)
 	f.BoolVar(&client.ShowDescription, "show-desc", false, "if set, display the description message of the named release")
+	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
+	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
+	f.BoolVar(&client.WaitForJobs, "wait-for-jobs", false, "if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout")
 
 	return cmd
 }

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -108,6 +108,14 @@ func TestStatusCmd(t *testing.T) {
 				},
 			},
 		),
+	}, {
+		name:   "get status of a deployed release with wait",
+		cmd:    "status --wait flummoxed-chickadee",
+		golden: "output/status.txt",
+		rels: releasesMockWithStatus(&release.Info{
+			Status:      release.StatusDeployed,
+			Description: "Mock description",
+		}),
 	}}
 	runTestCmd(t, tests)
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -88,7 +88,7 @@ func compare(actual []byte, filename string) error {
 	}
 	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
-		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'\n", filename, expected, actual)
+		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for blocking `status` command until all pods (and other resources) start, similarly to `install`, `upgrade` and `rollback` commands.

closes #10750

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
