### PR TITLE
#11369 Fix custom repo index cache directory for unmanaged dependency updates

### DIFF
--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -206,6 +206,61 @@ func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 	}
 }
 
+func TestDependencyUpdateCmd_WithRepoThatWasNotAdded(t *testing.T) {
+	srv := setupMockRepoServer(t)
+	srvForUnmanagedRepo := setupMockRepoServer(t)
+	defer srv.Stop()
+	defer srvForUnmanagedRepo.Stop()
+
+	dir := func(p ...string) string {
+		return filepath.Join(append([]string{srv.Root()}, p...)...)
+	}
+
+	chartname := "depup"
+	ch := createTestingMetadata(chartname, srv.URL())
+	chartDependency := &chart.Dependency{
+		Name:       "signtest",
+		Version:    "0.1.0",
+		Repository: srvForUnmanagedRepo.URL(),
+	}
+	ch.Metadata.Dependencies = append(ch.Metadata.Dependencies, chartDependency)
+
+	if err := chartutil.SaveDir(ch, dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	_, out, err := executeActionCommand(
+		fmt.Sprintf("dependency update '%s' --repository-config %s --repository-cache %s", dir(chartname),
+			dir("repositories.yaml"), dir()),
+	)
+
+	if err != nil {
+		t.Logf("Output: %s", out)
+		t.Fatal(err)
+	}
+
+	// This is written directly to stdout, so we have to capture as is
+	if !strings.Contains(out, `Getting updates for unmanaged Helm repositories...`) {
+		t.Errorf("No ‘unmanaged’ Helm repo used in test chartdependency or it doesn’t cause the creation "+
+			"of an ‘ad hoc’ repo index cache file\n%s", out)
+	}
+}
+
+func setupMockRepoServer(t *testing.T) *repotest.Server {
+	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Listening on directory %s", srv.Root())
+
+	if err := srv.LinkIndices(); err != nil {
+		t.Fatal(err)
+	}
+
+	return srv
+}
+
 // createTestingMetadata creates a basic chart that depends on reqtest-0.1.0
 //
 // The baseURL can be used to point to a particular repository server.

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -668,6 +668,7 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 		if err != nil {
 			return err
 		}
+		r.CachePath = m.RepositoryCache
 		wg.Add(1)
 		go func(r *repo.ChartRepository) {
 			if _, err := r.DownloadIndexFile(); err != nil {


### PR DESCRIPTION
Closes #11369 

**What this PR does / why we need it**:

Using the `--repository-cache` flag for a chart with unmanaged dependencies consistently fails with:

>Error: no cached repository for helm-manager-[some-hash] found. (try 'helm repo update'): open /tmp/helm-cache/helm-manager-[some-hash]-index.yaml: no such file or directory

This PR fixes that.

**Special notes for your reviewer**:

The unit test case could probably be a bit cleaner, but this is my first attempt at writing Go code 👼 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
