### PR TITLE
Ensure `helm test --logs` only gets logs from pods

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -108,19 +108,21 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 	}
 
 	for _, h := range rel.Hooks {
-		for _, e := range h.Events {
-			if e == release.HookTest {
-				req := client.CoreV1().Pods(r.Namespace).GetLogs(h.Name, &v1.PodLogOptions{})
-				logReader, err := req.Stream(context.Background())
-				if err != nil {
-					return errors.Wrapf(err, "unable to get pod logs for %s", h.Name)
-				}
+		if h.Kind == "Pod" {
+			for _, e := range h.Events {
+				if e == release.HookTest {
+					req := client.CoreV1().Pods(r.Namespace).GetLogs(h.Name, &v1.PodLogOptions{})
+					logReader, err := req.Stream(context.Background())
+					if err != nil {
+						return errors.Wrapf(err, "unable to get pod logs for %s", h.Name)
+					}
 
-				fmt.Fprintf(out, "POD LOGS: %s\n", h.Name)
-				_, err = io.Copy(out, logReader)
-				fmt.Fprintln(out)
-				if err != nil {
-					return errors.Wrapf(err, "unable to write pod logs for %s", h.Name)
+					fmt.Fprintf(out, "POD LOGS: %s\n", h.Name)
+					_, err = io.Copy(out, logReader)
+					fmt.Fprintln(out)
+					if err != nil {
+						return errors.Wrapf(err, "unable to write pod logs for %s", h.Name)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Partially fixes https://github.com/helm/helm/issues/11236#issuecomment-1332554000 by ensuring that `helm test --logs` only tries to get logs of a hook of kind `Pod`. 
Of course, a more comprehensive fix would be nice but perhaps someone is already working on it as the issue is labelled `in-progress`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
