### PR TITLE
Fix 32bit-x86 typo in testsuite

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -86,7 +86,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
 			Name:    "test",
 			Command: "echo -n os-arch",
 			PlatformCommand: []PlatformCommand{
-				{OperatingSystem: "linux", Architecture: "i386", Command: "echo -n linux-i386"},
+				{OperatingSystem: "linux", Architecture: "386", Command: "echo -n linux-386"},
 				{OperatingSystem: "linux", Architecture: "amd64", Command: "echo -n linux-amd64"},
 				{OperatingSystem: "linux", Architecture: "arm64", Command: "echo -n linux-arm64"},
 				{OperatingSystem: "linux", Architecture: "ppc64le", Command: "echo -n linux-ppc64le"},
@@ -98,8 +98,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
 	var osStrCmp string
 	os := runtime.GOOS
 	arch := runtime.GOARCH
-	if os == "linux" && arch == "i386" {
-		osStrCmp = "linux-i386"
+	if os == "linux" && arch == "386" {
+		osStrCmp = "linux-386"
 	} else if os == "linux" && arch == "amd64" {
 		osStrCmp = "linux-amd64"
 	} else if os == "linux" && arch == "arm64" {
@@ -125,7 +125,7 @@ func TestPartialPlatformPrepareCommand(t *testing.T) {
 			Name:    "test",
 			Command: "echo -n os-arch",
 			PlatformCommand: []PlatformCommand{
-				{OperatingSystem: "linux", Architecture: "i386", Command: "echo -n linux-i386"},
+				{OperatingSystem: "linux", Architecture: "386", Command: "echo -n linux-386"},
 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
 			},
 		},
@@ -134,7 +134,7 @@ func TestPartialPlatformPrepareCommand(t *testing.T) {
 	os := runtime.GOOS
 	arch := runtime.GOARCH
 	if os == "linux" {
-		osStrCmp = "linux-i386"
+		osStrCmp = "linux-386"
 	} else if os == "windows" && arch == "amd64" {
 		osStrCmp = "win-64"
 	} else {
@@ -166,7 +166,7 @@ func TestNoMatchPrepareCommand(t *testing.T) {
 		Metadata: &Metadata{
 			Name: "test",
 			PlatformCommand: []PlatformCommand{
-				{OperatingSystem: "no-os", Architecture: "amd64", Command: "echo -n linux-i386"},
+				{OperatingSystem: "no-os", Architecture: "amd64", Command: "echo -n linux-386"},
 			},
 		},
 	}


### PR DESCRIPTION
The GOARCH here is 386 not i386. This caused a slightly odd test suite failure on that architecture:

--- FAIL: TestPlatformPrepareCommand (0.00s)
     plugin_test.go:45: Expected arg="os-arch", got "linux-s390x"
     plugin_test.go:64: Expected arg="os-arch", got "linux-s390x"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
