### PR TITLE
test(create): Add test to check deprecated `apiVersion`s in resource templates created by `helm create`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,15 @@ test-unit:
 	@echo
 	@echo "==> Running unit tests <=="
 	GO111MODULE=on go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
+	@echo
+	@echo "==> Running unit test(s) with ldflags <=="
+# Test to check the deprecation warnings on Kubernetes templates created by `helm create` against the current Kubernetes
+# version. Note: The version details are set in var LDFLAGS. To avoid the ldflags impact on other unit tests that are
+# based on older versions, this is run separately. When run without the ldflags in the unit test (above) or coverage
+# test, it still passes with a false-positive result as the resources shouldn’t be deprecated in the older Kubernetes
+# version if it only starts failing with the latest. 
+	GO111MODULE=on go test $(GOFLAGS) -run ^TestHelmCreateChart_CheckDeprecatedWarnings$$ ./pkg/lint/ $(TESTFLAGS) -ldflags '$(LDFLAGS)'
+
 
 .PHONY: test-coverage
 test-coverage:

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -622,6 +622,10 @@ func Create(name, dir string) (string, error) {
 		return cdir, errors.Errorf("file %s already exists and is not a directory", cdir)
 	}
 
+	// Note: If adding a new template below (i.e., to `helm create`) which is disabled by default (similar to hpa and
+	// ingress below); or making an existing template disabled by default, add the enabling condition in
+	// `TestHelmCreateChart_CheckDeprecatedWarnings` in `pkg/lint/lint_test.go` to make it run through deprecation checks
+	// with latest Kubernetes version.
 	files := []struct {
 		path    string
 		content []byte


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Change `HorizontalPodAutoscaler`'s version from `autoscaling/v2beta1` -> `autoscaling/v2` in `helm create`.
2. Add a test `TestHelmCreateChart_CheckDeprecatedWarnings` to check the deprecated versions from being created by `helm create`.
3. A comment is added in `pkg/chartutil/create.go` for future manifest files added to `helm create` to follow the same pattern and update the test.

About `TestHelmCreateChart_CheckDeprecatedWarnings`:
- Checks the manifests created by `helm create` to not have deprecated `apiVersion`s.
- This requires the following `ldflags` to be set per the current Kubernetes version for avoiding false positive results.
    1. `-X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=`\<k8s-major-version>
    2. `-X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=`\<k8s-minor-version>
- In order to avoid the `ldflags` passed for this test from conflicting with other tests, a seperate `go test` is added in `make test-unit`.
- Without the `ldflags`, this test passes with a false positive result. This behavior will help in the former run of `go test` and in `make test-coverage`. Note: This test doesn't contribute to coverage anyway.

Closes #11495 

**Special notes for your reviewer**:
Not sure how backward compatibility is checked when the changes are related to the `apiVersion` of the object. But else, I think this change qualifies as backward compatible. Please check.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

@userbradley @joejulian @hzliangbin @wujunwei Please validate whether these changes achieve the expected result. Thanks!
