### PR TITLE
Fixed Helm plugin install and update from VCS 

### DIFF
--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -29,8 +29,7 @@ import (
 )
 
 type pluginUpdateOptions struct {
-	names   map[string]string
-	version string
+	names map[string]string
 }
 
 const pluginUpdateDesc = `
@@ -41,7 +40,7 @@ func newPluginUpdateCmd(out io.Writer) *cobra.Command {
 	o := &pluginUpdateOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "update <plugin:[version]>...",
+		Use:     "update <plugin[:version]>...",
 		Aliases: []string{"up"},
 		Short:   "update one or more Helm plugins",
 		Long:    pluginUpdateDesc,
@@ -55,7 +54,6 @@ func newPluginUpdateCmd(out io.Writer) *cobra.Command {
 			return o.run(out)
 		},
 	}
-	cmd.Flags().StringVar(&o.version, "version", "", "specify a version constraint. If this is not specified, the latest version is installed")
 	return cmd
 }
 
@@ -109,7 +107,13 @@ func updatePlugin(p *plugin.Plugin, version string) error {
 		return err
 	}
 
-	i, err := installer.FindSource(absExactLocation, version)
+	var i installer.Installer
+
+	if version != "" {
+		i, err = installer.FindSourceWithVersion(absExactLocation, version)
+	} else {
+		i, err = installer.FindSource(absExactLocation)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -75,8 +75,17 @@ func NewForSource(source, version string) (Installer, error) {
 }
 
 // FindSource determines the correct Installer for the given source.
-func FindSource(location, version string) (Installer, error) {
-	installer, err := existingVCSRepo(location, version)
+func FindSource(location string) (Installer, error) {
+	installer, err := existingVCSRepo(location)
+	if err != nil && err.Error() == "Cannot detect VCS" {
+		return installer, errors.New("cannot get information about plugin source")
+	}
+	return installer, err
+}
+
+// FindSourceWithVersion determines the correct Installer for the given source with provided version.
+func FindSourceWithVersion(location, version string) (Installer, error) {
+	installer, err := existingVCSRepoWithVersion(location, version)
 	if err != nil && err.Error() == "Cannot detect VCS" {
 		return installer, errors.New("cannot get information about plugin source")
 	}

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -75,8 +75,8 @@ func NewForSource(source, version string) (Installer, error) {
 }
 
 // FindSource determines the correct Installer for the given source.
-func FindSource(location string) (Installer, error) {
-	installer, err := existingVCSRepo(location)
+func FindSource(location, version string) (Installer, error) {
+	installer, err := existingVCSRepo(location, version)
 	if err != nil && err.Error() == "Cannot detect VCS" {
 		return installer, errors.New("cannot get information about plugin source")
 	}

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,11 +16,11 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"github.com/Masterminds/vcs"
 	"os"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/Masterminds/vcs"
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/third_party/dep/fs"
@@ -35,14 +35,15 @@ type VCSInstaller struct {
 	base
 }
 
-func existingVCSRepo(location string) (Installer, error) {
+func existingVCSRepo(location, version string) (Installer, error) {
 	repo, err := vcs.NewRepo("", location)
 	if err != nil {
 		return nil, err
 	}
 	i := &VCSInstaller{
-		Repo: repo,
-		base: newBase(repo.Remote()),
+		Repo:    repo,
+		Version: version,
+		base:    newBase(repo.Remote()),
 	}
 	return i, nil
 }
@@ -82,6 +83,8 @@ func (i *VCSInstaller) Install() error {
 		if err := i.setVersion(i.Repo, ref); err != nil {
 			return err
 		}
+	} else if err := updateToLatest(i.Repo); err != nil {
+		return err
 	}
 
 	if !isPlugin(i.Repo.LocalPath()) {
@@ -98,7 +101,15 @@ func (i *VCSInstaller) Update() error {
 	if i.Repo.IsDirty() {
 		return errors.New("plugin repo was modified")
 	}
-	if err := i.Repo.Update(); err != nil {
+	ref, err := i.solveVersion(i.Repo)
+	if err != nil {
+		return err
+	}
+	if ref != "" {
+		if err := i.setVersion(i.Repo, ref); err != nil {
+			debug(err.Error())
+		}
+	} else if err := updateToLatest(i.Repo); err != nil {
 		return err
 	}
 	if !isPlugin(i.Repo.LocalPath()) {
@@ -139,7 +150,6 @@ func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
 		if constraint.Check(v) {
 			// If the constraint passes get the original reference
 			ver := v.Original()
-			debug("setting to %s", ver)
 			return ver, nil
 		}
 	}
@@ -173,4 +183,20 @@ func getSemVers(refs []string) []*semver.Version {
 		}
 	}
 	return sv
+}
+
+func updateToLatest(repo vcs.Repo) error {
+	refs, err := repo.Tags()
+	if err != nil {
+		return err
+	}
+	debug("found refs: %s", refs)
+
+	// Convert and filter the list to semver.Version instances
+	semvers := getSemVers(refs)
+
+	// Sort semver list
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	latest := semvers[0].Original()
+	return repo.UpdateVersion(latest)
 }

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,11 +16,11 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
-	"github.com/Masterminds/vcs"
 	"os"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/Masterminds/vcs"
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/third_party/dep/fs"
@@ -35,7 +35,19 @@ type VCSInstaller struct {
 	base
 }
 
-func existingVCSRepo(location, version string) (Installer, error) {
+func existingVCSRepo(location string) (Installer, error) {
+	repo, err := vcs.NewRepo("", location)
+	if err != nil {
+		return nil, err
+	}
+	i := &VCSInstaller{
+		Repo: repo,
+		base: newBase(repo.Remote()),
+	}
+	return i, nil
+}
+
+func existingVCSRepoWithVersion(location, version string) (Installer, error) {
 	repo, err := vcs.NewRepo("", location)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Mihael Rodek <mihael.rodek1@gmail.com>

closes #10929

**What this PR does / why we need it**: Fixes the plugin update and plugin install commands using better version handling
please refer to issue #10929 for more detailed explanation

**Special notes for your reviewer**: Plugin now prioritizes latest version over the cached one 

e.g.
 ```helm plugin install [options] <path|url>...``` now installs the latest version and not one fetched from cache
 ```helm plugin update <plugin:[version]>...``` now allows user to specify to which version should plugin be updated to