### PR TITLE
Process all hook deletions on failure

### DIFF
--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -137,15 +137,23 @@ data:
 				Namespace: "test",
 			}, []resource.Info{
 				{
+					// This should be in the record for `before-hook-creation`
 					Name:      "build-config-1",
 					Namespace: "test",
 				},
 				{
+					// This should be in the record for `before-hook-creation`
 					Name:      "build-config-2",
 					Namespace: "test",
 				},
 				{
+					// This should be in the record for cleaning up (the failure first)
 					Name:      "build-config-2",
+					Namespace: "test",
+				},
+				{
+					// This should be in the record for cleaning up (then the previously successful)
+					Name:      "build-config-1",
 					Namespace: "test",
 				},
 			}, true,

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -151,30 +151,30 @@ data:
 					},
 				},
 			}, resource.Info{
-			Name:      "build-config-2",
-			Namespace: "test",
-		}, []resource.Info{
-			{
-				// This should be in the record for `before-hook-creation`
-				Name:      "build-config-1",
-				Namespace: "test",
-			},
-			{
-				// This should be in the record for `before-hook-creation`
 				Name:      "build-config-2",
 				Namespace: "test",
-			},
-			{
-				// This should be in the record for cleaning up (the failure first)
-				Name:      "build-config-2",
-				Namespace: "test",
-			},
-			{
-				// This should be in the record for cleaning up (then the previously successful)
-				Name:      "build-config-1",
-				Namespace: "test",
-			},
-		}, true,
+			}, []resource.Info{
+				{
+					// This should be in the record for `before-hook-creation`
+					Name:      "build-config-1",
+					Namespace: "test",
+				},
+				{
+					// This should be in the record for `before-hook-creation`
+					Name:      "build-config-2",
+					Namespace: "test",
+				},
+				{
+					// This should be in the record for cleaning up (the failure first)
+					Name:      "build-config-2",
+					Namespace: "test",
+				},
+				{
+					// This should be in the record for cleaning up (then the previously successful)
+					Name:      "build-config-1",
+					Namespace: "test",
+				},
+			}, true,
 		},
 	}
 

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -29,7 +29,7 @@ type HookFailingKubeClient struct {
 	deleteRecord []resource.Info
 }
 
