### PR TITLE
Use wrapped error so that ErrNoObjectsVisited can be compared

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -325,10 +325,8 @@ func (c *Client) Delete(resources ResourceList) (*Result, []error) {
 		return nil
 	})
 	if err != nil {
-		// Rewrite the message from "no objects visited" if that is what we got
-		// back
 		if err == ErrNoObjectsVisited {
-			err = errors.New("object not found, skipping delete")
+			err = fmt.Errorf("object not found, skipping delete: %w", ErrNoObjectsVisited)
 		}
 		errs = append(errs, err)
 	}
@@ -352,10 +350,10 @@ func (c *Client) watchTimeout(t time.Duration) func(*resource.Info) error {
 // For most kinds, it checks to see if the resource is marked as Added or Modified
 // by the Kubernetes event stream. For some kinds, it does more:
 //
-// - Jobs: A job is marked "Ready" when it has successfully completed. This is
-//   ascertained by watching the Status fields in a job's output.
-// - Pods: A pod is marked "Ready" when it has successfully completed. This is
-//   ascertained by watching the status.phase field in a pod's output.
+//   - Jobs: A job is marked "Ready" when it has successfully completed. This is
+//     ascertained by watching the Status fields in a job's output.
+//   - Pods: A pod is marked "Ready" when it has successfully completed. This is
+//     ascertained by watching the status.phase field in a pod's output.
 //
 // Handling for other kinds will be added as necessary.
 func (c *Client) WatchUntilReady(resources ResourceList, timeout time.Duration) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
In the current client, when encounter  `ErrNoObjectsVisited`, it will be converted to a new error, I understand the purpose of the original thought is trying to provide an error message that is more readable. But the problem with this approach is, it's lost the possibility to compare the error `ErrNoObjectsVisited` directly when needed.

In this PR, it changes to `fmt.Errorf` with wrapped error `%w` verb so that this error can be used by `errors.Is` and `errors.As` later.
