### PR TITLE
Fix improper use of Table request/response to k8s API

### DIFF
--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -65,6 +65,13 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compListReleases(toComplete, args, cfg)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			// When the output format is a table the resources should be fetched
+			// and displayed as a table. When YAML or JSON the resources will be
+			// returned. This mirrors the handling in kubectl.
+			if outfmt == output.Table {
+				client.ShowResourcesTable = true
+			}
 			rel, err := client.Run(args[0])
 			if err != nil {
 				return err

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -253,6 +253,45 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestBuildTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		reader    io.Reader
+		count     int
+		err       bool
+	}{
+		{
+			name:      "Valid input",
+			namespace: "test",
+			reader:    strings.NewReader(guestbookManifest),
+			count:     6,
+		}, {
+			name:      "Valid input, deploying resources into different namespaces",
+			namespace: "test",
+			reader:    strings.NewReader(namespacedGuestbookManifest),
+			count:     1,
+		},
+	}
+
+	c := newTestClient(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test for an invalid manifest
+			infos, err := c.BuildTable(tt.reader, false)
+			if err != nil && !tt.err {
+				t.Errorf("Got error message when no error should have occurred: %v", err)
+			} else if err != nil && strings.Contains(err.Error(), "--validate=false") {
+				t.Error("error message was not scrubbed")
+			}
+
+			if len(infos) != tt.count {
+				t.Errorf("expected %d result objects, got %d", tt.count, len(infos))
+			}
+		})
+	}
+}
+
 func TestPerform(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"helm.sh/helm/v3/pkg/kube"
@@ -33,11 +34,13 @@ import (
 type FailingKubeClient struct {
 	PrintingKubeClient
 	CreateError                      error
+	GetError                         error
 	WaitError                        error
 	DeleteError                      error
 	WatchUntilReadyError             error
 	UpdateError                      error
 	BuildError                       error
+	BuildTableError                  error
 	BuildUnstructuredError           error
 	WaitAndGetCompletedPodPhaseError error
 	WaitDuration                     time.Duration
@@ -49,6 +52,14 @@ func (f *FailingKubeClient) Create(resources kube.ResourceList) (*kube.Result, e
 		return nil, f.CreateError
 	}
 	return f.PrintingKubeClient.Create(resources)
+}
+
+// Get returns the configured error if set or prints
+func (f *FailingKubeClient) Get(resources kube.ResourceList, related bool) (map[string][]runtime.Object, error) {
+	if f.GetError != nil {
+		return nil, f.GetError
+	}
+	return f.PrintingKubeClient.Get(resources, related)
 }
 
 // Waits the amount of time defined on f.WaitDuration, then returns the configured error if set or prints.
@@ -106,6 +117,14 @@ func (f *FailingKubeClient) Build(r io.Reader, _ bool) (kube.ResourceList, error
 		return []*resource.Info{}, f.BuildError
 	}
 	return f.PrintingKubeClient.Build(r, false)
+}
+
+// BuildTable returns the configured error if set or prints
+func (f *FailingKubeClient) BuildTable(r io.Reader, _ bool) (kube.ResourceList, error) {
+	if f.BuildTableError != nil {
+		return []*resource.Info{}, f.BuildTableError
+	}
+	return f.PrintingKubeClient.BuildTable(r, false)
 }
 
 // WaitAndGetCompletedPodPhase returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -48,7 +48,7 @@ func (p *PrintingKubeClient) Create(resources kube.ResourceList) (*kube.Result, 
 	return &kube.Result{Created: resources}, nil
 }
 
-func (p *PrintingKubeClient) Get(resources kube.ResourceList, reader io.Reader) (map[string][]runtime.Object, error) {
+func (p *PrintingKubeClient) Get(resources kube.ResourceList, related bool) (map[string][]runtime.Object, error) {
 	_, err := io.Copy(p.Out, bufferize(resources))
 	if err != nil {
 		return nil, err
@@ -102,6 +102,11 @@ func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kub
 
 // Build implements KubeClient Build.
 func (p *PrintingKubeClient) Build(_ io.Reader, _ bool) (kube.ResourceList, error) {
+	return []*resource.Info{}, nil
+}
+
+// BuildTable implements KubeClient BuildTable.
+func (p *PrintingKubeClient) BuildTable(_ io.Reader, _ bool) (kube.ResourceList, error) {
 	return []*resource.Info{}, nil
 }
 

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -83,8 +83,22 @@ type InterfaceExt interface {
 //
 // TODO Helm 4: Remove InterfaceResources and integrate its method(s) into the Interface.
 type InterfaceResources interface {
-	// Get details of deployed resources in ResourceList to be printed.
-	Get(resources ResourceList, reader io.Reader) (map[string][]runtime.Object, error)
+	// Get details of deployed resources.
+	// The first argument is a list of resources to get. The second argument
+	// specifies if related pods should be fetched. For example, the pods being
+	// managed by a deployment.
+	Get(resources ResourceList, related bool) (map[string][]runtime.Object, error)
+
+	// BuildTable creates a resource list from a Reader. This differs from
+	// Interface.Build() in that a table kind is returned. A table is useful
+	// if you want to use a printer to display the information.
+	//
+	// Reader must contain a YAML stream (one or more YAML documents separated
+	// by "\n---\n")
+	//
+	// Validates against OpenAPI schema if validate is true.
+	// TODO Helm 4: Integrate into Build with an argument
+	BuildTable(reader io.Reader, validate bool) (ResourceList, error)
 }
 
 var _ Interface = (*Client)(nil)


### PR DESCRIPTION
A change was made that when validation was turned off the Kubernetes packages were building objects as a Table type. This was done for display purposes. When details about the objects was going to be printed as part of #10912.

This broke rollback, and possibly other functionality, as a Table type was returned in some cases that needed the regular object. This caused things to break silently.

The fix involved adding in a new Function (and interface) to query for tables instead of the objects themselves. There was not a clean way to add it to the existing function that covered all cases.

A second problem was noticed along the way. When data was output via status as YAML or JSON it was in the form of a table rather than the objects themselves. This did not reflect expectations and did not match the functionality in kubectl. The code was updated to return a table when that was presented and the objects when they are being output for YAML or JSON. The API also supports this handling to SDK users can replicate this functionality.

API changes made here were never released. The functions were developed for this release of Helm and only ever appeared in an RC. In this case, they can be changed.

Note, extensive testing is not covered by this PR as our testing system doesn't have the ability to cover this :(. The additional testing needs can be covered in follow-up pull requests.

Fixes #11712

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: There is a regression in 3.11.0-rc.1 that needs to be fixed before release

**Special notes for your reviewer**:

Two things:
1. The lack of specific testing has to do with limitations of the testing system for things like this. That is additional future work we need to do.
2. The API changes presented here are to things that have never been released so they are ok to do.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
