### PR TITLE
Adding test for pkg/chart/v2/util AsMap()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
     environment:
       GOCACHE: "/tmp/go/cache"
-      GOLANGCI_LINT_VERSION: "1.43.0"
+      GOLANGCI_LINT_VERSION: "1.46.2"
 
     steps:
       - checkout

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -79,7 +79,7 @@ func compare(actual []byte, filename string) error {
 	}
 	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
-		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'\n", filename, expected, actual)
+		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
 	}
 	return nil
 }

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -68,7 +68,7 @@ func (v Values) Table(name string) (Values, error) {
 //
 // It protects against nil map panics.
 func (v Values) AsMap() map[string]interface{} {
-	if v == nil || len(v) == 0 {
+	if len(v) == 0 {
 		return map[string]interface{}{}
 	}
 	return v

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -25,6 +25,22 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 )
 
+func TestAsMap(t *testing.T) {
+	var nilValues Values
+	asMap := nilValues.AsMap()
+	if asMap == nil {
+		t.Error("nilValues.AsMap() must not be nil")
+	}
+	asMap["foo"] = "bar"
+	nilValuesPtr := &nilValues
+	nilPtrAsMap := nilValuesPtr.AsMap()
+	if nilPtrAsMap == nil {
+		t.Error("nilValuesPtr.AsMap() must not be nil")
+	}
+	nilPtrAsMap["foo"] = "bar"
+
+}
+
 func TestReadValues(t *testing.T) {
 	doc := `# Test YAML parse
 poet: "Coleridge"


### PR DESCRIPTION
**Update golangci-lint from to latest version**:

Update golangci-lint from version 1.43.0 to the latest linter version 1.46.2.

This is the latest version of golangci-lint which finds new (small) errors in the source code. This linting issues have been fixed in this merge request, too.

Fixed linting issues:

Remove newline from error string in internal/test/test.go
and remove redundant nil / len(0) check from asMap() function
in pkg/chartutil/values.go. Guard this function by a unit test.


**Special notes for your reviewer**:
Only linting issues fixed, added unit tests for changed logic to ensure nothing breaks.

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
