### PR TITLE
fail quiet linting when an error occurs

### DIFF
--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -53,6 +53,11 @@ func TestLintCmdWithQuietFlag(t *testing.T) {
 		name:   "lint chart with warning using --quiet flag",
 		cmd:    "lint --quiet testdata/testcharts/chart-with-only-crds",
 		golden: "output/lint-quiet-with-warning.txt",
+	}, {
+		name:      "lint non-existent chart using --quiet flag",
+		cmd:       "lint --quiet thischartdoesntexist/",
+		golden:    "",
+		wantError: true,
 	}}
 	runTestCmd(t, tests)
 

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -82,7 +82,7 @@ func HasWarningsOrErrors(result *LintResult) bool {
 			return true
 		}
 	}
-	return false
+	return len(result.Errors) > 0
 }
 
 func lintChart(path string, vals map[string]interface{}, namespace string, strict bool) (support.Linter, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When linting with the `--quiet` flag, non-linting errors, such as `no such file or directory` would not fail and would exit with a 0 result. This now checks for errors as well as linting messages and fails correctly.

Fixes #11411 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
