### PR TITLE
Fix code style

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -128,7 +128,6 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "can't create TLS config for client")
 		}
-		tlsConf.BuildNameToCertificate()
 
 		sni, err := urlutil.ExtractHostname(g.opts.url)
 		if err != nil {

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -291,7 +291,6 @@ func TestDownloadTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "can't create TLS config for client"))
 	}
-	tlsConf.BuildNameToCertificate()
 	tlsConf.ServerName = "helm.sh"
 	tlsSrv.TLS = tlsConf
 	tlsSrv.StartTLS()

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -371,7 +371,6 @@ func (s *Server) StartTLS() {
 	if err != nil {
 		panic(err)
 	}
-	tlsConf.BuildNameToCertificate()
 	tlsConf.ServerName = "helm.sh"
 	s.srv.TLS = tlsConf
 	s.srv.StartTLS()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the code style so the unit tests can run.

```console
$ make test   
GO111MODULE=on CGO_ENABLED=0 go build  -trimpath -tags '' -ldflags '-w -s -X helm.sh/helm/v3/internal/version.metadata=unreleased -X helm.sh/helm/v3/internal/version.gitCommit=bed23120b048977d67c929cec915e1d6e0887c5d -X helm.sh/helm/v3/internal/version.gitTreeState=clean  -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=1 -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=25 -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=1 -X GO111MODULE=on golangci-lint run
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
pkg/getter/httpgetter.go:131:3: SA1019: tlsConf.BuildNameToCertificate has been deprecated since Go 1.14: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates. (staticcheck)
		tlsConf.BuildNameToCertificate()
		^
pkg/getter/httpgetter_test.go:294:2: SA1019: tlsConf.BuildNameToCertificate has been deprecated since Go 1.14: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates. (staticcheck)
	tlsConf.BuildNameToCertificate()
	^
pkg/repo/repotest/server.go:374:2: SA1019: tlsConf.BuildNameToCertificate has been deprecated since Go 1.14: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates. (staticcheck)
	tlsConf.BuildNameToCertificate()
```

**Special notes for your reviewer**:

[TLS Config.BuildNameToCertificate](https://pkg.go.dev/crypto/tls#Config.BuildNameToCertificate) is deprecated.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
