### PR TITLE
fix: support waiting for jobs with ttlSecondsAfterFinished

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -99,7 +99,7 @@ func (c *ReadyChecker) getResourceWatch(ctx context.Context, resource *resource.
 	case *batchv1.Job:
 		return c.client.BatchV1().Jobs(resource.Namespace).Watch(ctx, listOpts)
 	default:
-		return nil, fmt.Errorf("can't get watch for resoure of type %T - not implemented", resourceType)
+		return nil, fmt.Errorf("can't get watch for resource of type %T - not implemented", resourceType)
 	}
 }
 

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -42,15 +42,15 @@ type waiter struct {
 	log     func(string, ...interface{})
 }
 
-// waitForResources polls to get the current status of all pods, PVCs, Services and
-// Jobs(optional) until all are ready or a timeout is reached
+// waitForResources polls to get the current status of all pods, PVCs, Services and until all are ready or a timeout is reached.
+// For jobs (optional) it watches for events and checks if the job is (or was) ready at the time of event.
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
 
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 
-	return wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		for _, v := range created {
 			ready, err := w.c.IsReady(ctx, v)
 			if !ready || err != nil {
@@ -59,6 +59,21 @@ func (w *waiter) waitForResources(created ResourceList) error {
 		}
 		return true, nil
 	})
+
+	if err != nil {
+		return err
+	}
+
+	if w.c.checkJobs {
+		jobsReady, err := w.c.waitJobsReady(ctx, created)
+		if err != nil {
+			return err
+		}
+		if !jobsReady {
+			return errors.New("jobs not ready")
+		}
+	}
+	return nil
 }
 
 // waitForDeletedResources polls to check if all the resources are deleted or a timeout is reached


### PR DESCRIPTION
Rely on job events instead of polling while waiting for job readiness. This way job completion can be observed even if the job was removed because of expired TTL

Signed-off-by: Vladislav Koriakov <dkfl12@yahoo.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR is intended to fix the behavior of '--wait-for-jobs' flag when jobs with ttlSecondsAfterFinished present (using lower values in particular). Previously used polling to check for job readiness might wail as the job might have reached its TTL and was already removed by the time polling happens. Instead of polling there is event watch for jobs starting from particular resource version (after helm upgrade/install is performed) that can capture job completion.

**Special notes for your reviewer**:
The fix was tested using minikube and helm chart with jobs (with and without ttlSecondsAfterFinished set) and different scenarios, e.g. two successful jobs, one failed and one successful job, etc.

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
