### PR TITLE
Bump github.com/emicklei/go-restful from 3.9.0 to 3.10.1

### DIFF
--- a/cmd/helm/pull.go
+++ b/cmd/helm/pull.go
@@ -80,7 +80,8 @@ func newPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Untar, "untar", false, "if set to true, will untar the chart after downloading it")
 	f.BoolVar(&client.VerifyLater, "prov", false, "fetch the provenance file, but don't perform verification")
 	f.StringVar(&client.UntarDir, "untardir", ".", "if untar is specified, this flag specifies the name of the directory into which the chart is expanded")
-	f.StringVarP(&client.DestDir, "destination", "d", ".", "location to write the chart. If this and untardir are specified, untardir is appended to this")
+	f.StringVarP(&client.DestDir, "destination", "d", ".", "location to write the chart. If this and tardir are specified, tardir is appended to this")
+	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use plain http and not https to connect oci registry")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 
 	err := cmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/helm/push.go
+++ b/cmd/helm/push.go
@@ -72,5 +72,9 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		},
 	}
 
+	f := cmd.Flags()
+	f.BoolVar(&client.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart upload")
+	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use plain http and not https to connect oci registry")
+
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 // indirect
-	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
+github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -46,6 +46,7 @@ type Pull struct {
 	VerifyLater bool
 	UntarDir    string
 	DestDir     string
+	PlainHTTP   bool
 	cfg         *Configuration
 }
 
@@ -75,6 +76,12 @@ func NewPullWithOpts(opts ...PullOpt) *Pull {
 // Run executes 'helm pull' against the given release.
 func (p *Pull) Run(chartRef string) (string, error) {
 	var out strings.Builder
+
+	if p.InsecureSkipTLSverify || p.PlainHTTP {
+		if err := p.cfg.RegistryClient.WithResolver(p.InsecureSkipTLSverify, p.PlainHTTP); err != nil {
+			return out.String(), err
+		}
+	}
 
 	c := downloader.ChartDownloader{
 		Out:     &out,

--- a/pkg/action/push.go
+++ b/pkg/action/push.go
@@ -29,8 +29,10 @@ import (
 //
 // It provides the implementation of 'helm push'.
 type Push struct {
-	Settings *cli.EnvSettings
-	cfg      *Configuration
+	Settings              *cli.EnvSettings
+	cfg                   *Configuration
+	InsecureSkipTLSverify bool
+	PlainHTTP             bool
 }
 
 // PushOpt is a type of function that sets options for a push action.
@@ -55,6 +57,12 @@ func NewPushWithOpts(opts ...PushOpt) *Push {
 // Run executes 'helm push' against the given chart archive.
 func (p *Push) Run(chartRef string, remote string) (string, error) {
 	var out strings.Builder
+
+	if p.InsecureSkipTLSverify || p.PlainHTTP {
+		if err := p.cfg.RegistryClient.WithResolver(p.InsecureSkipTLSverify, p.PlainHTTP); err != nil {
+			return out.String(), err
+		}
+	}
 
 	c := uploader.ChartUploader{
 		Out:     &out,

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -18,6 +18,7 @@ package registry // import "helm.sh/helm/v3/pkg/registry"
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -164,6 +165,36 @@ func ClientOptCredentialsFile(credentialsFile string) ClientOption {
 	return func(client *Client) {
 		client.credentialsFile = credentialsFile
 	}
+}
+
+func (c *Client) newResolver(insecure, plainHTTP bool) (remotes.Resolver, error) {
+	headers := http.Header{}
+	headers.Set("User-Agent", version.GetUserAgent())
+	opts := []auth.ResolverOption{auth.WithResolverHeaders(headers)}
+
+	if insecure {
+		httpClient := http.DefaultClient
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		opts = append(opts, auth.WithResolverClient(httpClient))
+	}
+	if plainHTTP {
+		opts = append(opts, auth.WithResolverPlainHTTP())
+	}
+
+	return c.authorizer.ResolverWithOpts(opts...)
+}
+
+func (c *Client) WithResolver(insecure, plainHTTP bool) error {
+	resolver, err := c.newResolver(insecure, plainHTTP)
+	if err != nil {
+		return err
+	}
+	c.resolver = resolver
+	return nil
 }
 
 type (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This includes improvement. This addresses PRISMA-2022-0227 which has no entry anywhere useful on the internet but is reported by IronBank. It has a fix for https://github.com/emicklei/go-restful/issues/497.

**Special notes for your reviewer**:
Path parser inconsistency could lead to bypass several security checks in emicklei/go-restful
With this PR it will include the latest emicklei/go-restful v3.10.1 which have the fix for this vulnerability
