### PR TITLE
fix: use `go install` instead of `go get`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,15 +149,15 @@ gen-test-golden: test-unit
 # ------------------------------------------------------------------------------
 #  dependencies
 
-# If go get is run from inside the project directory it will add the dependencies
-# to the go.mod file. To avoid that we change to a directory without a go.mod file
-# when downloading the following dependencies
+# If go install is run from inside the project directory it will add the
+# dependencies to the go.mod file. To avoid that we change to a directory
+# without a go.mod file when downloading the following dependencies
 
 $(GOX):
-	(cd /; GO111MODULE=on go get -u github.com/mitchellh/gox)
+	(cd /; GO111MODULE=on go install github.com/mitchellh/gox@latest)
 
 $(GOIMPORTS):
-	(cd /; GO111MODULE=on go get -u golang.org/x/tools/cmd/goimports)
+	(cd /; GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest)
 
 # ------------------------------------------------------------------------------
 #  release

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -117,9 +117,9 @@ func TestFuncs(t *testing.T) {
 // version of mergo (even accidentally) that causes a breaking change. See
 // sprig changelog and notes for more details.
 // Note, Go modules assume semver is never broken. So, there is no way to tell
-// the tooling to not update to a minor or patch version. `go get -u` could be
-// used to accidentally update mergo. This test and message should catch the
-// problem and explain why it's happening.
+// the tooling to not update to a minor or patch version. `go install` could
+// be used to accidentally update mergo. This test and message should catch
+// the problem and explain why it's happening.
 func TestMerge(t *testing.T) {
 	dict := map[string]interface{}{
 		"src2": map[string]interface{}{


### PR DESCRIPTION
There were a few other locations where `go get` was being used, which was missed in #11110. This fixes the current issues in CI.