### PR TITLE
Fix namespace mismatch during installation

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -366,6 +366,7 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
 	kc.Log = log
+	kc.Namespace = namespace
 
 	lazyClient := &lazyClient{
 		namespace: namespace,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Using the SDK and pass namespace to installation does not take effect, helm show the ns is different to the real deployed ns.
namespace shoud be passed to kube.Client anyway.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
