### PR TITLE
Use common labels instead of selectorLabels for pod labels

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -310,7 +310,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+        {{- include "<CHARTNAME>.labels" . | nindent 8 }}
 	{{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Signed-off-by: Tim Chaplin <tim.chaplin@datadoghq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
By default, a newly generated Helm chart provides a `labels` macro and a `selectorLabels` macro. `selectorLabels` is currently used for the `selector.matchLabels` section of a Deployment, as well as `template.metadata.labels`. As a result, pods only get a subset of the common labels applied. I couldn't find any documented rationale for why you would only want to use `selectorLabels` for pods, so my guess is that it's a bug.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
