### PR TITLE
fix: update action.go  add postrenderer to hook Manifest 

### DIFF
--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Helm Authors.

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright The Helm Authors.

--- a/internal/third_party/dep/fs/rename.go
+++ b/internal/third_party/dep/fs/rename.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 /*
 Copyright (c) for portions of rename.go are held by The Go Authors, 2016 and are provided under

--- a/internal/third_party/dep/fs/rename_windows.go
+++ b/internal/third_party/dep/fs/rename_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 /*
 Copyright (c) for portions of rename_windows.go are held by The Go Authors, 2016 and are provided under

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -220,6 +220,13 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 		if err != nil {
 			return hs, b, notes, errors.Wrap(err, "error while running post render on files")
 		}
+		for _, hook := range hs {
+			sb, err := pr.Run(bytes.NewBufferString(hook.Manifest))
+			if err != nil {
+				return hs, b, notes, errors.Wrap(err, "error while running post render on hooks")
+			}
+			hook.Manifest = sb.String()
+		}
 	}
 
 	return hs, b, notes, nil

--- a/pkg/helmpath/home_unix_test.go
+++ b/pkg/helmpath/home_unix_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package helmpath
 

--- a/pkg/helmpath/home_windows_test.go
+++ b/pkg/helmpath/home_windows_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_darwin.go
+++ b/pkg/helmpath/lazypath_darwin.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_unix.go
+++ b/pkg/helmpath/lazypath_unix.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_unix_test.go
+++ b/pkg/helmpath/lazypath_unix_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_windows.go
+++ b/pkg/helmpath/lazypath_windows.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 

--- a/pkg/helmpath/lazypath_windows_test.go
+++ b/pkg/helmpath/lazypath_windows_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package helmpath
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Support  Run PostRenderer with Hooks Manifest. 

There is usecase is when install helm chart in private k8s cluster which has no internet access,  after we push the images to local docker registry,  we need rewrite the repo of images within charts to local docker registry domain.
```
helm install chart  ./chart_path  -n namespace  --post-renderer=sed --post-renderer-args='s|docker.io\([^\"]*\)|192.168.1.1:5000\1-aarch64|g'
```
but at current versions the hooks Manifest did not  run with PostRenderer,  so this PR fix it
**Special notes for your reviewer**:
may this can be merge into helm v3.9.0

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x ] this PR has been tested for backwards compatibility
