### PR TITLE
Support for multiple yaml documents in stdin/file

### DIFF
--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -84,5 +85,33 @@ func TestReadFile(t *testing.T) {
 	_, err := readFile(filePath, p)
 	if err == nil {
 		t.Errorf("Expected error when has special strings")
+	}
+}
+
+func TestMergeYaml(t *testing.T) {
+	var p getter.Providers
+	valuesFile, err := os.CreateTemp("", "values.yaml")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = valuesFile.WriteString("---\nkey1: value1\n---\nkey2: value2")
+	if err != nil {
+		t.Error(err)
+	}
+
+	options := Options{ValueFiles: []string{valuesFile.Name()}}
+	testMap, err := options.MergeValues(p)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedMap := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	equal := reflect.DeepEqual(testMap, expectedMap)
+	if !equal {
+		t.Errorf("Expected a map with different keys to merge properly with another map. Expected: %v, got %v", expectedMap, testMap)
 	}
 }


### PR DESCRIPTION
Support for multiple yaml documents in stdin/file

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #10866 

**Special notes for your reviewer**:

Tested stdin yaml:

```yaml
---
a:
  b: c
  c: d
  e: f
---
e: value
a:
  b: f
  e:
  
test: >-
  hello
  ---
  world
---
a:
  c: 4
```

Before (main branch):
```
% cat values.yaml | ./bin/helm template --repo https://jkroepke.github.io/helm-charts/ values -f - 
---
# Source: values/templates/values.yaml
a:
  b: c
  c: d
  e: f
```

After (this PR):
```
% cat values.yaml | ./bin/helm template --repo https://jkroepke.github.io/helm-charts/ values -f - 
---
# Source: values/templates/values.yaml
a:
  b: f
  c: 4
  e: null
e: value
test: hello --- world
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
