### PR TITLE
helm search: new CLI flag `--fail-on-no-result` to fail when no results found for search (repo and hub)

### DIFF
--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -64,14 +64,15 @@ Repositories are managed with 'helm repo' commands.
 const searchMaxScore = 25
 
 type searchRepoOptions struct {
-	versions     bool
-	regexp       bool
-	devel        bool
-	version      string
-	maxColWidth  uint
-	repoFile     string
-	repoCacheDir string
-	outputFormat output.Format
+	versions       bool
+	regexp         bool
+	devel          bool
+	version        string
+	maxColWidth    uint
+	repoFile       string
+	repoCacheDir   string
+	outputFormat   output.Format
+	failOnNoResult bool
 }
 
 func newSearchRepoCmd(out io.Writer) *cobra.Command {
@@ -94,6 +95,8 @@ func newSearchRepoCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&o.devel, "devel", false, "use development versions (alpha, beta, and release candidate releases), too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.StringVar(&o.version, "version", "", "search using semantic versioning constraints on repositories you have added")
 	f.UintVar(&o.maxColWidth, "max-col-width", 50, "maximum column width for output table")
+	f.BoolVar(&o.failOnNoResult, "fail-on-no-result", false, "search fails if no results are found")
+
 	bindOutputFlag(cmd, &o.outputFormat)
 
 	return cmd
@@ -124,7 +127,7 @@ func (o *searchRepoOptions) run(out io.Writer, args []string) error {
 		return err
 	}
 
-	return o.outputFormat.Write(out, &repoSearchWriter{data, o.maxColWidth})
+	return o.outputFormat.Write(out, &repoSearchWriter{data, o.maxColWidth, o.failOnNoResult})
 }
 
 func (o *searchRepoOptions) setupSearchedVersion() {
@@ -205,12 +208,18 @@ type repoChartElement struct {
 }
 
 type repoSearchWriter struct {
-	results     []*search.Result
-	columnWidth uint
+	results        []*search.Result
+	columnWidth    uint
+	failOnNoResult bool
 }
 
 func (r *repoSearchWriter) WriteTable(out io.Writer) error {
 	if len(r.results) == 0 {
+		// Fail if no results found and --fail-on-no-result is enabled
+		if r.failOnNoResult {
+			return fmt.Errorf("no results found")
+		}
+
 		_, err := out.Write([]byte("No results found\n"))
 		if err != nil {
 			return fmt.Errorf("unable to write results: %s", err)
@@ -235,6 +244,11 @@ func (r *repoSearchWriter) WriteYAML(out io.Writer) error {
 }
 
 func (r *repoSearchWriter) encodeByFormat(out io.Writer, format output.Format) error {
+	// Fail if no results found and --fail-on-no-result is enabled
+	if len(r.results) == 0 && r.failOnNoResult {
+		return fmt.Errorf("no results found")
+	}
+
 	// Initialize the array so no results returns an empty array instead of null
 	chartList := make([]repoChartElement, 0, len(r.results))
 

--- a/cmd/helm/search_repo_test.go
+++ b/cmd/helm/search_repo_test.go
@@ -57,6 +57,20 @@ func TestSearchRepositoriesCmd(t *testing.T) {
 		cmd:    "search repo syzygy",
 		golden: "output/search-not-found.txt",
 	}, {
+		name:      "search for 'syzygy' with --fail-on-no-result, expect failure for no results",
+		cmd:       "search repo syzygy --fail-on-no-result",
+		golden:    "output/search-not-found-error.txt",
+		wantError: true,
+	}, {name: "search for 'syzygy' with json output and --fail-on-no-result, expect failure for no results",
+		cmd:       "search repo syzygy --output json --fail-on-no-result",
+		golden:    "output/search-not-found-error.txt",
+		wantError: true,
+	}, {
+		name:      "search for 'syzygy' with yaml output --fail-on-no-result, expect failure for no results",
+		cmd:       "search repo syzygy --output yaml --fail-on-no-result",
+		golden:    "output/search-not-found-error.txt",
+		wantError: true,
+	}, {
 		name:   "search for 'alp[a-z]+', expect two matches",
 		cmd:    "search repo alp[a-z]+ --regexp",
 		golden: "output/search-regex.txt",

--- a/cmd/helm/testdata/output/search-not-found-error.txt
+++ b/cmd/helm/testdata/output/search-not-found-error.txt
@@ -1,0 +1,1 @@
+Error: no results found


### PR DESCRIPTION
**What this PR does / why we need it**:

Add new CLI flag `--fail-on-no-result` for failing the `helm search` when there are no results found. This works with:
1. `helm search repo`
2. `helm search hub`

Closes #7197 

**Special notes for your reviewer**:
- Since this is a new flag altogether, it should be backward-compatible.
- I believe no documentation is required as the flag is self-explanatory.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

@giggio @hickeyma @roubles @joejulian @gjenkins8 Please validate whether these changes achieve the expected result. Thanks!
