### PR TITLE
fix: support waiting for jobs with ttlSecondsAfterFinished

### DIFF
--- a/pkg/kube/converter.go
+++ b/pkg/kube/converter.go
@@ -19,6 +19,8 @@ package kube // import "helm.sh/helm/v3/pkg/kube"
 import (
 	"sync"
 
+	"github.com/pkg/errors"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -66,4 +68,16 @@ func kubernetesNativeScheme() *runtime.Scheme {
 		apiextensionsv1.AddToScheme(k8sNativeScheme)
 	})
 	return k8sNativeScheme
+}
+
+// ConvertUnstructuredObject converts runtime.Unstructured to concrete resource representation.
+func ConvertUnstructuredObject(obj runtime.Object, concrete interface{}) error {
+	unstructObj, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return errors.Errorf("object expected to be runtime.Unstrcutured, but got %T", obj)
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(
+		unstructObj.UnstructuredContent(),
+		concrete,
+	)
 }


### PR DESCRIPTION
Rely on job events instead of polling while waiting for job readiness. This way job completion can be observed even if the job was removed because of expired TTL

Signed-off-by: Vladislav Koriakov <Dkfl12@github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR is intended to fix the behavior of '--wait-for-jobs' flag when jobs with ttlSecondsAfterFinished present (using lower values in particular). Previously used polling to check for job readiness might wail as the job might have reached its TTL and was already removed by the time polling happens. Instead of polling there is event watch for jobs starting from particular resource version (after helm upgrade/install is performed) that can capture job completion.

**Special notes for your reviewer**:
The fix was tested using minikube and helm chart with jobs (with and without ttlSecondsAfterFinished set) and different scenarios, e.g. two successful jobs, one failed and one successful job, etc.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
