### PR TITLE
feat: updateable hooks

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -74,6 +74,7 @@ metadata:
   name: test-cm
   annotations:
     "helm.sh/hook": post-install,pre-delete,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   name: value`
 
@@ -810,6 +811,7 @@ metadata:
   name: test-cm-postrendered
   annotations:
     "helm.sh/hook": post-install,pre-delete,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   name: value`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This should fix: #10987, instead of just deleting hooks before creation or just failing if the resource already exists allow the hook to be updated if the right labels are present.

**Special notes for your reviewer**:

- This implements a previously existing `TODO` comment: https://github.com/helm/helm/blob/a499b4b179307c267bdf3ec49b880e3dbd2a5591/pkg/action/hooks.go#L47:L50
- This can be a breaking change for users that don't explicitly set the hook deletion policies and/or don't set the helm release ownership labels, the new code will add the labels but for upgrades it can be a problem that we have to document, adding the right labels to the existing resources or explicitly setting a deletion policy will fix the issue, so it's not a blocker but it might require manual intervention. 
- An alternative approach could be to create an `UpdateInPlace` function that just takes one `ResourceList` and creates or updates the resources regardless of the ownership labels, I've considered that option, we could use the object returned by the call that is made to check for the existence of the resource to create the patch, but that could be potentially more dangerous than just failing the release and require manual intervention to move forward
- ~~I've added an additional commit with some linter fixes, I guess I'm running a newer version of the `golangci-lint` tool and it complained about some issues unrelated to my changes.~~ update: no longer needed after rebase
- There might be other resource types that should have the delete before creation policies by default, but at the moment I can only think of `Jobs` and `Pods` being the ones that should have it for sure, mainly because of immutability, if you think of other resources that might not work well with updates, let me know and I can update the PR.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
