### PR TITLE
Fix goroutine lead in install action

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -344,7 +344,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		// not working.
 		return rel, err
 	}
-	rChan := make(chan resultMessage)
+	rChan := make(chan resultMessage, 2)
 	doneChan := make(chan struct{})
 	defer close(doneChan)
 	go i.performInstall(rChan, rel, toBeAdopted, resources)
@@ -457,10 +457,10 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 //
 // Roughly, this will return an error if name is
 //
-//	- empty
-//	- too long
-//	- already in use, and not deleted
-//	- used by a deleted release, and i.Replace is false
+//   - empty
+//   - too long
+//   - already in use, and not deleted
+//   - used by a deleted release, and i.Replace is false
 func (i *Install) availableName() error {
 	start := i.ReleaseName
 


### PR DESCRIPTION




<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
a case in RunWithContex()
RunWithContex() {
go i.performInstall // running for a longer time
go i handleContex // return from ctx.Done() and send message to rchan, but performInstall is always running result := < -rChan //read message
}

the message in rchan will be received in RunWithContex(), and RunWithContex() returns soon. so, this case lead to goroutine performInstall leak

ref https://github.com/helm/helm/pull/10486#discussion_r878716007

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
