### PR TITLE
Feature/dry run server client

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -122,7 +122,7 @@ To see the list of chart repositories, use 'helm repo list'. To search for
 charts in a repository, use 'helm search'.
 `
 
-func determineInstallDryRunMode(dryRunModeFlag string) (*action.DryRunMode, error) {
+func determineDryRunMode(dryRunModeFlag string) (*action.DryRunMode, error) {
 	switch dryRunModeFlag {
 	case "none":
 	case "false": // TODO: Remove "false" helm v4
@@ -153,7 +153,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 
-			dryRunMode, err := determineInstallDryRunMode(dryRunModeFlag)
+			dryRunMode, err := determineDryRunMode(dryRunModeFlag)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -46,10 +46,28 @@ faked locally. Additionally, none of the server-side testing of chart validity
 (e.g. whether an API is supported) is done.
 `
 
+func determineTemplateDryRunMode(dryRunModeFlag string) (*action.DryRunMode, error) {
+	switch dryRunModeFlag {
+	case "none":
+		return nil, fmt.Errorf("Invalid flag --dry-run=none for template")
+	case "false": // TODO: Remove "false" helm v4
+		// helm template --dry-run=false was previously ignored, and dry-run set anyway
+		return &action.DryRunModeClient, nil
+	case "client":
+	case "true": // TODO: Remove "true" helm v4
+		return &action.DryRunModeClient, nil
+	case "server":
+		return &action.DryRunModeServer, nil
+	}
+
+	return nil, fmt.Errorf("Invalid --dry-run flag value: %s", dryRunModeFlag)
+}
+
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	var validate bool
 	var includeCrds bool
 	var skipTests bool
+	var dryRunModeFlag string
 	client := action.NewInstall(cfg)
 	valueOpts := &values.Options{}
 	var kubeVersion string
@@ -73,7 +91,12 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
+			dryRunMode, err := determineTemplateDryRunMode(dryRunModeFlag)
+			if err != nil {
+				return err
+			}
 			client.DryRun = true
+			client.DryRunMode = *dryRunMode
 			client.ReleaseName = "release-name"
 			client.Replace = true // Skip the name check
 			client.ClientOnly = !validate
@@ -173,7 +196,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	addInstallFlags(cmd, f, client, valueOpts)
+	addInstallFlags(cmd, f, client, &dryRunModeFlag, valueOpts)
 	f.StringArrayVarP(&showFiles, "show-only", "s", []string{}, "only show manifests rendered from the given templates")
 	f.StringVar(&client.OutputDir, "output-dir", "", "writes the executed templates to files in output-dir instead of stdout")
 	f.BoolVar(&validate, "validate", false, "validate your manifests against the Kubernetes cluster you are currently pointing at. This is the same validation performed on an install")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -72,6 +72,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	valueOpts := &values.Options{}
 	var outfmt output.Format
 	var createNamespace bool
