### PR TITLE
Fixing downloader plugin error handling

### DIFF
--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -75,6 +75,9 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 	for _, value := range opts.FileValues {
 		reader := func(rs []rune) (interface{}, error) {
 			bytes, err := readFile(string(rs), p)
+			if err != nil {
+				return nil, err
+			}
 			return string(bytes), err
 		}
 		if err := strvals.ParseIntoFile(value, base, reader); err != nil {
@@ -117,5 +120,8 @@ func readFile(filePath string, p getter.Providers) ([]byte, error) {
 		return ioutil.ReadFile(filePath)
 	}
 	data, err := g.Get(filePath, getter.WithURL(filePath))
+	if err != nil {
+		return nil, err
+	}
 	return data.Bytes(), err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

When downloader plugin exists with an error, Helm breaks with the following stack trace:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1ae9207]

goroutine 1 [running]:
bytes.(*Buffer).Bytes(...)
        bytes/buffer.go:54
helm.sh/helm/v3/pkg/cli/values.readFile(0xc0005a9f68, 0x12, 0xc000a345a0, 0x5, 0x5, 0x9, 0xc000a345a0, 0x3, 0xc000a79920, 0x1a4f36c)
        helm.sh/helm/v3/pkg/cli/values/options.go:120 +0x167
helm.sh/helm/v3/pkg/cli/values.(*Options).MergeValues(0xc0001d0ea0, 0xc000a345a0, 0x5, 0x5, 0x1, 0x3a, 0x0)
        helm.sh/helm/v3/pkg/cli/values/options.go:48 +0x115
main.runInstall(0xc000245c40, 0x2, 0x4, 0xc00043f8c0, 0xc0001d0ea0, 0x2292040, 0xc00000e018, 0x0, 0xc0008ad5f0, 0x1ffac3f)
        helm.sh/helm/v3/cmd/helm/install.go:193 +0x24e
main.newTemplateCmd.func2(0xc000508500, 0xc000245c40, 0x2, 0x4, 0x0, 0x0)
        helm.sh/helm/v3/cmd/helm/template.go:82 +0x146
github.com/spf13/cobra.(*Command).execute(0xc000508500, 0xc000245c00, 0x4, 0x4, 0xc000508500, 0xc000245c00)
        github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc00051a280, 0xc00000f4d0, 0x1, 0xc00089ff60)
        github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
        helm.sh/helm/v3/cmd/helm/helm.go:80 +0x25b

This PR adds necessary error handling to Helm in order to properly propagate errors from downloader plugins to Helm runtime so it exits gracefully.
