### PR TITLE
fix: do not error for remote chart if there's a missing local repo cache

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -54,7 +54,7 @@ const (
 )
 
 // ErrNoOwnerRepo indicates that a given chart URL can't be found in any repos.
-var ErrNoOwnerRepo = errors.New("could not find a repo containing the given URL")
+var ErrNoOwnerRepo = errors.New("could not find a repo containing the given URL (try 'helm repo update')")
 
 // ChartDownloader handles downloading a chart.
 //
@@ -380,7 +380,8 @@ func (c *ChartDownloader) scanReposForURL(u string, rf *repo.File) (*repo.Entry,
 		idxFile := filepath.Join(c.RepositoryCache, helmpath.CacheIndexFile(r.Config.Name))
 		i, err := repo.LoadIndexFile(idxFile)
 		if err != nil {
-			return nil, errors.Wrap(err, "no cached repo found. (try 'helm repo update')")
+			// No cache for this repository; let's keep looking rather than erroring
+			continue
 		}
 
 		for _, entry := range i.Entries {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR closes #11961 by continuing to `scanReposForURL` if one of the local repos doesn't have a cache rather than erroring. This PR also adds the hint to `helm repo update` to `ErrNoOwnerRepo` to catch cases that are expecting to find it in the local cache (i.e. `u := localrepo/cache`).

Ultimately, this makes it so that a full HTTP URL for the chart will never fail because in `chart_downloader.go` it will proceed to downloading it if `scanReposForUrl` returns `ErrNoOwnerRepo` (line 216):
> If there is no special config, return the default HTTP client and swallow the error.

This PR also adds a test that tests for the case where there's a non-empty repository config but an empty repository cache.

**Special notes for your reviewer**:
I verified this actually fixes #11961 by using the reproduction steps listed there compared with the released/installed version of `helm` and the manually built version located in `bin/helm` (after running `make build`). Here was the final output of that:

```
/mnt/d/work/helm$ helm template traefik --repo https://helm.traefik.io/traefik
Error: no cached repo found. (try 'helm repo update'): open /home/seese/.cache/helm/repository/ingress-nginx-index.yaml: no such file or directory
/mnt/d/work/helm$ bin/helm template traefik --repo https://helm.traefik.io/traefik
---
# Source: traefik/templates/rbac/serviceaccount.yaml
kind: ServiceAccount
apiVersion: v1
metadata
<...>
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
