### PR TITLE
feat: pass basic auth to env-vars when running download plugins

### DIFF
--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -66,6 +66,7 @@ type pluginGetter struct {
 func (p *pluginGetter) setupOptionsEnv(env []string) []string {
 	env = append(env, fmt.Sprintf("HELM_PLUGIN_USERNAME=%s", p.opts.username))
 	env = append(env, fmt.Sprintf("HELM_PLUGIN_PASSWORD=%s", p.opts.password))
+	env = append(env, fmt.Sprintf("HELM_PLUGIN_PASS_CREDENTIALS_ALL=%t", p.opts.passCredentialsAll))
 	return env
 }
 

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,6 +63,12 @@ type pluginGetter struct {
 	opts     options
 }
 
+func (p *pluginGetter) setupOptionsEnv(env []string) []string {
+	env = append(env, fmt.Sprintf("HELM_PLUGIN_USERNAME=%s", p.opts.username))
+	env = append(env, fmt.Sprintf("HELM_PLUGIN_PASSWORD=%s", p.opts.password))
+	return env
+}
+
 // Get runs downloader plugin command
 func (p *pluginGetter) Get(href string, options ...Option) (*bytes.Buffer, error) {
 	for _, opt := range options {
@@ -71,7 +78,7 @@ func (p *pluginGetter) Get(href string, options ...Option) (*bytes.Buffer, error
 	argv := append(commands[1:], p.opts.certFile, p.opts.keyFile, p.opts.caFile, href)
 	prog := exec.Command(filepath.Join(p.base, commands[0]), argv...)
 	plugin.SetupPluginEnv(p.settings, p.name, p.base)
-	prog.Env = os.Environ()
+	prog.Env = p.setupOptionsEnv(os.Environ())
 	buf := bytes.NewBuffer(nil)
 	prog.Stdout = buf
 	prog.Stderr = os.Stderr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR passes username and password from "helm repo add --username X --password Y" to download plugins. See #11877 for motivation.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility


closes #11877

I created this PR with help from @birjj