### PR TITLE
Add proper support for CRD 'crds/' templating & support for CRDs in 'templates/' folder

### DIFF
--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -1,5 +1,5 @@
 ---
-# Source: crds/crdA.yaml
+# Source: subchart/crds/crdA.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,7 +14,6 @@ spec:
     shortNames:
       - tc
     singular: authconfig
-
 ---
 # Source: subchart/templates/subdir/serviceaccount.yaml
 apiVersion: v1

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -173,6 +173,25 @@ func TestInstallRelease_WithNotes(t *testing.T) {
 	is.Equal(rel.Info.Notes, "note here")
 }
 
+func TestInstallRelease_WithTemplatedCRDs(t *testing.T) {
+	is := assert.New(t)
+	instAction := installAction(t)
+	instAction.ReleaseName = "with-crds"
+	vals := map[string]interface{}{}
+	res, err := instAction.Run(buildChart(withTemplatedCRDs()), vals)
+	if err != nil {
+		t.Fatalf("Failed install: %s", err)
+	}
+
+	rel, err := instAction.cfg.Releases.Get(res.Name, res.Version)
+	if err != nil {
+		t.Fatalf("Failed getting release: %s", err)
+	}
+	is.Contains(rel.Manifest, "---\n# Source: hello/crds/hello")
+	is.Contains(rel.Manifest, "namespace: spaced")
+	is.Contains(rel.Manifest, "name: Earth")
+}
+
 func TestInstallRelease_WithNotesRendered(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -231,7 +231,8 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
+	// ignore rendered 'crds/' folder files
+	hooks, _, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -45,6 +45,12 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return err
 		}
 
