### PR TITLE
feature: extra check for linting, chart name

### DIFF
--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -111,7 +111,7 @@ func validateChartName(cf *chart.Metadata) error {
 		return errors.New("name is required")
 	}
 	if !validNameRegex.MatchString(cf.Name) {
-		return fmt.Errorf("invalid release name, must match regex %s", validNameRegex.String())
+		return fmt.Errorf("invalid chart name, must match regex %s", validNameRegex.String())
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -111,7 +111,7 @@ func validateChartName(cf *chart.Metadata) error {
 		return errors.New("name is required")
 	}
 	if !validNameRegex.MatchString(cf.Name) {
-		return errors.New(fmt.Sprintf("invalid release name, must match regex %s", validNameRegex.String()))
+		return fmt.Errorf("invalid release name, must match regex %s", validNameRegex.String())
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/asaskevich/govalidator"
@@ -104,8 +105,13 @@ func validateChartYamlFormat(chartFileError error) error {
 }
 
 func validateChartName(cf *chart.Metadata) error {
+	var validNameRegex = regexp.MustCompile(`^[a-z0-9](([-a-z0-9]*)?)$`)
+
 	if cf.Name == "" {
 		return errors.New("name is required")
+	}
+	if !validNameRegex.MatchString(cf.Name) {
+		return errors.New(fmt.Sprintf("invalid release name, must match regex %s", validNameRegex.String()))
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
+	goodChartDir       = "testdata/goodone"
 	badChartDir        = "testdata/badchartfile"
 	anotherBadChartDir = "testdata/anotherbadchartfile"
 )
 
 var (
+	goodChartFilePath        = filepath.Join(goodChartDir, "Chart.yaml")
 	badChartFilePath         = filepath.Join(badChartDir, "Chart.yaml")
 	nonExistingChartFilePath = filepath.Join(os.TempDir(), "Chart.yaml")
 )
@@ -65,9 +67,15 @@ func TestValidateChartYamlFormat(t *testing.T) {
 }
 
 func TestValidateChartName(t *testing.T) {
-	err := validateChartName(badChart)
-	if err == nil {
-		t.Errorf("validateChartName to return a linter error, got no error")
+	badNameChart, _ := chartutil.LoadChartfile(goodChartFilePath)
+	badName := &badNameChart.Name
+
+	for _, name := range []string{"", "with-Capital", "with_underscore"} {
+		*badName = name
+		err := validateChartName(badNameChart)
+		if err == nil {
+			t.Errorf("validateChartName to return a linter error for chart name %s, got no error", name)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds an extra check for the linter. It checks if the chart-name only contains lower-case letters and (-). According to the [guidelines](https://helm.sh/docs/chart_best_practices/conventions/#chart-names).

It closes #10537 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
