### PR TITLE
Updating the Helm maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,18 @@
 maintainers:
-  - adamreese
-  - bacongobbler
   - hickeyma
   - jdolitsky
   - marckhouzam
   - mattfarina
   - sabre1041
   - scottrigby
-  - SlickNik
   - technosophos
 triage:
   - joejulian
   - yxxhero
   - zonggen
 emeritus:
+  - adamreese
+  - bacongobbler
   - fibonacci1729
   - jascott1
   - michelleN
@@ -22,6 +21,7 @@ emeritus:
   - prydonius
   - rimusz
   - seh
+  - SlickNik
   - thomastaylor312
   - vaikas-google
   - viglesiasce


### PR DESCRIPTION
These maintainers have made tremendous contributions but are currently inactive. I have connected with each of them and they are focused on other work, at present. They all confirmed moving to an emeritus status. If they ever want to return to active development/maintainer-ship of Helm, I would be delighted.

The governance has a process for inactive folks and, as there are items that need to be voted on, inactive maintainer make decision making difficult.

These maintainers are and will continue to be missed.
