### PR TITLE
Avoid confusing error when passing in '--version X.Y.Z' to get-helm

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -207,6 +207,10 @@ while [[ $# -gt 0 ]]; do
        shift
        if [[ $# -ne 0 ]]; then
            export DESIRED_VERSION="${1}"
+           if [[ "$1" != "v"* ]]; then
+               echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
+               export DESIRED_VERSION="v${1}"
+           fi
        else
            echo -e "Please provide the desired version. e.g. --version v2.4.0 or -v latest"
            exit 0

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -299,6 +299,10 @@ while [[ $# -gt 0 ]]; do
        shift
        if [[ $# -ne 0 ]]; then
            export DESIRED_VERSION="${1}"
+           if [[ "$1" != "v"* ]]; then
+               echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
+               export DESIRED_VERSION="v${1}"
+           fi
        else
            echo -e "Please provide the desired version. e.g. --version v3.0.0 or -v canary"
            exit 0


### PR DESCRIPTION
closes #11578

**What this PR does / why we need it**:
This magically adds "v" to the start of the desired version string if it was not passed in.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility

CC: @joejulian 