### PR TITLE
Updating the repo the azure cli is installed from

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -34,7 +34,7 @@ else
 fi
 
 echo "Installing Azure CLI"
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bullseye main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
 sudo apt install apt-transport-https
 sudo apt update


### PR DESCRIPTION
CircleCI is now using Ubuntu 20.04 for the Go 1.18 image. The azure CLI is expecting a version older than that. This change updates.

Note, we have been using the debian name for the repo rather than the ubuntu name. bullseye maps to Ubuntu 20.04 through 21.10.

Closes #11432
