### PR TITLE
Updating the circleci image we use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/helm.sh/helm
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17
       
         auth:
           username: $DOCKER_USER


### PR DESCRIPTION
The previous circleci images were deprecated and no longer getting
updates. The version of Go included had known CVEs. This moves to
the newer images which container newer patch versions of Go.

Closes #11105

Signed-off-by: Matt Farina <matt@mattfarina.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: CI is building binaries based on an older version of Go with known CVEs

**Special notes for your reviewer**: N/A

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
