### PR TITLE
redirect registry client output to stderr

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -155,7 +155,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	registryClient, err := registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
-		registry.ClientOptWriter(out),
+		registry.ClientOptWriter(os.Stderr),
 		registry.ClientOptCredentialsFile(settings.RegistryConfig),
 	)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Fix #11385

**Special notes for your reviewer**: 

before: `helm template oci://registry/charts/name --version 1.0.5 | head` yields on stdout :
```
Pulled: registry/charts/name:1.0.5
Digest: sha256:117bf9af073f070d41af119dc3bf31241b7817ba9ab9692e336e1cb39df1e354
---
# Source: xxx.yaml
apiVersion: v1
...
```

after: same output, but Pulled/Digest are on stderr
stderr:
```
Pulled: registry/charts/name:1.0.5
Digest: sha256:117bf9af073f070d41af119dc3bf31241b7817ba9ab9692e336e1cb39df1e354
```
stdout
```
---
# Source: xxx.yaml
apiVersion: v1
...
```

this impacts the output of *all* the commands interacting with the registry.

`make test`  ok locally

my reading of https://github.com/helm/helm/blob/main/CONTRIBUTING.md#semantic-versioning says it is backward compatible :)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
