### PR TITLE
sql driver with rw-roles

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -355,6 +355,7 @@ func (s *SQL) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
 		s.Log("list: failed to list: %v", err)
 		return nil, err
 	}
+
 	var releases []*rspb.Release
 	for _, record := range records {
 		release, err := decodeRelease(record.Body)

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -562,7 +562,54 @@ func TestCheckAlreadyAppliedNotFind(t *testing.T) {
 	mock.ExpectCommit()
 
 	if sqlDriver.checkAlreadyApplied(testMigrations) {
-		t.Errorf("Did find init id: %v, that not exists", initID)
+		t.Errorf("Did find init id: %v, that does not exist", initID)
+	}
+
+}
+
+func TestCheckAlreadyAppliedBigFind(t *testing.T) {
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	testMigrations := []*migrate.Migration{{Id: "init1"}, {Id: "init2"}, {Id: "init3"}}
+	mock.
+		ExpectQuery("").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "applied_at"}).
+				AddRow("1", time.Time{}).
+				AddRow("2", time.Time{}).
+				AddRow("init1", time.Time{}).
+				AddRow("init2", time.Time{}).
+				AddRow("3", time.Time{}).
+				AddRow("init3", time.Time{}).
+				AddRow("4", time.Time{}).
+				AddRow("5", time.Time{}))
+	mock.ExpectCommit()
+
+	if !sqlDriver.checkAlreadyApplied(testMigrations) {
+		t.Errorf("Did not find init ids, that exist")
+	}
+
+}
+
+func TestCheckAlreadyAppliedBigNotFind(t *testing.T) {
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	testMigrations := []*migrate.Migration{{Id: "init1"}, {Id: "init2"}, {Id: "init3"}}
+	mock.
+		ExpectQuery("").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "applied_at"}).
+				AddRow("1", time.Time{}).
+				AddRow("2", time.Time{}).
+				AddRow("init1", time.Time{}).
+				AddRow("3", time.Time{}).
+				AddRow("init2", time.Time{}).
+				AddRow("4", time.Time{}).
+				AddRow("5", time.Time{}))
+	mock.ExpectCommit()
+
+	if sqlDriver.checkAlreadyApplied(testMigrations) {
+		t.Errorf("Did not find init id: init3, that does not exist")
 	}
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Docs tells us that we need owner role only for first run to setup db. But in reality we always need owner role, because we always trying to execute "create table if not exists", what forbidden for read-write and less privileged users. (closes #11970)
https://helm.sh/docs/topics/permissions_sql_storage_backend/#initialization

In this pr we first check if migrations not applied, and only after run migrations.

Also it allows to apply custom migrations, in our case without RLS and GRANT ALL.

**Special notes for your reviewer**:
It's my first pr, sorry, if something wrong.
Can we finish pr due Thursday? 


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
