### PR TITLE
fix(helm): running linting using golangci-lint

### DIFF
--- a/cmd/helm/search/search.go
+++ b/cmd/helm/search/search.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package search provides client-side repository searching.
+/*
+Package search provides client-side repository searching.
 
 This supports building an in-memory search index based on the contents of
 multiple repositories, and then using string matching or regular expressions

--- a/internal/ignore/doc.go
+++ b/internal/ignore/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package ignore provides tools for writing ignore files (a la .gitignore).
+/*
+Package ignore provides tools for writing ignore files (a la .gitignore).
 
 This provides both an ignore parser and a file-aware processor.
 
@@ -23,19 +24,19 @@ format for .gitignore files (https://git-scm.com/docs/gitignore).
 
 The formatting rules are as follows:
 
-	- Parsing is line-by-line
-	- Empty lines are ignored
-	- Lines the begin with # (comments) will be ignored
-	- Leading and trailing spaces are always ignored
-	- Inline comments are NOT supported ('foo* # Any foo' does not contain a comment)
-	- There is no support for multi-line patterns
-	- Shell glob patterns are supported. See Go's "path/filepath".Match
-	- If a pattern begins with a leading !, the match will be negated.
-	- If a pattern begins with a leading /, only paths relatively rooted will match.
-	- If the pattern ends with a trailing /, only directories will match
-	- If a pattern contains no slashes, file basenames are tested (not paths)
-	- The pattern sequence "**", while legal in a glob, will cause an error here
-	  (to indicate incompatibility with .gitignore).
+  - Parsing is line-by-line
+  - Empty lines are ignored
+  - Lines the begin with # (comments) will be ignored
+  - Leading and trailing spaces are always ignored
+  - Inline comments are NOT supported ('foo* # Any foo' does not contain a comment)
+  - There is no support for multi-line patterns
+  - Shell glob patterns are supported. See Go's "path/filepath".Match
+  - If a pattern begins with a leading !, the match will be negated.
+  - If a pattern begins with a leading /, only paths relatively rooted will match.
+  - If the pattern ends with a trailing /, only directories will match
+  - If a pattern contains no slashes, file basenames are tested (not paths)
+  - The pattern sequence "**", while legal in a glob, will cause an error here
+    (to indicate incompatibility with .gitignore).
 
 Example:
 
@@ -58,10 +59,10 @@ Example:
 	a[b-d].txt
 
 Notable differences from .gitignore:
-	- The '**' syntax is not supported.
-	- The globbing library is Go's 'filepath.Match', not fnmatch(3)
-	- Trailing spaces are always ignored (there is no supported escape sequence)
-	- The evaluation of escape sequences has not been tested for compatibility
-	- There is no support for '\!' as a special leading sequence.
+  - The '**' syntax is not supported.
+  - The globbing library is Go's 'filepath.Match', not fnmatch(3)
+  - Trailing spaces are always ignored (there is no supported escape sequence)
+  - The evaluation of escape sequences has not been tested for compatibility
+  - There is no support for '\!' as a special leading sequence.
 */
 package ignore // import "helm.sh/helm/v3/internal/ignore"

