### PR TITLE
Bug fix for client certificate not reaching for mutual tls handshake in helm oci pull

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -61,6 +61,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 	f.BoolVar(&c.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
 	f.StringVar(&c.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 	f.BoolVar(&c.PassCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+	f.BoolVar(&c.TLSEnabled, "mtls-enabled", false, "if two-way tls authentication enabled then trying to send client certificate")
 }
 
 // bindOutputFlag will add the output flag to the given command and bind the

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -117,6 +117,7 @@ type ChartPathOptions struct {
 	Username              string // --username
 	Verify                bool   // --verify
 	Version               string // --version
+	TLSEnabled            bool   // --mtls-enabled
 
 	// registryClient provides a registry client but is not added with
 	// options from a flag

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"helm.sh/helm/v3/internal/tlsutil"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/downloader"
@@ -86,6 +87,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 			getter.WithPassCredentialsAll(p.PassCredentialsAll),
 			getter.WithTLSClientConfig(p.CertFile, p.KeyFile, p.CaFile),
 			getter.WithInsecureSkipVerifyTLS(p.InsecureSkipTLSverify),
+			getter.WithTwoWayTLSEnable(p.TLSEnabled),
 		},
 		RegistryClient:   p.cfg.RegistryClient,
 		RepositoryConfig: p.Settings.RepositoryConfig,
@@ -93,8 +95,24 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if registry.IsOCI(chartRef) {
-		c.Options = append(c.Options,
-			getter.WithRegistryClient(p.cfg.RegistryClient))
+		if !p.TLSEnabled {
+			c.Options = append(c.Options,
+				getter.WithRegistryClient(p.cfg.RegistryClient),
+			)
+		} else {
+			registryClient, err := registry.NewClient(
+				registry.ClientOptDebug(p.Settings.Debug),
+				registry.ClientOptCredentialsFile(p.Settings.RegistryConfig),
+				registry.ClientOptWriter(&out),
+				registry.ClientOptTwoWayTLSEnable(p.TLSEnabled),
+				registry.ClientOptChartRef(chartRef),
+				registry.ClientOptWithTLSOpts(tlsutil.Options{CaCertFile: p.CaFile, KeyFile: p.KeyFile, CertFile: p.CertFile, InsecureSkipVerify: p.InsecureSkipTLSverify}),
+			)
+			if err != nil {
+				return out.String(), err
+			}
+			c.Options = append(c.Options, getter.WithRegistryClient(registryClient))
+		}
 	}
 
 	if p.Verify {

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -42,6 +42,7 @@ type options struct {
 	passCredentialsAll    bool
 	userAgent             string
 	version               string
+	tlsEnabled            bool
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
@@ -84,6 +85,12 @@ func WithUserAgent(userAgent string) Option {
 func WithInsecureSkipVerifyTLS(insecureSkipVerifyTLS bool) Option {
 	return func(opts *options) {
 		opts.insecureSkipVerifyTLS = insecureSkipVerifyTLS
+	}
+}
+
+func WithTwoWayTLSEnable(tlsEnabled bool) Option {
+	return func(opts *options) {
+		opts.tlsEnabled = tlsEnabled
 	}
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
Fix for ([#10597](https://github.com/helm/helm/issues/10597))

Added 2-way TLS Support for oci pull for artifact repository which causes TLS handshake failure error.

Special notes for your reviewer:
Added flag for two-way authentication (--mtls-enabled) .
eg: helm pull oci://nginx.testharbor.com:9443/testrepo/sslcharttest --version 0.1.0 --ca-file /etc/docker/certs.d/nginx.testharbor.com/ca.crt --cert-file /etc/docker/certs.d/nginx.testharbor.com/root_client.crt --key-file /etc/docker/certs.d/nginx.testharbor.com/root_client.key --mtls-enabled