### PR TITLE
update .golangci for go1.18

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - misspell
     - nakedret
     - revive
-    - structcheck
     - unused
     - varcheck
     - staticcheck


### PR DESCRIPTION
**What this PR does / why we need it**:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/12080746/199051271-b9080864-57e6-4938-82dc-4a8ff77bd4ae.png">

I see the github ci is as above picture . 
So i install the golang-lint version and go version to test..
![image](https://user-images.githubusercontent.com/12080746/199051680-85e8abb9-d05c-47b8-9ead-20bda44e5406.png)



Before is 
![image](https://user-images.githubusercontent.com/12080746/199051495-d4dcf3bd-c84c-4789-9203-9b9d5160075f.png)

After modify the .golangci.yml , the result is 
![image](https://user-images.githubusercontent.com/12080746/199051721-e3ac6a13-0865-4d39-9356-7a05a1728835.png)


**Special notes for your reviewer**:


