### PR TITLE
Test that version X is resolved to X

### DIFF
--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -300,7 +300,7 @@ func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "0.2.0", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -334,7 +334,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	if chartURL != "https://charts.helm.sh/stable/nginx-0.2.0.tgz" {
+	if chartURL != "https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz" {
 		t.Errorf("%s is not the valid URL", chartURL)
 	}
 
@@ -344,6 +344,15 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 	if chartURL != "https://charts.helm.sh/stable/nginx-0.1.0.tgz" {
 		t.Errorf("%s is not the valid URL", chartURL)
+	}
+
+	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.3.0", "", "", "", getter.All(&cli.EnvSettings{}))
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	expectedChartVersionURL := "https://charts.helm.sh/stable/nginx-0.3.0.tgz"
+	if chartURL != expectedChartVersionURL {
+		t.Errorf("Expected version - '%s' (because it was requested), actual - %s", expectedChartVersionURL, chartURL)
 	}
 }
 

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -335,8 +335,8 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 	}
 
 	nginx, ok := i.Entries["nginx"]
-	if !ok || len(nginx) != 2 {
-		t.Fatalf("Expected 2 nginx entries")
+	if !ok || len(nginx) != 4 {
+		t.Fatalf("Expected 4 nginx entries, got %d", len(nginx))
 	}
 
 	expects := []*ChartVersion{
@@ -352,6 +352,34 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 			URLs: []string{
 				"https://charts.helm.sh/stable/alpine-1.0.0.tgz",
 				"http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz",
+			},
+			Digest: "sha256:1234567890abcdef",
+		},
+		{
+			Metadata: &chart.Metadata{
+				APIVersion:  "v2",
+				Name:        "nginx",
+				Description: "string",
+				Version:     "0.3.0+abc",
+				Keywords:    []string{"popular", "web server", "proxy"},
+				Home:        "https://github.com/something/else",
+			},
+			URLs: []string{
+				"https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz",
+			},
+			Digest: "sha256:1234567890abcdef",
+		},
+		{
+			Metadata: &chart.Metadata{
+				APIVersion:  "v2",
+				Name:        "nginx",
+				Description: "string",
+				Version:     "0.3.0",
+				Keywords:    []string{"popular", "web server", "proxy"},
+				Home:        "https://github.com/something/else",
+			},
+			URLs: []string{
+				"https://charts.helm.sh/stable/nginx-0.3.0.tgz",
 			},
 			Digest: "sha256:1234567890abcdef",
 		},

--- a/pkg/repo/testdata/chartmuseum-index.yaml
+++ b/pkg/repo/testdata/chartmuseum-index.yaml
@@ -4,6 +4,28 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz
+      name: nginx
+      description: string
+      version: 0.3.0+abc
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0.tgz
+      name: nginx
+      description: string
+      version: 0.3.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
         - https://charts.helm.sh/stable/nginx-0.2.0.tgz
       name: nginx
       description: string

--- a/pkg/repo/testdata/local-index-annotations.yaml
+++ b/pkg/repo/testdata/local-index-annotations.yaml
@@ -2,6 +2,30 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz
+      name: nginx
+      description: string
+      version: 0.3.0+abc
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+      apiVersion: v2
+    - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0.tgz
+      name: nginx
+      description: string
+      version: 0.3.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+      apiVersion: v2
+    - urls:
         - https://charts.helm.sh/stable/nginx-0.2.0.tgz
       name: nginx
       description: string

--- a/pkg/repo/testdata/local-index-unordered.yaml
+++ b/pkg/repo/testdata/local-index-unordered.yaml
@@ -25,6 +25,30 @@ entries:
         - web server
         - proxy
       apiVersion: v2
+    - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz
+      name: nginx
+      description: string
+      version: 0.3.0+abc
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+      apiVersion: v2
+    - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0.tgz
+      name: nginx
+      description: string
+      version: 0.3.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+      apiVersion: v2
   alpine:
     - urls:
         - https://charts.helm.sh/stable/alpine-1.0.0.tgz

--- a/pkg/repo/testdata/local-index.yaml
+++ b/pkg/repo/testdata/local-index.yaml
@@ -2,6 +2,28 @@ apiVersion: v1
 entries:
   nginx:
     - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0+abc.tgz
+      name: nginx
+      description: string
+      version: 0.3.0+abc
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
+        - https://charts.helm.sh/stable/nginx-0.3.0.tgz
+      name: nginx
+      description: string
+      version: 0.3.0
+      home: https://github.com/something/else
+      digest: "sha256:1234567890abcdef"
+      keywords:
+        - popular
+        - web server
+        - proxy
+    - urls:
         - https://charts.helm.sh/stable/nginx-0.2.0.tgz
       name: nginx
       description: string


### PR DESCRIPTION
**What this PR does / why we need it**:
Is needed to investigate #7563 . The problem is helm finds version `1.0.0+abc` even if version `1.0.0` was requested and both `1.0.0` and `1.0.0+abc` are in index.

New test checks this specifically and needed for further investigation.

**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [V] this PR contains unit tests
- [V] this PR has been tested for backwards compatibility
