### PR TITLE
#11375 display the content that has the error for easy troubleshooting

### DIFF
--- a/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
+++ b/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
@@ -11,7 +11,7 @@ spec:
     command: ["/bin/sleep","9000"]
 invalid
 Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml contents:
- apiVersion: v1
+apiVersion: v1
 kind: Pod
 metadata:
   name: "release-name-my-alpine"

--- a/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
+++ b/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
@@ -10,4 +10,14 @@ spec:
     image: "alpine:3.9"
     command: ["/bin/sleep","9000"]
 invalid
-Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
+Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml contents:
+ apiVersion: v1
+kind: Pod
+metadata:
+  name: "release-name-my-alpine"
+spec:
+  containers:
+  - name: waiter
+    image: "alpine:3.9"
+    command: ["/bin/sleep","9000"]
+invalid: error converting YAML to JSON: yaml: line 11: could not find expected ':'

--- a/cmd/helm/testdata/output/template-with-invalid-yaml.txt
+++ b/cmd/helm/testdata/output/template-with-invalid-yaml.txt
@@ -1,3 +1,13 @@
-Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
+Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml contents:
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "release-name-my-alpine"
+spec:
+  containers:
+  - name: waiter
+    image: "alpine:3.9"
+    command: ["/bin/sleep","9000"]
+invalid: error converting YAML to JSON: yaml: line 11: could not find expected ':'
 
 Use --debug flag to render out invalid YAML

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -143,7 +143,7 @@ func (file *manifestFile) sort(result *result) error {
 
 		var entry SimpleHead
 		if err := yaml.Unmarshal([]byte(m), &entry); err != nil {
-			return errors.Wrapf(err, "YAML parse error on %s", file.path)
+			return errors.Wrapf(err, "YAML parse error on %s contents: \n %s", file.path, m)
 		}
 
 		if !hasAnyAnnotation(entry) {

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -143,7 +143,7 @@ func (file *manifestFile) sort(result *result) error {
 
 		var entry SimpleHead
 		if err := yaml.Unmarshal([]byte(m), &entry); err != nil {
-			return errors.Wrapf(err, "YAML parse error on %s contents: \n %s", file.path, m)
+			return errors.Wrapf(err, "YAML parse error on %s contents:\n%s", file.path, m)
 		}
 
 		if !hasAnyAnnotation(entry) {


### PR DESCRIPTION
closes #11357 

Visual aid on YAML error when developing template functions, without seeing there formatting error it's a guessing game of adjusting tabs adding `{-` or `-}` `indent` `trim` etc. 

I am sure this may not sound very useful for those who are expert in Go Templates, But i am not, I am sure others might find this useful .

## before
```
Error: YAML parse error on portal-backend/templates/configmap.yml: error converting YAML to JSON: yaml: line 10: could not find expected ':'
helm.go:84: [debug] error converting YAML to JSON: yaml: line 10: could not find expected ':'
YAML parse error on portal-backend/templates/configmap.yml
```

## after

```
nayana@nayana-295:~/code/rads/portal-backend-helm$ helm template foobar-release -s templates/configmap.yml --debug .
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /home/nayana/code/rads/portal-backend-helm

---
# Source: portal-backend/templates/configmap.yml

apiVersion: v1
kind: ConfigMap
metadata:
  name: foobar-release-configmap
  labels:apps.reverseads.io/author:this
    apps.reverseads.io/build:foo
    apps.reverseads.io/commit:how
    apps.reverseads.io/repo:that
    apps.reverseads.io/version:bar
Error: YAML parse error on portal-backend/templates/configmap.yml: error converting YAML to JSON: yaml: line 10: could not find expected ':'
helm.go:84: [debug] error converting YAML to JSON: yaml: line 10: could not find expected ':'
YAML parse error on portal-backend/templates/configmap.yml
```

now it's clear to see the output on  `labels:apps.reverseads.io/author:this` is incorrect. 

Thank you