### PR TITLE
fix post install hook deletion due to before-hook-creation policy

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
 )
@@ -51,7 +52,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			h.DeletePolicies = []release.HookDeletePolicy{release.HookBeforeHookCreation}
 		}
 
-		if err := cfg.deleteHookByPolicy(h, release.HookBeforeHookCreation); err != nil {
+		if err := cfg.deleteHookByPolicy(h, release.HookBeforeHookCreation, timeout); err != nil {
 			return err
 		}
 
@@ -88,7 +89,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			h.LastRun.Phase = release.HookPhaseFailed
 			// If a hook is failed, check the annotation of the hook to determine whether the hook should be deleted
 			// under failed condition. If so, then clear the corresponding resource object in the hook
-			if err := cfg.deleteHookByPolicy(h, release.HookFailed); err != nil {
+			if err := cfg.deleteHookByPolicy(h, release.HookFailed, timeout); err != nil {
 				return err
 			}
 			return err
@@ -99,7 +100,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook
 	for _, h := range executingHooks {
-		if err := cfg.deleteHookByPolicy(h, release.HookSucceeded); err != nil {
+		if err := cfg.deleteHookByPolicy(h, release.HookSucceeded, timeout); err != nil {
 			return err
 		}
 	}
@@ -120,7 +121,7 @@ func (x hookByWeight) Less(i, j int) bool {
 }
 
 // deleteHookByPolicy deletes a hook if the hook policy instructs it to
-func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.HookDeletePolicy) error {
+func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.HookDeletePolicy, timeout time.Duration) error {
 	// Never delete CustomResourceDefinitions; this could cause lots of
 	// cascading garbage collection.
 	if h.Kind == "CustomResourceDefinition" {
@@ -134,6 +135,13 @@ func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.Hoo
 		_, errs := cfg.KubeClient.Delete(resources)
 		if len(errs) > 0 {
 			return errors.New(joinErrors(errs))
+		}
+
+		//wait for resources until they are deleted to avoid conflicts
+		if kubeClient, ok := cfg.KubeClient.(kube.InterfaceExt); ok {
+			if err := kubeClient.WaitForDelete(resources, timeout); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -420,6 +420,9 @@ func TestInstallRelease_Atomic(t *testing.T) {
 		failer.WaitError = fmt.Errorf("I timed out")
 		instAction.cfg.KubeClient = failer
 		instAction.Atomic = true
+		// disabling hooks to avoid an early fail when the
+		// the WaitForDelete is called on the pre-delete hook execution
+		instAction.DisableHooks = true
 		vals := map[string]interface{}{}
 
 		res, err := instAction.Run(buildChart(), vals)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #6879 

**What this PR does / why we need it**:
This PR fixes a bug/issue when applying an install to a chart that has hooks with `"helm.sh/hook-delete-policy": before-hook-creation`. If the hook resources (pod or job) take time to terminate or have finalizers,  then the release will fail with a message like:

```
Error: failed post-install: warning: Hook post-install testing-hooks-chart/templates/pod.yaml failed: object is being deleted: pods "random-pod" already exists
```

**Special notes for your reviewer**:

I added some example manifests on how to reproduce this issue in my last comment on the issue

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
