### PR TITLE
Add `WithIfModifiedSince` to enable use of HTTP caching

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -45,6 +45,7 @@ type options struct {
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
+	ifModifiedSince       *time.Time
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -118,6 +119,20 @@ func WithRegistryClient(client *registry.Client) Option {
 func WithUntar() Option {
 	return func(opts *options) {
 		opts.unTar = true
+	}
+}
+
+// WithIfModifiedSince leverages the HTTP caching mechanism
+// defined on RFC7234 4.3.2. It prevents the HTTP getter from
+// downloading index that haven't been modified based on `since`.
+// If the file was not modified, getter will return a
+// `304 Not Modified`, as per RFC.
+//
+// The caller is responsible for caching previously downloaded
+// index files and handling the returning error.
+func WithIfModifiedSince(since time.Time) Option {
+	return func(opts *options) {
+		opts.ifModifiedSince = &since
 	}
 }
 

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -56,6 +57,10 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 	req.Header.Set("User-Agent", version.GetUserAgent())
 	if g.opts.userAgent != "" {
 		req.Header.Set("User-Agent", g.opts.userAgent)
+	}
+
+	if g.opts.ifModifiedSince != nil {
+		req.Header.Set("If-Modified-Since", g.opts.ifModifiedSince.Format(time.RFC1123))
 	}
 
 	// Before setting the basic auth credentials, make sure the URL associated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The HTTP Getter can leverage the use of [RFC7234 4.3.2](https://datatracker.ietf.org/doc/html/rfc7234#section-4.3.2) by setting the
HTTP Header 'If-Modified-Since'. This will enable callers to avoid
downloading index files when they haven't been modified since the
last get operation.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
