### PR TITLE
use intstr.GetScaledValueFromIntOrPercent instead of the deprecated

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -291,7 +291,7 @@ func (c *ReadyChecker) daemonSetReady(ds *appsv1.DaemonSet) bool {
 		c.log("DaemonSet is not ready: %s/%s. %d out of %d expected pods have been scheduled", ds.Namespace, ds.Name, ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled)
 		return false
 	}
-	maxUnavailable, err := intstr.GetValueFromIntOrPercent(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, int(ds.Status.DesiredNumberScheduled), true)
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, int(ds.Status.DesiredNumberScheduled), true)
 	if err != nil {
 		// If for some reason the value is invalid, set max unavailable to the
 		// number of desired replicas. This is the same behavior as the


### PR DESCRIPTION
Signed-off-by: phoenixsqf <sqfphoenix@163.com>

use intstr.GetScaledValueFromIntOrPercent cause intstr.GetValueFromIntOrPercent is deprecated