### PR TITLE
add --install-dir and --binary-name to get-helm script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -183,6 +183,8 @@ help () {
   echo -e "\t[--version|-v <desired_version>]"
   echo -e "\te.g. --version v2.4.0  or -v latest"
   echo -e "\t[--no-sudo]  ->> install without sudo"
+  echo -e "\t[--install-dir] <install_destination_filepath> ->> install helm binary to a specific directory, e.g., /usr/bin"
+  echo -e "\t[--binary-name] <binary_filename> ->> name of helm binary, e.g., helm-v3.8.1"
 }
 
 # cleanup temporary files to avoid https://github.com/helm/helm/issues/2977
@@ -214,6 +216,24 @@ while [[ $# -gt 0 ]]; do
        ;;
     '--no-sudo')
        USE_SUDO="false"
+       ;;
+    '--install-dir')
+       shift
+       if [[ $# -ne 0 ]]; then
+           export HELM_INSTALL_DIR="${1}"
+       else
+           echo -e "Please provide the desired installation directory. e.g. --install-dir /usr/bin"
+           exit 0
+       fi
+       ;;
+    '--binary-name')
+       shift
+       if [[ $# -ne 0 ]]; then
+           export BINARY_NAME="${1}"
+       else
+           echo -e "Please provide the desired binary name. e.g. --binary-name helm-v3.8.1"
+           exit 0
+       fi
        ;;
     '--help'|-h)
        help

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -265,6 +265,8 @@ help () {
   echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub"
   echo -e "\te.g. --version v3.0.0 or -v canary"
   echo -e "\t[--no-sudo]  ->> install without sudo"
+  echo -e "\t[--install-dir] <install_destination_filepath> ->> install helm binary to a specific directory, e.g., /usr/bin"
+  echo -e "\t[--binary-name] <binary_filename> ->> name of helm binary, e.g., helm-v3.8.1"
 }
 
 # cleanup temporary files to avoid https://github.com/helm/helm/issues/2977
@@ -301,6 +303,24 @@ while [[ $# -gt 0 ]]; do
        ;;
     '--no-sudo')
        USE_SUDO="false"
+       ;;
+    '--install-dir')
+       shift
+       if [[ $# -ne 0 ]]; then
+           export HELM_INSTALL_DIR="${1}"
+       else
+           echo -e "Please provide the desired installation directory. e.g. --install-dir /usr/bin"
+           exit 0
+       fi
+       ;;
+    '--binary-name')
+       shift
+       if [[ $# -ne 0 ]]; then
+           export BINARY_NAME="${1}"
+       else
+           echo -e "Please provide the desired binary name. e.g. --binary-name helm-v3.8.1"
+           exit 0
+       fi
        ;;
     '--help'|-h)
        help


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Hi helm maintainers!

I've been integrating the canonical `get-helm.sh` into cluster-api-provider-azure CI scripts and was able to take advantage of the `HELM_INSTALL_DIR` and `BINARY_NAME` env vars consumed by `get-helm.sh` to conveniently place immutable helm binaries into the local `hack/tools/bin` (a common pattern). I wonder how durable these named environment variables are, and so this PR offers them as 1st class arguments that the CLI parses and displays in its help message.

Reference:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2209/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R753

Happy to up-scope this to include other named configuration currently expressed as "black box" environment variables to better ensure that folks using those configuration interfaces have a more reliable front door (i.e., the named args supported by the script itself when it runs).

Also if I've missed documentation where such a change would want to be annotated please let me know.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
