### PR TITLE
On hook failure, the cleanup mechanism should also run on all previous hooks

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -41,7 +41,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	// hooke are pre-ordered by kind, so keep order stable
 	sort.Stable(hookByWeight(executingHooks))
 
-	for _, h := range executingHooks {
+	for i, h := range executingHooks {
 		// Set default delete policy to before-hook-creation
 		if h.DeletePolicies == nil || len(h.DeletePolicies) == 0 {
 			// TODO(jlegrone): Only apply before-hook-creation delete policy to run to completion
@@ -91,6 +91,12 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			if err := cfg.deleteHookByPolicy(h, release.HookFailed); err != nil {
 				return err
 			}
+
+			// If a hook is failed, check the annotation of the previous successful hooks to determine whether the hook
+			// should be deleted under succeeded condition.
+			if err := cfg.deleteHooksByPolicy(executingHooks[0:i], release.HookSucceeded); err != nil {
+				return err
+			}
 			return err
 		}
 		h.LastRun.Phase = release.HookPhaseSucceeded
@@ -98,10 +104,8 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook
-	for _, h := range executingHooks {
-		if err := cfg.deleteHookByPolicy(h, release.HookSucceeded); err != nil {
-			return err
-		}
+	if err := cfg.deleteHooksByPolicy(executingHooks, release.HookSucceeded); err != nil {
+		return err
 	}
 
 	return nil
@@ -117,6 +121,17 @@ func (x hookByWeight) Less(i, j int) bool {
 		return x[i].Name < x[j].Name
 	}
 	return x[i].Weight < x[j].Weight
+}
+
+// deleteHooksByPolicy deletes all hooks if the hook policy instructs it to
+func (cfg *Configuration) deleteHooksByPolicy(hooks []*release.Hook, policy release.HookDeletePolicy) error {
+	for _, h := range hooks {
+		if err := cfg.deleteHookByPolicy(h, policy); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // deleteHookByPolicy deletes a hook if the hook policy instructs it to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #10279 

**What this PR does / why we need it**:
Currently, In case of multiple hooks if any of the hook fail, only that hook is deleted (if deletion policy is set). The other hooks are not deleted because code immediately returns error after cleaning up failed hook.

This PR adds mechanism to not only clean the failed hook, but clean the successful hook as well based on their deletion policy

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
