### PR TITLE
Fix data race in Client

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -68,6 +68,7 @@ type Client struct {
 	// Namespace allows to bypass the kubeconfig file for the choice of the namespace
 	Namespace string
 
+	mu         sync.Mutex
 	kubeClient *kubernetes.Clientset
 }
 
@@ -98,6 +99,8 @@ var nopLogger = func(_ string, _ ...interface{}) {}
 
 // getKubeClient get or create a new KubernetesClientSet
 func (c *Client) getKubeClient() (*kubernetes.Clientset, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	var err error
 	if c.kubeClient == nil {
 		c.kubeClient, err = c.Factory.KubernetesClientSet()


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `Client` safe for concurrent use. Relates to https://github.com/helm/helm/issues/11169.

**Special notes for your reviewer**:

Ideally `Client` would just take `*kubernetes.Clientset` as a direct dependency, but that'd break existing users.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
