### PR TITLE
Update go from 1.17 to 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/helm.sh/helm
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
       
         auth:
           username: $DOCKER_USER
@@ -13,7 +13,7 @@ jobs:
 
     environment:
       GOCACHE: "/tmp/go/cache"
-      GOLANGCI_LINT_VERSION: "1.43.0"
+      GOLANGCI_LINT_VERSION: "1.46.2"
 
     steps:
       - checkout

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Install golangci-lint
         run: |
           curl -sSLO https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VERSION/golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64.tar.gz
@@ -21,8 +21,8 @@ jobs:
           sudo mv golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64/golangci-lint /usr/local/bin/golangci-lint
           rm -rf golangci-lint-$GOLANGCI_LINT_VERSION-linux-amd64*
         env:
-          GOLANGCI_LINT_VERSION: '1.43.0'
-          GOLANGCI_LINT_SHA256: 'f3515cebec926257da703ba0a2b169e4a322c11dc31a8b4656b50a43e48877f4'
+          GOLANGCI_LINT_VERSION: '1.46.2'
+          GOLANGCI_LINT_SHA256: '242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b'
       - name: Test style
         run: make test-style
       - name: Run unit tests


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates go from 1.17 to 1.18. 

Go 1.18 closes https://github.com/golang/go/issues/31103 and the templating package will now short-circuit the evaluation of `and` and `or` arguments. All `{{ if .foo }}{{ if .foo.bar }}...{{ end }}{ end }}`s can finally be replaced with `{{ if and .foo .foo.bar }}...{{ end }}`s.
