### PR TITLE
Populate Capabilities.HelmVersion during install

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -272,6 +272,7 @@ func (cfg *Configuration) getCapabilities() (*chartutil.Capabilities, error) {
 			Major:   kubeVersion.Major,
 			Minor:   kubeVersion.Minor,
 		},
+		HelmVersion: chartutil.DefaultCapabilities.HelmVersion,
 	}
 	return cfg.Capabilities, nil
 }


### PR DESCRIPTION
Signed-off-by: Graham Reed <greed@7deadly.org>

refs #8834
refs #6689

**What this PR does / why we need it**:

The `Capabilities.HelmVersion` map is only filled out during `helm template`, which uses `DefaultCapabilities`.

The map is empty during `helm install` or `helm upgrade`, as that path uses a Kubernetes-context-specific Capabilities based on actually querying the API Server.

You can check this by using a simple configmap containing:

```
data:
  test.txt: |-
    {{- (.Capabilities | toJson | fromJson).HelmVersion | toYaml | nindent 4 }}
```

Using the HEAD of main (commit cba3b1ee), I get:

```
data:
  test.txt: '{}'
```

And using this patch I get:

```
data:
  test.txt: |-
    git_commit: 82a2a2e85ccd9f83455b211ac2a7c7c887ffb9bd
    git_tree_state: dirty
    go_version: go1.18
    version: v3.8+unreleased
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
