### PR TITLE
perf(resolver): use index cache when resolving

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -57,6 +57,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 	// Now we clone the dependencies, locking as we go.
 	locked := make([]*chart.Dependency, len(reqs))
 	missing := []string{}
+	cachedRepoIndex := map[string]*repo.IndexFile{}
 	for i, d := range reqs {
 		constraint, err := semver.NewConstraint(d.Version)
 		if err != nil {
@@ -123,11 +124,15 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 		var ok bool
 		found := true
 		if !registry.IsOCI(d.Repository) {
-			repoIndex, err := repo.LoadIndexFile(filepath.Join(r.cachepath, helmpath.CacheIndexFile(repoName)))
-			if err != nil {
-				return nil, errors.Wrapf(err, "no cached repository for %s found. (try 'helm repo update')", repoName)
+			repoIndex, existence := cachedRepoIndex[repoName]
+			if !existence {
+				var err error
+				repoIndex, err = repo.LoadIndexFile(filepath.Join(r.cachepath, helmpath.CacheIndexFile(repoName)))
+				if err != nil {
+					return nil, errors.Wrapf(err, "no cached repository for %s found. (try 'helm repo update')", repoName)
+				}
+				cachedRepoIndex[repoName] = repoIndex
 			}
-
 			vs, ok = repoIndex.Entries[d.Name]
 			if !ok {
 				return nil, errors.Errorf("%s chart not found in repo %s", d.Name, d.Repository)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Add a map to cache repo index file to avoid repetitive index loading. It will save up to 80% resolve time with about 100+ dependencies and 15000+ charts in a reposity.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
