### PR TITLE
Fixing x509 test on darwin

### DIFF
--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -309,8 +310,15 @@ func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
 
 	// If the insecureSkipTLsverify is false, it will return an error that contains "x509: certificate signed by unknown authority".
 	_, err = FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
-
-	if !strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
+	// Go communicates with the platform and different platforms return different messages. Go itself tests darwin
+	// differently for its message. On newer versions of Darwin the message includes the "Acme Co" portion while older
+	// versions of Darwin do not. As there are people developing Helm using both old and new versions of Darwin we test
+	// for both messages.
+	if runtime.GOOS == "darwin" {
+		if !strings.Contains(err.Error(), "x509: “Acme Co” certificate is not trusted") && !strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
+			t.Errorf("Expected TLS error for function  FindChartInAuthAndTLSAndPassRepoURL not found, but got a different error (%v)", err)
+		}
+	} else if !strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
 		t.Errorf("Expected TLS error for function  FindChartInAuthAndTLSAndPassRepoURL not found, but got a different error (%v)", err)
 	}
 }


### PR DESCRIPTION
Go passes x509 verification off to the platform and different
platforms provide different responses. The Go tests for x509
even have different test files for different platform providers
that check for different messages.

This update haldes darwins difference for x509 authority handling

Closes #11159

Signed-off-by: Matt Farina <matt@mattfarina.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
