### PR TITLE
strip trailing newline from Files.Lines

### DIFF
--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -131,7 +131,7 @@ func (f files) AsConfig() string {
 //
 //	data:
 //
-// {{ .Files.Glob("secrets/*").AsSecrets() }}
+// {{ .Files.Glob("secrets/*").AsSecrets() | indent 4 }}
 func (f files) AsSecrets() string {
 	if f == nil {
 		return ""
@@ -157,6 +157,9 @@ func (f files) Lines(path string) []string {
 	if f == nil || f[path] == nil {
 		return []string{}
 	}
-
-	return strings.Split(string(f[path]), "\n")
+	s := string(f[path])
+	if s[len(s)-1] == '\n' {
+		s = s[:len(s)-1]
+	}
+	return strings.Split(s, "\n")
 }

--- a/pkg/engine/files_test.go
+++ b/pkg/engine/files_test.go
@@ -28,7 +28,8 @@ var cases = []struct {
 	{"ship/stowaway.txt", "Legatt"},
 	{"story/name.txt", "The Secret Sharer"},
 	{"story/author.txt", "Joseph Conrad"},
-	{"multiline/test.txt", "bar\nfoo"},
+	{"multiline/test.txt", "bar\nfoo\n"},
+	{"multiline/test_with_blank_lines.txt", "bar\nfoo\n\n\n"},
 }
 
 func getTestFiles() files {
@@ -95,4 +96,16 @@ func TestLines(t *testing.T) {
 	as.Len(out, 2)
 
 	as.Equal("bar", out[0])
+}
+
+func TestBlankLines(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("multiline/test_with_blank_lines.txt")
+	as.Len(out, 4)
+
+	as.Equal("bar", out[0])
+	as.Equal("", out[3])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A trailing newline in a file would produce an extra empty list entry when using Files.Lines

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Fixes #10561 