### PR TITLE
Support for multiple yaml documents in stdin/file

### DIFF
--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package values
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/getter"
@@ -84,5 +86,119 @@ func TestReadFile(t *testing.T) {
 	_, err := readFile(filePath, p)
 	if err == nil {
 		t.Errorf("Expected error when has special strings")
+	}
+}
+
+func TestMergeYaml(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		input  string
+		err    bool
+		expect map[string]interface{}
+	}{
+		{"string value", "key: value1", false, map[string]interface{}{
+			"key": "value1",
+		}},
+		{"int value", "key: 1000", false, map[string]interface{}{
+			"key": 1000,
+		}},
+		{"nil value", "key: ~", false, map[string]interface{}{
+			"key": nil,
+		}},
+
+		{"sub map", "key: {subkey: sub value}", false, map[string]interface{}{
+			"key": map[string]interface{}{
+				"subkey": "sub value",
+			},
+		}},
+
+		{"empty document", "---", false, map[string]interface{}{}},
+		{"empty document with newline", "---\n", false, map[string]interface{}{}},
+
+		{"empty documents", "\n---\n", false, map[string]interface{}{}},
+
+		{"multiple documents w/o first separator", "key1: value1\n---\nkey2: value2", false, map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		}},
+		{"multiple documents w/ first separator", "---\nkey1: value1\n---\nkey2: value2", false, map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		}},
+		{"override keys with string", "---\nkey1: value1\n---\nkey1: value2", false, map[string]interface{}{
+			"key1": "value2",
+		}},
+		{"override keys with nil", "key1: value1\n---\nkey2: ", false, map[string]interface{}{
+			"key1": "value1",
+			"key2": nil,
+		}},
+		{"override keys with nil + additional separator", "key1: value1\n---\nkey2: \n---", false, map[string]interface{}{
+			"key1": "value1",
+			"key2": nil,
+		}},
+		{"override with map", "---\nfoo: {key: value}\n#---\nfoo: {key: value2}", false, map[string]interface{}{
+			"foo": map[string]interface{}{
+				"key": "value2",
+			},
+		}},
+
+		{"yaml syntax error in 2nd document", "key1: value1\n---\nkey2 ", true, nil},
+
+		{"7 yaml documents", "key1: value1\n---\nkey2: value2\n---\nkey3: value3\n---\nkey4: value4\n---\nkey5: value5\n---\nkey6: value6\n---\nkey7: value7\n---", false, map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
+			"key4": "value4",
+			"key5": "value5",
+			"key6": "value6",
+			"key7": "value7",
+		}},
+
+		{"comment in yaml separator", "---\nfoo: bar\n--- # with Comment\nbaz: biz", false, map[string]interface{}{
+			"foo": "bar",
+			"baz": "biz",
+		}},
+
+		{"yaml anchors", "---\nkey1: &value value\nkey2:\n- *value", false, map[string]interface{}{
+			"key1": "value",
+			"key2": []interface{}{"value"},
+		}},
+
+		{"separator in multiline", "key: >-\n  hello\n  ---\n  world", false, map[string]interface{}{
+			"key": "hello --- world",
+		}},
+
+		{"multiple json", "{\"1\":2}{\"3\":4}", false, map[string]interface{}{
+			"1": 2,
+			"3": 4,
+		}},
+		{"json with spaces", "   {\"1\":2}    ", false, map[string]interface{}{
+			"1": 2,
+		}},
+
+		{"big yaml", strings.Repeat("---\nkey1: value1\n---\nkey2: value2\n", 10*1024), false, map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		}},
+	}
+
+	for _, testCase := range testCases {
+		base := map[string]interface{}{}
+		base, err := mergeYaml(base, []byte(testCase.input))
+
+		switch {
+		case testCase.err && err == nil:
+			t.Errorf("%s: unexpected non-error", testCase.desc)
+			continue
+		case !testCase.err && err != nil:
+			t.Errorf("%s: unexpected error: %v", testCase.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if fmt.Sprintf("%#v", testCase.expect) != fmt.Sprintf("%#v", base) {
+			t.Errorf("%s: objects were not equal: \n%#v\n%#v", testCase.desc, testCase.expect, base)
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #10866 

**Special notes for your reviewer**:

Tested stdin yaml:

```yaml
---
a:
  b: c
  c: d
  e: f
---
e: value
a:
  b: f
  e:
  
test: >-
  hello
  ---
  world
---
a:
  c: 4
```

Before (main branch):
```
% cat values.yaml | ./bin/helm template --repo https://jkroepke.github.io/helm-charts/ values -f - 
---
# Source: values/templates/values.yaml
a:
  b: c
  c: d
  e: f
```

After (this PR):
```
% cat values.yaml | ./bin/helm template --repo https://jkroepke.github.io/helm-charts/ values -f - 
---
# Source: values/templates/values.yaml
a:
  b: f
  c: 4
  e: null
e: value
test: hello --- world
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
