### PR TITLE
During deletion, explicitly log already deleted resource.

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -308,16 +308,20 @@ func (c *Client) Delete(resources ResourceList) (*Result, []error) {
 	mtx := sync.Mutex{}
 	err := perform(resources, func(info *resource.Info) error {
 		c.Log("Starting delete for %q %s", info.Name, info.Mapping.GroupVersionKind.Kind)
-		if err := c.skipIfNotFound(deleteResource(info)); err != nil {
-			mtx.Lock()
-			defer mtx.Unlock()
-			// Collect the error and continue on
-			errs = append(errs, err)
-		} else {
+		err := deleteResource(info)
+		if err == nil || apierrors.IsNotFound(err) {
+			if err != nil {
+				c.Log("Ignoring delete failure for %q %s: %v", info.Name, info.Mapping.GroupVersionKind, err)
+			}
 			mtx.Lock()
 			defer mtx.Unlock()
 			res.Deleted = append(res.Deleted, info)
+			return nil
 		}
+		mtx.Lock()
+		defer mtx.Unlock()
+		// Collect the error and continue on
+		errs = append(errs, err)
 		return nil
 	})
 	if err != nil {
@@ -332,14 +336,6 @@ func (c *Client) Delete(resources ResourceList) (*Result, []error) {
 		return nil, errs
 	}
 	return res, nil
-}
-
-func (c *Client) skipIfNotFound(err error) error {
-	if apierrors.IsNotFound(err) {
-		c.Log("%v", err)
-		return nil
-	}
-	return err
 }
 
 func (c *Client) watchTimeout(t time.Duration) func(*resource.Info) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Unfortunately errors from the API server do not always (do they ever?) contain the name of the resource in question.
Here is an example of how an error might look like in the log before this change (ignore the garbled timestamps):

```
1.65469391899976e+09	DEBUG	controllers.Helm	Starting delete for "stackrox:update-namespaces-binding" ClusterRoleBinding
1.6546939189998794e+09	DEBUG	controllers.Helm	Starting delete for "stackrox:network-policies-binding" ClusterRoleBinding
1.6546939189999611e+09	DEBUG	controllers.Helm	Starting delete for "stackrox:create-events-binding" ClusterRoleBinding
1.654693918999529e+09	DEBUG	controllers.Helm	Starting delete for "stackrox:enforce-policies" ClusterRoleBinding
1.654693919009047e+09	DEBUG	controllers.Helm	Starting delete for "stackrox-kuttl-test-giving-hornet-scanner-psp" ClusterRole
1.6546939190095422e+09	DEBUG	controllers.Helm	Starting delete for "stackrox-kuttl-test-giving-hornet-central-psp" ClusterRole
1.6546939190107038e+09	DEBUG	controllers.Helm	the server could not find the requested resource
1.6546939190362186e+09	DEBUG	controllers.Helm	Starting delete for "stackrox:review-tokens" ClusterRole
[...]
```

**Note** however that deletions for multiple resources are processed concurrently, so in the above log the `Starting delete` line right before the `the server could not find the requested resource` might well be pointing user in a wrong direction.

**Special notes for your reviewer**:

There are a few ways to structure the code here, I opted for keeping the critical section small but otherwise avoiding duplication.

Also please note this logging was crucial in resolving the concurrency issue described at https://github.com/porridge/config-race-repro

**If applicable**:
- [x] ~this PR contains documentation~
- [x] ~this PR contains unit tests~
- [x] ~this PR has been tested for backwards compatibility~
