### PR TITLE
TestList_AllNamespaces with namespace cases

### DIFF
--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -286,7 +286,6 @@ func makeMeSomeReleases(store *storage.Storage, t *testing.T) {
 	assert.Len(t, all, 3, "sanity test: three items added")
 }
 
-
 func makeMeSomeReleasesWithDifferentNamespaces(store *storage.Storage, t *testing.T) {
 	t.Helper()
 	one := releaseStub()
@@ -312,7 +311,6 @@ func makeMeSomeReleasesWithDifferentNamespaces(store *storage.Storage, t *testin
 	assert.NoError(t, err)
 	assert.Len(t, all, 3, "sanity test: three items added")
 }
-
 
 func TestFilterLatestReleases(t *testing.T) {
 	t.Run("should filter old versions of the same release", func(t *testing.T) {

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -79,7 +79,7 @@ func TestList_OneNamespace(t *testing.T) {
 func TestList_AllNamespaces(t *testing.T) {
 	is := assert.New(t)
 	lister := newListFixture(t)
-	makeMeSomeReleases(lister.cfg.Releases, t)
+	makeMeSomeReleasesWithDifferentNamespaces(lister.cfg.Releases, t)
 	lister.AllNamespaces = true
 	lister.SetStateMask()
 	list, err := lister.Run()
@@ -285,6 +285,34 @@ func makeMeSomeReleases(store *storage.Storage, t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, all, 3, "sanity test: three items added")
 }
+
+
+func makeMeSomeReleasesWithDifferentNamespaces(store *storage.Storage, t *testing.T) {
+	t.Helper()
+	one := releaseStub()
+	one.Name = "one"
+	one.Namespace = "default1"
+	one.Version = 1
+	two := releaseStub()
+	two.Name = "two"
+	two.Namespace = "default2"
+	two.Version = 2
+	three := releaseStub()
+	three.Name = "three"
+	three.Namespace = "default3"
+	three.Version = 3
+
+	for _, rel := range []*release.Release{one, two, three} {
+		if err := store.Create(rel); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all, err := store.ListReleases()
+	assert.NoError(t, err)
+	assert.Len(t, all, 3, "sanity test: three items added")
+}
+
 
 func TestFilterLatestReleases(t *testing.T) {
 	t.Run("should filter old versions of the same release", func(t *testing.T) {


### PR DESCRIPTION
Updated the TestList_AllNamespaces to have different namespaces in the releases it tests with.

Signed-off-by: Aleksandar Faraj <AleksandarFaraj@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
action.NewList does not properly implement AllNamespaces, and this test gives does not actually test the required behaviour.  

**Special notes for your reviewer**:
Related to, #11656 but does not solve it, it only adds the cases.
