### PR TITLE
Addressing multi agent test race condition

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -422,7 +422,10 @@ func (i *Install) performInstall(c chan<- resultMessage, rel *release.Release, t
 	}
 
 	if !i.DisableHooks {
-		if err := i.cfg.execHook(rel, release.HookPostInstall, i.Timeout); err != nil {
+		i.Lock.Lock()
+		err := i.cfg.execHook(rel, release.HookPostInstall, i.Timeout)
+		i.Lock.Unlock()
+		if err != nil {
 			i.reportToRun(c, rel, fmt.Errorf("failed post-install: %s", err))
 			return
 		}

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -89,13 +89,22 @@ func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
 	}
 
 	if err := r.cfg.execHook(rel, release.HookTest, r.Timeout); err != nil {
-		rel.Hooks = append(skippedHooks, rel.Hooks...)
-		r.cfg.Releases.Update(rel)
+		rel, _ = r.updateHooks(rel, append(skippedHooks, rel.Hooks...))
 		return rel, err
 	}
 
-	rel.Hooks = append(skippedHooks, rel.Hooks...)
-	return rel, r.cfg.Releases.Update(rel)
+	return r.updateHooks(rel, append(skippedHooks, rel.Hooks...))
+}
+
+func (r *ReleaseTesting) updateHooks(rel *release.Release, hooks []*release.Hook) (*release.Release, error) {
+	rel, err := r.cfg.Releases.Get(rel.Name, rel.Version)
+	if err != nil {
+		return rel, err
+	}
+
+	rel.Hooks = hooks
+	err = r.cfg.Releases.Update(rel)
+	return rel, err
 }
 
 // GetPodLogs will write the logs for all test pods in the given release into

--- a/pkg/action/release_testing_test.go
+++ b/pkg/action/release_testing_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func testingActions(t *testing.T) *ReleaseTesting {
+	config := actionConfigFixture(t)
+
+	tester := config.KubeClient.(*kubefake.FailingKubeClient)
+	tester.WatchDuration = 5 * time.Second
+	config.KubeClient = tester
+
+	relTesting := NewReleaseTesting(config)
+	relTesting.Namespace = "spaced"
+
+	return relTesting
+}
+
+func TestReleaseTesting_RaceWithAWaitInstall(t *testing.T) {
+	is := assert.New(t)
+	req := require.New(t)
+
+	releaseTestingAction := testingActions(t)
+
+	err := releaseTestingAction.cfg.Releases.Create(getTestRelease())
+	req.NoError(err)
+
+	rel, err := releaseTestingAction.cfg.Releases.Get(getTestRelease().Name, 2)
+	req.NoError(err)
+	req.Equal(rel.Info.Status, release.StatusPendingUpgrade)
+
+	done := make(chan bool)
+	go func() {
+		_, err := releaseTestingAction.Run(rel.Name)
+		req.NoError(err)
+		done <- true
+	}()
+
+	time.Sleep(time.Second * 1)
+
+	updageTestRelease := getTestRelease() //Recreate cause mem otherwise shares same release -- Data race and shared resource
+	updageTestRelease.Info.Status = release.StatusDeployed
+	err = releaseTestingAction.cfg.Releases.Update(updageTestRelease)
+	req.NoError(err)
+
+	finalRelease, err := releaseTestingAction.cfg.Releases.Get(updageTestRelease.Name, 2)
+	req.NoError(err)
+	is.Equal(release.StatusDeployed, finalRelease.Info.Status)
+
+	<-done
+
+	finalRelease, err = releaseTestingAction.cfg.Releases.Get(updageTestRelease.Name, 2)
+	req.NoError(err)
+	is.Equal(release.StatusDeployed, finalRelease.Info.Status)
+}
+
+func getTestRelease() *release.Release {
+	testRelease := releaseStub()
+	testRelease.Info.Status = release.StatusPendingUpgrade
+	testRelease.Version = 2
+	return testRelease
+}

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -47,6 +47,7 @@ type FailingKubeClient struct {
 	BuildUnstructuredError           error
 	WaitAndGetCompletedPodPhaseError error
 	WaitDuration                     time.Duration
+	WatchDuration                    time.Duration
 }
 
 // Create returns the configured error if set or prints
@@ -100,6 +101,7 @@ func (f *FailingKubeClient) Delete(resources kube.ResourceList) (*kube.Result, [
 
 // WatchUntilReady returns the configured error if set or prints
 func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.Duration) error {
+	time.Sleep(f.WatchDuration)
 	if f.WatchUntilReadyError != nil {
 		return f.WatchUntilReadyError
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This addresses the helm test command overwriting any change in state to a release during its execution. While I'm not certain which behavior is more desired, when other actors execute a helm test while the installation is pending an install with --atomic of --wait a data race occurs on the status.  If the test execution begins while the release is in pending-upgrade and install/upgrade completes setting the status to deployed  before test completes the end status will be pending-upgrade.

fluxcd/flagger#816

**Special notes for your reviewer**:
While attempting to add unit tests to validate my data race I uncovered a data race detected that failed the tests.  I included a commit to address this.  This work was done a few months ago, but sat on it due to uncertainty of it was a worthwhile contribution.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
