### PR TITLE
replace +build with go:build

### DIFF
--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Helm Authors.

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Helm Authors.

--- a/internal/third_party/dep/fs/rename.go
+++ b/internal/third_party/dep/fs/rename.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 /*
 Copyright (c) for portions of rename.go are held by The Go Authors, 2016 and are provided under

--- a/internal/third_party/dep/fs/rename_windows.go
+++ b/internal/third_party/dep/fs/rename_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 /*
 Copyright (c) for portions of rename_windows.go are held by The Go Authors, 2016 and are provided under

--- a/pkg/helmpath/home_unix_test.go
+++ b/pkg/helmpath/home_unix_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package helmpath
 

--- a/pkg/helmpath/home_windows_test.go
+++ b/pkg/helmpath/home_windows_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_darwin.go
+++ b/pkg/helmpath/lazypath_darwin.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_unix.go
+++ b/pkg/helmpath/lazypath_unix.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_unix_test.go
+++ b/pkg/helmpath/lazypath_unix_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_windows.go
+++ b/pkg/helmpath/lazypath_windows.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_windows_test.go
+++ b/pkg/helmpath/lazypath_windows_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 


### PR DESCRIPTION
go:build is the new conditional compilation directive used to specify build constraints. It was introduced in Go 1.17. It is meant to replace the old +build directives.

Now that go.mod points to Go 1.17 we no longer need to support both
build flags.

https://pkg.go.dev/cmd/go#hdr-Build_constraints

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>