### PR TITLE
Add error handling for the filesystem operations of cache and index files

### DIFF
--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -152,12 +152,18 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 		fmt.Fprintln(&charts, name)
 	}
 	chartsFile := filepath.Join(r.CachePath, helmpath.CacheChartsFile(r.Config.Name))
-	os.MkdirAll(filepath.Dir(chartsFile), 0755)
-	ioutil.WriteFile(chartsFile, []byte(charts.String()), 0644)
+	if err := os.MkdirAll(filepath.Dir(chartsFile), 0755); err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(chartsFile, []byte(charts.String()), 0644); err != nil {
+		return "", err
+	}
 
 	// Create the index file in the cache directory
 	fname := filepath.Join(r.CachePath, helmpath.CacheIndexFile(r.Config.Name))
-	os.MkdirAll(filepath.Dir(fname), 0755)
+	if err := os.MkdirAll(filepath.Dir(fname), 0755); err != nil {
+		return "", err
+	}
 	return fname, ioutil.WriteFile(fname, index, 0644)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Error handling was missing for these statements. While I was using Helm Go client in a `gcr.io/distroless/static` image, I got the following error which made it hard to debug the actual problem, which turns out to be that `mkdir -p` is not allowed at root level.
```
failed to pull chart: looks like "https://charts.bitnami.com/bitnami" is not a valid chart repository or cannot be reached: open /.cache/helm/repository/gFha2BlGnhJAeJBJ1g1qOe3xNW4=-index.yaml: no such file or directory
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
