### PR TITLE
fix: values in library subcharts are ignored

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -268,7 +268,7 @@ func processImportValues(c *chart.Chart) error {
 	}
 
 	// set the new values
-	c.Values = CoalesceTables(cvals, b)
+	c.Values = CoalesceTables(b, cvals)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Alberto Garcia <albgp22@gmail.com>

closes #10899

Since helm v3.8.2 was released, values imports from library subcharts via import-values stopped working. This bug has also been reported by other collegues as you can see in the linked issue.

This PR solves this problem, reverting a change included in [this commit](https://github.com/helm/helm/commit/5d017e11f1f47345a3559bf70f63d81a7edc981a) which changed value precedence.

