### PR TITLE
Also follow HELM_PLUGINS when installing from http

### DIFF
--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -159,7 +159,7 @@ func (i HTTPInstaller) Path() string {
 	if i.base.Source == "" {
 		return ""
 	}
-	return helmpath.DataPath("plugins", i.PluginName)
+	return filepath.Join(i.base.PluginsDirectory, i.PluginName)
 }
 
 // cleanJoin resolves dest as a subpath of root.

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -348,3 +348,38 @@ func TestMediaTypeToExtension(t *testing.T) {
 		}
 	}
 }
+
+func TestHttpInstallerPath(t *testing.T) {
+	tests := []struct {
+		source         string
+		pluginName     string
+		helmPluginsDir string
+		expectPath     string
+	}{
+		{
+			source:         "",
+			pluginName:     "not-used",
+			helmPluginsDir: "/helm/data/plugins",
+			expectPath:     "",
+		}, {
+			source:         "https://github.com/jkroepke/helm-secrets",
+			pluginName:     "helm-http-plugin",
+			helmPluginsDir: "/helm/data/plugins",
+			expectPath:     "/helm/data/plugins/helm-http-plugin",
+		},
+	}
+
+	for _, tt := range tests {
+
+		os.Setenv("HELM_PLUGINS", tt.helmPluginsDir)
+		ins := &HTTPInstaller{
+			PluginName: tt.pluginName,
+			base:       newBase(tt.source),
+		}
+		insPath := ins.Path()
+		if insPath != tt.expectPath {
+			t.Errorf("expected name %s, got %s", tt.expectPath, insPath)
+		}
+		os.Unsetenv("HELM_PLUGINS")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is effectively <https://github.com/helm/helm/pull/10008> but for the overridden case of `Path()` in `pkg/plugins/installer/http_installer.go`. Well slightly simpler because it can just use the directory already in `base`.

The test is copied nearly wholesale from that PR.

It will solve cases where you've set `HELM_PLUGINS` somewhere else for testing a new plugin version, but Helm will install in the XDG_DATA_HOME path instead. (Failing to install if you've already got a version.) For example

```
# We have the release version for day-to-day use
% helm plugin install https://internal-server.example/helm-plugins/my-fancy-plugin-0.0.9.tar.gz
Installed plugin: my-fancy-plugin
# Now switch to our experiment path for checking the prerelase one
% HELM_PLUGINS=/tmp/experiment helm plugin list           
NAME  VERSION     DESCRIPTION                    
% HELM_PLUGINS=/tmp/experiment helm plugin install https://internal-server.example/helm-plugins/my-fancy-plugin-0.0.9-dev.2.tar.gz
Error: plugin already exists
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
