### PR TITLE
Only run tests once

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run unit tests
         run: make test-coverage
       - name: Test build
-        run: make test build
+        run: make build


### PR DESCRIPTION
Tests are being run twice in CI. Once with code coverage being report and once without. Tests only need to be run once.

When Helm previously had testing in CircleCI it was the code coverage tests so that was retained here.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: CI doesn't need to spend the time running tests twice.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
