### PR TITLE
Refactor template and  fix some bugs

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -235,13 +235,13 @@ func matchFilePatterns(target string, sf []string) bool {
 func writeManifest(outputDir, path, manifest string, fileWritten map[string]bool, withHeader bool, outStream io.Writer) error {
 	if outputDir == "" {
 		return writeStream(path, manifest, withHeader, outStream)
-	} else {
-		err := writeToFile(outputDir, path, manifest, fileWritten[path], withHeader)
-		if err != nil {
-			return err
-		}
-		fileWritten[path] = true
 	}
+	err := writeToFile(outputDir, path, manifest, fileWritten[path], withHeader)
+	if err != nil {
+		return err
+	}
+	fileWritten[path] = true
+
 	return nil
 }
 

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -112,6 +112,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			// with globs or directory names.
 			splitManifests := releaseutil.SplitManifests(manifests.String())
 			manifestsKeys := make([]string, 0, len(splitManifests))
+			// such as `# Source: subchart/templates/service.yaml` will be divided into two parts `subchart/`, `templates/service.yaml`
+			// and manifestName will be `templates/service.yaml` , manifestPath will be `subchart/templates/service.yam`
 			manifestNameRegex := regexp.MustCompile("# Source: ([^/]+/)(.+)")
 			for k := range splitManifests {
 				manifestsKeys = append(manifestsKeys, k)
@@ -229,7 +231,7 @@ func matchFilePatterns(target string, sf []string) bool {
 	return false
 }
 
-// writeManifest write manifest to stdout or file stream. use withHeader to control if write file header `# Source: XXXXX.yaml` or not.
+// writeManifest write manifest to stdout or file stream. use withHeader to control if write file header `# Source: XXXXX.yaml`.
 func writeManifest(outputDir, path, manifest string, fileWritten map[string]bool, withHeader bool, outStream io.Writer) error {
 	if outputDir == "" {
 		return writeStream(path, manifest, withHeader, outStream)

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -176,7 +176,7 @@ func TestTemplateOutputDir(t *testing.T) {
 		t.Logf("Output: %s", out)
 		t.Fatal(err)
 	}
-	var exitFileList = [][]string{
+	var existent = [][]string{
 		{dir, "subchart", "templates", "service.yaml"},
 		{dir, "subchart", "templates", "tests", "test-config.yaml"},
 		{dir, "subchart", "templates", "tests", "test-nothing.yaml"},
@@ -186,11 +186,11 @@ func TestTemplateOutputDir(t *testing.T) {
 		{dir, "subchart", "charts", "subcharta", "templates", "service.yaml"},
 		{dir, "subchart", "charts", "subchartb", "templates", "service.yaml"},
 	}
-	for _, s := range exitFileList {
+	for _, s := range existent {
 		_, err = os.Stat(filepath.Join(s...))
 		is.NoError(err)
 	}
-	notExistFileList := [][]string{
+	nonexistent := [][]string{
 		{dir, "hello", "templates", "empty"},
 		{dir, releaseName, "subchart", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "templates", "tests", "test-config.yaml"},
@@ -201,7 +201,7 @@ func TestTemplateOutputDir(t *testing.T) {
 		{dir, releaseName, "subchart", "charts", "subcharta", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "charts", "subchartb", "templates", "service.yaml"},
 	}
-	for _, f := range notExistFileList {
+	for _, f := range nonexistent {
 		_, err = os.Stat(filepath.Join(f...))
 		is.True(os.IsNotExist(err))
 	}
@@ -216,14 +216,14 @@ func TestTemplateWithCRDsOutputDir(t *testing.T) {
 		t.Logf("Output: %s", out)
 		t.Fatal(err)
 	}
-	var exitFileList = [][]string{
+	var existent = [][]string{
 		{dir, "subchart", "crds", "crdA.yaml"},
 	}
-	for _, s := range exitFileList {
+	for _, s := range existent {
 		_, err = os.Stat(filepath.Join(s...))
 		is.NoError(err)
 	}
-	notExistFileList := [][]string{
+	nonexistent := [][]string{
 		{dir, "hello", "templates", "empty"},
 		{dir, releaseName, "subchart", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "templates", "tests", "test-config.yaml"},
@@ -234,7 +234,7 @@ func TestTemplateWithCRDsOutputDir(t *testing.T) {
 		{dir, releaseName, "subchart", "charts", "subcharta", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "charts", "subchartb", "templates", "service.yaml"},
 	}
-	for _, f := range notExistFileList {
+	for _, f := range nonexistent {
 		_, err = os.Stat(filepath.Join(f...))
 		is.True(os.IsNotExist(err))
 	}
@@ -249,7 +249,7 @@ func TestTemplateOutputDirWithReleaseName(t *testing.T) {
 		t.Logf("Output: %s", out)
 		t.Fatal(err)
 	}
-	var exitFileList = [][]string{
+	var existent = [][]string{
 		{dir, releaseName, "subchart", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "templates", "tests", "test-config.yaml"},
 		{dir, releaseName, "subchart", "templates", "tests", "test-nothing.yaml"},
@@ -259,11 +259,11 @@ func TestTemplateOutputDirWithReleaseName(t *testing.T) {
 		{dir, releaseName, "subchart", "charts", "subcharta", "templates", "service.yaml"},
 		{dir, releaseName, "subchart", "charts", "subchartb", "templates", "service.yaml"},
 	}
-	for _, s := range exitFileList {
+	for _, s := range existent {
 		_, err = os.Stat(filepath.Join(s...))
 		is.NoError(err)
 	}
-	notExistFileList := [][]string{
+	nonexistent := [][]string{
 		{dir, releaseName, "hello", "templates", "empty"},
 		{dir, "subchart", "templates", "service.yaml"},
 		{dir, "subchart", "templates", "tests", "test-config.yaml"},
@@ -274,7 +274,7 @@ func TestTemplateOutputDirWithReleaseName(t *testing.T) {
 		{dir, "subchart", "charts", "subcharta", "templates", "service.yaml"},
 		{dir, "subchart", "charts", "subchartb", "templates", "service.yaml"},
 	}
-	for _, f := range notExistFileList {
+	for _, f := range nonexistent {
 		_, err = os.Stat(filepath.Join(f...))
 		is.True(os.IsNotExist(err))
 	}
@@ -289,11 +289,11 @@ func TestTemplateOutputDirSkiptest(t *testing.T) {
 		t.Logf("Output: %s", out)
 		t.Fatal(err)
 	}
-	notExistFileList := [][]string{
+	nonexistent := [][]string{
 		{dir, "subchart", "templates", "tests", "test-config.yaml"},
 		{dir, "subchart", "templates", "tests", "test-nothing.yaml"},
 	}
-	for _, f := range notExistFileList {
+	for _, f := range nonexistent {
 		_, err = os.Stat(filepath.Join(f...))
 		is.True(os.IsNotExist(err))
 	}

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var chartPath = "testdata/testcharts/subchart"

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -1,4 +1,21 @@
 ---
+# Source: subchart/charts/subcharta/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subcharta
+  labels:
+    helm.sh/chart: "subcharta-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subcharta
+---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -19,20 +36,3 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart
----
-# Source: subchart/charts/subcharta/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: subcharta
-  labels:
-    helm.sh/chart: "subcharta-0.1.0"
-spec:
-  type: ClusterIP
-  ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: apache
-  selector:
-    app.kubernetes.io/name: subcharta

--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -1,5 +1,5 @@
 ---
-# Source: crds/crdA.yaml
+# Source: subchart/crds/crdA.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,32 +75,6 @@ var manifestWithTestHook = `kind: Pod
 	  image: fake-image
 	  cmd: fake-command
   `
-
-var rbacManifests = `apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: schedule-agents
-rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/exec", "pods/log"]
-  verbs: ["*"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: schedule-agents
-  namespace: {{ default .Release.Namespace}}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: schedule-agents
-subjects:
-- kind: ServiceAccount
-  name: schedule-agents
-  namespace: {{ .Release.Namespace }}
-`
 
 type chartOptions struct {
 	*chart.Chart
@@ -204,15 +178,6 @@ func withSampleIncludingIncorrectTemplates() chartOption {
 			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
 			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
 			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
-		}
-		opts.Templates = append(opts.Templates, sampleTemplates...)
-	}
-}
-
-func withMultipleManifestTemplate() chartOption {
-	return func(opts *chartOptions) {
-		sampleTemplates := []*chart.File{
-			{Name: "templates/rbac", Data: []byte(rbacManifests)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -59,8 +59,6 @@ import (
 // since there can be filepath in front of it.
 const notesFileSuffix = "NOTES.txt"
 
-const defaultDirectoryPermission = 0755
-
 // Install performs an installation operation.
 type Install struct {
 	cfg *Configuration
@@ -83,12 +81,14 @@ type Install struct {
 	GenerateName     bool
 	NameTemplate     string
 	Description      string
+	// OutputDir is deprecated because of template-related  code is removed from install action.
 	// Deprecated
 	OutputDir                string
 	Atomic                   bool
 	SkipCRDs                 bool
 	SubNotes                 bool
 	DisableOpenAPIValidation bool
+	// IncludeCRDs is deprecated because of template-related code is removed from install action.
 	// Deprecated
 	IncludeCRDs              bool
 	// KubeVersion allows specifying a custom kubernetes version to use and
@@ -98,9 +98,10 @@ type Install struct {
 	APIVersions chartutil.VersionSet
 	// Used by helm template to render charts with .Release.IsUpgrade. Ignored if Dry-Run is false
 	IsUpgrade bool
-	// Used by helm template to add the release as part of OutputDir path
+	// Used by helm template to add the release as part of OutputDir path, UseReleaseName is deprecated because of template-related code is removed from install action.
 	// OutputDir/<ReleaseName>
-	UseReleaseName bool // Deprecated
+	//Deprecated
+	UseReleaseName bool
 	PostRenderer   postrender.PostRenderer
 	// Lock to control raceconditions when the process receives a SIGTERM
 	Lock sync.Mutex
@@ -216,7 +217,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	}
 
 	if i.ClientOnly {
-		// Add mock objects in here so it doesn't use Kube API server
+		// Add mock objects in here, so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
 		i.cfg.Capabilities = chartutil.DefaultCapabilities.Copy()
 		if i.KubeVersion != nil {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -90,7 +90,7 @@ type Install struct {
 	DisableOpenAPIValidation bool
 	// IncludeCRDs is deprecated because of template-related code is removed from install action.
 	// Deprecated
-	IncludeCRDs              bool
+	IncludeCRDs bool
 	// KubeVersion allows specifying a custom kubernetes version to use and
 	// APIVersions allows a manual set of supported API Versions to be passed
 	// (for things like templating). These are ignored if ClientOnly is false
@@ -459,10 +459,10 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 //
 // Roughly, this will return an error if name is
 //
-//	- empty
-//	- too long
-//	- already in use, and not deleted
-//	- used by a deleted release, and i.Replace is false
+//   - empty
+//   - too long
+//   - already in use, and not deleted
+//   - used by a deleted release, and i.Replace is false
 func (i *Install) availableName() error {
 	start := i.ReleaseName
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -30,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -544,74 +541,6 @@ func TestNameTemplate(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestInstallReleaseOutputDir(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir := t.TempDir()
-
-	instAction.OutputDir = dir
-
-	_, err := instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(dir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(dir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
-}
-
-func TestInstallOutputDirWithReleaseName(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-	vals := map[string]interface{}{}
-
-	dir := t.TempDir()
-
-	instAction.OutputDir = dir
-	instAction.UseReleaseName = true
-	instAction.ReleaseName = "madra"
-
-	newDir := filepath.Join(dir, instAction.ReleaseName)
-
-	_, err := instAction.Run(buildChart(withSampleTemplates(), withMultipleManifestTemplate()), vals)
-	if err != nil {
-		t.Fatalf("Failed install: %s", err)
-	}
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/goodbye"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/hello"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/with-partials"))
-	is.NoError(err)
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/rbac"))
-	is.NoError(err)
-
-	test.AssertGoldenFile(t, filepath.Join(newDir, "hello/templates/rbac"), "rbac.txt")
-
-	_, err = os.Stat(filepath.Join(newDir, "hello/templates/empty"))
-	is.True(os.IsNotExist(err))
 }
 
 func TestNameAndChart(t *testing.T) {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -231,7 +231,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, u.SubNotes, u.PostRenderer, u.DryRun)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes  #11550
conveniently:
fixes #11321
fixes #11481

**Special notes for your reviewer**:
what did I do?

-  refactor  `helm template` related code in [template.go](https://github.com/helm/helm/blob/main/cmd/helm/template.go) 
- remove `--output-dir` related code in method `renderResources` and move `--output-dir` related test case to `template_test.go`.
- remove useless parameters and mark them deprecated in  `Install`.
- do `--show-only` file filter for crds and hooks.
- fix bugs mentioned by issues.
- fix incorrect test case add more test case about `helm template`.
- fix  if we set `OutputDir`  `IncludeCRDs` in install action when using SDK, it will miss manifest or add redundancy CRDs in the generated  release.   
**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
