### PR TITLE
wait for release before post hooks

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -38,7 +38,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 	}
 
-	// hooke are pre-ordered by kind, so keep order stable
+	// hooks are pre-ordered by kind, so keep order stable
 	sort.Stable(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
@@ -105,6 +105,39 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	}
 
 	return nil
+}
+
+func (cfg *Configuration) hasPostInstallHooks(rl *release.Release) bool {
+	for _, h := range rl.Hooks {
+		for _, e := range h.Events {
+			if e == release.HookPostInstall {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (cfg *Configuration) hasPostUpgradeHooks(rl *release.Release) bool {
+	for _, h := range rl.Hooks {
+		for _, e := range h.Events {
+			if e == release.HookPostUpgrade {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (cfg *Configuration) hasPostRollbackHooks(rl *release.Release) bool {
+	for _, h := range rl.Hooks {
+		for _, e := range h.Events {
+			if e == release.HookPostRollback {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // hookByWeight is a sorter for hooks

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/v4/pkg/release"
+)
+
+func TestConfiguration_hasPostInstallHooks(t *testing.T) {
+	type args struct {
+		rl *release.Release
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "return true when chart has post-install hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPostInstall}}},
+			},
+			},
+			want: true,
+		},
+		{name: "return false when chart does not have post-install hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPreDelete}}},
+			}},
+			want: false,
+		},
+		{name: "return false when chart does not have any hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{}}},
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{}
+			assert.Equalf(t, tt.want, cfg.hasPostInstallHooks(tt.args.rl), "hasPostInstallHooks(%v)", tt.args.rl)
+		})
+	}
+}
+func TestConfiguration_hasPostUpgradeHooks(t *testing.T) {
+	type args struct {
+		rl *release.Release
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "return true when chart has post-upgrade hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPostUpgrade}}},
+			},
+			},
+			want: true,
+		},
+		{name: "return false when chart does not have post-upgrade hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPreDelete}}},
+			}},
+			want: false,
+		},
+		{name: "return false when chart does not have any hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{}}},
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{}
+			assert.Equalf(t, tt.want, cfg.hasPostUpgradeHooks(tt.args.rl), "hasPostUpgradeHooks(%v)", tt.args.rl)
+		})
+	}
+}
+func TestConfiguration_hasPostRollbackHooks(t *testing.T) {
+	type args struct {
+		rl *release.Release
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "return true when chart has post-rollback hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPostRollback}}},
+			},
+			},
+			want: true,
+		},
+		{name: "return false when chart does not have post-rollback hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{release.HookPreDelete}}},
+			}},
+			want: false,
+		},
+		{name: "return false when chart does not have any hooks",
+			args: args{rl: &release.Release{
+				Hooks: []*release.Hook{{Events: []release.HookEvent{}}},
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{}
+			assert.Equalf(t, tt.want, cfg.hasPostRollbackHooks(tt.args.rl), "hasPostRollbackHooks(%v)", tt.args.rl)
+		})
+	}
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -432,7 +432,9 @@ func (i *Install) performInstall(c chan<- resultMessage, rel *release.Release, t
 		}
 	}
 
-	if i.Wait {
+	waitBeforePostHooks := !i.DisableHooks && i.cfg.hasPostInstallHooks(rel) || i.cfg.hasPostUpgradeHooks(rel)
+
+	if i.Wait || waitBeforePostHooks {
 		if i.WaitForJobs {
 			if err := i.cfg.KubeClient.WaitWithJobs(resources, i.Timeout); err != nil {
 				i.reportToRun(c, rel, err)

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -222,7 +222,9 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		}
 	}
 
-	if r.Wait {
+	waitBeforePostHooks := !r.DisableHooks && r.cfg.hasPostRollbackHooks(targetRelease)
+
+	if r.Wait || waitBeforePostHooks {
 		if r.WaitForJobs {
 			if err := r.cfg.KubeClient.WaitWithJobs(target, r.Timeout); err != nil {
 				targetRelease.SetStatus(release.StatusFailed, fmt.Sprintf("Release %q failed: %s", targetRelease.Name, err.Error()))


### PR DESCRIPTION
**What this PR does / why we need it**:

If a release has post-install, post-delete, or post-rollback hooks, always wait for the main resources before doing the post - otherwise it's not really "post". This ensures that the behavior is correct if a chart user doesn't apply the `--wait` flag when a chart has "post" operations.

This was seen in the wild when one of our (Redpanda) chart users installed without the `--wait` flag and the post-install configuration failed because the statefulset wasn't ready to accept connections from the post-install,post-upgrade job. We never caught this in CI because ct always sets the `--wait` flag.

Fixes #11778

**Special notes for your reviewer**:

https://github.com/helm/chart-testing always tests with the `--wait` flag so this is a no-op for charts that are tested. In fact, this ensures the user has the same experience as the test if the user fails to set wait.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
