### PR TITLE
Backfill tests for the `tpl` function

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -865,3 +865,36 @@ func TestRenderLoadTemplateForTplFromFile(t *testing.T) {
 		t.Fatalf("Expected %q, got %q", expect, got)
 	}
 }
+
+func TestRenderTplEmpty(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "TplEmpty"},
+		Templates: []*chart.File{
+			{Name: "templates/empty-string", Data: []byte(`{{tpl "" .}}`)},
+			{Name: "templates/empty-action", Data: []byte(`{{tpl "{{ \"\"}}" .}}`)},
+			{Name: "templates/only-defines", Data: []byte(`{{tpl "{{define \"not-invoked\"}}not-rendered{{end}}" .}}`)},
+		},
+	}
+	v := chartutil.Values{
+		"Chart": c.Metadata,
+		"Release": chartutil.Values{
+			"Name": "TestRelease",
+		},
+	}
+
+	out, err := Render(c, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expects := map[string]string{
+		"TplEmpty/templates/empty-string": "",
+		"TplEmpty/templates/empty-action": "",
+		"TplEmpty/templates/only-defines": "",
+	}
+	for file, expect := range expects {
+		if out[file] != expect {
+			t.Errorf("Expected %q, got %q", expect, out[file])
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains test-only changes for the `tpl` function to cover all the sharp edges I encountered creating PR <http://github.com/helm/helm/pull/11351> and trying to use <http://github.com/helm/helm/pull/8371> instead.

It verifies current behaviour, especially the aspects affected by those PRs. (Or which I found mattered to our charts before composing <http://github.com/helm/helm/pull/11351>.)

**Special notes for your reviewer**:

I have run these tests against both v3.9.4 and v3.10.1 tags as well as the HEAD of main.

Both proposed `tpl` performance improvement PRs will fail after this PR is merged. I have a second set of cherries to pick onto <http://github.com/helm/helm/pull/11351>; I believe the changes are reasonable. (They involve access to `define` in the manifest invoking `tpl` and being able to override `define`s from partial files.)

 However, due to the nature of the `(t) ExecuteTemplate(...)` golang function, I now think that <http://github.com/helm/helm/pull/8371> cannot be used without effectively turning it into something very similar to <http://github.com/helm/helm/pull/11351>: it must use `(t) Execute(...)` instead.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