+		// Resources created by PrintingKubeClient do not have a Client or a Mapping value set.
+		// For these resources we can skip conflict detection.
+		if (info.Client == nil) || (info.Mapping == nil) {
+			return nil
+		}
+
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		existing, err := helper.Get(info.Namespace, info.Name)
 		if err != nil {

--- a/pkg/kube/filter_manifest.go
+++ b/pkg/kube/filter_manifest.go
@@ -1,0 +1,164 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type filteredReader struct {
+	reader io.ReadCloser
+
+	// a buffer allocation used by the reader
+	rawBuffer []byte
+	// maxBytes is the max size of the rawBuffer
+	maxBytes int
+
+	nread  int
+	nready int
+	ndone  int
+
+	recovering bool
+	eof        bool
+
+	// shouldInclude decides whether to skip an input resource or not
+	shouldInclude func(error, *metav1.PartialObjectMetadata) bool
+}
+
+var ErrObjectTooLarge = fmt.Errorf("object to decode was longer than maximum allowed size")
+
+const yamlSeparator = "\n---"
+
+func filterManifest(
+	reader io.ReadCloser,
+	shouldInclude func(error, *metav1.PartialObjectMetadata) bool,
+	initialBufferSize int,
+	maxBufferSize int,
+) io.ReadCloser {
+	return &filteredReader{
+		reader: reader,
+
+		rawBuffer: make([]byte, initialBufferSize),
+		maxBytes:  maxBufferSize,
+
+		nread:  0,
+		nready: 0,
+		ndone:  0,
+
+		recovering: false,
+		eof:        false,
+
+		shouldInclude: shouldInclude,
+	}
+}
+
+func FilterManifest(reader io.ReadCloser, shouldInclude func(error, *metav1.PartialObjectMetadata) bool) io.ReadCloser {
+	return filterManifest(reader, shouldInclude, 1024, 16*1024*1024)
+}
+
+// Decode reads the next object from the stream and decodes it.
+func (d *filteredReader) Read(buf []byte) (written int, err error) {
+	// write as much of the remaining readBuffer as possible
+	if d.nready > d.ndone {
+		n := copy(buf, d.rawBuffer[d.ndone:d.nready])
+		d.ndone += n
+		written += n
+	}
+
+	// we can't read anything and the buffer is empty
+	if d.eof && d.nread == 0 {
+		return written, io.EOF
+	}
+
+	// we can return if the buffer is filled already
+	if len(buf) == written {
+		return written, nil
+	}
+
+	if d.ndone != d.nready {
+		panic("unexpected")
+	}
+
+	d.nread = copy(d.rawBuffer, d.rawBuffer[d.nready:d.nread])
+	d.ndone, d.nready = 0, 0
+
+	sepLen := len([]byte(yamlSeparator))
+	for {
+		// go back in buffer to check for '\n---' sequence
+		d.nready -= sepLen
+		if d.nready < 0 {
+			d.nready = 0
+		}
+
+		// check if new bytes contain '\n---'
+		if i := bytes.Index(d.rawBuffer[d.nready:d.nread], []byte(yamlSeparator)); i >= 0 {
+			d.nready = d.nready + i + sepLen
+			break
+		} else {
+			d.nready = d.nread
+		}
+
+		if d.nread >= len(d.rawBuffer) {
+			if cap(d.rawBuffer) > d.maxBytes {
+				d.recovering = true // TODO
+				d.nready, d.nread = 0, 0
+				return written, ErrObjectTooLarge
+			}
+			d.rawBuffer = append(d.rawBuffer, 0)
+			d.rawBuffer = d.rawBuffer[:cap(d.rawBuffer)]
+		}
+
+		if d.eof {
+			d.nready = d.nread
+			break
+		}
+
+		n, err := d.reader.Read(d.rawBuffer[d.nread:])
+		d.nread += n
+		if err == io.EOF {
+			d.eof = true
+		} else if err != nil {
+			return written, err
+		}
+	}
+
+	var metadata metav1.PartialObjectMetadata
+
+	test := d.rawBuffer[:d.nready]
+
+	err = yaml.Unmarshal(test, &metadata)
+	if !d.shouldInclude(err, &metadata) {
+		// skip reading the current [0:d.nready] range
+		d.nread = copy(d.rawBuffer, d.rawBuffer[d.nready:d.nread])
+		for i := d.nread; i < cap(d.rawBuffer); i++ {
+			d.rawBuffer[i] = 0
+		}
+		d.nready = 0
+	}
+
+	n, err := d.Read(buf[written:])
+	return written + n, err
+}
+
+func (d *filteredReader) Close() error {
+	return d.reader.Close()
+}

--- a/pkg/kube/filter_manifest_test.go
+++ b/pkg/kube/filter_manifest_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/iotest"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testCase struct {
+	name   string
+	input  string
+	output string
+}
+
+var testCases = []testCase{
+	{
+		name: "testcase 1",
+		input: `
+apiVersion: v1
+kind: Namespace
+--- # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---
+apiVersion: test/v9
+kind: Test
+---`,
+		output: ` # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---`,
+	},
+	{
+		name: "testcase 2",
+		input: `
+apiVersion: v1
+kind: Namespace
+--- # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---
+apiVersion: test/v9
+kind: Test
+---
+# llllll
+aaa: whut
+
+`,
+		output: ` # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---`,
+	},
+	{
+		name: "testcase 3",
+		input: `
+apiVersion: v1
+kind: Namespace
+--- # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---
+apiVersion: test/v9
+kind: Test
+---
+# llllll
+aaa: aaaaaaaaaaa
+
+`,
+		output: ` # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---`,
+	},
+	{
+		name: "testcase 4",
+		input: `
+apiVersion: v1
+kind: Namespace
+--- # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---
+apiVersion: test/v9
+kind: Test
+---`,
+		output: ` # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value
+---`,
+	},
+	{
+		name: "testcase 5",
+		input: `
+apiVersion: v1
+kind: Namespace
+--- # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value---
+---
+apiVersion: test/v9
+kind: Test
+---
+apiVersion: test/v1
+kind: Test
+---
+apiVersion: test/v1
+kind: Test
+---
+---
+--
+-----
+---
+apiVersion: test/v1
+kind: Test
+---`,
+		output: ` # aaaa
+# aaaaa
+apiVersion: test/v1
+kind: Test
+field: value---
+---
+apiVersion: test/v1
+kind: Test
+---
+apiVersion: test/v1
+kind: Test
+---
+apiVersion: test/v1
+kind: Test
+---`,
+	},
+	{
+		name: "testcase 6",
+		input: `apiVersion: test/v1
+kind: Test`,
+		output: `apiVersion: test/v1
+kind: Test`,
+	},
+}
+
+func testTestCase(t *testing.T, initialBufferSize int, input io.Reader, output []byte) {
+	t.Helper()
+
+	reader := filterManifest(io.NopCloser(input), func(err error, o *metav1.PartialObjectMetadata) bool {
+		return (err == nil) && (o.GroupVersionKind().Kind == "Test" &&
+			o.GroupVersionKind().Version == "v1" &&
+			o.GroupVersionKind().Group == "test")
+	}, initialBufferSize, 9999999)
+
+	err := iotest.TestReader(reader, output)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAll(t *testing.T) {
+	for _, test := range testCases {
+		t.Log(test.name)
+		testTestCase(t, 10, bytes.NewBufferString(test.input), []byte(test.output))
+		testTestCase(t, 10, iotest.DataErrReader(bytes.NewBufferString(test.input)), []byte(test.output))
+		testTestCase(t, 10, iotest.HalfReader(bytes.NewBufferString(test.input)), []byte(test.output))
+		testTestCase(t, 10, iotest.OneByteReader(bytes.NewBufferString(test.input)), []byte(test.output))
+	}
+}
+
+func FuzzBufferSize(f *testing.F) {
+	f.Add(0)
+	f.Add(1)
+	f.Add(2)
+	f.Add(9)
+	f.Add(10000)
+	f.Fuzz(func(t *testing.T, initialBuffSize int) {
+		if initialBuffSize < 50*1024*1024 && initialBuffSize >= 0 {
+			for _, test := range testCases {
+				t.Log(test.name)
+				testTestCase(t, initialBuffSize, bytes.NewBufferString(test.input), []byte(test.output))
+				testTestCase(t, initialBuffSize, iotest.DataErrReader(bytes.NewBufferString(test.input)), []byte(test.output))
+				testTestCase(t, initialBuffSize, iotest.HalfReader(bytes.NewBufferString(test.input)), []byte(test.output))
+				testTestCase(t, initialBuffSize, iotest.OneByteReader(bytes.NewBufferString(test.input)), []byte(test.output))
+			}
+		}
+	})
+}

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package kube // import "helm.sh/helm/v3/pkg/kube"
 
-import "k8s.io/cli-runtime/pkg/resource"
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+)
 
 // ResourceList provides convenience methods for comparing collections of Infos.
 type ResourceList []*resource.Info


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently CRDs are too much of an afterthought. Keeping in mind <https://github.com/helm/community/blob/main/hips/hip-0011.md>, there are still quite a few improvements that can be made to Helm with regards to installing CRDs.

- adds support for templating crds in the 'crds/' folder
- filters crds in the 'templates/' folder and installs these resources first, also makes sure that the "discoveryClient.Invalidate" function is called after installing these CRDs

**Context**:
A request that we get a lot from cert-manager Helm Chart users is to move our CRDs to the "crds/" folder. However, we cannot do this because there are some templated fields in the CRDs (like labels & conversion webhook configs). Instead, we place the CRDs in the "templates/" folder, which makes it impossible to also add CRs in the Helm chart or in charts that use cert-manager as a dependency.
This PR proposes two fixes for the problem: 1) make resources in "crds/" folder templatable and 2) support CRDs in the "templates/" folder

**Special notes for your reviewer**:
Feel free to post some comments/ thoughts on these improvements. 

**If applicable**:
- [ ] this PR contains documentation // TODO
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