+	var dryRunModeFlag string
 
 	cmd := &cobra.Command{
 		Use:   "upgrade [RELEASE] [CHART]",
@@ -106,6 +107,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.Force = client.Force
 					instClient.DryRun = client.DryRun
+					instClient.DryRunMode = client.DryRunMode
 					instClient.DisableHooks = client.DisableHooks
 					instClient.SkipCRDs = client.SkipCRDs
 					instClient.Timeout = client.Timeout
@@ -214,7 +216,12 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
-	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an upgrade")
+	f.StringVar(
+		&dryRunModeFlag,
+		"dry-run",
+		"none",
+		`simulate an install. Must be "none", "server", or "client". If client strategy, X. If server strategy, Y. For backwards compatibility, boolean values "true" and "false" are also accepted. "true" being a synonym for "client". "false" meaning disable dry-run`,
+	)
 	f.BoolVar(&client.Recreate, "recreate-pods", false, "performs pods restart for the resource if applicable")
 	f.MarkDeprecated("recreate-pods", "functionality will no longer be updated. Consult the documentation for other methods to recreate pods")
 	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")

--- a/pkg/action/dryrunmode.go
+++ b/pkg/action/dryrunmode.go
@@ -1,0 +1,9 @@
+package action
+
+type DryRunMode string
+
+var (
+	DryRunModeNone   DryRunMode = "none"
+	DryRunModeClient DryRunMode = "client"
+	DryRunModeServer DryRunMode = "server"
+)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -266,7 +266,12 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	rel := i.createRelease(chrt, vals)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, i.DryRun)
+	// Determines whether `helm template` was used or another command with the --dry-run flag
+	// as they both set the Install.DryRun field to `true`. The `--dry-run` flag should be able
+	// to connect to remote for the lookup function. `helm template` is the only command that
+	// Install.APIVersions field will not be nil.
+	interactWithRemote := !i.DryRun || i.APIVersions == nil
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithRemote)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -266,11 +266,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	rel := i.createRelease(chrt, vals)
 
 	var manifestDoc *bytes.Buffer
-	// Determines whether `helm template` was used or another command with the --dry-run flag
-	// as they both set the Install.DryRun field to `true`. The `--dry-run` flag should be able
-	// to connect to remote for the lookup function. `helm template` is the only command that
-	// Install.APIVersions field will not be nil.
-	interactWithRemote := !i.DryRun || i.APIVersions == nil
+	interactWithRemote := i.DryRunMode == DryRunModeServer
 	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithRemote)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -62,14 +62,6 @@ const notesFileSuffix = "NOTES.txt"
 
 const defaultDirectoryPermission = 0755
 
-type DryRunMode string
-
-var (
-	DryRunModeNone   DryRunMode = "none"
-	DryRunModeClient DryRunMode = "client"
-	DryRunModeServer DryRunMode = "server"
-)
-
 // Install performs an installation operation.
 type Install struct {
 	cfg *Configuration

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -458,8 +458,7 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 func (i *Install) isDryRun() bool {
 	if i.DryRunMode != "" {
 		switch i.DryRunMode {
-		case DryRunModeClient:
-		case DryRunModeServer:
+		case DryRunModeClient, DryRunModeServer:
 			return true
 		case DryRunModeNone:
 			return false

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -254,7 +254,7 @@ func TestInstallRelease_DryRun(t *testing.T) {
 	is.Equal(res.Info.Description, "Dry run complete")
 }
 
-// Regression test for #7955: Lookup must not connect to Kubernetes on a dry-run.
+// Regression test for #7955
 func TestInstallRelease_DryRun_Lookup(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -230,8 +230,8 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	if err != nil {
 		return nil, nil, err
 	}
-
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, u.DryRun)
+	// Interacts with cluster if possible
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -171,8 +171,7 @@ func (u *Upgrade) RunWithContext(ctx context.Context, name string, chart *chart.
 func (u *Upgrade) isDryRun() bool {
 	if u.DryRunMode != "" {
 		switch u.DryRunMode {
-		case DryRunModeClient:
-		case DryRunModeServer:
+		case DryRunModeClient, DryRunModeServer:
 			return true
 		case DryRunModeNone:
 			return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Extend dry-run for `helm template` and `helm install|upgrade|delete|rollback` to support "client" and "server" modes. Somewhat analogous to `kubectl`'s `--dry-run=client|server` options, where `client` does all chart rendering locally. And `server` enables helm to contact the cluster e.g. for the `lookup` function (but note: this PR does not attempt to implement server side validation support like kubectl).

To retain backwards compatibility, "true" and "false" are also accepted. As alias for "client" and "none" respectively.

**Special notes for your reviewer**:

Since we are not implementing the full equivalent of `kubectl --dry-run=server`, will this confuse users?

Docs for need to be updated:
* lookup function: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function
* TBD

**If applicable**:
TBD
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
