### PR TITLE
Recursively call SaveDir, so that dependencies appear as directory

### DIFF
--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -83,8 +83,8 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save dependencies
 	base := filepath.Join(outdir, ChartsDir)
 	for _, dep := range c.Dependencies() {
-		// Here, we write each dependency as a tar file.
-		if _, err := Save(dep, base); err != nil {
+		// Here, we call the SaveDir function again for each dependency
+		if err := SaveDir(dep, base); err != nil {
 			return errors.Wrapf(err, "saving %s", dep.ChartFullPath())
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Jens Schneider <jens.schneider.ac@posteo.de>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
It makes sure that dependencies are included as directories, when charutil.SaveDir() is called. IMHO, this makes sense when you want to store charts and their dependencies locally for development purposes.
I don't know whether there was a specific reason for saving tar.gz-charts, instead. If so, just let me know :slightly_smiling_face: and reject the PR.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
- [x] This PR contains minimal changes :wink: 
