### PR TITLE
Wrap SQL time in a mock to reduce potential for flakes

### DIFF
--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -18,6 +18,7 @@ package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
 	"testing"
 
@@ -246,6 +247,15 @@ func (mock *MockSecretsInterface) Delete(_ context.Context, name string, _ metav
 	}
 	delete(mock.objects, name)
 	return nil
+}
+
+// MockSQLFuzzyTime is an int wrapper that represents a unix timestamp int and matches both the int provided and int+1 to reduce test flakes
+type MockSQLFuzzyTime int64
+
+// Match satisfies sqlmock.Argument interface for MockSQLFuzzyTime
+func (msft MockSQLFuzzyTime) Match(v driver.Value) bool {
+	val, ok := v.(int64)
+	return ok && (MockSQLFuzzyTime(val) == msft || MockSQLFuzzyTime(val) == msft+1)
 }
 
 // newTestFixtureSQL mocks the SQL database (for testing purposes)

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -179,7 +179,7 @@ func TestSqlCreate(t *testing.T) {
 	mock.ExpectBegin()
 	mock.
 		ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, int(time.Now().Unix())).
+		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, MockSQLFuzzyTime(time.Now().Unix())).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -220,7 +220,7 @@ func TestSqlCreateAlreadyExists(t *testing.T) {
 	mock.ExpectBegin()
 	mock.
 		ExpectExec(regexp.QuoteMeta(insertQuery)).
-		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, int(time.Now().Unix())).
+		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, MockSQLFuzzyTime(time.Now().Unix())).
 		WillReturnError(fmt.Errorf("dialect dependent SQL error"))
 
 	selectQuery := fmt.Sprintf(
@@ -278,7 +278,7 @@ func TestSqlUpdate(t *testing.T) {
 
 	mock.
 		ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(body, rel.Name, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, int(time.Now().Unix()), key, namespace).
+		WithArgs(body, rel.Name, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, MockSQLFuzzyTime(time.Now().Unix()), key, namespace).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := sqlDriver.Update(key, rel); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR is just a test change and wraps the unix time int passed in in some of the tests in `pkg/storage/driver/sql_test.go` with a fuzzy matcher (matches the `int` and `int+1`) to help reduce the likelihood of test flakes like occurred in this dependabot PR: https://github.com/helm/helm/actions/runs/4511407385/jobs/7943518517?pr=11922

**Special notes for your reviewer**:

Fixes: https://github.com/helm/helm/issues/12302

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