-func (_ *HookFailingKubeClient) Build(reader io.Reader, _ bool) (kube.ResourceList, error) {
+func (*HookFailingKubeClient) Build(reader io.Reader, _ bool) (kube.ResourceList, error) {
 	configMap := &v1.ConfigMap{}
 
 	err := yaml.NewYAMLOrJSONDecoder(reader, 1000).Decode(configMap)

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -1,20 +1,22 @@
 package action
 
 import (
+	"io"
+	"io/ioutil"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/resource"
+
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/kube"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
-	"io"
-	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/cli-runtime/pkg/resource"
-	"reflect"
-	"testing"
-	"time"
 )
 
 type HookFailedError struct{}

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (
@@ -135,30 +151,30 @@ data:
 					},
 				},
 			}, resource.Info{
+			Name:      "build-config-2",
+			Namespace: "test",
+		}, []resource.Info{
+			{
+				// This should be in the record for `before-hook-creation`
+				Name:      "build-config-1",
+				Namespace: "test",
+			},
+			{
+				// This should be in the record for `before-hook-creation`
 				Name:      "build-config-2",
 				Namespace: "test",
-			}, []resource.Info{
-				{
-					// This should be in the record for `before-hook-creation`
-					Name:      "build-config-1",
-					Namespace: "test",
-				},
-				{
-					// This should be in the record for `before-hook-creation`
-					Name:      "build-config-2",
-					Namespace: "test",
-				},
-				{
-					// This should be in the record for cleaning up (the failure first)
-					Name:      "build-config-2",
-					Namespace: "test",
-				},
-				{
-					// This should be in the record for cleaning up (then the previously successful)
-					Name:      "build-config-1",
-					Namespace: "test",
-				},
-			}, true,
+			},
+			{
+				// This should be in the record for cleaning up (the failure first)
+				Name:      "build-config-2",
+				Namespace: "test",
+			},
+			{
+				// This should be in the record for cleaning up (then the previously successful)
+				Name:      "build-config-1",
+				Namespace: "test",
+			},
+		}, true,
 		},
 	}
 

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -1,0 +1,167 @@
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/kube"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"io"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/resource"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type HookFailedError struct{}
+
+func (e *HookFailedError) Error() string {
+	return "Hook failed!"
+}
+
+type HookFailingKubeClient struct {
+	kubefake.PrintingKubeClient
+	failOn       resource.Info
+	deleteRecord []resource.Info
+}
+
+func (_ *HookFailingKubeClient) Build(reader io.Reader, _ bool) (kube.ResourceList, error) {
+	configMap := &v1.ConfigMap{}
+
+	err := yaml.NewYAMLOrJSONDecoder(reader, 1000).Decode(configMap)
+
+	if err != nil {
+		return kube.ResourceList{}, err
+	}
+
+	return kube.ResourceList{{
+		Name:      configMap.Name,
+		Namespace: configMap.Namespace,
+	}}, nil
+}
+
+func (h *HookFailingKubeClient) WatchUntilReady(resources kube.ResourceList, duration time.Duration) error {
+	for _, res := range resources {
+		if res.Name == h.failOn.Name && res.Namespace == h.failOn.Namespace {
+			return &HookFailedError{}
+		}
+	}
+
+	return h.PrintingKubeClient.WatchUntilReady(resources, duration)
+}
+
+func (h *HookFailingKubeClient) Delete(resources kube.ResourceList) (*kube.Result, []error) {
+	for _, res := range resources {
+		h.deleteRecord = append(h.deleteRecord, resource.Info{
+			Name:      res.Name,
+			Namespace: res.Namespace,
+		})
+	}
+
+	return h.PrintingKubeClient.Delete(resources)
+}
+
+func TestHooksCleanUp(t *testing.T) {
+	hookKubeClient := &HookFailingKubeClient{kubefake.PrintingKubeClient{Out: ioutil.Discard}, resource.Info{
+		Name:      "build-config-2",
+		Namespace: "test",
+	}, []resource.Info{}}
+
+	configuration := &Configuration{
+		Releases:     storage.Init(driver.NewMemory()),
+		KubeClient:   hookKubeClient,
+		Capabilities: chartutil.DefaultCapabilities,
+		Log: func(format string, v ...interface{}) {
+			t.Helper()
+			if *verbose {
+				t.Logf(format, v...)
+			}
+		},
+	}
+
+	hookEvent := release.HookPreInstall
+
+	r := &release.Release{
+		Name:      "test-release",
+		Namespace: "test",
+		Hooks: []*release.Hook{
+			{
+				Name: "hook-1",
+				Kind: "ConfigMap",
+				Path: "templates/service_account.yaml",
+				Manifest: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-config-1
+  namespace: test
+data:
+  foo: bar
+`,
+				Weight: -5,
+				Events: []release.HookEvent{
+					hookEvent,
+				},
+				DeletePolicies: []release.HookDeletePolicy{
+					release.HookBeforeHookCreation,
+					release.HookSucceeded,
+					release.HookFailed,
+				},
+				LastRun: release.HookExecution{
+					Phase: release.HookPhaseSucceeded,
+				},
+			},
+			{
+				Name: "hook-2",
+				Kind: "ConfigMap",
+				Path: "templates/job.yaml",
+				Manifest: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-config-2
+  namespace: test
+data:
+  foo: bar
+`,
+				Weight: 0,
+				Events: []release.HookEvent{
+					hookEvent,
+				},
+				DeletePolicies: []release.HookDeletePolicy{
+					release.HookBeforeHookCreation,
+					release.HookSucceeded,
+					release.HookFailed,
+				},
+				LastRun: release.HookExecution{
+					Phase: release.HookPhaseFailed,
+				},
+			},
+		},
+	}
+
+	_ = configuration.execHook(r, hookEvent, 600)
+
+	if !reflect.DeepEqual(hookKubeClient.deleteRecord, []resource.Info{
+		{
+			Name:      "build-config-1",
+			Namespace: "test",
+		},
+		{
+			Name:      "build-config-2",
+			Namespace: "test",
+		},
+		{
+			Name:      "build-config-2",
+			Namespace: "test",
+		},
+	}) {
+		t.Fatalf("Got unexpected delete record")
+	}
+
+	//if err != nil {
+	//	t.Fatalf("An expected error occured: %#v", err)
+	//}
+}


### PR DESCRIPTION
fixes https://github.com/helm/helm/issues/10279

**What this PR does / why we need it**:

This a long standing issue that `helm.sh/hook-delete-policy` is not respected when a hook fails. In such case resources created by previously successful hooks are left in the cluster.

This change is an extended version of https://github.com/helm/helm/pull/10811 with tests.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
