### PR TITLE
Add support for plain HTTP transport to OCI registry client

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -57,6 +57,7 @@ type (
 		enableCache bool
 		// path to repository config file e.g. ~/.docker/config.json
 		credentialsFile    string
+		plainHTTP          bool
 		out                io.Writer
 		authorizer         auth.Client
 		registryAuthorizer *registryauth.Client
@@ -90,6 +91,9 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		headers := http.Header{}
 		headers.Set("User-Agent", version.GetUserAgent())
 		opts := []auth.ResolverOption{auth.WithResolverHeaders(headers)}
+		if client.plainHTTP {
+			opts = append(opts, auth.WithResolverPlainHTTP())
+		}
 		resolver, err := client.authorizer.ResolverWithOpts(opts...)
 		if err != nil {
 			return nil, err
@@ -163,6 +167,12 @@ func ClientOptWriter(out io.Writer) ClientOption {
 func ClientOptCredentialsFile(credentialsFile string) ClientOption {
 	return func(client *Client) {
 		client.credentialsFile = credentialsFile
+	}
+}
+
+func ClientOptPlainHTTP() ClientOption {
+	return func(client *Client) {
+		client.plainHTTP = true
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The change introduces a new `ClientOption` in the OCI registry client for configuring plain HTTP transport of the underlying resolver. This makes it possible to consume charts from HTTP registries in downstream consumers such as Flux.

refs fluxcd/source-controller#807
refs #6324

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