--- a/internal/test/ensure/ensure.go
+++ b/internal/test/ensure/ensure.go
@@ -57,9 +57,9 @@ func TempDir(t *testing.T) string {
 //
 // You must clean up the directory that is returned.
 //
-// 	tempdir := TempFile(t, "foo", []byte("bar"))
-// 	defer os.RemoveAll(tempdir)
-// 	filename := filepath.Join(tempdir, "foo")
+//	tempdir := TempFile(t, "foo", []byte("bar"))
+//	defer os.RemoveAll(tempdir)
+//	filename := filepath.Join(tempdir, "foo")
 func TempFile(t *testing.T, name string, data []byte) string {
 	path := TempDir(t)
 	filename := filepath.Join(path, name)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -101,7 +101,8 @@ type Configuration struct {
 //
 // TODO: This function is badly in need of a refactor.
 // TODO: As part of the refactor the duplicate code in cmd/helm/template.go should be removed
-//       This code has to do with writing files to disk.
+//
+//	This code has to do with writing files to disk.
 func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, releaseName, outputDir string, subNotes, useReleaseName, includeCrds bool, pr postrender.PostRenderer, dryRun bool) ([]*release.Hook, *bytes.Buffer, string, error) {
 	hs := []*release.Hook{}
 	b := bytes.NewBuffer(nil)

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -457,10 +457,10 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 //
 // Roughly, this will return an error if name is
 //
-//	- empty
-//	- too long
-//	- already in use, and not deleted
-//	- used by a deleted release, and i.Replace is false
+//   - empty
+//   - too long
+//   - already in use, and not deleted
+//   - used by a deleted release, and i.Replace is false
 func (i *Install) availableName() error {
 	start := i.ReleaseName
 

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/chart/dependency_test.go
+++ b/pkg/chart/dependency_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/chart/metadata_test.go
+++ b/pkg/chart/metadata_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -37,11 +37,11 @@ func concatPrefix(a, b string) string {
 //
 // Values are coalesced together using the following rules:
 //
-//	- Values in a higher level chart always override values in a lower-level
-//		dependency chart
-//	- Scalar values and arrays are replaced, maps are merged
-//	- A chart has access to all of the variables for it, as well as all of
-//		the values destined for its dependencies.
+//   - Values in a higher level chart always override values in a lower-level
+//     dependency chart
+//   - Scalar values and arrays are replaced, maps are merged
+//   - A chart has access to all of the variables for it, as well as all of
+//     the values destined for its dependencies.
 func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (Values, error) {
 	v, err := copystructure.Copy(vals)
 	if err != nil {

--- a/pkg/chartutil/doc.go
+++ b/pkg/chartutil/doc.go
@@ -14,16 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package chartutil contains tools for working with charts.
+/*
+Package chartutil contains tools for working with charts.
 
 Charts are described in the chart package (pkg/chart).
 This package provides utilities for serializing and deserializing charts.
 
 A chart can be represented on the file system in one of two ways:
 
-	- As a directory that contains a Chart.yaml file and other chart things.
-	- As a tarred gzipped file containing a directory that then contains a
-	Chart.yaml file.
+  - As a directory that contains a Chart.yaml file and other chart things.
+  - As a tarred gzipped file containing a directory that then contains a
+    Chart.yaml file.
 
 This package provides utilities for working with those file formats.
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -184,11 +184,11 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 //
 // A version is a SemVer string (1.2.3-beta.1+f334a6789).
 //
-//	- For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
-//	- For a chart reference
-//		* If version is non-empty, this will return the URL for that version
-//		* If version is empty, this will return the URL for the latest version
-//		* If no version can be found, an error is returned
+//   - For fully qualified URLs, the version will be ignored (since URLs aren't versioned)
+//   - For a chart reference
+//   - If version is non-empty, this will return the URL for that version
+//   - If version is empty, this will return the URL for the latest version
+//   - If no version can be found, an error is returned
 func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, error) {
 	u, err := url.Parse(ref)
 	if err != nil {

--- a/pkg/downloader/doc.go
+++ b/pkg/downloader/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package downloader provides a library for downloading charts.
+/*
+Package downloader provides a library for downloading charts.
 
 This package contains various tools for downloading charts from repository
 servers, and then storing them in Helm-specific directory structures. This

--- a/pkg/engine/doc.go
+++ b/pkg/engine/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package engine implements the Go text template engine as needed for Helm.
+/*
+Package engine implements the Go text template engine as needed for Helm.
 
 When Helm renders templates it does so with additional functions and different
 modes (e.g., strict, lint mode). This package handles the helm specific

--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -99,7 +99,8 @@ func (f files) Glob(pattern string) files {
 // The output will not be indented, so you will want to pipe this to the
 // 'indent' template function.
 //
-//   data:
+//	data:
+//
 // {{ .Files.Glob("config/**").AsConfig() | indent 4 }}
 func (f files) AsConfig() string {
 	if f == nil {
@@ -128,7 +129,8 @@ func (f files) AsConfig() string {
 // The output will not be indented, so you will want to pipe this to the
 // 'indent' template function.
 //
-//   data:
+//	data:
+//
 // {{ .Files.Glob("secrets/*").AsSecrets() }}
 func (f files) AsSecrets() string {
 	if f == nil {

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -35,12 +35,11 @@ import (
 //
 // Known late-bound functions:
 //
-//	- "include"
-//	- "tpl"
+//   - "include"
+//   - "tpl"
 //
 // These are late-bound in Engine.Render().  The
 // version included in the FuncMap is a placeholder.
-//
 func funcMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")

--- a/pkg/gates/doc.go
+++ b/pkg/gates/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package gates provides a general tool for working with experimental feature gates.
+/*
+Package gates provides a general tool for working with experimental feature gates.
 
 This provides convenience methods where the user can determine if certain experimental features are enabled.
 */

--- a/pkg/getter/doc.go
+++ b/pkg/getter/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package getter provides a generalize tool for fetching data by scheme.
+/*
+Package getter provides a generalize tool for fetching data by scheme.
 
 This provides a method by which the plugin system can load arbitrary protocol
 handlers based upon a URL scheme.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -472,10 +472,10 @@ func (c *Client) watchTimeout(t time.Duration) func(*resource.Info) error {
 // For most kinds, it checks to see if the resource is marked as Added or Modified
 // by the Kubernetes event stream. For some kinds, it does more:
 //
-// - Jobs: A job is marked "Ready" when it has successfully completed. This is
-//   ascertained by watching the Status fields in a job's output.
-// - Pods: A pod is marked "Ready" when it has successfully completed. This is
-//   ascertained by watching the status.phase field in a pod's output.
+//   - Jobs: A job is marked "Ready" when it has successfully completed. This is
+//     ascertained by watching the Status fields in a job's output.
+//   - Pods: A pod is marked "Ready" when it has successfully completed. This is
+//     ascertained by watching the status.phase field in a pod's output.
 //
 // Handling for other kinds will be added as necessary.
 func (c *Client) WatchUntilReady(resources ResourceList, timeout time.Duration) error {

--- a/pkg/kube/resource_policy.go
+++ b/pkg/kube/resource_policy.go
@@ -22,5 +22,6 @@ const ResourcePolicyAnno = "helm.sh/resource-policy"
 // KeepPolicy is the resource policy type for keep
 //
 // This resource policy type allows resources to skip being deleted
-//   during an uninstallRelease action.
+//
+//	during an uninstallRelease action.
 const KeepPolicy = "keep"

--- a/pkg/lint/rules/dependencies_test.go
+++ b/pkg/lint/rules/dependencies_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/lint/support/doc.go
+++ b/pkg/lint/support/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package support contains tools for linting charts.
+/*
+Package support contains tools for linting charts.
 
 Linting is the process of testing charts for errors or warnings regarding
 formatting, compilation, or standards compliance.

--- a/pkg/provenance/doc.go
+++ b/pkg/provenance/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package provenance provides tools for establishing the authenticity of a chart.
+/*
+Package provenance provides tools for establishing the authenticity of a chart.
 
 In Helm, provenance is established via several factors. The primary factor is the
 cryptographic signature of a chart. Chart authors may sign charts, which in turn

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -42,9 +42,13 @@ var defaultPGPConfig = packet.Config{
 // SumCollection represents a collection of file and image checksums.
 //
 // Files are of the form:
+//
 //	FILENAME: "sha256:SUM"
+//
 // Images are of the form:
+//
 //	"IMAGE:TAG": "sha256:SUM"
+//
 // Docker optionally supports sha512, and if this is the case, the hash marker
 // will be 'sha512' instead of 'sha256'.
 type SumCollection struct {

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -117,19 +117,19 @@ func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering 
 //
 // To determine hook type, it looks for a YAML structure like this:
 //
-//  kind: SomeKind
-//  apiVersion: v1
-// 	metadata:
-//		annotations:
-//			helm.sh/hook: pre-install
+//	 kind: SomeKind
+//	 apiVersion: v1
+//		metadata:
+//			annotations:
+//				helm.sh/hook: pre-install
 //
 // To determine the policy to delete the hook, it looks for a YAML structure like this:
 //
-//  kind: SomeKind
-//  apiVersion: v1
-//  metadata:
-// 		annotations:
-// 			helm.sh/hook-delete-policy: hook-succeeded
+//	 kind: SomeKind
+//	 apiVersion: v1
+//	 metadata:
+//			annotations:
+//				helm.sh/hook-delete-policy: hook-succeeded
 func (file *manifestFile) sort(result *result) error {
 	// Go through manifests in order found in file (function `SplitManifests` creates integer-sortable keys)
 	var sortedEntryKeys []string

--- a/pkg/repo/doc.go
+++ b/pkg/repo/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package repo implements the Helm Chart Repository.
+/*
+Package repo implements the Helm Chart Repository.
 
 A chart repository is an HTTP server that provides information on charts. A local
 repository cache is an on-disk representation of a chart repository.
@@ -83,9 +84,9 @@ The format of a repository.yaml file is:
 
 This file maps three bits of information about a repository:
 
-	- The name the user uses to refer to it
-	- The fully qualified URL to the repository (index.yaml will be appended)
-    - The name of the local cachefile
+  - The name the user uses to refer to it
+  - The fully qualified URL to the repository (index.yaml will be appended)
+  - The name of the local cachefile
 
 The format for both files was changed after Helm v2.0.0-Alpha.4. Helm is not
 backwards compatible with those earlier versions.

--- a/pkg/repo/repotest/doc.go
+++ b/pkg/repo/repotest/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package repotest provides utilities for testing.
+/*
+Package repotest provides utilities for testing.
 
 The server provides a testing server that can be set up and torn down quickly.
 */

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -400,6 +400,7 @@ func (s *Server) Stop() {
 // URL returns the URL of the server.
 //
 // Example:
+//
 //	http://localhost:1776
 func (s *Server) URL() string {
 	return s.srv.URL

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -220,13 +220,12 @@ func (cfgmaps *ConfigMaps) Delete(key string) (rls *rspb.Release, err error) {
 //
 // The following labels are used within each configmap:
 //
-//    "modifiedAt"     - timestamp indicating when this configmap was last modified. (set in Update)
-//    "createdAt"      - timestamp indicating when this configmap was created. (set in Create)
-//    "version"        - version of the release.
-//    "status"         - status of the release (see pkg/release/status.go for variants)
-//    "owner"          - owner of the configmap, currently "helm".
-//    "name"           - name of the release.
-//
+//	"modifiedAt"     - timestamp indicating when this configmap was last modified. (set in Update)
+//	"createdAt"      - timestamp indicating when this configmap was created. (set in Create)
+//	"version"        - version of the release.
+//	"status"         - status of the release (see pkg/release/status.go for variants)
+//	"owner"          - owner of the configmap, currently "helm".
+//	"name"           - name of the release.
 func newConfigMapsObject(key string, rls *rspb.Release, lbs labels) (*v1.ConfigMap, error) {
 	const owner = "helm"
 

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -202,13 +202,12 @@ func (secrets *Secrets) Delete(key string) (rls *rspb.Release, err error) {
 //
 // The following labels are used within each secret:
 //
-//    "modifiedAt"    - timestamp indicating when this secret was last modified. (set in Update)
-//    "createdAt"     - timestamp indicating when this secret was created. (set in Create)
-//    "version"        - version of the release.
-//    "status"         - status of the release (see pkg/release/status.go for variants)
-//    "owner"          - owner of the secret, currently "helm".
-//    "name"           - name of the release.
-//
+//	"modifiedAt"    - timestamp indicating when this secret was last modified. (set in Update)
+//	"createdAt"     - timestamp indicating when this secret was created. (set in Create)
+//	"version"        - version of the release.
+//	"status"         - status of the release (see pkg/release/status.go for variants)
+//	"owner"          - owner of the secret, currently "helm".
+//	"name"           - name of the release.
 func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, error) {
 	const owner = "helm"
 

--- a/pkg/strvals/doc.go
+++ b/pkg/strvals/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package strvals provides tools for working with strval lines.
+/*
+Package strvals provides tools for working with strval lines.
 
 Helm supports a compressed format for YAML settings which we call strvals.
 The format is roughly like this:

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -110,7 +110,6 @@ func ParseIntoString(s string, dest map[string]interface{}) error {
 // An empty val is treated as null.
 //
 // If a key exists in dest, the new value overwrites the dest version.
-//
 func ParseJSON(s string, dest map[string]interface{}) error {
 	scanner := bytes.NewBufferString(s)
 	t := newJSONParser(scanner, dest)

--- a/pkg/uploader/doc.go
+++ b/pkg/uploader/doc.go
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package uploader provides a library for uploading charts.
+/*
+Package uploader provides a library for uploading charts.
 
 This package contains tools for uploading charts to registries.
 */


### PR DESCRIPTION
Signed-off-by: Constantin Bugneac <cosbug@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
Fixes #11707 

**What this PR does / why we need it**:
Fixes security vulnerability.
Applies lint formatting using `golangci-lint`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
