### PR TITLE
Make test scripts run without /bin/bash

### DIFF
--- a/internal/plugin/installer/http_installer_test.go
+++ b/internal/plugin/installer/http_installer_test.go
@@ -368,7 +368,7 @@ func TestExtractWithNestedDirectories(t *testing.T) {
 	}{
 		{"plugin.yaml", "plugin metadata", 0600, tar.TypeReg},
 		{"bin/", "", 0755, tar.TypeDir},
-		{"bin/plugin", "#!/bin/bash\necho plugin", 0755, tar.TypeReg},
+		{"bin/plugin", "#!/usr/bin/env sh\necho plugin", 0755, tar.TypeReg},
 		{"docs/", "", 0755, tar.TypeDir},
 		{"docs/README.md", "readme content", 0644, tar.TypeReg},
 		{"docs/examples/", "", 0755, tar.TypeDir},
@@ -531,7 +531,7 @@ func TestExtractPluginInSubdirectory(t *testing.T) {
 		{"my-plugin/", "", 0755, tar.TypeDir},
 		{"my-plugin/plugin.yaml", "name: my-plugin\nversion: 1.0.0\nusage: test\ndescription: test plugin\ncommand: $HELM_PLUGIN_DIR/bin/my-plugin", 0644, tar.TypeReg},
 		{"my-plugin/bin/", "", 0755, tar.TypeDir},
-		{"my-plugin/bin/my-plugin", "#!/bin/bash\necho test", 0755, tar.TypeReg},
+		{"my-plugin/bin/my-plugin", "#!/usr/bin/env sh\necho test", 0755, tar.TypeReg},
 	}
 
 	for _, file := range files {

--- a/internal/plugin/installer/local_installer_test.go
+++ b/internal/plugin/installer/local_installer_test.go
@@ -87,7 +87,7 @@ func TestLocalInstallerTarball(t *testing.T) {
 		Mode int64
 	}{
 		{"test-plugin/plugin.yaml", "name: test-plugin\napiVersion: v1\ntype: cli/v1\nruntime: subprocess\nversion: 1.0.0\nconfig:\n  shortHelp: test\n  longHelp: test\nruntimeConfig:\n  platformCommand:\n  - command: echo", 0644},
-		{"test-plugin/bin/test-plugin", "#!/bin/bash\necho test", 0755},
+		{"test-plugin/bin/test-plugin", "#!/usr/bin/env sh\necho test", 0755},
 	}
 
 	for _, file := range files {

--- a/internal/plugin/testdata/plugdir/good/hello-legacy/hello.sh
+++ b/internal/plugin/testdata/plugdir/good/hello-legacy/hello.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 echo "Hello from a Helm plugin"
 
 echo "PARAMS"
-echo $*
+echo "$@"
 
 $HELM_BIN ls --all
 

--- a/internal/plugin/testdata/plugdir/good/hello-v1/hello.sh
+++ b/internal/plugin/testdata/plugdir/good/hello-v1/hello.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 echo "Hello from a Helm plugin"
 
 echo "PARAMS"
-echo $*
+echo "$@"
 
 $HELM_BIN ls --all
 

--- a/pkg/cmd/testdata/helmhome/helm/plugins/args/args.sh
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/args/args.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-echo $*
+#!/usr/bin/env sh
+echo "$@"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/exitwith.sh
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/exitwith.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-exit $*
+#!/usr/bin/env sh
+exit "$1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The test scripts hardcoded `#!/bin/bash` while they are not really requiring bash. Use the more portable `#!/usr/bin/env sh` instead, so that they use the default shell. This makes things work on systems without a bash in the /bin folder.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
