### PR TITLE
full source path for CRDs when output-dir is not provided

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -189,13 +189,13 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
 			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Name, string(crd.File.Data[:]))
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data[:]))
 			} else {
-				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data[:]), fileWritten[crd.Name])
+				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data[:]), fileWritten[crd.Filename])
 				if err != nil {
 					return hs, b, "", err
 				}
-				fileWritten[crd.Name] = true
+				fileWritten[crd.Filename] = true
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Related to: https://github.com/helm/helm/issues/11321 and https://github.com/helm/helm/issues/11550

This PR makes the output from `helm template` more consistent whether an `--output-dir` is provided or not.  Currently, the `Source` is different for CRDs when run without the `--output-dir` flag and the path is ambiguous, making it hard to tell where the CRD originated from.

Example chart:
```
$ tree ./template-crds            
./template-crds
├── Chart.yaml
├── charts
│   └── my-subchart
│       ├── Chart.yaml
│       ├── crds
│       │   └── my-subchart-crd.yaml
│       └── templates
│           └── my-subchart-configmap.yaml
├── crds
│   └── my-chart-crd.yaml
└── templates
    └── my-chart-configmap.yaml
```

Before these changes, the `Source` does not indicate which chart the CRD came from, but the rest of the manifests do.
```
$ helm template ./template-crds --include-crds | grep Source
# Source: crds/my-chart-crd.yaml
# Source: crds/my-subchart-crd.yaml
# Source: my-chart/charts/my-sub-chart/templates/my-subchart-configmap.yaml
# Source: my-chart/templates/my-chart-configmap.yaml
```

After these changes, the `Source` reflects the chart it came from, similar to the rest of the manifests.
```
$ helm template ./template-crds --include-crds | grep Source
# Source: my-chart/crds/my-chart-crd.yaml
# Source: my-chart/charts/my-sub-chart/crds/my-subchart-crd.yaml
# Source: my-chart/charts/my-sub-chart/templates/my-subchart-configmap.yaml
# Source: my-chart/templates/my-chart-configmap.yaml
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
