### PR TITLE
Accept `gzip` for fetching a repository index file.

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -42,6 +42,7 @@ type options struct {
 	passCredentialsAll    bool
 	userAgent             string
 	version               string
+	enableCompression     bool
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
@@ -112,6 +113,13 @@ func WithTagName(tagname string) Option {
 func WithRegistryClient(client *registry.Client) Option {
 	return func(opts *options) {
 		opts.registryClient = client
+	}
+}
+
+// WithCompression enables compression
+func WithCompression() Option {
+	return func(opts *options) {
+		opts.enableCompression = true
 	}
 }
 

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -131,6 +131,7 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 		getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile),
 		getter.WithBasicAuth(r.Config.Username, r.Config.Password),
 		getter.WithPassCredentialsAll(r.Config.PassCredentialsAll),
+		getter.WithCompression(),
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What this PR does / why we need it**:

The change introduces a new `getter` option - `enableCompression`, and enables this feature for downloading a repository index file.

When the option value is `true`:
- `HttpGetter` adds "Accept-Encoding: gzip" header to a request.
- `HttpGetter` performs decompression of a response body if the response contains "Content-Encoding: gzip" header.

The motivation is leveraging compression for fetching big index files. Most of the public helm repositories are served by CDNs that support compression and the feature drastically reduces the amount of transferred traffic.

I've tested the changes against some of the popular Helm repositories:
```
httpgetter.go:118: URL: https://prometheus-community.github.io/helm-charts/index.yaml, Index size: 1.80MB, Transferred: 0.11MB
httpgetter.go:118: URL: https://charts.bitnami.com/bitnami/index.yaml, Index size: 3.72MB, Transferred: 0.25MB
httpgetter.go:118: URL: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/index.yaml, Index size: 14.20MB, Transferred: 1.05MB
```

And the result shows a significant(**~14x**) reduction for transferred traffic: 1,41mb vs 19,72mb.

⚠️  The change only applies to the index file downloading logic and doesn't affect a chart downloading process (I saw the issue - https://github.com/helm/helm/issues/2916)

**Special notes for your reviewer**:

The lack of this feature made the Bitnami charts repo maintainers remove all charts uploaded more than six months ago (https://github.com/bitnami/charts/issues/10539#issue-1257888825), and that caused many deployments to fail.


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
