### PR TITLE
fix HTTPInstaller not handling octet-stream media types

### DIFF
--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -64,7 +64,7 @@ var Extractors = map[string]Extractor{
 // This should be refactored in Helm 4, combined with the extension-based mechanism.
 func mediaTypeToExtension(mt string) (string, bool) {
 	switch strings.ToLower(mt) {
-	case "application/gzip", "application/x-gzip", "application/x-tgz", "application/x-gtar":
+	case "application/gzip", "application/x-gzip", "application/x-tgz", "application/x-gtar", "application/octet-stream":
 		return ".tgz", true
 	default:
 		return "", false


### PR DESCRIPTION
partial-fix #11272
Signed-off-by: Stephen Bell <8148044+s7m4b4@users.noreply.github.com>

**What this PR does / why we need it**:
As mentioned in #11272, Github uses "application/octet-stream" media type which `mediaTypeToExtension` does not consider, meaning any plugin installs from Github will fail when using `HTTPInstaller`. This fixes that.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
