### PR TITLE
Readiness & liveness probes correct port

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -312,7 +312,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Port number now comes from values.yaml

closes #11461 

**What this PR does / why we need it**: Fixes port number in generated `deployment.yaml` (during `helm create ...`)

**Special notes for your reviewer**: This works but might not be the right approach

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
