### PR TITLE
feat(helm): Support the newly created helm template with startup Probes

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -322,6 +322,10 @@ spec:
             httpGet:
               path: /
               port: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commits adds the possibility to integrate startup Probes when creating a new custom helm chat via helm cli.

It has resolved #10933

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backward compatibility
