### PR TITLE
WIP: Backup Kube Config to Helm Config Directory

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -80,7 +80,7 @@ func main() {
 				log.Fatal(err)
 			}
 		} else {
-			debug("kube config backup aborted due to empty KubeConfig path in settings")
+			debug("kubeconfig backup aborted due to the empty KubeConfig path in the settings")
 		}
 
 		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, debug); err != nil {

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -74,7 +74,7 @@ func main() {
 		helmDriver := os.Getenv("HELM_DRIVER")
 
 		if settings.KubeConfig != "" {
-			// If KubeConfig path is not empty, backup kube config to: <helm-config-path>/kubeconfig
+			// If KubeConfig path is not empty, backup kubeconfig to: <helm-config-path>/kubeconfig
 			// When the backup is successful, the settings.KubeConfig path is updated to backup file's path.
 			if err := settings.BackupKubeConfig(); err != nil {
 				log.Fatal(err)

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -72,6 +72,18 @@ func main() {
 	// run when each command's execute method is called
 	cobra.OnInitialize(func() {
 		helmDriver := os.Getenv("HELM_DRIVER")
+
+		if settings.KubeConfig != "" {
+			// If KubeConfig path is not empty, backup kube config to: <helm-config-path>/kubeconfig
+			// When the backup is successful, the settings.KubeConfig path is updated to backup file's path.
+			err = settings.BackupKubeConfig()
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			debug("kube config backup aborted due to empty KubeConfig path in settings")
+		}
+
 		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, debug); err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -76,8 +76,7 @@ func main() {
 		if settings.KubeConfig != "" {
 			// If KubeConfig path is not empty, backup kube config to: <helm-config-path>/kubeconfig
 			// When the backup is successful, the settings.KubeConfig path is updated to backup file's path.
-			err = settings.BackupKubeConfig()
-			if err != nil {
+			if err := settings.BackupKubeConfig(); err != nil {
 				log.Fatal(err)
 			}
 		} else {

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -270,7 +270,7 @@ func (s *EnvSettings) BackupKubeConfig() error {
 			s.KubeConfig, kubeConfigBackupFilename, err)
 	}
 
-	// Update the kube config in EnvSettings to backup file path
+	// Update the kubeconfig in EnvSettings to a backup file path.
 	s.KubeConfig = kubeConfigBackupFilename
 
 	return nil

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -255,7 +255,7 @@ func (s *EnvSettings) BackupKubeConfig() error {
 	helmConfigPath := helmpath.ConfigPath("")
 	kubeConfigBackupFilename := filepath.Join(helmConfigPath, "kubeconfig")
 
-	// Create reader from actual kube config file
+	// Create reader from actual kubeconfig file.
 	kubeConfigReader, err := os.Open(s.KubeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to read input kubeconfig file %q: %v",

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 
+	"helm.sh/helm/v3/internal/fileutil"
 	"helm.sh/helm/v3/internal/version"
 	"helm.sh/helm/v3/pkg/helmpath"
 )
@@ -234,4 +236,42 @@ func (s *EnvSettings) SetNamespace(namespace string) {
 // RESTClientGetter gets the kubeconfig from EnvSettings
 func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	return s.config
+}
+
+// BackupKubeConfig copies kube config file to <helm-config-path>/kubeconfig
+// as backup. The backup file will have rw permissions for user.
+// The backup file's path is updated in EnvSettings.KubeConfig.
+//
+// There is no safety check on EnvSettings.KubeConfig, i.e., the caller
+// should call this method only when there is kube config path specified.
+// Else, the actual kubeconfig file read fails.
+func (s *EnvSettings) BackupKubeConfig() error {
+	// Form the backup file path as: <helm-config-path>/kubeconfig
+	// The helm-config-path is derived from envs HELM_CONFIG_HOME,
+	// XDG_CONFIG_HOME and default path. Defaults paths:
+	// 	- Linux	 : $HOME/.config/helm
+	// 	- Mac	 : $HOME/Library/Preferences/helm
+	// 	- Windows : %APPDATA%\helm
+	helmConfigPath := helmpath.ConfigPath("")
+	kubeConfigBackupFilename := filepath.Join(helmConfigPath, "kubeconfig")
+
+	// Create reader from actual kube config file
+	kubeConfigReader, err := os.Open(s.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to read input kubeconfig file %q: %v",
+			s.KubeConfig, err)
+	}
+	defer kubeConfigReader.Close()
+
+	// Copy actual kube config file to backup file
+	err = fileutil.AtomicWriteFile(kubeConfigBackupFilename, kubeConfigReader, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to copy kubeconfig from %q to %q: %v",
+			s.KubeConfig, kubeConfigBackupFilename, err)
+	}
+
+	// Update the kube config in EnvSettings to backup file path
+	s.KubeConfig = kubeConfigBackupFilename
+
+	return nil
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -238,7 +238,7 @@ func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 	return s.config
 }
 
-// BackupKubeConfig copies kube config file to <helm-config-path>/kubeconfig
+// BackupKubeConfig copies kubeconfig file to <helm-config-path>/kubeconfig
 // as backup. The backup file will have rw permissions for user.
 // The backup file's path is updated in EnvSettings.KubeConfig.
 //

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -243,7 +243,7 @@ func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 // The backup file's path is updated in EnvSettings.KubeConfig.
 //
 // There is no safety check on EnvSettings.KubeConfig, i.e., the caller
-// should call this method only when there is kube config path specified.
+// should call this method only when there is kubeconfig path specified.
 // Else, the actual kubeconfig file read fails.
 func (s *EnvSettings) BackupKubeConfig() error {
 	// Form the backup file path as: <helm-config-path>/kubeconfig

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -263,3 +263,87 @@ func resetEnv() func() {
 		}
 	}
 }
+
+func TestEnvSettings_BackupKubeConfig(t *testing.T) {
+	var (
+		testDataDir        = `testdata/`
+		kubeConfigFilename = testDataDir + "kubeconfig"
+	)
+
+	type fields struct {
+		KubeConfig     string
+		helmConfigHome string
+	}
+
+	type toggles struct {
+		wantErr               bool
+		cleanUpTestKubeConfig bool
+	}
+
+	type testCase struct {
+		name    string
+		fields  fields
+		toggles toggles
+	}
+
+	tests := []testCase{
+		{
+			name: "Backup kube config",
+			fields: fields{
+				KubeConfig:     testDataDir + `valid-kubeconfig-no-contexts`,
+				helmConfigHome: testDataDir,
+			},
+			toggles: toggles{
+				cleanUpTestKubeConfig: true,
+			},
+		},
+		{
+			name: "Failure missing input kube config file",
+			fields: fields{
+				KubeConfig:     testDataDir + `missing-kubeconfig`,
+				helmConfigHome: testDataDir,
+			},
+			toggles: toggles{
+				wantErr: true,
+			},
+		},
+		{
+			name: "Failure invalid destination path",
+			fields: fields{
+				KubeConfig:     testDataDir + `valid-kubeconfig-no-contexts`,
+				helmConfigHome: testDataDir + `non-existing-dir/`,
+			},
+			toggles: toggles{
+				wantErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &EnvSettings{
+				KubeConfig: tt.fields.KubeConfig,
+			}
+
+			t.Setenv(`HELM_CONFIG_HOME`, tt.fields.helmConfigHome)
+
+			err := s.BackupKubeConfig()
+			if (err != nil) != tt.toggles.wantErr {
+				t.Errorf("EnvSettings.BackupKubeConfig() error = %v, wantErr %v",
+					err, tt.toggles.wantErr)
+			}
+
+			if !tt.toggles.wantErr && s.KubeConfig != kubeConfigFilename {
+				t.Errorf("kube config path not updated after backup, want = %s, got = %s",
+					kubeConfigFilename, s.KubeConfig)
+			}
+
+			if tt.toggles.cleanUpTestKubeConfig {
+				err = os.Remove(kubeConfigFilename)
+				if err != nil {
+					t.Errorf("failed to delete %q: %v", kubeConfigFilename, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/testdata/valid-kubeconfig-no-contexts
+++ b/pkg/cli/testdata/valid-kubeconfig-no-contexts
@@ -1,0 +1,11 @@
+apiVersion: v1
+clusters: null
+contexts: null
+current-context: ""
+kind: Config
+preferences: {}
+users:
+- name: kubeuser/
+  user:
+    password: password
+    username: user


### PR DESCRIPTION
**What this PR does / why we need it**:

Backup kubeconfig to `<helm-config-path>/kubeconfig` during initialization of sub-commands (`env`, `install`, etc.).
The backup file will have `rw` permissions for `user`. All sub-commands will then use the backup kubeconfig file.

This change will help in reading the kubeconfig from a file descriptor. Eg., `/proc/self/fd/16`
```
helm --kubeconfig <(echo $KUBECONFIG) list 
```

Closes #11419 

**Special notes for your reviewer**:
Since the backup of kubeconfig runs on all command initialization (nothing to add explicitly by the user), as per my understanding, this should be backup compatible. But please review and let me know.

Also, since this backup happens with all sub-command initializations, no need to delete the backup file explicitly. It will get replaced every time.

I believe no documentation is required for this change as nothing much changes for the user.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

@eumel8 @joejulian @programmer04 Please validate whether these changes achieve the expected result. Thanks!