### PR TITLE
add template to store env vars in secrets

### DIFF
--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -105,7 +105,7 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 9
+	expectedNumberOfTemplates := 10
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}
@@ -173,7 +173,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 9
+	expectedNumberOfTemplates := 10
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -56,6 +56,8 @@ const (
 	IngressFileName = TemplatesDir + sep + "ingress.yaml"
 	// DeploymentName is the name of the example deployment file.
 	DeploymentName = TemplatesDir + sep + "deployment.yaml"
+	// EnvSecretName is the name of the example secret file for env vars.
+	EnvSecretName = TemplatesDir + sep + "secret-env.yaml"
 	// ServiceName is the name of the example service file.
 	ServiceName = TemplatesDir + sep + "service.yaml"
 	// ServiceAccountName is the name of the example serviceaccount file.
@@ -128,6 +130,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+env: {}
+  # Specify multiple environment parameters for the container
+  # EXAMPLE_KEY: example-value
 
 podAnnotations: {}
 podLabels: {}
@@ -305,9 +311,9 @@ spec:
       {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with include "<CHARTNAME>.podAnnotations" . }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "<CHARTNAME>.labels" . | nindent 8 }}
@@ -342,9 +348,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- with .Values.env }}
+          envFrom:
+            - secretRef:
+                name: {{ include "<CHARTNAME>.fullname" $ }}-env
           {{- end }}
       {{- with .Values.volumes }}
       volumes:
@@ -362,6 +369,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+`
+
+const defaultenvSecret = `{{- if .Values.env -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "<CHARTNAME>.fullname" . }}-env
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+stringData:
+  {{- toYaml .Values.env | nindent 2 }}
+{{- end }}
 `
 
 const defaultService = `apiVersion: v1
@@ -516,6 +536,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create a checksum for all env parameters in the secret.
+Adds the checksum to podAnnotations to ensure pod reloads on env secret changes.
+*/}}
+{{- define "<CHARTNAME>.podAnnotations" -}}
+{{- if .Values.env -}}
+{{- $envChecksum := .Values.env | toYaml | sha256sum | printf "%.*s" 60 -}}
+{{ toYaml (set .Values.podAnnotations "env-checksum" $envChecksum) }}
+{{- else -}}
+{{ toYaml .Values.podAnnotations }}
+{{- end -}}
+{{- end -}}
 `
 
 const defaultTestConnection = `apiVersion: v1
@@ -645,6 +678,11 @@ func Create(name, dir string) (string, error) {
 			// deployment.yaml
 			path:    filepath.Join(cdir, DeploymentName),
 			content: transform(defaultDeployment, name),
+		},
+		{
+			// env-secret.yaml
+			path:    filepath.Join(cdir, EnvSecretName),
+			content: transform(defaultenvSecret, name),
 		},
 		{
 			// service.yaml

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -48,6 +48,7 @@ func TestCreate(t *testing.T) {
 	for _, f := range []string{
 		ChartfileName,
 		DeploymentName,
+		EnvSecretName,
 		HelpersName,
 		IgnorefileName,
 		NotesName,


### PR DESCRIPTION
Signed-off-by: Marian Poeschmann <github@mail.itsmethemojo.eu>

closes #11284

**What this PR does / why we need it**:

This Feature enhances the default chart created with `helm create`. It adds the structure to add multiple environment variables and stores them in a separate secret. Because still most of the time developer still add sensitive configuration via environment variables and if there would be a out-of-the-box functionality storing those configuration the right way, a lot of future charts will be better by default. Most importently this also adds out-of-the-box pod recreation, when those secrets change, by adding an additional checksum environment parameter. By default Kubernetes will not recreate the pod if a secret changes, from which environment variables are referenced. This will be solved for those new environment variables.


**unit test**
I did run the tests but was a bit confused that the unit test suite fails by default. Nevertheless the tests for the module modified look ok.

```
docker run --rm -v$(pwd):/app -w /app -e PKG=pkg/chart-util -e TESTS=pkg/chart-util -e GOLANGCI_LINT_VERSION=1.46.2 cimg/go:1.18 bash -c 'cd /tmp && /app/.circleci/bootstrap.sh && cd /app && make build test'
> /tmp/out.txt
```

to compare here is the unchanged master

```
$ cat /tmp/out-org.txt | grep -vE '^FAIL$' | grep FAIL
--- FAIL: TestDependencyBuildCmdWithHelmV2Hash (0.01s)
FAIL    helm.sh/helm/v3/cmd/helm        59.833s
--- FAIL: TestWalk (0.00s)
FAIL    helm.sh/helm/v3/internal/sympath        0.056s
--- FAIL: TestLoadDirWithSymlink (0.00s)
FAIL    helm.sh/helm/v3/pkg/chart/loader        0.695s
--- FAIL: TestDependentChartsWithSubChartsSymlink (0.00s)
FAIL    helm.sh/helm/v3/pkg/chartutil   1.569s
--- FAIL: TestTemplateIntegrationHappyPath (0.01s)
FAIL    helm.sh/helm/v3/pkg/lint/rules  0.853s
--- FAIL: TestRegistryClientTestSuite (1.41s)
FAIL    helm.sh/helm/v3/pkg/registry    1.481s
--- FAIL: TestIndex (0.05s)
FAIL    helm.sh/helm/v3/pkg/repo        0.235s
```
and here is my branch

```
$ cat /tmp/out.txt | grep -vE '^FAIL$' | grep FAIL
--- FAIL: TestDependencyBuildCmdWithHelmV2Hash (0.02s)
FAIL    helm.sh/helm/v3/cmd/helm        89.903s
--- FAIL: TestWalk (0.00s)
FAIL    helm.sh/helm/v3/internal/sympath        0.086s
--- FAIL: TestLoadDirWithSymlink (0.00s)
FAIL    helm.sh/helm/v3/pkg/chart/loader        0.845s
--- FAIL: TestDependentChartsWithSubChartsSymlink (0.00s)
FAIL    helm.sh/helm/v3/pkg/chartutil   1.768s
--- FAIL: TestTemplateIntegrationHappyPath (0.02s)
FAIL    helm.sh/helm/v3/pkg/lint/rules  0.881s
--- FAIL: TestRegistryClientTestSuite (1.85s)
FAIL    helm.sh/helm/v3/pkg/registry    1.986s
--- FAIL: TestIndex (0.08s)
FAIL    helm.sh/helm/v3/pkg/repo        0.487s
```

**how to test the new template**

I tested with 2 minimal configs. The test should show that the environment parameters are referenced properly and a change will result in a pod recreation.
```
$ mkdir bin
$ chmod 777 -R bin
$ docker run --rm -v$(pwd):/app -w /app -e PKG=pkg/chart-util -e TESTS=pkg/chart-util -e GOLANGCI_LINT_VERSION=1.46.2 cimg/go:1.18 bash -c 'cd /tmp && /app/.circleci/bootstrap.sh && cd /app && make build

$ bin/helm create env-chart

$ cat test.yaml
env:
  POSTGRES_PASSWORD: ""
image:
  repository: postgres
  tag: "latest"

$ cat reload.yaml
env:
  POSTGRES_PASSWORD: mysecretpassword
  
$ helm install env-test env-chart/ -f test.yaml
$ kubectl logs -l app.kubernetes.io/instance=env-test
# you will see that the database wont come up, because the parameter POSTGRES_PASSWORD is missing

$ helm upgrade env-test env-chart/ -f test.yaml -f reload.yaml
$ kubectl logs -l app.kubernetes.io/instance=env-test
# you should now see that the database will come up 
```
