### PR TITLE
feat(starter): enable preserving custom Chart.yaml using --keep-metadata flag

### DIFF
--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -105,7 +105,7 @@ func (o *createOptions) run(out io.Writer) error {
 		if filepath.IsAbs(o.starter) {
 			lstarter = o.starter
 		}
-		return chartutil.CreateFrom(chartname, filepath.Dir(chartname), lstarter, o.keepMetadata)
+		return chartutil.CreateFromWithMetadata(chartname, filepath.Dir(chartname), lstarter, o.keepMetadata)
 	}
 
 	chartutil.Stderr = out

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -77,7 +77,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(o.starter) == 0 && o.noOverride {
-				return errors.New("the -k/--keep-metadata flag can only be specified when using a starter")
+				return errors.New("the -o/--no-override flag can only be specified when using a starter")
 			}
 
 			return nil

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -90,7 +90,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
-	cmd.Flags().BoolVarP(&o.noOverride, "no-override", "n", false, "if specified, does not override the starter's Chart.yaml")
+	cmd.Flags().BoolVarP(&o.noOverride, "no-override", "o", false, "if specified, does not override the starter's Chart.yaml")
 	return cmd
 }
 

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/chart"
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -97,6 +98,18 @@ func (o *createOptions) run(out io.Writer) error {
 	fmt.Fprintf(out, "Creating %s\n", o.name)
 
 	chartname := filepath.Base(o.name)
+	cfile := &chart.Metadata{
+		Name:        chartname,
+		Description: "A Helm chart for Kubernetes",
+		Type:        "application",
+		Version:     "0.1.0",
+		AppVersion:  "0.1.0",
+		APIVersion:  chart.APIVersionV2,
+	}
+
+	if o.keepMetadata {
+		cfile = nil
+	}
 
 	if o.starter != "" {
 		// Create from the starter
@@ -105,7 +118,7 @@ func (o *createOptions) run(out io.Writer) error {
 		if filepath.IsAbs(o.starter) {
 			lstarter = o.starter
 		}
-		return chartutil.CreateFromWithMetadata(chartname, filepath.Dir(chartname), lstarter, o.keepMetadata)
+		return chartutil.CreateFromWithOverride(chartname, filepath.Dir(chartname), lstarter, cfile)
 	}
 
 	chartutil.Stderr = out

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/chart"
 
 	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/helmpath"
 )

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -52,10 +52,10 @@ will be overwritten, but other files will be left alone.
 `
 
 type createOptions struct {
-	starter      string // --starter
-	name         string
-	starterDir   string
-	keepMetadata bool
+	starter    string // --starter
+	name       string
+	starterDir string
+	noOverride bool
 }
 
 func newCreateCmd(out io.Writer) *cobra.Command {
@@ -76,7 +76,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(o.starter) == 0 && o.keepMetadata {
+			if len(o.starter) == 0 && o.noOverride {
 				return errors.New("the -k/--keep-metadata flag can only be specified when using a starter")
 			}
 
@@ -90,7 +90,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
-	cmd.Flags().BoolVarP(&o.keepMetadata, "keep-metadata", "k", false, "if specified, does not override the starter's Chart.yaml")
+	cmd.Flags().BoolVarP(&o.noOverride, "no-override", "n", false, "if specified, does not override the starter's Chart.yaml")
 	return cmd
 }
 
@@ -107,7 +107,7 @@ func (o *createOptions) run(out io.Writer) error {
 		APIVersion:  chart.APIVersionV2,
 	}
 
-	if o.keepMetadata {
+	if o.noOverride {
 		cfile = nil
 	}
 

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -548,7 +548,15 @@ spec:
 var Stderr io.Writer = os.Stderr
 
 // CreateFrom creates a new chart, but scaffolds it from the src chart.
-func CreateFrom(name, dest, src string, keepMetadata bool) error {
+// Deprecated: Use CreateFromWithMetadata
+// TODO Helm 4: Fold CreateFromWithMetadata back into CreateFrom
+func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
+	return CreateFromWithMetadata(chartfile.Name, dest, src, false)
+}
+
+// CreateFromWithMetadata creates a new chart, but scaffolds it from the src chart and
+// provides the option to preserve custom metadata (Chart.yaml) files.
+func CreateFromWithMetadata(name, dest, src string, keepMetadata bool) error {
 	schart, err := loader.Load(src)
 	if err != nil {
 		return errors.Wrapf(err, "could not load %s", src)

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -548,22 +548,23 @@ spec:
 var Stderr io.Writer = os.Stderr
 
 // CreateFrom creates a new chart, but scaffolds it from the src chart.
-// Deprecated: Use CreateFromWithMetadata
-// TODO Helm 4: Fold CreateFromWithMetadata back into CreateFrom
+// Deprecated: Use CreateFromWithOverride
+// TODO Helm 4: Fold CreateFromWithOverride back into CreateFrom
 func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
-	return CreateFromWithMetadata(chartfile.Name, dest, src, false)
+	return CreateFromWithOverride(chartfile.Name, dest, src, chartfile)
 }
 
-// CreateFromWithMetadata creates a new chart, but scaffolds it from the src chart and
-// provides the option to preserve custom metadata (Chart.yaml) files.
-func CreateFromWithMetadata(name, dest, src string, keepMetadata bool) error {
+// CreateFromWithOverride creates a new chart, but scaffolds it from the src chart and
+// provides the option to override the chart's metadata (Chart.yaml).
+func CreateFromWithOverride(name, dest, src string, override *chart.Metadata) error {
 	schart, err := loader.Load(src)
 	if err != nil {
 		return errors.Wrapf(err, "could not load %s", src)
 	}
 
-	if err = setMetadata(schart, name, keepMetadata); err != nil {
-		return errors.Wrap(err, "could not set metadata")
+	// Override the chart's metadata if the user requested it
+	if err := setMetadata(schart, name, override); err != nil {
+		return errors.Wrap(err, "setting metadata")
 	}
 
 	var updatedTemplates []*chart.File
@@ -733,20 +734,36 @@ func validateChartName(name string) error {
 	return nil
 }
 
-func setMetadata(schart *chart.Chart, name string, keepMetadata bool) error {
+func setMetadata(schart *chart.Chart, name string, override *chart.Metadata) error {
+	// Override the source chart's metadata and raw chart file content
+	// if the user provided a chart.Metadata struct
+	if override != nil {
+		schart.Metadata = override
+		for _, f := range schart.Raw {
+			if f.Name == ChartfileName {
+				metadataBytes, err := yaml.Marshal(schart.Metadata)
+				if err != nil {
+					return errors.Wrap(err, "marshalling metadata override")
+				}
+
+				f.Data = metadataBytes
+				break
+			}
+		}
+
+		return nil
+	}
+
+	// Unmarshal Chart.yaml from source directory while replacing
+	// all <CHARTNAME> placeholders if no override was requested
 	for _, f := range schart.Raw {
 		if f.Name == ChartfileName {
-			// Overwrite Metadata only if flag was not set by user to keep backwards compatibility.
-			if !keepMetadata {
-				f.Data = []byte(fmt.Sprintf(defaultChartfile, name))
-			}
-
-			// Deserialize Metadata and check for errors
 			var m chart.Metadata
 			if err := yaml.Unmarshal(transform(string(f.Data), name), &m); err != nil {
 				return errors.Wrap(err, "transforming charts file")
 			}
 			schart.Metadata = &m
+			break
 		}
 	}
 

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -547,13 +548,15 @@ spec:
 var Stderr io.Writer = os.Stderr
 
 // CreateFrom creates a new chart, but scaffolds it from the src chart.
-func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
+func CreateFrom(name, dest, src string, keepMetadata bool) error {
 	schart, err := loader.Load(src)
 	if err != nil {
 		return errors.Wrapf(err, "could not load %s", src)
 	}
 
-	schart.Metadata = chartfile
+	if err = setMetadata(schart, name, keepMetadata); err != nil {
+		return errors.Wrap(err, "could not set metadata")
+	}
 
 	var updatedTemplates []*chart.File
 
@@ -574,12 +577,12 @@ func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
 	}
 	schart.Values = m
 
-	// SaveDir looks for the file values.yaml when saving rather than the values
-	// key in order to preserve the comments in the YAML. The name placeholder
-	// needs to be replaced on that file.
+	// SaveDir looks for the files values.yaml and Chart.yaml when saving rather than the values
+	// and metadata keys in order to preserve the comments in the YAML. The name placeholder
+	// needs to be replaced on these files.
 	for _, f := range schart.Raw {
-		if f.Name == ValuesfileName {
-			f.Data = transform(string(f.Data), schart.Name())
+		if slices.Contains([]string{ValuesfileName, ChartfileName}, f.Name) {
+			f.Data = transform(string(f.Data), name)
 		}
 	}
 
@@ -719,5 +722,25 @@ func validateChartName(name string) error {
 	if !chartName.MatchString(name) {
 		return fmt.Errorf("chart name must match the regular expression %q", chartName.String())
 	}
+	return nil
+}
+
+func setMetadata(schart *chart.Chart, name string, keepMetadata bool) error {
+	for _, f := range schart.Raw {
+		if f.Name == ChartfileName {
+			// Overwrite Metadata only if flag was not set by user to keep backwards compatibility.
+			if !keepMetadata {
+				f.Data = []byte(fmt.Sprintf(defaultChartfile, name))
+			}
+
+			// Deserialize Metadata and check for errors
+			var m chart.Metadata
+			if err := yaml.Unmarshal(transform(string(f.Data), name), &m); err != nil {
+				return errors.Wrap(err, "transforming charts file")
+			}
+			schart.Metadata = &m
+		}
+	}
+
 	return nil
 }

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
@@ -67,10 +68,16 @@ func TestCreate(t *testing.T) {
 func TestCreateFrom(t *testing.T) {
 	tdir := t.TempDir()
 
+	cf := &chart.Metadata{
+		APIVersion: chart.APIVersionV1,
+		Name:       "foo",
+		Version:    "0.1.0",
+	}
+
 	chartname := "foo"
 	srcdir := "./testdata/frobnitz/charts/mariner"
 
-	if err := CreateFrom(chartname, tdir, srcdir, false); err != nil {
+	if err := CreateFrom(cf, tdir, srcdir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -105,7 +112,7 @@ func TestCreateFrom(t *testing.T) {
 	}
 }
 
-func TestCreateFromKeepMetadata(t *testing.T) {
+func TestCreateFromWithOverride(t *testing.T) {
 	tdir := t.TempDir()
 
 	chartname := "foo"
@@ -116,7 +123,7 @@ func TestCreateFromKeepMetadata(t *testing.T) {
 		t.Errorf("Unable to read file %s: %s", srcMetadata, err)
 	}
 
-	if err := CreateFrom(chartname, tdir, srcdir, true); err != nil {
+	if err := CreateFromWithOverride(chartname, tdir, srcdir, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -57,6 +57,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 	for _, f := range c.Raw {
 		if f.Name == ChartfileName {
 			hasRawMetadata = true
+			break
 		}
 	}
 

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -51,15 +52,28 @@ func SaveDir(c *chart.Chart, dest string) error {
 		return err
 	}
 
-	// Save the chart file.
-	if err := SaveChartfile(filepath.Join(outdir, ChartfileName), c.Metadata); err != nil {
-		return err
+	// Check if Chart has raw metadata stored
+	hasRawMetadata := false
+	for _, f := range c.Raw {
+		if f.Name == ChartfileName {
+			hasRawMetadata = true
+		}
 	}
 
-	// Save values.yaml
+	// This ensures that the Chart always has raw metadata stored, since some tests
+	// call SaveDir without adding raw metadata to the Chart.
+	if !hasRawMetadata {
+		b, err := yaml.Marshal(c.Metadata)
+		if err != nil {
+			return errors.Wrap(err, "reading charts file")
+		}
+		c.Raw = append(c.Raw, &chart.File{Name: ChartfileName, Data: b})
+	}
+
+	// Save values.yaml and Chart.yaml
 	for _, f := range c.Raw {
-		if f.Name == ValuesfileName {
-			vf := filepath.Join(outdir, ValuesfileName)
+		if slices.Contains([]string{ValuesfileName, ChartfileName}, f.Name) {
+			vf := filepath.Join(outdir, f.Name)
 			if err := writeFile(vf, f.Data); err != nil {
 				return err
 			}

--- a/pkg/chartutil/testdata/frobnitz/charts/custom/Chart.yaml
+++ b/pkg/chartutil/testdata/frobnitz/charts/custom/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: <CHARTNAME>
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+dependencies:
+  - name: albatross
+    repository: https://example.com/mariner/charts
+    version: "0.1.0"

--- a/pkg/chartutil/testdata/frobnitz/charts/custom/templates/deployment.yaml
+++ b/pkg/chartutil/testdata/frobnitz/charts/custom/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "<CHARTNAME>.fullname" . }}
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP

--- a/pkg/chartutil/testdata/frobnitz/charts/custom/values.yaml
+++ b/pkg/chartutil/testdata/frobnitz/charts/custom/values.yaml
@@ -1,0 +1,22 @@
+# Default values for <CHARTNAME>.
+# This is a YAML-formatted file. https://github.com/toml-lang/toml
+# Declare name/value pairs to be passed into your templates.
+# name: "value"
+
+<CHARTNAME>:
+  test: true
+
+replicaCount: 1
+
+image:
+  repository: ""
+  pullPolicy: IfNotPresent
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80


### PR DESCRIPTION
## Related Issues
refs helm/helm#4060
refs helm/helm#4745
refs helm/helm#7566
refs helm/helm#9551
refs helm/helm#10057

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

As the [chart starter docs](https://helm.sh/docs/topics/charts/#chart-starter-packs) say, the current behavior for generating charts from starters results in an overwritten `Charts.yaml` file (i.e. the user's provided `Charts.yaml` is ignored, although required).

This PR adds an optional ~~`--keep-metadata`~~  `--no-override` flag (defaults to `false`) to the `helm create` command, which disables the mentioned behavior and uses the user-provided `Chart.yaml`.

By enabling custom `Chart.yaml` templates, it is possible to declare starters that already contain dependencies or other metadata.

**Special notes for your reviewer**:

  * Previously, [`chartutil.CreateFrom`](https://github.com/helm/helm/blob/106f1fb45c93fe862ac86d9b774e2de8b1dd314c/cmd/helm/create.go#L107) and [`chartutil.Create`](https://github.com/helm/helm/blob/106f1fb45c93fe862ac86d9b774e2de8b1dd314c/cmd/helm/create.go#L111) resulted in different `Chart.yaml` files, where the first contained no comments and the second did (see https://github.com/helm/helm/issues/9551#issuecomment-810700613). I changed this behavior by using the same template for both to ensure consistency between using the `helm create` command with and without the `--starter` option.
 

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
