### PR TITLE
Strict file permissions for repository.yaml

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -213,7 +213,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 
 	f.Update(&c)
 
-	if err := f.WriteFile(o.repoFile, 0644); err != nil {
+	if err := f.WriteFile(o.repoFile, 0600); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "%q has been added to your repositories\n", o.name)

--- a/cmd/helm/repo_remove.go
+++ b/cmd/helm/repo_remove.go
@@ -67,7 +67,7 @@ func (o *repoRemoveOptions) run(out io.Writer) error {
 		if !r.Remove(name) {
 			return errors.Errorf("no repo named %q found", name)
 		}
-		if err := r.WriteFile(o.repoFile, 0644); err != nil {
+		if err := r.WriteFile(o.repoFile, 0600); err != nil {
 			return err
 		}
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -203,7 +203,7 @@ func TestWriteFile(t *testing.T) {
 		t.Errorf("failed to create test-file (%v)", err)
 	}
 	defer os.Remove(file.Name())
-	if err := sampleRepository.WriteFile(file.Name(), 0644); err != nil {
+	if err := sampleRepository.WriteFile(file.Name(), 0600); err != nil {
 		t.Errorf("failed to write file (%v)", err)
 	}
 

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -385,7 +385,7 @@ func (s *Server) StartTLS() {
 		CAFile: filepath.Join("../../testdata", "rootca.crt"),
 	})
 
-	if err := r.WriteFile(repoConfig, 0644); err != nil {
+	if err := r.WriteFile(repoConfig, 0600); err != nil {
 		panic(err)
 	}
 }
@@ -400,6 +400,7 @@ func (s *Server) Stop() {
 // URL returns the URL of the server.
 //
 // Example:
+//
 //	http://localhost:1776
 func (s *Server) URL() string {
 	return s.srv.URL
@@ -421,5 +422,5 @@ func setTestingRepository(url, fname string) error {
 		Name: "test",
 		URL:  url,
 	})
-	return r.WriteFile(fname, 0644)
+	return r.WriteFile(fname, 0640)
 }


### PR DESCRIPTION
Closes #11451 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR remove read access of  "repository.yaml"  to world

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
