### PR TITLE
Allow CGO_ENABLED to be overridden for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ ACCEPTANCE_DIR:=../acceptance-testing
 ACCEPTANCE_RUN_TESTS=.
 
 # go option
-PKG        := ./...
-TAGS       :=
-TESTS      := .
-TESTFLAGS  :=
-LDFLAGS    := -w -s
-GOFLAGS    :=
+PKG         := ./...
+TAGS        :=
+TESTS       := .
+TESTFLAGS   :=
+LDFLAGS     := -w -s
+GOFLAGS     :=
+CGO_ENABLED ?= 0
 
 # Rebuild the binary if any of these files change
 SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
@@ -77,7 +78,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	GO111MODULE=on CGO_ENABLED=0 go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/helm
 
 # ------------------------------------------------------------------------------
 #  install


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

On Mac OS they have some custom dns c library that uses some configuration files other than resolv.conf to configure dns lookups. The standard go library does not handle these custom configuration files which causes dns lookups to fail for some mac users.

This allows the downstream pacakgers to override CGO_ENABLED to build binaries that use the custom dns library.

Fixes #5800

Enables https://github.com/Homebrew/homebrew-core/issues/110500

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
