### PR TITLE
Validates against OpenAPI schema while rolling back to previous release

### DIFF
--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -146,11 +146,12 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		return targetRelease, nil
 	}
 
-	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), false)
+	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), true)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
-	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), false)
+
+	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), true)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -141,10 +141,6 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 }
 
 func (r *Rollback) performRollback(currentRelease, targetRelease *release.Release) (*release.Release, error) {
-	if r.DryRun {
-		r.cfg.Log("dry run for %s", targetRelease.Name)
-		return targetRelease, nil
-	}
 
 	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), true)
 	if err != nil {
@@ -154,6 +150,11 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), true)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
+	}
+
+	if r.DryRun {
+		r.cfg.Log("dry run for %s", targetRelease.Name)
+		return targetRelease, nil
 	}
 
 	// pre-rollback hooks

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -35,16 +35,17 @@ import (
 type Rollback struct {
 	cfg *Configuration
 
-	Version       int
-	Timeout       time.Duration
-	Wait          bool
-	WaitForJobs   bool
-	DisableHooks  bool
-	DryRun        bool
-	Recreate      bool // will (if true) recreate pods after a rollback.
-	Force         bool // will (if true) force resource upgrade through uninstall/recreate if needed
-	CleanupOnFail bool
-	MaxHistory    int // MaxHistory limits the maximum number of revisions saved per release
+	Version                  int
+	Timeout                  time.Duration
+	Wait                     bool
+	WaitForJobs              bool
+	DisableHooks             bool
+	DryRun                   bool
+	Recreate                 bool // will (if true) recreate pods after a rollback.
+	Force                    bool // will (if true) force resource upgrade through uninstall/recreate if needed
+	CleanupOnFail            bool
+	MaxHistory               int  // MaxHistory limits the maximum number of revisions saved per release
+	DisableOpenAPIValidation bool // DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
 }
 
 // NewRollback creates a new Rollback object with the given configuration.
@@ -142,12 +143,12 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 
 func (r *Rollback) performRollback(currentRelease, targetRelease *release.Release) (*release.Release, error) {
 
-	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), true)
+	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), r.DisableOpenAPIValidation)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
 
-	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), true)
+	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), r.DisableOpenAPIValidation)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -35,17 +35,17 @@ import (
 type Rollback struct {
 	cfg *Configuration
 
-	Version                  int
-	Timeout                  time.Duration
-	Wait                     bool
-	WaitForJobs              bool
-	DisableHooks             bool
-	DryRun                   bool
-	Recreate                 bool // will (if true) recreate pods after a rollback.
-	Force                    bool // will (if true) force resource upgrade through uninstall/recreate if needed
-	CleanupOnFail            bool
-	MaxHistory               int  // MaxHistory limits the maximum number of revisions saved per release
-	DisableOpenAPIValidation bool // DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
+	Version                 int
+	Timeout                 time.Duration
+	Wait                    bool
+	WaitForJobs             bool
+	DisableHooks            bool
+	DryRun                  bool
+	Recreate                bool // will (if true) recreate pods after a rollback.
+	Force                   bool // will (if true) force resource upgrade through uninstall/recreate if needed
+	CleanupOnFail           bool
+	MaxHistory              int  // MaxHistory limits the maximum number of revisions saved per release
+	EnableOpenAPIValidation bool // EnableOpenAPIValidation controls whether OpenAPI validation is enforced.
 }
 
 // NewRollback creates a new Rollback object with the given configuration.
@@ -143,12 +143,12 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 
 func (r *Rollback) performRollback(currentRelease, targetRelease *release.Release) (*release.Release, error) {
 
-	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), r.DisableOpenAPIValidation)
+	current, err := r.cfg.KubeClient.Build(bytes.NewBufferString(currentRelease.Manifest), r.EnableOpenAPIValidation)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
 
-	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), r.DisableOpenAPIValidation)
+	target, err := r.cfg.KubeClient.Build(bytes.NewBufferString(targetRelease.Manifest), r.EnableOpenAPIValidation)
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Validates against OpenAPI schema while rolling back to the previous release.
Also, i think this validation should be part of dry-run itself, so in dry-run only we can catch this behaviour.
There's always a possibility that user can corrupt the Helm revisions secrets, stored in users namespace only and to avoid that we should validate it before applying/rolling back it. 


**Special notes for your reviewer**:
Any advice is greatly appreciated.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
