### PR TITLE
docs: add docs for cli/values.Options

### DIFF
--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -29,16 +29,17 @@ import (
 	"helm.sh/helm/v3/pkg/strvals"
 )
 
+// Options captures the different ways to specify values
 type Options struct {
-	ValueFiles   []string
-	StringValues []string
-	Values       []string
-	FileValues   []string
-	JSONValues   []string
+	ValueFiles   []string // -f/--values
+	StringValues []string // --set-string
+	Values       []string // --set
+	FileValues   []string // --set-file
+	JSONValues   []string // --set-json
 }
 
 // MergeValues merges values from files specified via -f/--values and directly
-// via --set, --set-string, or --set-file, marshaling them to YAML
+// via --set-json, --set, --set-string, or --set-file, marshaling them to YAML
 func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, error) {
 	base := map[string]interface{}{}
 


### PR DESCRIPTION
Add documentation for cli/values.Options

**What this PR does / why we need it**:
Without reading the code, it is hard to know which flag corresponds to which field in `values.Options`. This PR adds the simplest possible documentation.

**If applicable**:
- [x] this PR contains documentation
