### PR TITLE
Remove warning for template directory not found

### DIFF
--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
@@ -1,6 +1,6 @@
 ==> Linting testdata/testcharts/chart-with-bad-subcharts
 [INFO] Chart.yaml: icon is recommended
-[WARNING] templates/: directory not found
+[ERROR] templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 
@@ -9,12 +9,11 @@
 [ERROR] Chart.yaml: apiVersion is required. The value must be either "v1" or "v2"
 [ERROR] Chart.yaml: version is required
 [INFO] Chart.yaml: icon is recommended
-[WARNING] templates/: directory not found
+[ERROR] templates/: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	validation: chart.metadata.name is required
 
 ==> Linting testdata/testcharts/chart-with-bad-subcharts/charts/good-subchart
 [INFO] Chart.yaml: icon is recommended
-[WARNING] templates/: directory not found
 
 Error: 3 chart(s) linted, 2 chart(s) failed

--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts.txt
@@ -1,6 +1,6 @@
 ==> Linting testdata/testcharts/chart-with-bad-subcharts
 [INFO] Chart.yaml: icon is recommended
-[WARNING] templates/: directory not found
+[ERROR] templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
 

--- a/cmd/helm/testdata/output/lint-quiet-with-error.txt
+++ b/cmd/helm/testdata/output/lint-quiet-with-error.txt
@@ -1,7 +1,7 @@
 ==> Linting testdata/testcharts/chart-bad-requirements
 [ERROR] Chart.yaml: unable to parse YAML
 	error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
-[WARNING] templates/: directory not found
+[ERROR] templates/: cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
 [ERROR] : unable to load chart
 	cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
 

--- a/cmd/helm/testdata/output/lint-quiet-with-warning.txt
+++ b/cmd/helm/testdata/output/lint-quiet-with-warning.txt
@@ -1,4 +1,0 @@
-==> Linting testdata/testcharts/chart-with-only-crds
-[WARNING] templates/: directory not found
-
-1 chart(s) linted, 0 chart(s) failed

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -149,12 +149,12 @@ func TestLint_ChartWithWarnings(t *testing.T) {
 		}
 	})
 
-	t.Run("should fail with errors when strict", func(t *testing.T) {
+	t.Run("should pass with no errors when strict", func(t *testing.T) {
 		testCharts := []string{chartWithNoTemplatesDir}
 		testLint := NewLint()
 		testLint.Strict = true
-		if result := testLint.Run(testCharts, values); len(result.Errors) != 1 {
-			t.Error("expected one error, but got", len(result.Errors))
+		if result := testLint.Run(testCharts, values); len(result.Errors) != 0 {
+			t.Error("expected no errors, but got", len(result.Errors))
 		}
 	})
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -43,17 +43,12 @@ func TestBadChart(t *testing.T) {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)
 	}
-	// There should be one INFO, 2 WARNINGs and 2 ERROR messages, check for them
-	var i, w, e, e2, e3, e4, e5, e6 bool
+	// There should be one INFO, and 2 ERROR messages, check for them
+	var i, e, e2, e3, e4, e5, e6 bool
 	for _, msg := range m {
 		if msg.Severity == support.InfoSev {
 			if strings.Contains(msg.Err.Error(), "icon is recommended") {
 				i = true
-			}
-		}
-		if msg.Severity == support.WarningSev {
-			if strings.Contains(msg.Err.Error(), "directory not found") {
-				w = true
 			}
 		}
 		if msg.Severity == support.ErrorSev {
@@ -81,7 +76,7 @@ func TestBadChart(t *testing.T) {
 			}
 		}
 	}
-	if !e || !e2 || !e3 || !e4 || !e5 || !w || !i || !e6 {
+	if !e || !e2 || !e3 || !e4 || !e5 || !i || !e6 {
 		t.Errorf("Didn't find all the expected errors, got %#v", m)
 	}
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -188,10 +188,10 @@ func validateTopIndentLevel(content string) error {
 
 // Validation functions
 func validateTemplatesDir(templatesPath string) error {
-	if fi, err := os.Stat(templatesPath); err != nil {
-		return errors.New("directory not found")
-	} else if !fi.IsDir() {
-		return errors.New("not a directory")
+	if fi, err := os.Stat(templatesPath); err == nil {
+		if !fi.IsDir() {
+			return errors.New("not a directory")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Some charts don't need a templates directory. The warning appears to originate back when helm expected all charts to contain templates. In CI situations where linting is performed with --strict the lint warning causes unnecessary failures for charts that quite legitimately do not contain a templates directory.

As discussed in #8033 there are no longer any scenarios understood where this warning is helpful so this commit removes it.

Closes #8033 


**Special notes for your reviewer**:

I have verified this change removes the warning as follows:

*Chart.yaml*
```yaml
apiVersion: v2
name: a
description: A Helm chart for Kubernetes
type: application
version: 0.1.0
appVersion: 1.16.0
icon: https://artifacthub.io/image/681732c0-8168-4b95-8600-894449c02b79@1x.png
dependencies:
- name: nginx
  version: 13.2.14
  repository: "https://charts.bitnami.com/bitnami"
```

*Commands:*

```bash
helm dep update

Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Saving 1 charts
Downloading nginx from repo https://charts.bitnami.com/bitnami
Deleting outdated charts


helm lint .

==> Linting test

1 chart(s) linted, 0 chart(s) failed


tree

.
├── Chart.lock
├── charts
│   └── nginx-13.2.14.tgz
├── Chart.yaml
└── values.yaml
```


**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
