### PR TITLE
Fix goroutine leak in action install

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -369,13 +369,17 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		return rel, err
 	}
 	rChan := make(chan resultMessage)
+	ctxChan := make(chan resultMessage)
 	doneChan := make(chan struct{})
 	defer close(doneChan)
 	go i.performInstall(rChan, rel, toBeAdopted, resources)
-	go i.handleContext(ctx, rChan, doneChan, rel)
-	result := <-rChan
-	//start preformInstall go routine
-	return result.r, result.e
+	go i.handleContext(ctx, ctxChan, doneChan, rel)
+	select {
+	case result := <-rChan:
+		return result.r, result.e
+	case result := <-ctxChan:
+		return result.r, result.e
+	}
 }
 
 func (i *Install) performInstall(c chan<- resultMessage, rel *release.Release, toBeAdopted kube.ResourceList, resources kube.ResourceList) {


### PR DESCRIPTION
During the install process there was a place where an install process could be stuck trying to write to a channel. This would happen when a context had completed prior to performInstall finishing. In a short running Helm Client this was not a problem. But, for long running applications that use Helm as an SDK there are problems where a memory leak ends up happening due to goroutines never being able to complete.

This fix provides a means for performInstall to write to its channel using the method already used to fix the upgrade issue of the same kind.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Fixes a memory leak described in #11805

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
