### PR TITLE
helm history UPDATED should print local time

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -106,7 +106,7 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 	tbl := uitable.New()
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for _, item := range r {
-		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.Local().Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }


### PR DESCRIPTION
At the moment history ignores timezones:

```
MacBook-Pro:~ faucct$ helm history shadow-ranker --max=3
REVISION	UPDATED                 	STATUS    	CHART       	APP VERSION	DESCRIPTION                       
403     	Wed Mar 22 06:57:54 2023	deployed  	ranker-0.1.0	           	ranker-feature__java-17-ca53f05.38
404     	Wed Mar 22 11:17:56 2023	superseded	ranker-0.1.0	           	Rollback to 402                   
405     	Wed Mar 22 07:22:45 2023	deployed  	ranker-0.1.0	           	ranker-master-50fb173.138         
MacBook-Pro:~ faucct$ helm history shadow-ranker --max=3 --output=json | jq
[
  {
    "revision": 403,
    "updated": "2023-03-22T06:57:54.4714541Z",
    "status": "deployed",
    "chart": "ranker-0.1.0",
    "app_version": "",
    "description": "ranker-feature__java-17-ca53f05.38"
  },
  {
    "revision": 404,
    "updated": "2023-03-22T11:17:56.517365+04:00",
    "status": "superseded",
    "chart": "ranker-0.1.0",
    "app_version": "",
    "description": "Rollback to 402"
  },
  {
    "revision": 405,
    "updated": "2023-03-22T07:22:45.612469614Z",
    "status": "deployed",
    "chart": "ranker-0.1.0",
    "app_version": "",
    "description": "ranker-master-50fb173.138"
  }
]
```