### PR TITLE
fix(pkg/plugin/installer): unix-style paths in HELM_PLUGINS

### DIFF
--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -30,9 +30,10 @@ type base struct {
 
 func newBase(source string) base {
 	settings := cli.New()
+	pluginsDirs := filepath.SplitList(settings.PluginsDirectory)
 	return base{
 		Source:           source,
-		PluginsDirectory: settings.PluginsDirectory,
+		PluginsDirectory: pluginsDirs[0],
 	}
 }
 

--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -29,12 +29,22 @@ type base struct {
 }
 
 func newBase(source string) base {
-	settings := cli.New()
-	pluginsDirs := filepath.SplitList(settings.PluginsDirectory)
+	pluginsDir := getPluginsDir()
 	return base{
 		Source:           source,
-		PluginsDirectory: pluginsDirs[0],
+		PluginsDirectory: pluginsDir,
 	}
+}
+
+func getPluginsDir() string {
+	settings := cli.New()
+
+	if settings.PluginsDirectory == "" {
+		return ""
+	}
+
+	pluginsDirs := filepath.SplitList(settings.PluginsDirectory)
+	return pluginsDirs[0]
 }
 
 // Path is where the plugin will be installed.

--- a/pkg/plugin/installer/base_test.go
+++ b/pkg/plugin/installer/base_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -34,7 +35,7 @@ func TestPath(t *testing.T) {
 			expectPath:     "/helm/data/plugins/helm-secrets",
 		}, {
 			source:         "https://github.com/jkroepke/helm-secrets",
-			helmPluginsDir: "/helm/data/plugins:/remote/helm/data/plugins",
+			helmPluginsDir: fmt.Sprintf("/helm/data/plugins%c/remote/helm/data/plugins", os.PathListSeparator),
 			expectPath:     "/helm/data/plugins/helm-secrets",
 		},
 	}

--- a/pkg/plugin/installer/base_test.go
+++ b/pkg/plugin/installer/base_test.go
@@ -32,6 +32,10 @@ func TestPath(t *testing.T) {
 			source:         "https://github.com/jkroepke/helm-secrets",
 			helmPluginsDir: "/helm/data/plugins",
 			expectPath:     "/helm/data/plugins/helm-secrets",
+		}, {
+			source:         "https://github.com/jkroepke/helm-secrets",
+			helmPluginsDir: "/helm/data/plugins:/remote/helm/data/plugins",
+			expectPath:     "/helm/data/plugins/helm-secrets",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Supports unix-style paths (with a colon) in the HELM_PLUGINS env for installing new plugins.

Closes #11310

Signed-off-by: Sergei Karpov <xodmqjw@gmail.com>

**Special notes for your reviewer**:


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
