### PR TITLE
bugfix: add cases.NoLower opt for we can get same effect to strings.Title

### DIFF
--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -86,7 +86,7 @@ func (o *docsOptions) run(out io.Writer) error {
 			hdrFunc := func(filename string) string {
 				base := filepath.Base(filename)
 				name := strings.TrimSuffix(base, path.Ext(base))
-				title := cases.Title(language.Und).String(strings.Replace(name, "_", " ", -1))
+				title := cases.Title(language.Und, cases.NoLower).String(strings.Replace(name, "_", " ", -1))
 				return fmt.Sprintf("---\ntitle: \"%s\"\n---\n\n", title)
 			}
 


### PR DESCRIPTION
Adding `cases.NoLower` option, with that we can get same effect to `strings.Title`

Signed-off-by: wujunwei <wjw3323@live.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
see #11275 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

fixed #11275 