### PR TITLE
Provide a helper to set the registryClient in cmd

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -136,6 +136,12 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile, client.InsecureSkipTLSverify)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+			client.SetRegistryClient(registryClient)
+
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
 				return errors.Wrap(err, "INSTALLATION FAILED")
@@ -201,7 +207,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	}
 	client.ReleaseName = name
 
-	cp, err := client.ChartPathOptions.LocateChart(chart, out, settings)
+	cp, err := client.ChartPathOptions.LocateChart(chart, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/helm/pull.go
+++ b/cmd/helm/pull.go
@@ -43,7 +43,7 @@ result in an error, and the chart will not be saved locally.
 `
 
 func newPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	client := action.NewPullWithOpts(action.WithConfig(cfg), action.WithPullOptWriter(out))
+	client := action.NewPullWithOpts(action.WithConfig(cfg))
 
 	cmd := &cobra.Command{
 		Use:     "pull [chart URL | repo/chartname] [...]",
@@ -63,6 +63,12 @@ func newPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				debug("setting version to >0.0.0-0")
 				client.Version = ">0.0.0-0"
 			}
+
+			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile, client.InsecureSkipTLSverify)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+			client.SetRegistryClient(registryClient)
 
 			for i := 0; i < len(args); i++ {
 				output, err := client.Run(args[i])

--- a/cmd/helm/push.go
+++ b/cmd/helm/push.go
@@ -67,6 +67,11 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			registryClient, err := newRegistryClient(o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSverify)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+			cfg.RegistryClient = registryClient
 			chartRef := args[0]
 			remote := args[1]
 			client := action.NewPushWithOpts(action.WithPushConfig(cfg),

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -152,7 +152,7 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	flags.Parse(args)
 
-	registryClient, err := newRegistryClient(out)
+	registryClient, err := newDefaultRegistryClient()
 	if err != nil {
 		return nil, err
 	}
@@ -257,13 +257,39 @@ func checkForExpiredRepos(repofile string) {
 
 }
 
-func newRegistryClient(out io.Writer) (*registry.Client, error) {
+func newRegistryClient(certFile, keyFile, caFile string, insecureSkipTLSverify bool) (*registry.Client, error) {
+	if certFile != "" && keyFile != "" || caFile != "" || insecureSkipTLSverify {
+		registryClient, err := newRegistryClientWithTLS(certFile, keyFile, caFile, insecureSkipTLSverify)
+		if err != nil {
+			return nil, err
+		}
+		return registryClient, nil
+	}
+	registryClient, err := newDefaultRegistryClient()
+	if err != nil {
+		return nil, err
+	}
+	return registryClient, nil
+}
+
+func newDefaultRegistryClient() (*registry.Client, error) {
 	// Create a new registry client
 	registryClient, err := registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
 		registry.ClientOptWriter(os.Stderr),
 		registry.ClientOptCredentialsFile(settings.RegistryConfig),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return registryClient, nil
+}
+
+func newRegistryClientWithTLS(certFile, keyFile, caFile string, insecureSkipTLSverify bool) (*registry.Client, error) {
+	// Create a new registry client
+	registryClient, err := registry.NewRegistryClientWithTLS(os.Stderr, certFile, keyFile, caFile, insecureSkipTLSverify,
+		settings.RegistryConfig, settings.Debug,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -84,7 +84,11 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowAll
-			output, err := runShow(args, client, out)
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -101,7 +105,11 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowValues
-			output, err := runShow(args, client, out)
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -118,7 +126,11 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowChart
-			output, err := runShow(args, client, out)
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -135,7 +147,11 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowReadme
-			output, err := runShow(args, client, out)
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -152,7 +168,11 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowCRDs
-			output, err := runShow(args, client, out)
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -191,16 +211,25 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 	}
 }
 
-func runShow(args []string, client *action.Show, out io.Writer) (string, error) {
+func runShow(args []string, client *action.Show) (string, error) {
 	debug("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		debug("setting version to >0.0.0-0")
 		client.Version = ">0.0.0-0"
 	}
 
-	cp, err := client.ChartPathOptions.LocateChart(args[0], out, settings)
+	cp, err := client.ChartPathOptions.LocateChart(args[0], settings)
 	if err != nil {
 		return "", err
 	}
 	return client.Run(cp)
+}
+
+func addRegistryClient(client *action.Show) error {
+	registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile, client.InsecureSkipTLSverify)
+	if err != nil {
+		return fmt.Errorf("missing registry client: %w", err)
+	}
+	client.SetRegistryClient(registryClient)
+	return nil
 }

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -73,6 +73,12 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
+			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile, client.InsecureSkipTLSverify)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+			client.SetRegistryClient(registryClient)
+
 			client.DryRun = true
 			client.ReleaseName = "release-name"
 			client.Replace = true // Skip the name check

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -90,6 +90,12 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.Namespace = settings.Namespace()
 
+			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile, client.InsecureSkipTLSverify)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+			client.SetRegistryClient(registryClient)
+
 			// Fixes #7002 - Support reading values from STDIN for `upgrade` command
 			// Must load values AFTER determining if we have to call install so that values loaded from stdin are are not read twice
 			if client.Install {
@@ -134,7 +140,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.Version = ">0.0.0-0"
 			}
 
-			chartPath, err := client.ChartPathOptions.LocateChart(args[1], out, settings)
+			chartPath, err := client.ChartPathOptions.LocateChart(args[1], settings)
 			if err != nil {
 				return err
 			}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -132,6 +131,11 @@ func NewInstall(cfg *Configuration) *Install {
 	in.ChartPathOptions.registryClient = cfg.RegistryClient
 
 	return in
+}
+
+// SetRegistryClient sets the registry client for the install action
+func (i *Install) SetRegistryClient(registryClient *registry.Client) {
+	i.ChartPathOptions.registryClient = registryClient
 }
 
 func (i *Install) installCRDs(crds []chart.CRD) error {
@@ -673,22 +677,11 @@ OUTER:
 // - URL
 //
 // If 'verify' was set on ChartPathOptions, this will attempt to also verify the chart.
-func (c *ChartPathOptions) LocateChart(name string, out io.Writer, settings *cli.EnvSettings) (string, error) {
-	// If there is no registry client and the name is in an OCI registry return
-	// an error and a lookup will not occur.
-	if registry.IsOCI(name) {
-		if (c.CertFile != "" && c.KeyFile != "") || c.CaFile != "" || c.InsecureSkipTLSverify {
-			registryClient, err := registry.NewRegistryClientWithTLS(out, c.CertFile, c.KeyFile, c.CaFile,
-				c.InsecureSkipTLSverify, settings.RegistryConfig, settings.Debug)
-			if err != nil {
-				return "", err
-			}
-			c.registryClient = registryClient
-		}
-		if c.registryClient == nil {
-			return "", fmt.Errorf("unable to lookup chart %q, missing registry client", name)
-		}
+func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (string, error) {
+	if registry.IsOCI(name) && c.registryClient == nil {
+		return "", fmt.Errorf("unable to lookup chart %q, missing registry client", name)
 	}
+
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 

--- a/pkg/action/push.go
+++ b/pkg/action/push.go
@@ -90,21 +90,11 @@ func (p *Push) Run(chartRef string, remote string) (string, error) {
 		Pushers: pusher.All(p.Settings),
 		Options: []pusher.Option{
 			pusher.WithTLSClientConfig(p.certFile, p.keyFile, p.caFile),
+			pusher.WithInsecureSkipTLSVerify(p.insecureSkipTLSverify),
 		},
 	}
 
 	if registry.IsOCI(remote) {
-		// Provide a tls enabled client for the pull command if the user has
-		// specified the cert file or key file or ca file.
-		if (p.certFile != "" && p.keyFile != "") || p.caFile != "" || p.insecureSkipTLSverify {
-			registryClient, err := registry.NewRegistryClientWithTLS(p.out, p.certFile, p.keyFile, p.caFile,
-				p.insecureSkipTLSverify, p.Settings.RegistryConfig, p.Settings.Debug)
-			if err != nil {
-				return out.String(), err
-			}
-			p.cfg.RegistryClient = registryClient
-		}
-
 		// Don't use the default registry client if tls options are set.
 		c.Options = append(c.Options, pusher.WithRegistryClient(p.cfg.RegistryClient))
 	}

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -28,6 +28,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/registry"
 )
 
 // ShowOutputFormat is the format of the output of `helm show`
@@ -80,6 +81,11 @@ func NewShowWithConfig(output ShowOutputFormat, cfg *Configuration) *Show {
 	sh.ChartPathOptions.registryClient = cfg.RegistryClient
 
 	return sh
+}
+
+// SetRegistryClient sets the registry client to use when pulling a chart from a registry.
+func (s *Show) SetRegistryClient(client *registry.Client) {
+	s.ChartPathOptions.registryClient = client
 }
 
 // Run executes 'helm show' against the given release.

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -32,6 +32,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/postrender"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -118,6 +119,11 @@ func NewUpgrade(cfg *Configuration) *Upgrade {
 	up.ChartPathOptions.registryClient = cfg.RegistryClient
 
 	return up
+}
+
+// SetRegistryClient sets the registry client to use when fetching charts.
+func (u *Upgrade) SetRegistryClient(client *registry.Client) {
+	u.ChartPathOptions.registryClient = client
 }
 
 // Run executes the upgrade on the given release.


### PR DESCRIPTION
If enabled the registryClient is set using a helper that accepts the TLS flags. This keeps the client creation consistent accross the different commands.

Signed-off-by: Soule BA <bah.soule@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

cc @sabre1041 