### PR TITLE
don't mark issues as stale where a PR is in progress

### DIFF
--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -10,7 +10,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
-        exempt-issue-labels: 'keep open,v4.x'
+        exempt-issue-labels: 'keep open,v4.x,in progress'
         days-before-stale: 90
         days-before-close: 30
         operations-per-run: 100


### PR DESCRIPTION
**What this PR does / why we need it**:

PR reviews take much longer than 90 days. Let's not nag issues that are labeled "in progress"

**Special notes for your reviewer**:

