### PR TITLE
Use stdout in registry writer only with commands that don't use structured output

### DIFF
--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -53,6 +53,8 @@ func newGetValuesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
+
 			vals, err := client.Run(args[0])
 			if err != nil {
 				return err

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -53,7 +54,7 @@ func newGetValuesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			vals, err := client.Run(args[0])
 			if err != nil {

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -67,6 +67,8 @@ func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
+
 			history, err := getHistory(client, args[0])
 			if err != nil {
 				return err

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"time"
 
@@ -67,7 +68,7 @@ func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			history, err := getHistory(client, args[0])
 			if err != nil {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -136,6 +136,8 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
+
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
 				return errors.Wrap(err, "INSTALLATION FAILED")

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -136,7 +136,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -70,6 +70,8 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:              require.NoArgs,
 		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
+
 			if client.AllNamespaces {
 				if err := cfg.Init(settings.RESTClientGetter(), "", os.Getenv("HELM_DRIVER"), debug); err != nil {
 					return err

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -70,7 +70,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:              require.NoArgs,
 		ValidArgsFunction: noCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			if client.AllNamespaces {
 				if err := cfg.Init(settings.RESTClientGetter(), "", os.Getenv("HELM_DRIVER"), debug); err != nil {

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -263,9 +263,9 @@ func checkForExpiredRepos(repofile string) {
 
 }
 
-func overrideRegistryWriter(cfg *action.Configuration, outfmt output.Format) {
+func overrideRegistryWriter(cfg *action.Configuration, outfmt output.Format, newWriter io.Writer) {
 	// Ensure registry output doesn't break structured output
 	if outfmt != output.Table {
-		registry.ClientOptWriter(os.Stderr)(cfg.RegistryClient)
+		registry.ClientOptWriter(newWriter)(cfg.RegistryClient)
 	}
 }

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/repo"
 )
@@ -155,7 +156,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	registryClient, err := registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
-		registry.ClientOptWriter(os.Stderr),
+		registry.ClientOptWriter(out),
 		registry.ClientOptCredentialsFile(settings.RegistryConfig),
 	)
 	if err != nil {
@@ -260,4 +261,11 @@ func checkForExpiredRepos(repofile string) {
 		}
 	}
 
+}
+
+func overrideRegistryWriter(cfg *action.Configuration, outfmt output.Format) {
+	// Ensure registry output doesn't break structured output
+	if outfmt != output.Table {
+		registry.ClientOptWriter(os.Stderr)(cfg.RegistryClient)
+	}
 }

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -65,6 +65,7 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
 
 			// When the output format is a table the resources should be fetched
 			// and displayed as a table. When YAML or JSON the resources will be

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -65,7 +66,7 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			// When the output format is a table the resources should be fetched
 			// and displayed as a table. When YAML or JSON the resources will be

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -66,7 +66,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, output.YAML)
+			overrideRegistryWriter(cfg, output.YAML, os.Stderr)
 
 			if kubeVersion != "" {
 				parsedKubeVersion, err := chartutil.ParseKubeVersion(kubeVersion)

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -34,6 +34,7 @@ import (
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/releaseutil"
 )
@@ -65,6 +66,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, output.YAML)
+
 			if kubeVersion != "" {
 				parsedKubeVersion, err := chartutil.ParseKubeVersion(kubeVersion)
 				if err != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -88,6 +88,8 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideRegistryWriter(cfg, outfmt)
+
 			client.Namespace = settings.Namespace()
 
 			// Fixes #7002 - Support reading values from STDIN for `upgrade` command

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -88,7 +88,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			overrideRegistryWriter(cfg, outfmt)
+			overrideRegistryWriter(cfg, outfmt, os.Stderr)
 
 			client.Namespace = settings.Namespace()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Partially reverts https://github.com/helm/helm/commit/c3a62f7880be8bdc904f2d54c4b0c16a86ec204c. Registry writer will use stderr only with subcommands that use structured output.

closes #11533

**Special notes for your reviewer**:

This attempts to address the issue.  However, it is reasonable to expect the caller to check exit code and not assume that stuff in stderr indicates failure.   The redirect suggested in https://github.com/helm/helm/issues/11533#issuecomment-1312176464 is also a reasonable solution. There are plenty of tools that send output to separate streams even on success.  So https://github.com/helm/helm/commit/c3a62f7880be8bdc904f2d54c4b0c16a86ec204c seems like a reasonable change in behavior and the broken pipelines should be adjusted to accommodate.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
