### PR TITLE
test: replace `ensure.TempDir` with `t.TempDir`

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 func TestCreateCmd(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 	cname := "testchart"
-	dir := ensure.TempDir(t)
+	dir := t.TempDir()
 	defer testChdir(t, dir)()
 
 	// Run a create
@@ -61,7 +61,7 @@ func TestCreateCmd(t *testing.T) {
 }
 
 func TestCreateStarterCmd(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 	cname := "testchart"
 	defer resetEnv()()
 	os.MkdirAll(helmpath.CachePath(), 0755)
@@ -127,7 +127,7 @@ func TestCreateStarterCmd(t *testing.T) {
 
 func TestCreateStarterAbsoluteCmd(t *testing.T) {
 	defer resetEnv()()
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 	cname := "testchart"
 
 	// Create a starter.

--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -149,7 +149,7 @@ func TestDependencyUpdateCmd(t *testing.T) {
 
 func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 	defer resetEnv()()
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
 	if err != nil {

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
@@ -111,7 +110,7 @@ func TestPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cachePath := ensure.TempDir(t)
+			cachePath := t.TempDir()
 			defer testChdir(t, cachePath)()
 
 			if err := os.MkdirAll("toot", 0777); err != nil {
@@ -170,7 +169,7 @@ func TestSetAppVersion(t *testing.T) {
 	var ch *chart.Chart
 	expectedAppVersion := "app-version-foo"
 	chartToPackage := "testdata/testcharts/alpine"
-	dir := ensure.TempDir(t)
+	dir := t.TempDir()
 	cmd := fmt.Sprintf("package %s --destination=%s --app-version=%s", chartToPackage, dir, expectedAppVersion)
 	_, output, err := executeActionCommand(cmd)
 	if err != nil {

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -27,7 +27,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/helmpath"
 	"helm.sh/helm/v3/pkg/helmpath/xdg"
 	"helm.sh/helm/v3/pkg/repo"
@@ -48,7 +47,7 @@ func TestRepoAddCmd(t *testing.T) {
 	}
 	defer srv2.Stop()
 
-	tmpdir := filepath.Join(ensure.TempDir(t), "path-component.yaml/data")
+	tmpdir := filepath.Join(t.TempDir(), "path-component.yaml/data")
 	err = os.MkdirAll(tmpdir, 0777)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +87,7 @@ func TestRepoAdd(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	rootDir := ensure.TempDir(t)
+	rootDir := t.TempDir()
 	repoFile := filepath.Join(rootDir, "repositories.yaml")
 
 	const testRepoName = "test-name"
@@ -145,8 +144,8 @@ func TestRepoAddCheckLegalName(t *testing.T) {
 
 	const testRepoName = "test-hub/test-name"
 
-	rootDir := ensure.TempDir(t)
-	repoFile := filepath.Join(ensure.TempDir(t), "repositories.yaml")
+	rootDir := t.TempDir()
+	repoFile := filepath.Join(t.TempDir(), "repositories.yaml")
 
 	o := &repoAddOptions{
 		name:               testRepoName,
@@ -170,25 +169,25 @@ func TestRepoAddCheckLegalName(t *testing.T) {
 
 func TestRepoAddConcurrentGoRoutines(t *testing.T) {
 	const testName = "test-name"
-	repoFile := filepath.Join(ensure.TempDir(t), "repositories.yaml")
+	repoFile := filepath.Join(t.TempDir(), "repositories.yaml")
 	repoAddConcurrent(t, testName, repoFile)
 }
 
 func TestRepoAddConcurrentDirNotExist(t *testing.T) {
 	const testName = "test-name-2"
-	repoFile := filepath.Join(ensure.TempDir(t), "foo", "repositories.yaml")
+	repoFile := filepath.Join(t.TempDir(), "foo", "repositories.yaml")
 	repoAddConcurrent(t, testName, repoFile)
 }
 
 func TestRepoAddConcurrentNoFileExtension(t *testing.T) {
 	const testName = "test-name-3"
-	repoFile := filepath.Join(ensure.TempDir(t), "repositories")
+	repoFile := filepath.Join(t.TempDir(), "repositories")
 	repoAddConcurrent(t, testName, repoFile)
 }
 
 func TestRepoAddConcurrentHiddenFile(t *testing.T) {
 	const testName = "test-name-4"
-	repoFile := filepath.Join(ensure.TempDir(t), ".repositories")
+	repoFile := filepath.Join(t.TempDir(), ".repositories")
 	repoAddConcurrent(t, testName, repoFile)
 }
 
@@ -254,7 +253,7 @@ func TestRepoAddWithPasswordFromStdin(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	tmpdir := ensure.TempDir(t)
+	tmpdir := t.TempDir()
 	repoFile := filepath.Join(tmpdir, "repositories.yaml")
 
 	store := storageFixture()

--- a/cmd/helm/repo_index_test.go
+++ b/cmd/helm/repo_index_test.go
@@ -23,13 +23,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
 func TestRepoIndexCmd(t *testing.T) {
 
-	dir := ensure.TempDir(t)
+	dir := t.TempDir()
 
 	comp := filepath.Join(dir, "compressedchart-0.1.0.tgz")
 	if err := linkOrCopy("testdata/testcharts/compressedchart-0.1.0.tgz", comp); err != nil {

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/helmpath"
 	"helm.sh/helm/v3/pkg/repo"
 	"helm.sh/helm/v3/pkg/repo/repotest"
@@ -37,7 +36,7 @@ func TestRepoRemove(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	rootDir := ensure.TempDir(t)
+	rootDir := t.TempDir()
 	repoFile := filepath.Join(rootDir, "repositories.yaml")
 
 	const testRepoName = "test-name"
@@ -169,7 +168,7 @@ func TestRepoRemoveCompletion(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	rootDir := ensure.TempDir(t)
+	rootDir := t.TempDir()
 	repoFile := filepath.Join(rootDir, "repositories.yaml")
 	repoCache := filepath.Join(rootDir, "cache/")
 

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -102,10 +102,9 @@ func TestUpdateCmdInvalid(t *testing.T) {
 }
 
 func TestUpdateCustomCacheCmd(t *testing.T) {
-	rootDir := ensure.TempDir(t)
+	rootDir := t.TempDir()
 	cachePath := filepath.Join(rootDir, "updcustomcache")
 	os.Mkdir(cachePath, os.ModePerm)
-	defer os.RemoveAll(cachePath)
 
 	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
 	if err != nil {
@@ -129,7 +128,7 @@ func TestUpdateCustomCacheCmd(t *testing.T) {
 
 func TestUpdateCharts(t *testing.T) {
 	defer resetEnv()()
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
 	if err != nil {
@@ -164,7 +163,7 @@ func TestRepoUpdateFileCompletion(t *testing.T) {
 
 func TestUpdateChartsFail(t *testing.T) {
 	defer resetEnv()()
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
 	if err != nil {
@@ -197,7 +196,7 @@ func TestUpdateChartsFail(t *testing.T) {
 
 func TestUpdateChartsFailWithError(t *testing.T) {
 	defer resetEnv()()
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
 	if err != nil {

--- a/cmd/helm/root_test.go
+++ b/cmd/helm/root_test.go
@@ -77,7 +77,7 @@ func TestRootCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer ensure.HelmHome(t)()
+			ensure.HelmHome(t)
 
 			for k, v := range tt.envvars {
 				os.Setenv(k, v)

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -32,7 +31,7 @@ import (
 
 func TestUpgradeCmd(t *testing.T) {
 
-	tmpChart := ensure.TempDir(t)
+	tmpChart := t.TempDir()
 	cfile := &chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion:  chart.APIVersionV1,
@@ -357,7 +356,7 @@ func TestUpgradeInstallWithValuesFromStdin(t *testing.T) {
 }
 
 func prepareMockRelease(releaseName string, t *testing.T) (func(n string, v int, ch *chart.Chart) *release.Release, *chart.Chart, string) {
-	tmpChart := ensure.TempDir(t)
+	tmpChart := t.TempDir()
 	configmapData, err := os.ReadFile("testdata/testcharts/upgradetest/templates/configmap.yaml")
 	if err != nil {
 		t.Fatalf("Error loading template yaml %v", err)

--- a/internal/test/ensure/ensure.go
+++ b/internal/test/ensure/ensure.go
@@ -26,41 +26,27 @@ import (
 )
 
 // HelmHome sets up a Helm Home in a temp dir.
-func HelmHome(t *testing.T) func() {
+func HelmHome(t *testing.T) {
 	t.Helper()
-	base := TempDir(t)
+	base := t.TempDir()
 	os.Setenv(xdg.CacheHomeEnvVar, base)
 	os.Setenv(xdg.ConfigHomeEnvVar, base)
 	os.Setenv(xdg.DataHomeEnvVar, base)
 	os.Setenv(helmpath.CacheHomeEnvVar, "")
 	os.Setenv(helmpath.ConfigHomeEnvVar, "")
 	os.Setenv(helmpath.DataHomeEnvVar, "")
-	return func() {
-		os.RemoveAll(base)
-	}
-}
-
-// TempDir ensures a scratch test directory for unit testing purposes.
-func TempDir(t *testing.T) string {
-	t.Helper()
-	d, err := os.MkdirTemp("", "helm")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return d
 }
 
 // TempFile ensures a temp file for unit testing purposes.
 //
 // It returns the path to the directory (to which you will still need to join the filename)
 //
-// You must clean up the directory that is returned.
+// The returned directory is automatically removed when the test and all its subtests complete.
 //
 //	tempdir := TempFile(t, "foo", []byte("bar"))
-//	defer os.RemoveAll(tempdir)
 //	filename := filepath.Join(tempdir, "foo")
 func TempFile(t *testing.T, name string, data []byte) string {
-	path := TempDir(t)
+	path := t.TempDir()
 	filename := filepath.Join(path, name)
 	if err := os.WriteFile(filename, data, 0755); err != nil {
 		t.Fatal(err)

--- a/pkg/action/package_test.go
+++ b/pkg/action/package_test.go
@@ -29,7 +29,6 @@ import (
 func TestPassphraseFileFetcher(t *testing.T) {
 	secret := "secret"
 	directory := ensure.TempFile(t, "passphrase-file", []byte(secret))
-	defer os.RemoveAll(directory)
 
 	fetcher, err := passphraseFileFetcher(path.Join(directory, "passphrase-file"), nil)
 	if err != nil {
@@ -49,7 +48,6 @@ func TestPassphraseFileFetcher(t *testing.T) {
 func TestPassphraseFileFetcher_WithLineBreak(t *testing.T) {
 	secret := "secret"
 	directory := ensure.TempFile(t, "passphrase-file", []byte(secret+"\n\n."))
-	defer os.RemoveAll(directory)
 
 	fetcher, err := passphraseFileFetcher(path.Join(directory, "passphrase-file"), nil)
 	if err != nil {
@@ -67,8 +65,7 @@ func TestPassphraseFileFetcher_WithLineBreak(t *testing.T) {
 }
 
 func TestPassphraseFileFetcher_WithInvalidStdin(t *testing.T) {
-	directory := ensure.TempDir(t)
-	defer os.RemoveAll(directory)
+	directory := t.TempDir()
 
 	stdin, err := os.CreateTemp(directory, "non-existing")
 	if err != nil {

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -29,14 +29,12 @@ import (
 	"testing"
 	"time"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 func TestSave(t *testing.T) {
-	tmp := ensure.TempDir(t)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	for _, dest := range []string{tmp, filepath.Join(tmp, "newdir")} {
 		t.Run("outDir="+dest, func(t *testing.T) {

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -269,10 +269,9 @@ func TestDownloadTo_TLS(t *testing.T) {
 }
 
 func TestDownloadTo_VerifyLater(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
-	dest := ensure.TempDir(t)
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	// Set up a fake repo
 	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")

--- a/pkg/lint/rules/dependencies_test.go
+++ b/pkg/lint/rules/dependencies_test.go
@@ -16,11 +16,9 @@ limitations under the License.
 package rules
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/lint/support"
@@ -79,8 +77,7 @@ func TestValidateDependencyInMetadata(t *testing.T) {
 }
 
 func TestDependencies(t *testing.T) {
-	tmp := ensure.TempDir(t)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	c := chartWithBadDependencies()
 	err := chartutil.SaveDir(&c, tmp)

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/lint/support"
@@ -221,8 +220,7 @@ func TestDeprecatedAPIFails(t *testing.T) {
 			},
 		},
 	}
-	tmpdir := ensure.TempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	if err := chartutil.SaveDir(&mychart, tmpdir); err != nil {
 		t.Fatal(err)
@@ -278,8 +276,7 @@ func TestStrictTemplateParsingMapError(t *testing.T) {
 			},
 		},
 	}
-	dir := ensure.TempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	if err := chartutil.SaveDir(&ch, dir); err != nil {
 		t.Fatal(err)
 	}
@@ -408,8 +405,7 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 			},
 		},
 	}
-	tmpdir := ensure.TempDir(t)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	if err := chartutil.SaveDir(&mychart, tmpdir); err != nil {
 		t.Fatal(err)

--- a/pkg/lint/rules/values_test.go
+++ b/pkg/lint/rules/values_test.go
@@ -66,7 +66,6 @@ func TestValidateValuesFileWellFormed(t *testing.T) {
 	not:well[]{}formed
 	`
 	tmpdir := ensure.TempFile(t, "values.yaml", []byte(badYaml))
-	defer os.RemoveAll(tmpdir)
 	valfile := filepath.Join(tmpdir, "values.yaml")
 	if err := validateValuesFile(valfile, map[string]interface{}{}); err == nil {
 		t.Fatal("expected values file to fail parsing")
@@ -76,7 +75,6 @@ func TestValidateValuesFileWellFormed(t *testing.T) {
 func TestValidateValuesFileSchema(t *testing.T) {
 	yaml := "username: admin\npassword: swordfish"
 	tmpdir := ensure.TempFile(t, "values.yaml", []byte(yaml))
-	defer os.RemoveAll(tmpdir)
 	createTestingSchema(t, tmpdir)
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
@@ -89,7 +87,6 @@ func TestValidateValuesFileSchemaFailure(t *testing.T) {
 	// 1234 is an int, not a string. This should fail.
 	yaml := "username: 1234\npassword: swordfish"
 	tmpdir := ensure.TempFile(t, "values.yaml", []byte(yaml))
-	defer os.RemoveAll(tmpdir)
 	createTestingSchema(t, tmpdir)
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
@@ -108,7 +105,6 @@ func TestValidateValuesFileSchemaOverrides(t *testing.T) {
 		"password": "swordfish",
 	}
 	tmpdir := ensure.TempFile(t, "values.yaml", []byte(yaml))
-	defer os.RemoveAll(tmpdir)
 	createTestingSchema(t, tmpdir)
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
@@ -145,7 +141,6 @@ func TestValidateValuesFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpdir := ensure.TempFile(t, "values.yaml", []byte(tt.yaml))
-			defer os.RemoveAll(tmpdir)
 			createTestingSchema(t, tmpdir)
 
 			valfile := filepath.Join(tmpdir, "values.yaml")

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -79,7 +79,7 @@ func mockArchiveServer() *httptest.Server {
 }
 
 func TestHTTPInstaller(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	srv := mockArchiveServer()
 	defer srv.Close()
@@ -128,7 +128,7 @@ func TestHTTPInstaller(t *testing.T) {
 }
 
 func TestHTTPInstallerNonExistentVersion(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 	srv := mockArchiveServer()
 	defer srv.Close()
 	source := srv.URL + "/plugins/fake-plugin-0.0.1.tar.gz"
@@ -164,7 +164,7 @@ func TestHTTPInstallerUpdate(t *testing.T) {
 	srv := mockArchiveServer()
 	defer srv.Close()
 	source := srv.URL + "/plugins/fake-plugin-0.0.1.tar.gz"
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	if err := os.MkdirAll(helmpath.DataPath("plugins"), 0755); err != nil {
 		t.Fatalf("Could not create %s: %s", helmpath.DataPath("plugins"), err)

--- a/pkg/plugin/installer/vcs_installer_test.go
+++ b/pkg/plugin/installer/vcs_installer_test.go
@@ -49,7 +49,7 @@ func (r *testRepo) UpdateVersion(version string) error {
 }
 
 func TestVCSInstaller(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	if err := os.MkdirAll(helmpath.DataPath("plugins"), 0755); err != nil {
 		t.Fatalf("Could not create %s: %s", helmpath.DataPath("plugins"), err)
@@ -102,7 +102,7 @@ func TestVCSInstaller(t *testing.T) {
 }
 
 func TestVCSInstallerNonExistentVersion(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	source := "https://github.com/adamreese/helm-env"
 	version := "0.2.0"
@@ -124,7 +124,7 @@ func TestVCSInstallerNonExistentVersion(t *testing.T) {
 	}
 }
 func TestVCSInstallerUpdate(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	source := "https://github.com/adamreese/helm-env"
 

--- a/pkg/postrender/exec_test.go
+++ b/pkg/postrender/exec_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"helm.sh/helm/v3/internal/test/ensure"
 )
 
 const testingScript = `#!/bin/sh
@@ -40,8 +38,7 @@ fi
 func TestGetFullPath(t *testing.T) {
 	is := assert.New(t)
 	t.Run("full path resolves correctly", func(t *testing.T) {
-		testpath, cleanup := setupTestingScript(t)
-		defer cleanup()
+		testpath := setupTestingScript(t)
 
 		fullPath, err := getFullPath(testpath)
 		is.NoError(err)
@@ -49,8 +46,7 @@ func TestGetFullPath(t *testing.T) {
 	})
 
 	t.Run("relative path resolves correctly", func(t *testing.T) {
-		testpath, cleanup := setupTestingScript(t)
-		defer cleanup()
+		testpath := setupTestingScript(t)
 
 		currentDir, err := os.Getwd()
 		require.NoError(t, err)
@@ -62,8 +58,7 @@ func TestGetFullPath(t *testing.T) {
 	})
 
 	t.Run("binary in PATH resolves correctly", func(t *testing.T) {
-		testpath, cleanup := setupTestingScript(t)
-		defer cleanup()
+		testpath := setupTestingScript(t)
 
 		realPath := os.Getenv("PATH")
 		os.Setenv("PATH", filepath.Dir(testpath))
@@ -116,8 +111,7 @@ func TestExecRun(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 	is := assert.New(t)
-	testpath, cleanup := setupTestingScript(t)
-	defer cleanup()
+	testpath := setupTestingScript(t)
 
 	renderer, err := NewExec(testpath)
 	require.NoError(t, err)
@@ -133,8 +127,7 @@ func TestNewExecWithOneArgsRun(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 	is := assert.New(t)
-	testpath, cleanup := setupTestingScript(t)
-	defer cleanup()
+	testpath := setupTestingScript(t)
 
 	renderer, err := NewExec(testpath, "ARG1")
 	require.NoError(t, err)
@@ -150,8 +143,7 @@ func TestNewExecWithTwoArgsRun(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 	is := assert.New(t)
-	testpath, cleanup := setupTestingScript(t)
-	defer cleanup()
+	testpath := setupTestingScript(t)
 
 	renderer, err := NewExec(testpath, "ARG1", "ARG2")
 	require.NoError(t, err)
@@ -161,10 +153,10 @@ func TestNewExecWithTwoArgsRun(t *testing.T) {
 	is.Contains(output.String(), "ARG1 ARG2")
 }
 
-func setupTestingScript(t *testing.T) (filepath string, cleanup func()) {
+func setupTestingScript(t *testing.T) (filepath string) {
 	t.Helper()
 
-	tempdir := ensure.TempDir(t)
+	tempdir := t.TempDir()
 
 	f, err := os.CreateTemp(tempdir, "post-render-test.sh")
 	if err != nil {
@@ -186,7 +178,5 @@ func setupTestingScript(t *testing.T) (filepath string, cleanup func()) {
 		t.Fatalf("unable to close tempfile after writing: %s", err)
 	}
 
-	return f.Name(), func() {
-		os.RemoveAll(tempdir)
-	}
+	return f.Name()
 }

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -30,7 +30,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
@@ -147,8 +146,7 @@ func TestIndexCustomSchemeDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Problem loading chart repository from %s: %v", repoURL, err)
 	}
-	repo.CachePath = ensure.TempDir(t)
-	defer os.RemoveAll(repo.CachePath)
+	repo.CachePath = t.TempDir()
 
 	tempIndexFile, err := os.CreateTemp("", "test-repo")
 	if err != nil {
@@ -349,7 +347,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 func TestErrorFindChartInRepoURL(t *testing.T) {
 
 	g := getter.All(&cli.EnvSettings{
-		RepositoryCache: ensure.TempDir(t),
+		RepositoryCache: t.TempDir(),
 	})
 
 	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", g); err == nil {

--- a/pkg/repo/repotest/server_test.go
+++ b/pkg/repo/repotest/server_test.go
@@ -18,7 +18,6 @@ package repotest
 import (
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,10 +30,9 @@ import (
 // Young'n, in these here parts, we test our tests.
 
 func TestServer(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
-	rootDir := ensure.TempDir(t)
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	srv := NewServer(rootDir)
 	defer srv.Stop()
@@ -99,7 +97,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestNewTempServer(t *testing.T) {
-	defer ensure.HelmHome(t)()
+	ensure.HelmHome(t)
 
 	srv, err := NewTempServerWithCleanup(t, "testdata/examplechart-0.1.0.tgz")
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
A testing cleanup. 

This pull request replaces `ensure.TempDir(t)` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir := ensure.TempDir(t)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
