### PR TITLE
populate chart metadata with a repoURL [hip-0018]

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -228,6 +228,12 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, err
 	}
 
+	if client.ChartPathOptions.RepoURL != "" {
+		chartRequested.Metadata.RepoURL = client.ChartPathOptions.RepoURL
+	} else {
+		chartRequested.Metadata.RepoURL = "path"
+	}
+
 	if err := checkIfInstallable(chartRequested); err != nil {
 		return nil, err
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -158,6 +158,11 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if client.ChartPathOptions.RepoURL != "" {
+				ch.Metadata.RepoURL = client.ChartPathOptions.RepoURL
+			} else {
+				ch.Metadata.RepoURL = "path"
+			}
 			if req := ch.Metadata.Dependencies; req != nil {
 				if err := action.CheckDependencies(ch, req); err != nil {
 					err = errors.Wrap(err, "An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies")

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -785,6 +785,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	if err != nil {
 		return "", err
 	}
+	c.RepoURL = dl.RepositoryURL
 
 	lname, err := filepath.Abs(filename)
 	if err != nil {

--- a/pkg/chart/metadata.go
+++ b/pkg/chart/metadata.go
@@ -80,6 +80,8 @@ type Metadata struct {
 	Dependencies []*Dependency `json:"dependencies,omitempty"`
 	// Specifies the chart type: application or library
 	Type string `json:"type,omitempty"`
+	// Specifies the chart URL that was used to initially install a chart.
+	RepoURL string `json:"repoURL,omitempty"`
 }
 
 // Validate checks the metadata for known issues and sanitizes string
@@ -97,6 +99,7 @@ func (md *Metadata) Validate() error {
 	md.Tags = sanitizeString(md.Tags)
 	md.AppVersion = sanitizeString(md.AppVersion)
 	md.KubeVersion = sanitizeString(md.KubeVersion)
+	md.RepoURL = sanitizeString(md.RepoURL)
 	for i := range md.Sources {
 		md.Sources[i] = sanitizeString(md.Sources[i])
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -73,6 +73,7 @@ type ChartDownloader struct {
 	RegistryClient   *registry.Client
 	RepositoryConfig string
 	RepositoryCache  string
+	RepositoryURL    string
 }
 
 // DownloadTo retrieves a chart. Depending on the settings, it may also download a provenance file.
@@ -196,6 +197,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	}
 
 	if registry.IsOCI(u.String()) {
+		c.RepositoryURL = ref
 		return c.getOciURI(ref, version, u)
 	}
 
@@ -266,6 +268,9 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	}
 
 	if r != nil && r.Config != nil {
+		if r.Config.URL != "" {
+			c.RepositoryURL = r.Config.URL
+		}
 		if r.Config.CertFile != "" || r.Config.KeyFile != "" || r.Config.CAFile != "" {
 			c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Implements https://github.com/helm/community/blob/main/hips/hip-0018.md

Fixes: #4256

Signed-off-by: Luke Reed <luke@lreed.net>
Signed-off-by: Andy Suderman <andy@suderman.dev>

**Special notes for your reviewer**:
rebased off of, and supersedes (with permission from original author): https://github.com/helm/helm/pull/10369


**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility


**Output when using OCI registry**
```
 k get secret -n goldilocks sh.helm.release.v1.goldilocks.v1 -ojson |jq -r .data.release | base64 -D|base64 -D|gunzip|jq .chart.metadata
{
  "name": "goldilocks",
  "sources": [
    "https://github.com/FairwindsOps/goldilocks"
  ],
  "version": "5.1.0",
  "description": "A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks ",
  "keywords": [
    "goldilocks",
    "resources",
    "kubernetes"
  ],
  "maintainers": [
    {
      "name": "sudermanjr"
    },
    {
      "name": "lucasreed"
    }
  ],
  "icon": "https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png",
  "apiVersion": "v2",
  "appVersion": "v4.1.0",
  "repoURL": "oci://us-docker.pkg.dev/fairwinds-ops/helm/goldilocks"
}
```

**Output when installing from a locally pulled tarball or a path**
```
▶ k get secret -n polaris2 sh.helm.release.v1.polaris2.v1 -ojson |jq -r .data.release | base64 -D|base64 -D|gunzip|jq .chart.metadata
{
  "name": "polaris",
  "version": "5.5.0",
  "description": "Validation of best practices in your Kubernetes clusters",
  "maintainers": [
    {
      "name": "rbren",
      "email": "robertb@fairwinds.com"
    }
  ],
  "icon": "https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png",
  "apiVersion": "v1",
  "appVersion": "7.0",
  "repoURL": "path"
}
```

**Output when pulling from a standard helm repository**
```
▶ k get secret -n polaris sh.helm.release.v1.polaris.v1 -ojson |jq -r .data.release | base64 -D|base64 -D|gunzip|jq .chart.metadata
{
  "name": "polaris",
  "version": "5.5.0",
  "description": "Validation of best practices in your Kubernetes clusters",
  "maintainers": [
    {
      "name": "rbren",
      "email": "robertb@fairwinds.com"
    }
  ],
  "icon": "https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png",
  "apiVersion": "v1",
  "appVersion": "7.0",
  "repoURL": "https://charts.fairwinds.com/stable"
}
```