### PR TITLE
[helm/pkg] add volumes and volumeMounts in chartutil

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -190,7 +190,7 @@ volumes: []
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
 # - name: foo
-#   mounthPath: "/etc/foo"
+#   mountPath: "/etc/foo"
 #   readOnly: true
 
 nodeSelector: {}

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -180,6 +180,19 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mounthPath: "/etc/foo"
+#   readOnly: true
+
 nodeSelector: {}
 
 tolerations: []
@@ -324,6 +337,14 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
- add volumes in defaultValues
- add volumes in defaultDeployment
- add volumeMounts in defaultValues
- add volumeMounts in defaultDeployment

This PR makes `helm create` more usefull - end-user can use volumes by default.

**Special notes for your reviewer**:
Nope.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
