### PR TITLE
Remove unnecessary line break

### DIFF
--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -60,7 +60,6 @@ func (d *Dependency) List(chartpath string, out io.Writer) error {
 	}
 
 	d.printDependencies(chartpath, out, c)
-	fmt.Fprintln(out)
 	d.printMissing(chartpath, out, c.Metadata.Dependencies)
 	return nil
 }


### PR DESCRIPTION
If you do a `helm dep list` you get two empty lines after the actual output, yielding in:

```bash
nilfr@pc:~/repos/Platform$ helm dep list charts/rancher
NAME    VERSION REPOSITORY                                              STATUS
rancher 2.6.5   https://releases.rancher.com/server-charts/latest       ok    

nilfr@pc:~/repos/Platform$ 
```

No other command does this, hence I removed it.