### PR TITLE
Log error message on failed download

### DIFF
--- a/cmd/helm/show_test.go
+++ b/cmd/helm/show_test.go
@@ -47,14 +47,14 @@ func TestShowPreReleaseChart(t *testing.T) {
 			name:        "show pre-release chart",
 			args:        "test/pre-release-chart",
 			fail:        true,
-			expectedErr: "failed to download \"test/pre-release-chart\"",
+			expectedErr: "chart \"pre-release-chart\" matching  not found in test index. (try 'helm repo update'): no chart version found for pre-release-chart-",
 		},
 		{
 			name:        "show pre-release chart",
 			args:        "test/pre-release-chart",
 			fail:        true,
 			flags:       "--version 1.0.0",
-			expectedErr: "failed to download \"test/pre-release-chart\" at version \"1.0.0\"",
+			expectedErr: "chart \"pre-release-chart\" matching 1.0.0 not found in test index. (try 'helm repo update'): no chart version found for pre-release-chart-1.0.0",
 		},
 		{
 			name:  "show pre-release chart with 'devel' flag",

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -751,13 +751,13 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	}
 
 	filename, _, err := dl.DownloadTo(name, version, settings.RepositoryCache)
-	if err == nil {
-		lname, err := filepath.Abs(filename)
-		if err != nil {
-			return filename, err
-		}
-		return lname, nil
-	} else {
+	if err != nil {
 		return "", err
 	}
+
+	lname, err := filepath.Abs(filename)
+	if err != nil {
+		return filename, err
+	}
+	return lname, nil
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -757,14 +757,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 			return filename, err
 		}
 		return lname, nil
-	} else if settings.Debug {
-		return filename, err
+	} else {
+		return "", err
 	}
-
-	atVersion := ""
-	if version != "" {
-		atVersion = fmt.Sprintf(" at version %q", version)
-	}
-
-	return filename, errors.Errorf("failed to download %q%s because of %s", name, atVersion, err)
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -766,5 +766,5 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		atVersion = fmt.Sprintf(" at version %q", version)
 	}
 
-	return filename, errors.Errorf("failed to download %q%s", name, atVersion)
+	return filename, errors.Errorf("failed to download %q%s because of %s", name, atVersion, err)
 }


### PR DESCRIPTION
Add logging of the actual cause of the failure to download the helm chart. Related to #10285