### PR TITLE
This change adds support for timeout of each resource

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -147,6 +147,23 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	return w.waitForResources(resources)
 }
 
+// Wait waits up to the given timeout for the specified resources to be ready. perResourceTimeout means the timeout of each resource
+func (c *Client) WaitWithPerResource(resources ResourceList, timeout, perResourceTimeout time.Duration) error {
+	cs, err := c.getKubeClient()
+	if err != nil {
+		return err
+	}
+	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true))
+	w := waiter{
+		c:                  checker,
+		log:                c.Log,
+		timeout:            timeout,
+		perResourceTimeout: perResourceTimeout,
+	}
+	return w.waitForResources(resources)
+}
+
+
 // WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
 func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) error {
 	cs, err := c.getKubeClient()


### PR DESCRIPTION
Signed-off-by: anhj <anhongyang125@163.com>

 This change adds support for timeout of each resource to query kubernetes objects
 close#11535

**What this PR does / why we need it**:   

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
