### PR TITLE
Fail if could not retrieve latest release tag from github

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -108,11 +108,17 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://github.com/helm/helm/releases"
+    local latest_release_url="https://api.github.com/repos/helm/helm/releases/latest"
+    local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
-      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+      latest_release_response=$( wget "$latest_release_url" -O - 2>&1 || true )
+    fi
+    TAG=$( echo "$latest_release_response" | grep '"tag_name"' | sed -E 's/.*"(v[0-9\.]+)".*/\1/g' )
+    if [ "x$TAG" == "x" ]; then
+      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
+      exit 1
     fi
   else
     TAG=$DESIRED_VERSION


### PR DESCRIPTION
Happened to me when trying to install helm on a server located in China. Github was blocked so `curl` could not get a page from github, so the $TAG was empty and after that the URL for installing helm was missing version but the error was not clear at all as it was difficult to notice that the URL is missing the version. Had to look into the script code to figure out what went wrong. I propose to fail the script early if the version info could not be retrieved from github. 

Signed-off-by: Sho Ce <261885+shoce@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
