### PR TITLE
Parse vX.Y.Z v-prefixed versions in OCI version tags

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -621,9 +621,7 @@ func (c *Client) Tags(ref string) ([]string, error) {
 
 	var tagVersions []*semver.Version
 	for _, tag := range registryTags {
-		// Change underscore (_) back to plus (+) for Helm
-		// See https://github.com/helm/helm/issues/10166
-		tagVersion, err := semver.StrictNewVersion(strings.ReplaceAll(tag, "_", "+"))
+		tagVersion, err := tagToVersion(tag)
 		if err == nil {
 			tagVersions = append(tagVersions, tagVersion)
 		}
@@ -640,4 +638,10 @@ func (c *Client) Tags(ref string) ([]string, error) {
 
 	return tags, nil
 
+}
+
+func tagToVersion(tag string) (*semver.Version, error) {
+	// Change underscore (_) back to plus (+) for Helm
+	// See https://github.com/helm/helm/issues/10166
+	return semver.StrictNewVersion(strings.ReplaceAll(tag, "_", "+"))
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -640,8 +640,12 @@ func (c *Client) Tags(ref string) ([]string, error) {
 
 }
 
+// tagToVersion parses an OCI tag string and converts it to a semantic version.
+// It returns an error if the tag can not be parsed.
+// semver allows plus (+) which is now allowed in OCI tags, so these will have
+// been converted to underscore (_) by helm push.
+// This function will change underscore (_) in the tag back to plus (+).
+// See https://github.com/helm/helm/issues/10166
 func tagToVersion(tag string) (*semver.Version, error) {
-	// Change underscore (_) back to plus (+) for Helm
-	// See https://github.com/helm/helm/issues/10166
 	return semver.NewVersion(strings.ReplaceAll(tag, "_", "+"))
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -643,5 +643,5 @@ func (c *Client) Tags(ref string) ([]string, error) {
 func tagToVersion(tag string) (*semver.Version, error) {
 	// Change underscore (_) back to plus (+) for Helm
 	// See https://github.com/helm/helm/issues/10166
-	return semver.StrictNewVersion(strings.ReplaceAll(tag, "_", "+"))
+	return semver.NewVersion(strings.ReplaceAll(tag, "_", "+"))
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -616,9 +616,19 @@ func (c *Client) Tags(ref string) ([]string, error) {
 		}
 
 		break
-
 	}
+	return extractVersionsFromRegistryTags(registryTags), nil
+}
 
+// extractVersionsFromRegistryTags parses a list of OCI tag strings returns a
+// list containing only those that are valid Helm chart version strings.
+// The returned list is ordered by semantic version with the newest version
+// first.
+// Semantic versions are *not* de-duplicated.
+// Versions may have a v-prefix and if there are two semantically equal versions
+// with and without a v-prefix, both will be returned in their same order that
+// they were supplied.
+func extractVersionsFromRegistryTags(registryTags []string) []string {
 	var tagVersions []*semver.Version
 	for _, tag := range registryTags {
 		tagVersion, err := tagToVersion(tag)
@@ -633,11 +643,9 @@ func (c *Client) Tags(ref string) ([]string, error) {
 	tags := make([]string, len(tagVersions))
 
 	for iTv, tv := range tagVersions {
-		tags[iTv] = tv.String()
+		tags[iTv] = tv.Original()
 	}
-
-	return tags, nil
-
+	return tags
 }
 
 // tagToVersion parses an OCI tag string and converts it to a semantic version.

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -455,3 +455,64 @@ func TestTagToVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractVersionsFromRegistryTags(t *testing.T) {
+	type testCase struct {
+		tags     []string
+		versions []string
+	}
+
+	tests := map[string]testCase{
+		"empty tags": {
+			tags:     []string{},
+			versions: []string{},
+		},
+		"nil tags": {
+			tags:     nil,
+			versions: []string{},
+		},
+		"one-empty-string": {
+			tags:     []string{""},
+			versions: []string{},
+		},
+		"non-semver": {
+			tags:     []string{"test-tag"},
+			versions: []string{},
+		},
+		"one-strict": {
+			tags:     []string{"1.2.3"},
+			versions: []string{"1.2.3"},
+		},
+		"one-v-prefix": {
+			tags:     []string{"v1.2.3"},
+			versions: []string{"v1.2.3"},
+		},
+		"duplicate-versions": {
+			tags:     []string{"1.2.3", "1.2.3"},
+			versions: []string{"1.2.3", "1.2.3"},
+		},
+		"duplicate-versions-with-and-without-v-prefix-retain-original-order-1": {
+			tags:     []string{"1.2.3", "v1.2.3"},
+			versions: []string{"1.2.3", "v1.2.3"},
+		},
+		"duplicate-versions-with-and-without-v-prefix-retain-original-order-2": {
+			tags:     []string{"v1.2.3", "1.2.3"},
+			versions: []string{"v1.2.3", "1.2.3"},
+		},
+		"unsorted-are-returned-sorted": {
+			tags:     []string{"1.2.3-alpha.1", "v2.3.4-beta.10", "2.3.4", "v1.2.3", "2.3.4-alpha.3"},
+			versions: []string{"2.3.4", "v2.3.4-beta.10", "2.3.4-alpha.3", "v1.2.3", "1.2.3-alpha.1"},
+		},
+		"mix": {
+			tags:     []string{"v1.2.3", "2.3.4", "test-tag", "v1.2.3"},
+			versions: []string{"2.3.4", "v1.2.3", "v1.2.3"},
+		},
+	}
+	for title, tc := range tests {
+		tc := tc
+		t.Run(title, func(t *testing.T) {
+			versions := extractVersionsFromRegistryTags(tc.tags)
+			assert.Equal(t, tc.versions, versions)
+		})
+	}
+}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -384,17 +384,17 @@ func TestTagToVersion(t *testing.T) {
 		"empty": {
 			tag:     "",
 			version: nil,
-			err:     "Version string empty",
+			err:     "Invalid Semantic Version",
 		},
 		"x": {
 			tag:     "1",
-			version: nil,
-			err:     "Invalid Semantic Version",
+			version: semver.MustParse("1"),
+			err:     "",
 		},
 		"x.y": {
 			tag:     "1.1",
-			version: nil,
-			err:     "Invalid Semantic Version",
+			version: semver.MustParse("1.1"),
+			err:     "",
 		},
 		"x.y.z": {
 			tag:     "1.22.333",
@@ -410,6 +410,36 @@ func TestTagToVersion(t *testing.T) {
 			tag:     "1.22.333_xzy",
 			version: semver.MustParse("1.22.333+xzy"),
 			err:     "",
+		},
+		"vX.Y.Z+metadata": {
+			tag:     "v1.22.333_xyz",
+			version: semver.MustParse("v1.22.333+xyz"),
+			err:     "",
+		},
+		"vX.Y.Z-prerelease": {
+			tag:     "v1.22.333-alpha.0",
+			version: semver.MustParse("v1.22.333-alpha.0"),
+			err:     "",
+		},
+		"vX.Y.Z": {
+			tag:     "v1.22.333",
+			version: semver.MustParse("v1.22.333"),
+			err:     "",
+		},
+		"vX.Y": {
+			tag:     "v1.22",
+			version: semver.MustParse("v1.22"),
+			err:     "",
+		},
+		"vX": {
+			tag:     "v1",
+			version: semver.MustParse("v1"),
+			err:     "",
+		},
+		"v": {
+			tag:     "v",
+			version: nil,
+			err:     "Invalid Semantic Version",
 		},
 	}
 	for title, tc := range tests {


### PR DESCRIPTION
Allows helm to discover OCI published charts with v-prefixed version numbers. 


```
$ make build
...

$ ./bin/helm pull oci://gcr.io/jetstack-richard/cert-manager-chart/cert-manager
Pulled: gcr.io/jetstack-richard/cert-manager-chart/cert-manager:v1.8.2
Digest: sha256:5dd707dbffebc478d1005016674bdb8484a52b64355486c3afd8d350bf8c0578

```

- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Fixes: #11107 