### PR TITLE
Apply label selector at server side

### DIFF
--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -350,6 +350,14 @@ func TestSelectorList(t *testing.T) {
 		is.Error(err)
 	})
 
+	t.Run("should select two releases with set selector", func(t *testing.T) {
+		lister.Selector = "key in (value1, value2)"
+		res, _ := lister.Run()
+
+		expectedFilteredList := []*release.Release{r1, r2}
+		assert.ElementsMatch(t, expectedFilteredList, res)
+	})
+
 	t.Run("should select one release with matching label", func(t *testing.T) {
 		lister.Selector = "key==value1"
 		res, _ := lister.Run()

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -128,6 +128,26 @@ func TestConfigMapList(t *testing.T) {
 	if len(ssd) != 2 {
 		t.Errorf("Expected 2 superseded, got %d", len(ssd))
 	}
+
+	// list all uninstalled releases with label selectors
+	delSel, err := cfgmaps.ListWithSelector(func(rel *rspb.Release) bool { return true }, "status=uninstalled")
+	// check
+	if err != nil {
+		t.Errorf("Failed to list uninstalled: %s", err)
+	}
+	if len(delSel) != 2 {
+		t.Errorf("Expected 2 uninstalled, got %d:\n%v\n", len(del), del)
+	}
+
+	// list all uninstalled or deployed releases with label selectors
+	dplOrDelSel, err := cfgmaps.ListWithSelector(func(rel *rspb.Release) bool { return true }, "status in (uninstalled, deployed)")
+	// check
+	if err != nil {
+		t.Errorf("Failed to list uninstalled or deployed: %s", err)
+	}
+	if len(dplOrDelSel) != 4 {
+		t.Errorf("Expected 4 uninstalled or deployed, got %d:\n%v\n", len(del), del)
+	}
 }
 
 func TestConfigMapQuery(t *testing.T) {

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -85,11 +85,16 @@ type Deletor interface {
 //
 // List returns the set of all releases that satisfy the filter predicate.
 //
+// ListWithSelector returns the set of all releases that satisfy the filter predicate.
+// and label selector expression.
+//
 // Query returns the set of all releases that match the provided label set.
 type Queryor interface {
 	Get(key string) (*rspb.Release, error)
 	List(filter func(*rspb.Release) bool) ([]*rspb.Release, error)
+	ListWithSelector(filter func(*rspb.Release) bool, selector string) ([]*rspb.Release, error)
 	Query(labels map[string]string) ([]*rspb.Release, error)
+	CanPushDownLabelSelector() bool
 }
 
 // Driver is the interface composed of Creator, Updator, Deletor, and Queryor

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,6 +43,14 @@ type Memory struct {
 	namespace string
 	// A map of namespaces to releases
 	cache map[string]memReleases
+}
+
+func (mem *Memory) ListWithSelector(filter func(*rspb.Release) bool, selector string) ([]*rspb.Release, error) {
+	return nil, fmt.Errorf("selector based release list is not supported by this storage")
+}
+
+func (mem *Memory) CanPushDownLabelSelector() bool {
+	return false
 }
 
 // NewMemory initializes a new memory driver.

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -128,6 +128,26 @@ func TestSecretList(t *testing.T) {
 	if len(ssd) != 2 {
 		t.Errorf("Expected 2 superseded, got %d", len(ssd))
 	}
+
+	// list all uninstalled releases with label selectors
+	delSel, err := secrets.ListWithSelector(func(rel *rspb.Release) bool { return true }, "status=uninstalled")
+	// check
+	if err != nil {
+		t.Errorf("Failed to list uninstalled: %s", err)
+	}
+	if len(delSel) != 2 {
+		t.Errorf("Expected 2 uninstalled, got %d:\n%v\n", len(del), del)
+	}
+
+	// list all uninstalled or deployed releases with label selectors
+	dplOrDelSel, err := secrets.ListWithSelector(func(rel *rspb.Release) bool { return true }, "status in (uninstalled, deployed)")
+	// check
+	if err != nil {
+		t.Errorf("Failed to list uninstalled or deployed: %s", err)
+	}
+	if len(dplOrDelSel) != 4 {
+		t.Errorf("Expected 4 uninstalled or deployed, got %d:\n%v\n", len(del), del)
+	}
 }
 
 func TestSecretQuery(t *testing.T) {

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -77,6 +77,14 @@ type SQL struct {
 	Log func(string, ...interface{})
 }
 
+func (s *SQL) ListWithSelector(filter func(*rspb.Release) bool, selector string) ([]*rspb.Release, error) {
+	return nil, fmt.Errorf("selector based release list is not supported by this storage")
+}
+
+func (s *SQL) CanPushDownLabelSelector() bool {
+	return false
+}
+
 // Name returns the name of the driver.
 func (s *SQL) Name() string {
 	return SQLDriverName

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -308,6 +308,12 @@ func (d *MaxHistoryMockDriver) Query(labels map[string]string) ([]*rspb.Release,
 func (d *MaxHistoryMockDriver) Name() string {
 	return d.Driver.Name()
 }
+func (d *MaxHistoryMockDriver) ListWithSelector(filter func(*rspb.Release) bool, selector string) ([]*rspb.Release, error) {
+	return d.Driver.ListWithSelector(filter, selector)
+}
+func (d *MaxHistoryMockDriver) CanPushDownLabelSelector() bool {
+	return d.Driver.CanPushDownLabelSelector()
+}
 
 func TestMaxHistoryErrorHandling(t *testing.T) {
 	//func TestStorageRemoveLeastRecentWithError(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This change introduces an option to push down label selectors to storage layer, if supported. When Kubernetes secrets or configmaps are used as backing storage for releases, then pushing down label selectors to API server can result in significant performance improvement and reduced memory footprint when there are hundreds or thousands of versions in the cluster. Currently this change does pushdown only for `--selector` parameter, but probably something similar would make sense to consider for other Helm commands, like list by release status. This closes #11875 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
