### PR TITLE
bugfix: daemonSetReady doesn't work

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -300,7 +300,7 @@ func (c *ReadyChecker) daemonSetReady(ds *appsv1.DaemonSet) bool {
 	}
 
 	expectedReady := int(ds.Status.DesiredNumberScheduled) - maxUnavailable
-	if !(int(ds.Status.NumberReady) >= expectedReady) {
+	if !(int(ds.Status.NumberReady) >= expectedReady) || expectedReady < 0 {
 		c.log("DaemonSet is not ready: %s/%s. %d out of %d expected pods are ready", ds.Namespace, ds.Name, ds.Status.NumberReady, expectedReady)
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: mincheol_jeon fdop104@gmail.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
If daemonSetReady() is called immediately after daemonset is created, 
`ds.Status.DesiredNumberScheduled is set to 0 -> expectedReady is set to negative`. 

So **true is unconditionally returned.**

I could be wrong, but here's the reason this is happening
 - daemonSetReady()  is called before ds.Status.DesiredNumberScheduled is calculated by scheduler

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
