### PR TITLE
Fix User-Agent header in requests made by Helm 

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package cli describes the operating environment for the Helm CLI.
+/*
+Package cli describes the operating environment for the Helm CLI.
 
 Helm's environment encapsulates all of the service dependencies Helm has.
 These dependencies are expressed as interfaces so that alternate implementations
@@ -121,6 +122,7 @@ func New() *EnvSettings {
 			config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 				return &retryingRoundTripper{wrapped: rt}
 			})
+			config.UserAgent = version.GetUserAgent()
 			return config
 		},
 	}
@@ -231,9 +233,5 @@ func (s *EnvSettings) SetNamespace(namespace string) {
 
 // RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
-	s.config.WrapConfigFn = func(c *rest.Config) *rest.Config {
-		c.UserAgent = version.GetUserAgent()
-		return c
-	}
 	return s.config
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 
+	"helm.sh/helm/v3/internal/version"
 	"helm.sh/helm/v3/pkg/helmpath"
 )
 
@@ -230,5 +231,9 @@ func (s *EnvSettings) SetNamespace(namespace string) {
 
 // RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
+	s.config.WrapConfigFn = func(c *rest.Config) *rest.Config {
+		c.UserAgent = version.GetUserAgent()
+		return c
+	}
 	return s.config
 }

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+
+	"helm.sh/helm/v3/internal/version"
 )
 
 func TestSetNamespace(t *testing.T) {
@@ -228,6 +230,21 @@ func TestEnvOrBool(t *testing.T) {
 				t.Errorf("expected result %t, got %t", tt.expected, actual)
 			}
 		})
+	}
+}
+
+func TestUserAgentHeaderInK8sRESTClientConfig(t *testing.T) {
+	defer resetEnv()()
+
+	settings := New()
+	restConfig, err := settings.RESTClientGetter().ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedUserAgent := version.GetUserAgent()
+	if restConfig.UserAgent != expectedUserAgent {
+		t.Errorf("expected User-Agent header %q in K8s REST client config, got %q", expectedUserAgent, restConfig.UserAgent)
 	}
 }
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -184,11 +184,11 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 //
 // A version is a SemVer string (1.2.3-beta.1+f334a6789).
 //
-//	- For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
-//	- For a chart reference
-//		* If version is non-empty, this will return the URL for that version
-//		* If version is empty, this will return the URL for the latest version
-//		* If no version can be found, an error is returned
+//   - For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
+//   - For a chart reference
+//   - If version is non-empty, this will return the URL for that version
+//   - If version is empty, this will return the URL for the latest version
+//   - If no version can be found, an error is returned
 func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, error) {
 	u, err := url.Parse(ref)
 	if err != nil {

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -184,11 +184,11 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 //
 // A version is a SemVer string (1.2.3-beta.1+f334a6789).
 //
-//   - For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
-//   - For a chart reference
-//   - If version is non-empty, this will return the URL for that version
-//   - If version is empty, this will return the URL for the latest version
-//   - If no version can be found, an error is returned
+//	- For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
+//	- For a chart reference
+//		* If version is non-empty, this will return the URL for that version
+//		* If version is empty, this will return the URL for the latest version
+//		* If no version can be found, an error is returned
 func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, error) {
 	u, err := url.Parse(ref)
 	if err != nil {

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -155,9 +155,8 @@ func TestHTTPGetter(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	expect := "Call me Ishmael"
-	expectedUserAgent := "I am Groot"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defaultUserAgent := "Helm/" + strings.TrimPrefix(version.GetVersion(), "v")
+		defaultUserAgent := version.GetUserAgent()
 		if r.UserAgent() != defaultUserAgent {
 			t.Errorf("Expected '%s', got '%s'", defaultUserAgent, r.UserAgent())
 		}
@@ -179,6 +178,7 @@ func TestDownload(t *testing.T) {
 	}
 
 	// test with http server
+	const expectedUserAgent = "I am Groot"
 	basicAuthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok || username != "username" || password != "password" {

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -120,7 +120,6 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 		return "", err
 	}
 
-	// TODO add user-agent
 	resp, err := r.Client.Get(indexURL,
 		getter.WithURL(r.Config.URL),
 		getter.WithInsecureSkipVerifyTLS(r.Config.InsecureSkipTLSverify),


### PR DESCRIPTION
> This is the recreation of PR #10207 which has been closed due to problems kicking off CI for it.


Current Helm v3.8.1 installed from package manager or build from main branch when makes requests to K8s API (with use of K8s SDK), e.g. executing the command

```
helm history test
```
does not have the proper value set in `User-Agent` header. It looks like that on macOS Monterey with Apple Silicon.
```yaml
User-Agent: Go-http-client/1.1
```
This PR fixes it and makes it consistent with `User-Agent` set when requests are made to chart repositories (it works as expected). So now it always looks like that
```yaml
User-Agent: Helm/3.8+unreleased
```
or
```yaml
User-Agent: Helm/3.8
```

Hence I removed those comments too from the code
```
// TODO add user-agent
```
because it's been already done and works as expected for interaction with chart repos and etc. Here is the line which provides it https://github.com/helm/helm/blob/0d9ebc7885e427373fbdaa95f461b349fb0b1ac1/pkg/getter/httpgetter.go#L53
