### PR TITLE
Updating the deb location for azure cli

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -34,7 +34,7 @@ else
 fi
 
 echo "Installing Azure CLI"
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bullseye main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ jammy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
 sudo apt install apt-transport-https
 sudo apt update


### PR DESCRIPTION
This update moves to ubuntu jammy. The name moves off of debian version names because jammy is based on bookworm and azure cli does not have debian package support with bookworm

This is an update to the previous update for this because the CircleCI environment is ubuntu 20.04 but the container this is running is has 22.04 as the ubuntu version. Updating the in container to 22.04 (jammy).

