### PR TITLE
Update go.mod version from 1.17 to 1.19 [#11838]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module helm.sh/helm/v3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module helm.sh/helm/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Signed-off-by: nikzayn [nikhilvaidyar1997@gmail.com](mailto:nikhilvaidyar1997@gmail.com)

What type of PR is this?
/kind cleanup
/feature

/enhancement
/priority important-soon

What this PR does / why we need it:
- This PR is the enhancement for the go version from **1.17** to **1.19** as the latest go version is **1.20**, so we can update the mod to the stable version of 1.19. 
- There is a bug issue assigned to it previously as [11838](https://github.com/helm/helm/issues/11838) to revert go.mod from **1.17** to **1.18** as it is obsolete now because of the above-mentioned point
----------------------------------------------------------------------------------------------------------------------------------
- Here's more information related to the same: Changing Go version 1.18 to 1.17 was introduced in this commit https://github.com/helm/helm/commit/ffa19a4b5d836283a91a4c16f8b81e734a973afc (see it [inline here](https://github.com/helm/helm/pull/10912/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6)).

Special notes for your reviewer:
Do again check with the new go build and the tests of circle-ci too.