### PR TITLE
Update httpgetter.go to send accept header

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -52,9 +52,9 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	req.Header.Set("Accept", "application/gzip,application/octet-stream")
-	
+
 	req.Header.Set("User-Agent", version.GetUserAgent())
 	if g.opts.userAgent != "" {
 		req.Header.Set("User-Agent", g.opts.userAgent)
@@ -117,7 +117,7 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 			Timeout:   g.opts.timeout,
 		}, nil
 	}
-	
+
 	g.once.Do(func() {
 		g.transport = &http.Transport{
 			DisableCompression: true,

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -52,7 +52,9 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
+	req.Header.Set("Accept", "application/gzip,application/octet-stream")
+	
 	req.Header.Set("User-Agent", version.GetUserAgent())
 	if g.opts.userAgent != "" {
 		req.Header.Set("User-Agent", g.opts.userAgent)
@@ -115,8 +117,6 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 			Timeout:   g.opts.timeout,
 		}, nil
 	}
-	
-	req.Header.Set("Accept", "application/gzip,application/octet-stream")
 	
 	g.once.Do(func() {
 		g.transport = &http.Transport{

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -115,7 +115,9 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 			Timeout:   g.opts.timeout,
 		}, nil
 	}
-
+	
+	req.Header.Set("Accept", "application/gzip,application/octet-stream")
+	
 	g.once.Do(func() {
 		g.transport = &http.Transport{
 			DisableCompression: true,


### PR DESCRIPTION
Signed-off-by: Patric Wellershaus <p.wellershaus@googlemail.com>

**What this PR does**:
This PR adds the accept header to request sent by the HTTPGetter. The function accepts gzip and so it would be preferable if it also notified the server about this. Additionally this adds support for private helm charts hosted with github. 

**Special notes for your reviewer**:
Issue related to this are [9507](https://github.com/helm/helm/issues/9507)
