### PR TITLE
Use standard lib `errors` to replace most uses of `github.com/pkg/errors`

### DIFF
--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"golang.org/x/text/cases"
@@ -99,6 +98,6 @@ func (o *docsOptions) run(out io.Writer) error {
 	case "bash":
 		return o.topCmd.GenBashCompletionFile(filepath.Join(o.dest, "completions.bash"))
 	default:
-		return errors.Errorf("unknown doc type %q. Try 'markdown' or 'man'", o.docTypeString)
+		return fmt.Errorf("unknown doc type %q. Try 'markdown' or 'man'", o.docTypeString)
 	}
 }

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -294,7 +294,7 @@ func checkIfInstallable(ch *chart.Chart) error {
 	case "", "application":
 		return nil
 	}
-	return errors.Errorf("%s charts are not installable", ch.Metadata.Type)
+	return fmt.Errorf("%s charts are not installable", ch.Metadata.Type)
 }
 
 // Provide dynamic auto-completion for the install and template commands

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -17,13 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/action"

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -87,7 +86,7 @@ func loadPlugins(baseCmd *cobra.Command, out io.Writer) {
 				main, argv, prepCmdErr := plug.PrepareCommand(u)
 				if prepCmdErr != nil {
 					os.Stderr.WriteString(prepCmdErr.Error())
-					return errors.Errorf("plugin %q exited with error", md.Name)
+					return fmt.Errorf("plugin %q exited with error", md.Name)
 				}
 
 				return callPluginExecutable(md.Name, main, argv, out)
@@ -138,7 +137,7 @@ func callPluginExecutable(pluginName string, main string, argv []string, out io.
 			os.Stderr.Write(eerr.Stderr)
 			status := eerr.Sys().(syscall.WaitStatus)
 			return pluginError{
-				error: errors.Errorf("plugin %q exited with error", pluginName),
+				error: fmt.Errorf("plugin %q exited with error", pluginName),
 				code:  status.ExitStatus(),
 			}
 		}

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -17,12 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -57,7 +57,7 @@ func newPackageCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:  packageDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.Errorf("need at least one argument, the path to the chart")
+				return fmt.Errorf("need at least one argument, the path to the chart")
 			}
 			if client.Sign {
 				if client.Key == "" {

--- a/cmd/helm/plugin.go
+++ b/cmd/helm/plugin.go
@@ -16,11 +16,11 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/plugin"
@@ -64,7 +64,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)
-			return errors.Errorf("plugin %s hook for %q exited with error", event, p.Metadata.Name)
+			return fmt.Errorf("plugin %s hook for %q exited with error", event, p.Metadata.Name)
 		}
 		return err
 	}

--- a/cmd/helm/plugin_uninstall.go
+++ b/cmd/helm/plugin_uninstall.go
@@ -16,12 +16,12 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/plugin"
@@ -78,7 +78,7 @@ func (o *pluginUninstallOptions) run(out io.Writer) error {
 		}
 	}
 	if len(errorPlugins) > 0 {
-		return errors.Errorf(strings.Join(errorPlugins, "\n"))
+		return fmt.Errorf(strings.Join(errorPlugins, "\n"))
 	}
 	return nil
 }

--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -16,12 +16,12 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/pkg/plugin"
@@ -81,7 +81,7 @@ func (o *pluginUpdateOptions) run(out io.Writer) error {
 		}
 	}
 	if len(errorPlugins) > 0 {
-		return errors.Errorf(strings.Join(errorPlugins, "\n"))
+		return fmt.Errorf(strings.Join(errorPlugins, "\n"))
 	}
 	return nil
 }

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -49,5 +50,5 @@ func newRepoCmd(out io.Writer) *cobra.Command {
 }
 
 func isNotExist(err error) bool {
-	return os.IsNotExist(err)
+	return os.IsNotExist(errors.Cause(err))
 }

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -50,5 +49,5 @@ func newRepoCmd(out io.Writer) *cobra.Command {
 }
 
 func isNotExist(err error) bool {
-	return os.IsNotExist(errors.Cause(err))
+	return os.IsNotExist(err)
 }

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -178,7 +178,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 
 	// Check if the repo name is legal
 	if strings.Contains(o.name, "/") {
-		return errors.Errorf("repository name (%s) contains '/', please specify a different name without '/'", o.name)
+		return fmt.Errorf("repository name (%s) contains '/', please specify a different name without '/'", o.name)
 	}
 
 	// If the repo exists do one of two things:
@@ -190,7 +190,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 
 			// The input coming in for the name is different from what is already
 			// configured. Return an error.
-			return errors.Errorf("repository name (%s) already exists, please specify a different name", o.name)
+			return fmt.Errorf("repository name (%s) already exists, please specify a different name", o.name)
 		}
 
 		// The add is idempotent so do nothing

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -17,11 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/gosuri/uitable"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"

--- a/cmd/helm/repo_remove.go
+++ b/cmd/helm/repo_remove.go
@@ -17,12 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -65,7 +66,7 @@ func (o *repoRemoveOptions) run(out io.Writer) error {
 
 	for _, name := range o.names {
 		if !r.Remove(name) {
-			return errors.Errorf("no repo named %q found", name)
+			return fmt.Errorf("no repo named %q found", name)
 		}
 		if err := r.WriteFile(o.repoFile, 0644); err != nil {
 			return err
@@ -90,7 +91,7 @@ func removeRepoCache(root, name string) error {
 	if _, err := os.Stat(idx); os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
-		return errors.Wrapf(err, "can't remove index file %s", idx)
+		return githubErrors.Wrapf(err, "can't remove index file %s", idx)
 	}
 	return os.Remove(idx)
 }

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -83,7 +84,7 @@ func (o *repoUpdateOptions) run(out io.Writer) error {
 	case isNotExist(err):
 		return errNoRepositories
 	case err != nil:
-		return errors.Wrapf(err, "failed loading file: %s", o.repoFile)
+		return githubErrors.Wrapf(err, "failed loading file: %s", o.repoFile)
 	case len(f.Repositories) == 0:
 		return errNoRepositories
 	}
@@ -133,7 +134,7 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer, failOnRepoUpdate
 	wg.Wait()
 
 	if len(repoFailList) > 0 && failOnRepoUpdateFail {
-		return fmt.Errorf("Failed to update the following repositories: %s",
+		return fmt.Errorf("failed to update the following repositories: %s",
 			repoFailList)
 	}
 
@@ -151,7 +152,7 @@ func checkRequestedRepos(requestedRepos []string, validRepos []*repo.Entry) erro
 			}
 		}
 		if !found {
-			return errors.Errorf("no repositories found matching '%s'.  Nothing will be updated", requestedRepo)
+			return fmt.Errorf("no repositories found matching '%s'.  Nothing will be updated", requestedRepo)
 		}
 	}
 	return nil

--- a/cmd/helm/require/args.go
+++ b/cmd/helm/require/args.go
@@ -16,14 +16,15 @@ limitations under the License.
 package require
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
 // NoArgs returns an error if any args are included.
 func NoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"%q accepts no arguments\n\nUsage:  %s",
 			cmd.CommandPath(),
 			cmd.UseLine(),
@@ -36,7 +37,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 func ExactArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != n {
-			return errors.Errorf(
+			return fmt.Errorf(
 				"%q requires %d %s\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,
@@ -52,7 +53,7 @@ func ExactArgs(n int) cobra.PositionalArgs {
 func MaximumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) > n {
-			return errors.Errorf(
+			return fmt.Errorf(
 				"%q accepts at most %d %s\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,
@@ -68,7 +69,7 @@ func MaximumNArgs(n int) cobra.PositionalArgs {
 func MinimumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) < n {
-			return errors.Errorf(
+			return fmt.Errorf(
 				"%q requires at least %d %s\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,

--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,7 +28,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gosuri/uitable"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/search"
@@ -149,7 +150,7 @@ func (o *searchRepoOptions) applyConstraint(res []*search.Result) ([]*search.Res
 
 	constraint, err := semver.NewConstraint(o.version)
 	if err != nil {
-		return res, errors.Wrap(err, "an invalid version/constraint format")
+		return res, githubErrors.Wrap(err, "an invalid version/constraint format")
 	}
 
 	data := res[:0]

--- a/internal/ignore/rules.go
+++ b/internal/ignore/rules.go
@@ -19,13 +19,12 @@ package ignore
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // HelmIgnore default name of an ignorefile.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -130,7 +130,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 
 			vs, ok = repoIndex.Entries[d.Name]
 			if !ok {
-				return nil, errors.Errorf("%s chart not found in repo %s", d.Name, d.Repository)
+				return nil, fmt.Errorf("%s chart not found in repo %s", d.Name, d.Repository)
 			}
 			found = false
 		} else {
@@ -193,7 +193,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 		}
 	}
 	if len(missing) > 0 {
-		return nil, errors.Errorf("can't get a valid version for repositories %s. Try changing the version constraint in Chart.yaml", strings.Join(missing, ", "))
+		return nil, fmt.Errorf("can't get a valid version for repositories %s. Try changing the version constraint in Chart.yaml", strings.Join(missing, ", "))
 	}
 
 	digest, err := HashReq(reqs, locked)
@@ -254,7 +254,7 @@ func GetLocalPath(repo, chartpath string) (string, error) {
 	}
 
 	if _, err = os.Stat(depPath); os.IsNotExist(err) {
-		return "", errors.Errorf("directory %s not found", depPath)
+		return "", fmt.Errorf("directory %s not found", depPath)
 	} else if err != nil {
 		return "", err
 	}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -19,6 +19,7 @@ package test
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -79,7 +80,7 @@ func compare(actual []byte, filename string) error {
 	}
 	expected = normalize(expected)
 	if !bytes.Equal(expected, actual) {
-		return errors.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
+		return fmt.Errorf("does not match golden file %s\n\nWANT:\n'%s'\n\nGOT:\n'%s'", filename, expected, actual)
 	}
 	return nil
 }

--- a/internal/third_party/dep/fs/fs.go
+++ b/internal/third_party/dep/fs/fs.go
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package fs
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -226,7 +227,7 @@ func IsDir(name string) (bool, error) {
 		return false, err
 	}
 	if !fi.IsDir() {
-		return false, errors.Errorf("%q is not a directory", name)
+		return false, fmt.Errorf("%q is not a directory", name)
 	}
 	return true, nil
 }

--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -19,6 +19,7 @@ package tlsutil
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -56,11 +57,11 @@ func NewClientTLS(certFile, keyFile, caFile string, insecureSkipTLSverify bool) 
 func CertPoolFromFile(filename string) (*x509.CertPool, error) {
 	b, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, errors.Errorf("can't read CA file: %v", filename)
+		return nil, fmt.Errorf("can't read CA file: %v", filename)
 	}
 	cp := x509.NewCertPool()
 	if !cp.AppendCertsFromPEM(b) {
-		return nil, errors.Errorf("failed to append certificates from file: %s", filename)
+		return nil, fmt.Errorf("failed to append certificates from file: %s", filename)
 	}
 	return cp, nil
 }

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -114,7 +114,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 
 	if ch.Metadata.KubeVersion != "" {
 		if !chartutil.IsCompatibleRange(ch.Metadata.KubeVersion, caps.KubeVersion.String()) {
-			return hs, b, "", errors.Errorf("chart requires kubeVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.String())
+			return hs, b, "", fmt.Errorf("chart requires kubeVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.String())
 		}
 	}
 
@@ -302,7 +302,7 @@ func (cfg *Configuration) Now() time.Time {
 
 func (cfg *Configuration) releaseContent(name string, version int) (*release.Release, error) {
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, errors.Errorf("releaseContent: Release name is invalid: %s", name)
+		return nil, fmt.Errorf("releaseContent: Release name is invalid: %s", name)
 	}
 
 	if version <= 0 {

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -17,7 +17,7 @@ limitations under the License.
 package action
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
@@ -50,7 +50,7 @@ func (h *History) Run(name string) ([]*release.Release, error) {
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, errors.Errorf("release name is invalid: %s", name)
+		return nil, fmt.Errorf("release name is invalid: %s", name)
 	}
 
 	h.cfg.Log("getting history for release %s", name)

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -17,10 +17,11 @@ package action
 
 import (
 	"bytes"
+	"errors"
 	"sort"
 	"time"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
@@ -57,7 +58,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 
 		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), true)
 		if err != nil {
-			return errors.Wrapf(err, "unable to build kubernetes object for %s hook %s", hook, h.Path)
+			return githubErrors.Wrapf(err, "unable to build kubernetes object for %s hook %s", hook, h.Path)
 		}
 
 		// Record the time at which the hook was applied to the cluster
@@ -76,7 +77,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		if _, err := cfg.KubeClient.Create(resources); err != nil {
 			h.LastRun.CompletedAt = helmtime.Now()
 			h.LastRun.Phase = release.HookPhaseFailed
-			return errors.Wrapf(err, "warning: Hook %s %s failed", hook, h.Path)
+			return githubErrors.Wrapf(err, "warning: Hook %s %s failed", hook, h.Path)
 		}
 
 		// Watch hook resources until they have completed
@@ -129,7 +130,7 @@ func (cfg *Configuration) deleteHookByPolicy(h *release.Hook, policy release.Hoo
 	if hookHasDeletePolicy(h, policy) {
 		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), false)
 		if err != nil {
-			return errors.Wrapf(err, "unable to build kubernetes object for deleting hook %s", h.Path)
+			return githubErrors.Wrapf(err, "unable to build kubernetes object for deleting hook %s", h.Path)
 		}
 		_, errs := cfg.KubeClient.Delete(resources)
 		if len(errs) > 0 {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -621,7 +621,7 @@ func (i *Install) NameAndChart(args []string) (string, string, error) {
 	}
 
 	if len(args) > 2 {
-		return args[0], args[1], errors.Errorf("expected at most two arguments, unexpected arguments: %v", strings.Join(args[2:], ", "))
+		return args[0], args[1], fmt.Errorf("expected at most two arguments, unexpected arguments: %v", strings.Join(args[2:], ", "))
 	}
 
 	if len(args) == 2 {
@@ -686,7 +686,7 @@ OUTER:
 	}
 
 	if len(missing) > 0 {
-		return errors.Errorf("found in Chart.yaml, but missing in charts/ directory: %s", strings.Join(missing, ", "))
+		return fmt.Errorf("found in Chart.yaml, but missing in charts/ directory: %s", strings.Join(missing, ", "))
 	}
 	return nil
 }
@@ -722,7 +722,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		return abs, nil
 	}
 	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
-		return name, errors.Errorf("path %q not found", name)
+		return name, fmt.Errorf("path %q not found", name)
 	}
 
 	dl := downloader.ChartDownloader{

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -19,6 +19,7 @@ package action
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -31,7 +32,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -149,7 +150,7 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 		// Read in the resources
 		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.File.Data), false)
 		if err != nil {
-			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+			return githubErrors.Wrapf(err, "failed to install CRD %s", obj.Name)
 		}
 
 		// Send them to Kube
@@ -160,7 +161,7 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 				i.cfg.Log("CRD %s is already present. Skipping.", crdName)
 				continue
 			}
-			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+			return githubErrors.Wrapf(err, "failed to install CRD %s", obj.Name)
 		}
 		totalItems = append(totalItems, res...)
 	}
@@ -299,7 +300,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	var toBeAdopted kube.ResourceList
 	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), !i.DisableOpenAPIValidation)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
+		return nil, githubErrors.Wrap(err, "unable to build kubernetes objects from release manifest")
 	}
 
 	// It is safe to use "force" here because these are resources currently rendered by the chart.
@@ -317,7 +318,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	if !i.ClientOnly && !isUpgrade && len(resources) > 0 {
 		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace)
 		if err != nil {
-			return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with install")
+			return nil, githubErrors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with install")
 		}
 	}
 
@@ -473,9 +474,9 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 		uninstall.KeepHistory = false
 		uninstall.Timeout = i.Timeout
 		if _, uninstallErr := uninstall.Run(i.ReleaseName); uninstallErr != nil {
-			return rel, errors.Wrapf(uninstallErr, "an error occurred while uninstalling the release. original install error: %s", err)
+			return rel, githubErrors.Wrapf(uninstallErr, "an error occurred while uninstalling the release. original install error: %s", err)
 		}
-		return rel, errors.Wrapf(err, "release %s failed, and has been uninstalled due to atomic being set", i.ReleaseName)
+		return rel, githubErrors.Wrapf(err, "release %s failed, and has been uninstalled due to atomic being set", i.ReleaseName)
 	}
 	i.recordRelease(rel) // Ignore the error, since we have another error to deal with.
 	return rel, err
@@ -493,7 +494,7 @@ func (i *Install) availableName() error {
 	start := i.ReleaseName
 
 	if err := chartutil.ValidateReleaseName(start); err != nil {
-		return errors.Wrapf(err, "release name %q", start)
+		return githubErrors.Wrapf(err, "release name %q", start)
 	}
 	if i.DryRun {
 		return nil

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,7 +112,7 @@ func lintChart(path string, vals map[string]interface{}, namespace string, stric
 			return linter, errors.Wrapf(err, "unable to read temporary output directory %s", tempDir)
 		}
 		if !files[0].IsDir() {
-			return linter, errors.Errorf("unexpected file %s in temporary output directory %s", files[0].Name(), tempDir)
+			return linter, fmt.Errorf("unexpected file %s in temporary output directory %s", files[0].Name(), tempDir)
 		}
 
 		chartPath = filepath.Join(tempDir, files[0].Name())

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -162,7 +162,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 			}
 
 		} else {
-			return out.String(), errors.Errorf("failed to untar: a file or directory with the name %s already exists", udCheck)
+			return out.String(), fmt.Errorf("failed to untar: a file or directory with the name %s already exists", udCheck)
 		}
 
 		return out.String(), chartutil.ExpandFile(ud, saved)

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -55,7 +55,7 @@ func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, errors.Errorf("releaseTest: Release name is invalid: %s", name)
+		return nil, fmt.Errorf("releaseTest: Release name is invalid: %s", name)
 	}
 
 	// finds the non-deleted release with the given name

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -93,7 +93,7 @@ func (r *Rollback) Run(name string) error {
 // the previous release's configuration
 func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Release, error) {
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, nil, errors.Errorf("prepareRollback: Release name is invalid: %s", name)
+		return nil, nil, fmt.Errorf("prepareRollback: Release name is invalid: %s", name)
 	}
 
 	if r.Version < 0 {

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -68,7 +69,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, errors.Errorf("uninstall: Release name is invalid: %s", name)
+		return nil, fmt.Errorf("uninstall: Release name is invalid: %s", name)
 	}
 
 	rels, err := u.cfg.Releases.History(name)
@@ -91,7 +92,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 			}
 			return &release.UninstallReleaseResponse{Release: rel}, nil
 		}
-		return nil, errors.Errorf("the release named %q is already deleted", name)
+		return nil, fmt.Errorf("the release named %q is already deleted", name)
 	}
 
 	u.cfg.Log("uninstall: Deleting %s", name)
@@ -117,7 +118,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	deletedResources, kept, errs := u.deleteRelease(rel)
 	if errs != nil {
 		u.cfg.Log("uninstall: Failed to delete release: %s", errs)
-		return nil, errors.Errorf("failed to delete release: %s", name)
+		return nil, fmt.Errorf("failed to delete release: %s", name)
 	}
 
 	if kept != "" {
@@ -155,7 +156,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 
 		// Return the errors that occurred while deleting the release, if any
 		if len(errs) > 0 {
-			return res, errors.Errorf("uninstallation completed with %d error(s): %s", len(errs), joinErrors(errs))
+			return res, fmt.Errorf("uninstallation completed with %d error(s): %s", len(errs), joinErrors(errs))
 		}
 
 		return res, nil
@@ -166,7 +167,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	if len(errs) > 0 {
-		return res, errors.Errorf("uninstallation completed with %d error(s): %s", len(errs), joinErrors(errs))
+		return res, fmt.Errorf("uninstallation completed with %d error(s): %s", len(errs), joinErrors(errs))
 	}
 	return res, nil
 }

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -145,7 +145,7 @@ func (u *Upgrade) RunWithContext(ctx context.Context, name string, chart *chart.
 	u.Wait = u.Wait || u.Atomic
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, errors.Errorf("release name is invalid: %s", name)
+		return nil, fmt.Errorf("release name is invalid: %s", name)
 	}
 	u.cfg.Log("preparing upgrade for %s", name)
 	currentRelease, upgradedRelease, err := u.prepareUpgrade(name, chart, vals)

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -17,7 +17,7 @@ limitations under the License.
 package action
 
 import (
-	 "errors"
+	"errors"
 	"fmt"
 
 	githubErrors "github.com/pkg/errors"
@@ -89,7 +89,7 @@ func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) er
 	}
 
 	if len(errs) > 0 {
-		err := githubErrors.New("invalid ownership metadata")
+		err := errors.New("invalid ownership metadata")
 		for _, e := range errs {
 			err = fmt.Errorf("%w; %s", err, e)
 		}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -17,9 +17,10 @@ limitations under the License.
 package action
 
 import (
+	 "errors"
 	"fmt"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +52,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
-			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
+			return githubErrors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
 		}
 
 		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
@@ -88,7 +89,7 @@ func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) er
 	}
 
 	if len(errs) > 0 {
-		err := errors.New("invalid ownership metadata")
+		err := githubErrors.New("invalid ownership metadata")
 		for _, e := range errs {
 			err = fmt.Errorf("%w; %s", err, e)
 		}

--- a/pkg/chart/loader/archive.go
+++ b/pkg/chart/loader/archive.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,8 +28,6 @@ import (
 	"path"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/chart"
 )
@@ -151,7 +150,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 		n = path.Clean(n)
 		if n == "." {
 			// In this case, the original path was relative when it should have been absolute.
-			return nil, errors.Errorf("chart illegally contains content outside the base directory: %q", hd.Name)
+			return nil, fmt.Errorf("chart illegally contains content outside the base directory: %q", hd.Name)
 		}
 		if strings.HasPrefix(n, "..") {
 			return nil, errors.New("chart illegally references parent directory")

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -18,13 +18,14 @@ package loader
 
 import (
 	"bytes"
+	 "errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -83,7 +84,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 				c.Metadata = new(chart.Metadata)
 			}
 			if err := yaml.Unmarshal(f.Data, c.Metadata); err != nil {
-				return c, errors.Wrap(err, "cannot load Chart.yaml")
+				return c, githubErrors.Wrap(err, "cannot load Chart.yaml")
 			}
 			// NOTE(bacongobbler): while the chart specification says that APIVersion must be set,
 			// Helm 2 accepted charts that did not provide an APIVersion in their chart metadata.
@@ -101,12 +102,12 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		case f.Name == "Chart.lock":
 			c.Lock = new(chart.Lock)
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {
-				return c, errors.Wrap(err, "cannot load Chart.lock")
+				return c, githubErrors.Wrap(err, "cannot load Chart.lock")
 			}
 		case f.Name == "values.yaml":
 			c.Values = make(map[string]interface{})
 			if err := yaml.Unmarshal(f.Data, &c.Values); err != nil {
-				return c, errors.Wrap(err, "cannot load values.yaml")
+				return c, githubErrors.Wrap(err, "cannot load values.yaml")
 			}
 		case f.Name == "values.schema.json":
 			c.Schema = f.Data
@@ -121,7 +122,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 				log.Printf("Warning: Dependencies are handled in Chart.yaml since apiVersion \"v2\". We recommend migrating dependencies to Chart.yaml.")
 			}
 			if err := yaml.Unmarshal(f.Data, c.Metadata); err != nil {
-				return c, errors.Wrap(err, "cannot load requirements.yaml")
+				return c, githubErrors.Wrap(err, "cannot load requirements.yaml")
 			}
 			if c.Metadata.APIVersion == chart.APIVersionV1 {
 				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
@@ -130,7 +131,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		case f.Name == "requirements.lock":
 			c.Lock = new(chart.Lock)
 			if err := yaml.Unmarshal(f.Data, &c.Lock); err != nil {
-				return c, errors.Wrap(err, "cannot load requirements.lock")
+				return c, githubErrors.Wrap(err, "cannot load requirements.lock")
 			}
 			if c.Metadata == nil {
 				c.Metadata = new(chart.Metadata)
@@ -192,7 +193,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		}
 
 		if err != nil {
-			return c, errors.Wrapf(err, "error unpacking %s in %s", n, c.Name())
+			return c, githubErrors.Wrapf(err, "error unpacking %s in %s", n, c.Name())
 		}
 		c.AddDependency(sc)
 	}

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -18,6 +18,7 @@ package loader
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -171,7 +172,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 		case filepath.Ext(n) == ".tgz":
 			file := files[0]
 			if file.Name != n {
-				return c, errors.Errorf("error unpacking tar in %s: expected %s, got %s", c.Name(), n, file.Name)
+				return c, fmt.Errorf("error unpacking tar in %s: expected %s, got %s", c.Name(), n, file.Name)
 			}
 			// Untar the chart and add to c.Dependencies
 			sc, err = LoadArchive(bytes.NewBuffer(file.Data))

--- a/pkg/chartutil/chartfile.go
+++ b/pkg/chartutil/chartfile.go
@@ -17,10 +17,10 @@ limitations under the License.
 package chartutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -64,17 +64,17 @@ func IsChartDir(dirName string) (bool, error) {
 	if fi, err := os.Stat(dirName); err != nil {
 		return false, err
 	} else if !fi.IsDir() {
-		return false, errors.Errorf("%q is not a directory", dirName)
+		return false, fmt.Errorf("%q is not a directory", dirName)
 	}
 
 	chartYaml := filepath.Join(dirName, ChartfileName)
 	if _, err := os.Stat(chartYaml); os.IsNotExist(err) {
-		return false, errors.Errorf("no %s exists in directory %q", ChartfileName, dirName)
+		return false, fmt.Errorf("no %s exists in directory %q", ChartfileName, dirName)
 	}
 
 	chartYamlContent, err := os.ReadFile(chartYaml)
 	if err != nil {
-		return false, errors.Errorf("cannot read %s in directory %q", ChartfileName, dirName)
+		return false, fmt.Errorf("cannot read %s in directory %q", ChartfileName, dirName)
 	}
 
 	chartContent := new(chart.Metadata)
@@ -82,10 +82,10 @@ func IsChartDir(dirName string) (bool, error) {
 		return false, err
 	}
 	if chartContent == nil {
-		return false, errors.Errorf("chart metadata (%s) missing", ChartfileName)
+		return false, fmt.Errorf("chart metadata (%s) missing", ChartfileName)
 	}
 	if chartContent.Name == "" {
-		return false, errors.Errorf("invalid chart (%s): name must not be empty", ChartfileName)
+		return false, fmt.Errorf("invalid chart (%s): name must not be empty", ChartfileName)
 	}
 
 	return true, nil

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -21,7 +21,6 @@ import (
 	"log"
 
 	"github.com/mitchellh/copystructure"
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/chart"
 )
@@ -73,7 +72,7 @@ func coalesceDeps(printf printFn, chrt *chart.Chart, dest map[string]interface{}
 			// If dest doesn't already have the key, create it.
 			dest[subchart.Name()] = make(map[string]interface{})
 		} else if !istable(c) {
-			return dest, errors.Errorf("type mismatch on %s: %t", subchart.Name(), c)
+			return dest, fmt.Errorf("type mismatch on %s: %t", subchart.Name(), c)
 		}
 		if dv, ok := dest[subchart.Name()]; ok {
 			dvmap := dv.(map[string]interface{})

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -577,12 +577,12 @@ func Create(name, dir string) (string, error) {
 	if fi, err := os.Stat(path); err != nil {
 		return path, err
 	} else if !fi.IsDir() {
-		return path, errors.Errorf("no such directory %s", path)
+		return path, fmt.Errorf("no such directory %s", path)
 	}
 
 	cdir := filepath.Join(path, name)
 	if fi, err := os.Stat(cdir); err == nil && !fi.IsDir() {
-		return cdir, errors.Errorf("file %s already exists and is not a directory", cdir)
+		return cdir, fmt.Errorf("file %s already exists and is not a directory", cdir)
 	}
 
 	files := []struct {

--- a/pkg/chartutil/expand.go
+++ b/pkg/chartutil/expand.go
@@ -17,12 +17,13 @@ limitations under the License.
 package chartutil
 
 import (
+	 "errors"
 	"io"
 	"os"
 	"path/filepath"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -42,7 +43,7 @@ func Expand(dir string, r io.Reader) error {
 		if file.Name == "Chart.yaml" {
 			ch := &chart.Metadata{}
 			if err := yaml.Unmarshal(file.Data, ch); err != nil {
-				return errors.Wrap(err, "cannot load Chart.yaml")
+				return githubErrors.Wrap(err, "cannot load Chart.yaml")
 			}
 			chartName = ch.Name
 		}

--- a/pkg/chartutil/jsonschema.go
+++ b/pkg/chartutil/jsonschema.go
@@ -18,10 +18,10 @@ package chartutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
 

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -41,7 +41,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Create the chart directory
 	outdir := filepath.Join(dest, c.Name())
 	if fi, err := os.Stat(outdir); err == nil && !fi.IsDir() {
-		return errors.Errorf("file %s already exists and is not a directory", outdir)
+		return fmt.Errorf("file %s already exists and is not a directory", outdir)
 	}
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return err
@@ -116,7 +116,7 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 			return "", errors.Wrapf(err, "stat %s", dir)
 		}
 	} else if !stat.IsDir() {
-		return "", errors.Errorf("is not a directory: %s", dir)
+		return "", fmt.Errorf("is not a directory: %s", dir)
 	}
 
 	f, err := os.Create(filename)

--- a/pkg/chartutil/save.go
+++ b/pkg/chartutil/save.go
@@ -20,12 +20,13 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
+	 "errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -85,7 +86,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 	for _, dep := range c.Dependencies() {
 		// Here, we write each dependency as a tar file.
 		if _, err := Save(dep, base); err != nil {
-			return errors.Wrapf(err, "saving %s", dep.ChartFullPath())
+			return githubErrors.Wrapf(err, "saving %s", dep.ChartFullPath())
 		}
 	}
 	return nil
@@ -101,7 +102,7 @@ func SaveDir(c *chart.Chart, dest string) error {
 // This returns the absolute path to the chart archive file.
 func Save(c *chart.Chart, outDir string) (string, error) {
 	if err := c.Validate(); err != nil {
-		return "", errors.Wrap(err, "chart validation")
+		return "", githubErrors.Wrap(err, "chart validation")
 	}
 
 	filename := fmt.Sprintf("%s-%s.tgz", c.Name(), c.Metadata.Version)
@@ -113,7 +114,7 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 				return "", err2
 			}
 		} else {
-			return "", errors.Wrapf(err, "stat %s", dir)
+			return "", githubErrors.Wrapf(err, "stat %s", dir)
 		}
 	} else if !stat.IsDir() {
 		return "", fmt.Errorf("is not a directory: %s", dir)

--- a/pkg/chartutil/validate_name.go
+++ b/pkg/chartutil/validate_name.go
@@ -17,10 +17,9 @@ limitations under the License.
 package chartutil
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 // validName is a regular expression for resource names.

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,12 +17,12 @@ limitations under the License.
 package chartutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"

--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -63,7 +64,7 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 	// User specified a value via --set-json
 	for _, value := range opts.JSONValues {
 		if err := strvals.ParseJSON(value, base); err != nil {
-			return nil, errors.Errorf("failed parsing --set-json data %s", value)
+			return nil, fmt.Errorf("failed parsing --set-json data %s", value)
 		}
 	}
 

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -119,7 +119,7 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 		body, err := g.Get(u.String() + ".prov")
 		if err != nil {
 			if c.Verify == VerifyAlways {
-				return destfile, ver, errors.Errorf("failed to fetch provenance %q", u.String()+".prov")
+				return destfile, ver, fmt.Errorf("failed to fetch provenance %q", u.String()+".prov")
 			}
 			fmt.Fprintf(c.Out, "WARNING: Verification not found for %s: %s\n", ref, err)
 			return destfile, ver, nil
@@ -156,7 +156,7 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 			return nil, err
 		}
 		if len(tags) == 0 {
-			return nil, errors.Errorf("Unable to locate any tags in provided repository: %s", ref)
+			return nil, fmt.Errorf("Unable to locate any tags in provided repository: %s", ref)
 		}
 
 		// Determine if version provided
@@ -192,7 +192,7 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, error) {
 	u, err := url.Parse(ref)
 	if err != nil {
-		return nil, errors.Errorf("invalid chart URL format: %s", ref)
+		return nil, fmt.Errorf("invalid chart URL format: %s", ref)
 	}
 
 	if registry.IsOCI(u.String()) {
@@ -245,7 +245,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	// See if it's of the form: repo/path_to_chart
 	p := strings.SplitN(u.Path, "/", 2)
 	if len(p) < 2 {
-		return u, errors.Errorf("non-absolute URLs should be in form of repo_name/path_to_chart, got: %s", u)
+		return u, fmt.Errorf("non-absolute URLs should be in form of repo_name/path_to_chart, got: %s", u)
 	}
 
 	repoName := p[0]
@@ -290,14 +290,14 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	}
 
 	if len(cv.URLs) == 0 {
-		return u, errors.Errorf("chart %q has no downloadable URLs", ref)
+		return u, fmt.Errorf("chart %q has no downloadable URLs", ref)
 	}
 
 	// TODO: Seems that picking first URL is not fully correct
 	resolvedURL, err := repo.ResolveReferenceURL(rc.URL, cv.URLs[0])
 
 	if err != nil {
-		return u, errors.Errorf("invalid chart URL format: %s", ref)
+		return u, fmt.Errorf("invalid chart URL format: %s", ref)
 	}
 
 	return url.Parse(resolvedURL)
@@ -342,12 +342,12 @@ func pickChartRepositoryConfigByName(name string, cfgs []*repo.Entry) (*repo.Ent
 	for _, rc := range cfgs {
 		if rc.Name == name {
 			if rc.URL == "" {
-				return nil, errors.Errorf("no URL found for repository %s", name)
+				return nil, fmt.Errorf("no URL found for repository %s", name)
 			}
 			return rc, nil
 		}
 	}
-	return nil, errors.Errorf("repo %s not found", name)
+	return nil, fmt.Errorf("repo %s not found", name)
 }
 
 // scanReposForURL scans all repos to find which repo contains the given URL.

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -400,7 +400,7 @@ func (c *ChartDownloader) scanReposForURL(u string, rf *repo.File) (*repo.Entry,
 
 func loadRepoConfig(file string) (*repo.File, error) {
 	r, err := repo.LoadFile(file)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(githubErrors.Cause(err)) {
 		return nil, err
 	}
 	return r, nil

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -156,7 +156,7 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 			return nil, err
 		}
 		if len(tags) == 0 {
-			return nil, fmt.Errorf("Unable to locate any tags in provided repository: %s", ref)
+			return nil, fmt.Errorf("unable to locate any tags in provided repository: %s", ref)
 		}
 
 		// Determine if version provided

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -251,7 +251,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	// Check if 'charts' directory is not actally a directory. If it does not exist, create it.
 	if fi, err := os.Stat(destPath); err == nil {
 		if !fi.IsDir() {
-			return errors.Errorf("%q is not a directory", destPath)
+			return fmt.Errorf("%q is not a directory", destPath)
 		}
 	} else if os.IsNotExist(err) {
 		if err := os.MkdirAll(destPath, 0755); err != nil {
@@ -377,7 +377,7 @@ func parseOCIRef(chartRef string) (string, string, error) {
 	refTagRegexp := regexp.MustCompile(`^(oci://[^:]+(:[0-9]{1,5})?[^:]+):(.*)$`)
 	caps := refTagRegexp.FindStringSubmatch(chartRef)
 	if len(caps) != 4 {
-		return "", "", errors.Errorf("improperly formatted oci chart reference: %s", chartRef)
+		return "", "", fmt.Errorf("improperly formatted oci chart reference: %s", chartRef)
 	}
 	chartRef = caps[1]
 	tag := caps[3]
@@ -738,7 +738,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
 	}
-	err = errors.Errorf("chart %s not found in %s: %s", name, repoURL, err)
+	err = fmt.Errorf("chart %s not found in %s: %s", name, repoURL, err)
 	return url, username, password, false, false, "", "", "", err
 }
 
@@ -850,7 +850,7 @@ func writeLock(chartpath string, lock *chart.Lock, legacyLockfile bool) error {
 // archive a dep chart from local directory and save it into destPath
 func tarFromLocalDir(chartpath, name, repo, version, destPath string) (string, error) {
 	if !strings.HasPrefix(repo, "file://") {
-		return "", errors.Errorf("wrong format: chart %s repository %s", name, repo)
+		return "", fmt.Errorf("wrong format: chart %s repository %s", name, repo)
 	}
 
 	origPath, err := resolver.GetLocalPath(repo, chartpath)
@@ -878,7 +878,7 @@ func tarFromLocalDir(chartpath, name, repo, version, destPath string) (string, e
 		return ch.Metadata.Version, err
 	}
 
-	return "", errors.Errorf("can't get a valid version for dependency %s", name)
+	return "", fmt.Errorf("can't get a valid version for dependency %s", name)
 }
 
 // The prefix to use for cache keys created by the manager for repo names

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -168,7 +168,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 				log.Printf("[INFO] Missing required value: %s", warn)
 				return "", nil
 			}
-			return val, errors.Errorf(warnWrap(warn))
+			return val, fmt.Errorf(warnWrap(warn))
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {
@@ -176,7 +176,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 					log.Printf("[INFO] Missing required value: %s", warn)
 					return "", nil
 				}
-				return val, errors.Errorf(warnWrap(warn))
+				return val, fmt.Errorf(warnWrap(warn))
 			}
 		}
 		return val, nil
@@ -226,7 +226,7 @@ func (e Engine) renderWithReferences(tpls, referenceTpls map[string]renderable) 
 	// template engine.
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.Errorf("rendering template failed: %v", r)
+			err = fmt.Errorf("rendering template failed: %v", r)
 		}
 	}()
 	t := template.New("gotpl")

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -25,8 +25,9 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"errors"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -122,7 +123,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 		var buf strings.Builder
 		if v, ok := includedNames[name]; ok {
 			if v > recursionMaxNums {
-				return "", errors.Wrapf(fmt.Errorf("unable to execute template"), "rendering template has a nested reference name: %s", name)
+				return "", githubErrors.Wrapf(fmt.Errorf("unable to execute template"), "rendering template has a nested reference name: %s", name)
 			}
 			includedNames[name]++
 		} else {
@@ -137,12 +138,12 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 	funcMap["tpl"] = func(tpl string, vals chartutil.Values) (string, error) {
 		basePath, err := vals.PathValue("Template.BasePath")
 		if err != nil {
-			return "", errors.Wrapf(err, "cannot retrieve Template.Basepath from values inside tpl function: %s", tpl)
+			return "", githubErrors.Wrapf(err, "cannot retrieve Template.Basepath from values inside tpl function: %s", tpl)
 		}
 
 		templateName, err := vals.PathValue("Template.Name")
 		if err != nil {
-			return "", errors.Wrapf(err, "cannot retrieve Template.Name from values inside tpl function: %s", tpl)
+			return "", githubErrors.Wrapf(err, "cannot retrieve Template.Name from values inside tpl function: %s", tpl)
 		}
 
 		templates := map[string]renderable{
@@ -155,7 +156,7 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 
 		result, err := e.renderWithReferences(templates, referenceTpls)
 		if err != nil {
-			return "", errors.Wrapf(err, "error during tpl function execution for %q", tpl)
+			return "", githubErrors.Wrapf(err, "error during tpl function execution for %q", tpl)
 		}
 		return result[templateName.(string)], nil
 	}

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -18,10 +18,9 @@ package getter
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
@@ -169,7 +168,7 @@ func (p Providers) ByScheme(scheme string) (Getter, error) {
 			return pp.New()
 		}
 	}
-	return nil, errors.Errorf("scheme %q not supported", scheme)
+	return nil, fmt.Errorf("scheme %q not supported", scheme)
 }
 
 var httpProvider = Provider{

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -18,6 +18,7 @@ package getter
 import (
 	"bytes"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -89,7 +90,7 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("failed to fetch %s : %s", href, resp.Status)
+		return nil, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -17,12 +17,11 @@ package getter
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/plugin"
@@ -78,7 +77,7 @@ func (p *pluginGetter) Get(href string, options ...Option) (*bytes.Buffer, error
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)
-			return nil, errors.Errorf("plugin %q exited with error", p.command)
+			return nil, fmt.Errorf("plugin %q exited with error", p.command)
 		}
 		return nil, err
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -410,7 +410,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 		originalInfo := original.Get(info)
 		if originalInfo == nil {
 			kind := info.Mapping.GroupVersionKind.Kind
-			return errors.Errorf("no %s with the name %q found", kind, info.Name)
+			return fmt.Errorf("no %s with the name %q found", kind, info.Name)
 		}
 
 		if err := updateResource(c, info, originalInfo.Object, force); err != nil {
@@ -427,7 +427,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 	case err != nil:
 		return res, err
 	case len(updateErrors) != 0:
-		return res, errors.Errorf(strings.Join(updateErrors, " && "))
+		return res, fmt.Errorf(strings.Join(updateErrors, " && "))
 	}
 
 	for _, info := range original.Difference(target) {
@@ -745,7 +745,7 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 		case watch.Error:
 			// Handle error and return with an error.
 			c.Log("Error event for %s", info.Name)
-			return true, errors.Errorf("failed to deploy %s", info.Name)
+			return true, fmt.Errorf("failed to deploy %s", info.Name)
 		default:
 			return false, nil
 		}
@@ -759,14 +759,14 @@ func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) err
 func (c *Client) waitForJob(obj runtime.Object, name string) (bool, error) {
 	o, ok := obj.(*batch.Job)
 	if !ok {
-		return true, errors.Errorf("expected %s to be a *batch.Job, got %T", name, obj)
+		return true, fmt.Errorf("expected %s to be a *batch.Job, got %T", name, obj)
 	}
 
 	for _, c := range o.Status.Conditions {
 		if c.Type == batch.JobComplete && c.Status == "True" {
 			return true, nil
 		} else if c.Type == batch.JobFailed && c.Status == "True" {
-			return true, errors.Errorf("job failed: %s", c.Reason)
+			return true, fmt.Errorf("job failed: %s", c.Reason)
 		}
 	}
 
@@ -780,7 +780,7 @@ func (c *Client) waitForJob(obj runtime.Object, name string) (bool, error) {
 func (c *Client) waitForPodSuccess(obj runtime.Object, name string) (bool, error) {
 	o, ok := obj.(*v1.Pod)
 	if !ok {
-		return true, errors.Errorf("expected %s to be a *v1.Pod, got %T", name, obj)
+		return true, fmt.Errorf("expected %s to be a *v1.Pod, got %T", name, obj)
 	}
 
 	switch o.Status.Phase {
@@ -788,7 +788,7 @@ func (c *Client) waitForPodSuccess(obj runtime.Object, name string) (bool, error
 		c.Log("Pod %s succeeded", o.Name)
 		return true, nil
 	case v1.PodFailed:
-		return true, errors.Errorf("pod %s failed", o.Name)
+		return true, fmt.Errorf("pod %s failed", o.Name)
 	case v1.PodPending:
 		c.Log("Pod %s pending", o.Name)
 	case v1.PodRunning:

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -28,9 +28,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"errors"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -121,10 +122,10 @@ func (c *Client) IsReachable() error {
 		return errors.New("Kubernetes cluster unreachable")
 	}
 	if err != nil {
-		return errors.Wrap(err, "Kubernetes cluster unreachable")
+		return githubErrors.Wrap(err, "Kubernetes cluster unreachable")
 	}
 	if _, err := client.ServerVersion(); err != nil {
-		return errors.Wrap(err, "Kubernetes cluster unreachable")
+		return githubErrors.Wrap(err, "Kubernetes cluster unreachable")
 	}
 	return nil
 }
@@ -391,7 +392,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 		helper := resource.NewHelper(info.Client, info.Mapping).WithFieldManager(getManagedFieldsManager())
 		if _, err := helper.Get(info.Namespace, info.Name); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return errors.Wrap(err, "could not get information about the resource")
+				return githubErrors.Wrap(err, "could not get information about the resource")
 			}
 
 			// Append the created resource to the results, even if something fails
@@ -399,7 +400,7 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 
 			// Since the resource does not exist, create it.
 			if err := createResource(info); err != nil {
-				return errors.Wrap(err, "failed to create resource")
+				return githubErrors.Wrap(err, "failed to create resource")
 			}
 
 			kind := info.Mapping.GroupVersionKind.Kind
@@ -606,24 +607,24 @@ func deleteResource(info *resource.Info, policy metav1.DeletionPropagation) erro
 func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.PatchType, error) {
 	oldData, err := json.Marshal(current)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing current configuration")
+		return nil, types.StrategicMergePatchType, githubErrors.Wrap(err, "serializing current configuration")
 	}
 	newData, err := json.Marshal(target.Object)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing target configuration")
+		return nil, types.StrategicMergePatchType, githubErrors.Wrap(err, "serializing target configuration")
 	}
 
 	// Fetch the current object for the three way merge
 	helper := resource.NewHelper(target.Client, target.Mapping).WithFieldManager(getManagedFieldsManager())
 	currentObj, err := helper.Get(target.Namespace, target.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, types.StrategicMergePatchType, errors.Wrapf(err, "unable to get data for current object %s/%s", target.Namespace, target.Name)
+		return nil, types.StrategicMergePatchType, githubErrors.Wrapf(err, "unable to get data for current object %s/%s", target.Namespace, target.Name)
 	}
 
 	// Even if currentObj is nil (because it was not found), it will marshal just fine
 	currentData, err := json.Marshal(currentObj)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing live configuration")
+		return nil, types.StrategicMergePatchType, githubErrors.Wrap(err, "serializing live configuration")
 	}
 
 	// Get a versioned object
@@ -646,7 +647,7 @@ func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.P
 
 	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(versionedObject)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "unable to create patch metadata from object")
+		return nil, types.StrategicMergePatchType, githubErrors.Wrap(err, "unable to create patch metadata from object")
 	}
 
 	patch, err := strategicpatch.CreateThreeWayMergePatch(oldData, newData, currentData, patchMeta, true)
@@ -665,13 +666,13 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		var err error
 		obj, err = helper.Replace(target.Namespace, target.Name, true, target.Object)
 		if err != nil {
-			return errors.Wrap(err, "failed to replace object")
+			return githubErrors.Wrap(err, "failed to replace object")
 		}
 		c.Log("Replaced %q with kind %s for kind %s", target.Name, currentObj.GetObjectKind().GroupVersionKind().Kind, kind)
 	} else {
 		patch, patchType, err := createPatch(target, currentObj)
 		if err != nil {
-			return errors.Wrap(err, "failed to create patch")
+			return githubErrors.Wrap(err, "failed to create patch")
 		}
 
 		if patch == nil || string(patch) == "{}" {
@@ -679,7 +680,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 			// This needs to happen to make sure that Helm has the latest info from the API
 			// Otherwise there will be no labels and other functions that use labels will panic
 			if err := target.Get(); err != nil {
-				return errors.Wrap(err, "failed to refresh resource information")
+				return githubErrors.Wrap(err, "failed to refresh resource information")
 			}
 			return nil
 		}
@@ -687,7 +688,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		c.Log("Patch %s %q in namespace %s", kind, target.Name, target.Namespace)
 		obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
 		if err != nil {
-			return errors.Wrapf(err, "cannot patch %q with kind %s", target.Name, kind)
+			return githubErrors.Wrapf(err, "cannot patch %q with kind %s", target.Name, kind)
 		}
 	}
 

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -17,13 +17,13 @@ limitations under the License.
 package rules // import "helm.sh/helm/v3/pkg/lint/rules"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/asaskevich/govalidator"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -81,7 +81,7 @@ func isStringValue(data map[string]interface{}, key string) error {
 	}
 	valueType := fmt.Sprintf("%T", value)
 	if valueType != "string" {
-		return errors.Errorf("%s should be of type string but it's of type %s", key, valueType)
+		return fmt.Errorf("%s should be of type string but it's of type %s", key, valueType)
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func validateChartYamlNotDirectory(chartPath string) error {
 
 func validateChartYamlFormat(chartFileError error) error {
 	if chartFileError != nil {
-		return errors.Errorf("unable to parse YAML\n\t%s", chartFileError.Error())
+		return fmt.Errorf("unable to parse YAML\n\t%s", chartFileError.Error())
 	}
 	return nil
 }
@@ -129,7 +129,7 @@ func validateChartVersion(cf *chart.Metadata) error {
 	version, err := semver.NewVersion(cf.Version)
 
 	if err != nil {
-		return errors.Errorf("version '%s' is not a valid SemVer", cf.Version)
+		return fmt.Errorf("version '%s' is not a valid SemVer", cf.Version)
 	}
 
 	c, err := semver.NewConstraint(">0.0.0-0")
@@ -139,7 +139,7 @@ func validateChartVersion(cf *chart.Metadata) error {
 	valid, msg := c.Validate(version)
 
 	if !valid && len(msg) > 0 {
-		return errors.Errorf("version %v", msg[0])
+		return fmt.Errorf("version %v", msg[0])
 	}
 
 	return nil
@@ -150,9 +150,9 @@ func validateChartMaintainer(cf *chart.Metadata) error {
 		if maintainer.Name == "" {
 			return errors.New("each maintainer requires a name")
 		} else if maintainer.Email != "" && !govalidator.IsEmail(maintainer.Email) {
-			return errors.Errorf("invalid email '%s' for maintainer '%s'", maintainer.Email, maintainer.Name)
+			return fmt.Errorf("invalid email '%s' for maintainer '%s'", maintainer.Email, maintainer.Name)
 		} else if maintainer.URL != "" && !govalidator.IsURL(maintainer.URL) {
-			return errors.Errorf("invalid url '%s' for maintainer '%s'", maintainer.URL, maintainer.Name)
+			return fmt.Errorf("invalid url '%s' for maintainer '%s'", maintainer.URL, maintainer.Name)
 		}
 	}
 	return nil
@@ -161,7 +161,7 @@ func validateChartMaintainer(cf *chart.Metadata) error {
 func validateChartSources(cf *chart.Metadata) error {
 	for _, source := range cf.Sources {
 		if source == "" || !govalidator.IsRequestURL(source) {
-			return errors.Errorf("invalid source URL '%s'", source)
+			return fmt.Errorf("invalid source URL '%s'", source)
 		}
 	}
 	return nil
@@ -176,7 +176,7 @@ func validateChartIconPresence(cf *chart.Metadata) error {
 
 func validateChartIconURL(cf *chart.Metadata) error {
 	if cf.Icon != "" && !govalidator.IsRequestURL(cf.Icon) {
-		return errors.Errorf("invalid icon URL '%s'", cf.Icon)
+		return fmt.Errorf("invalid icon URL '%s'", cf.Icon)
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package rules
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"

--- a/pkg/lint/rules/dependencies.go
+++ b/pkg/lint/rules/dependencies.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/lint/support"
@@ -42,7 +40,7 @@ func Dependencies(linter *support.Linter) {
 
 func validateChartFormat(chartError error) error {
 	if chartError != nil {
-		return errors.Errorf("unable to load chart\n\t%s", chartError)
+		return fmt.Errorf("unable to load chart\n\t%s", chartError)
 	}
 	return nil
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -26,8 +26,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"errors"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	apipath "k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -209,7 +210,7 @@ func validateAllowedExtension(fileName string) error {
 }
 
 func validateYamlContent(err error) error {
-	return errors.Wrap(err, "unable to parse YAML")
+	return githubErrors.Wrap(err, "unable to parse YAML")
 }
 
 // validateMetadataName uses the correct validation function for the object
@@ -222,7 +223,7 @@ func validateMetadataName(obj *K8sYamlStruct) error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), obj.Metadata.Name, msg))
 	}
 	if len(allErrs) > 0 {
-		return errors.Wrapf(allErrs.ToAggregate(), "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
+		return githubErrors.Wrapf(allErrs.ToAggregate(), "object name does not conform to Kubernetes naming requirements: %q", obj.Metadata.Name)
 	}
 	return nil
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -205,7 +205,7 @@ func validateAllowedExtension(fileName string) error {
 		}
 	}
 
-	return errors.Errorf("file extension '%s' not valid. Valid extensions are .yaml, .yml, .tpl, or .txt", ext)
+	return fmt.Errorf("file extension '%s' not valid. Valid extensions are .yaml, .yml, .tpl, or .txt", ext)
 }
 
 func validateYamlContent(err error) error {

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -54,7 +55,7 @@ func ValuesWithOverrides(linter *support.Linter, values map[string]interface{}) 
 func validateValuesFileExistence(valuesPath string) error {
 	_, err := os.Stat(valuesPath)
 	if err != nil {
-		return errors.Errorf("file does not exist")
+		return fmt.Errorf("file does not exist")
 	}
 	return nil
 }

--- a/pkg/lint/support/message_test.go
+++ b/pkg/lint/support/message_test.go
@@ -17,9 +17,8 @@ limitations under the License.
 package support
 
 import (
+	"errors"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 var linter = Linter{}

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -19,6 +19,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -78,7 +79,7 @@ func NewExtractor(source string) (Extractor, error) {
 			return extractor, nil
 		}
 	}
-	return nil, errors.Errorf("no extractor implemented yet for %s", source)
+	return nil, fmt.Errorf("no extractor implemented yet for %s", source)
 }
 
 // NewHTTPInstaller creates a new HttpInstaller.
@@ -151,7 +152,7 @@ func (i *HTTPInstaller) Install() error {
 // Update updates a local repository
 // Not implemented for now since tarball most likely will be packaged by version
 func (i *HTTPInstaller) Update() error {
-	return errors.Errorf("method Update() not implemented for HttpInstaller")
+	return fmt.Errorf("method Update() not implemented for HttpInstaller")
 }
 
 // Path is overridden because we want to join on the plugin name not the file name
@@ -261,7 +262,7 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 		case tar.TypeXGlobalHeader, tar.TypeXHeader:
 			continue
 		default:
-			return errors.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
+			return fmt.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
 		}
 	}
 	return nil

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -19,6 +19,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,7 +29,7 @@ import (
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/third_party/dep/fs"
 	"helm.sh/helm/v3/pkg/cli"
@@ -133,7 +134,7 @@ func (i *HTTPInstaller) Install() error {
 	}
 
 	if err := i.extractor.Extract(pluginData, i.CacheDir); err != nil {
-		return errors.Wrap(err, "extracting files from archive")
+		return githubErrors.Wrap(err, "extracting files from archive")
 	}
 
 	if !isPlugin(i.CacheDir) {

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -29,8 +29,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"helm.sh/helm/v3/internal/test/ensure"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/helmpath"
@@ -150,7 +148,7 @@ func TestHTTPInstallerNonExistentVersion(t *testing.T) {
 
 	// inject fake http client responding with error
 	httpInstaller.getter = &TestHTTPGetter{
-		MockError: errors.Errorf("failed to download plugin for some reason"),
+		MockError: fmt.Errorf("failed to download plugin for some reason"),
 	}
 
 	// attempt to install the plugin

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -16,14 +16,13 @@ limitations under the License.
 package installer
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/plugin"
 )

--- a/pkg/plugin/installer/local_installer.go
+++ b/pkg/plugin/installer/local_installer.go
@@ -16,10 +16,11 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 )
 
 // ErrPluginNotAFolder indicates that the plugin path is not a folder.
@@ -34,7 +35,7 @@ type LocalInstaller struct {
 func NewLocalInstaller(source string) (*LocalInstaller, error) {
 	src, err := filepath.Abs(source)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get absolute path to plugin")
+		return nil, githubErrors.Wrap(err, "unable to get absolute path to plugin")
 	}
 	i := &LocalInstaller{
 		base: newBase(src),

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,12 +16,13 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/vcs"
-	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/third_party/dep/fs"
 	"helm.sh/helm/v3/pkg/helmpath"
@@ -144,7 +145,7 @@ func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
 		}
 	}
 
-	return "", errors.Errorf("requested version %q does not exist for plugin %q", i.Version, i.Repo.Remote())
+	return "", fmt.Errorf("requested version %q does not exist for plugin %q", i.Version, i.Repo.Remote())
 }
 
 // setVersion attempts to checkout the version

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -143,7 +144,7 @@ func NewFromKeyring(keyringfile, id string) (*Signatory, error) {
 		}
 	}
 	if vague {
-		return s, errors.Errorf("more than one key contain the id %q", id)
+		return s, fmt.Errorf("more than one key contain the id %q", id)
 	}
 
 	s.Entity = candidate
@@ -254,7 +255,7 @@ func (s *Signatory) Verify(chartpath, sigpath string) (*Verification, error) {
 		if fi, err := os.Stat(fname); err != nil {
 			return ver, err
 		} else if fi.IsDir() {
-			return ver, errors.Errorf("%s cannot be a directory", fname)
+			return ver, fmt.Errorf("%s cannot be a directory", fname)
 		}
 	}
 
@@ -283,9 +284,9 @@ func (s *Signatory) Verify(chartpath, sigpath string) (*Verification, error) {
 	sum = "sha256:" + sum
 	basename := filepath.Base(chartpath)
 	if sha, ok := sums.Files[basename]; !ok {
-		return ver, errors.Errorf("provenance does not contain a SHA for a file named %q", basename)
+		return ver, fmt.Errorf("provenance does not contain a SHA for a file named %q", basename)
 	} else if sha != sum {
-		return ver, errors.Errorf("sha256 sum does not match for %s: %q != %q", basename, sha, sum)
+		return ver, fmt.Errorf("sha256 sum does not match for %s: %q != %q", basename, sha, sum)
 	}
 	ver.FileHash = sum
 	ver.FileName = basename

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -19,13 +19,14 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"           //nolint
 	"golang.org/x/crypto/openpgp/clearsign" //nolint
 	"golang.org/x/crypto/openpgp/packet"    //nolint
@@ -237,12 +238,12 @@ func (s *Signatory) ClearSign(chartpath string) (string, error) {
 		// In other words, if we call Close here, there's a risk that there's an attempt to use the
 		// private key to sign garbage data (since we know that io.Copy failed, `w` won't contain
 		// anything useful).
-		return "", errors.Wrap(err, "failed to write to clearsign encoder")
+		return "", githubErrors.Wrap(err, "failed to write to clearsign encoder")
 	}
 
 	err = w.Close()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to either sign or armor message block")
+		return "", githubErrors.Wrap(err, "failed to either sign or armor message block")
 	}
 
 	return out.String(), nil
@@ -262,7 +263,7 @@ func (s *Signatory) Verify(chartpath, sigpath string) (*Verification, error) {
 	// First verify the signature
 	sig, err := s.decodeSignature(sigpath)
 	if err != nil {
-		return ver, errors.Wrap(err, "failed to decode signature")
+		return ver, githubErrors.Wrap(err, "failed to decode signature")
 	}
 
 	by, err := s.verifySignature(sig)

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -48,7 +48,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 	stat, err := os.Stat(chartRef)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errors.Errorf("%s: no such file", chartRef)
+			return fmt.Errorf("%s: no such file", chartRef)
 		}
 		return err
 	}

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -23,8 +23,9 @@ import (
 	"path"
 	"strings"
 	"time"
+	"errors"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/tlsutil"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -108,7 +109,7 @@ func (pusher *OCIPusher) newRegistryClient() (*registry.Client, error) {
 	if (pusher.opts.certFile != "" && pusher.opts.keyFile != "") || pusher.opts.caFile != "" || pusher.opts.insecureSkipTLSverify {
 		tlsConf, err := tlsutil.NewClientTLS(pusher.opts.certFile, pusher.opts.keyFile, pusher.opts.caFile, pusher.opts.insecureSkipTLSverify)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't create TLS config for client")
+			return nil, githubErrors.Wrap(err, "can't create TLS config for client")
 		}
 
 		registryClient, err := registry.NewClient(

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -17,7 +17,7 @@ limitations under the License.
 package pusher
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
@@ -99,7 +99,7 @@ func (p Providers) ByScheme(scheme string) (Pusher, error) {
 			return pp.New()
 		}
 	}
-	return nil, errors.Errorf("scheme %q not supported", scheme)
+	return nil, fmt.Errorf("scheme %q not supported", scheme)
 }
 
 var ociProvider = Provider{

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -19,6 +19,7 @@ package registry // import "helm.sh/helm/v3/pkg/registry"
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,7 +29,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"oras.land/oras-go/pkg/auth"
 	dockerauth "oras.land/oras-go/pkg/auth/docker"
 	"oras.land/oras-go/pkg/content"
@@ -392,7 +392,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 	}
 	var getManifestErr error
 	if _, manifestData, ok := memoryStore.Get(manifest); !ok {
-		getManifestErr = errors.Errorf("Unable to retrieve blob with digest %s", manifest.Digest)
+		getManifestErr = fmt.Errorf("Unable to retrieve blob with digest %s", manifest.Digest)
 	} else {
 		result.Manifest.Data = manifestData
 	}
@@ -401,7 +401,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 	}
 	var getConfigDescriptorErr error
 	if _, configData, ok := memoryStore.Get(*configDescriptor); !ok {
-		getConfigDescriptorErr = errors.Errorf("Unable to retrieve blob with digest %s", configDescriptor.Digest)
+		getConfigDescriptorErr = fmt.Errorf("Unable to retrieve blob with digest %s", configDescriptor.Digest)
 	} else {
 		result.Config.Data = configData
 		var meta *chart.Metadata
@@ -416,7 +416,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 	if operation.withChart {
 		var getChartDescriptorErr error
 		if _, chartData, ok := memoryStore.Get(*chartDescriptor); !ok {
-			getChartDescriptorErr = errors.Errorf("Unable to retrieve blob with digest %s", chartDescriptor.Digest)
+			getChartDescriptorErr = fmt.Errorf("Unable to retrieve blob with digest %s", chartDescriptor.Digest)
 		} else {
 			result.Chart.Data = chartData
 			result.Chart.Digest = chartDescriptor.Digest.String()
@@ -429,7 +429,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 	if operation.withProv && !provMissing {
 		var getProvDescriptorErr error
 		if _, provData, ok := memoryStore.Get(*provDescriptor); !ok {
-			getProvDescriptorErr = errors.Errorf("Unable to retrieve blob with digest %s", provDescriptor.Digest)
+			getProvDescriptorErr = fmt.Errorf("Unable to retrieve blob with digest %s", provDescriptor.Digest)
 		} else {
 			result.Prov.Data = provData
 			result.Prov.Digest = provDescriptor.Digest.String()

--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	orascontext "oras.land/oras-go/pkg/context"
 	"oras.land/oras-go/pkg/registry"
@@ -90,7 +89,7 @@ func GetTagMatchingVersionOrConstraint(tags []string, versionString string) (str
 		}
 	}
 
-	return "", errors.Errorf("Could not locate a version matching provided version string %s", versionString)
+	return "", fmt.Errorf("Could not locate a version matching provided version string %s", versionString)
 }
 
 // extractChartMeta is used to extract a chart metadata from a byte array

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -63,12 +63,12 @@ type ChartRepository struct {
 func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository, error) {
 	u, err := url.Parse(cfg.URL)
 	if err != nil {
-		return nil, errors.Errorf("invalid chart URL format: %s", cfg.URL)
+		return nil, fmt.Errorf("invalid chart URL format: %s", cfg.URL)
 	}
 
 	client, err := getters.ByScheme(u.Scheme)
 	if err != nil {
-		return nil, errors.Errorf("could not find protocol handler for: %s", u.Scheme)
+		return nil, fmt.Errorf("could not find protocol handler for: %s", u.Scheme)
 	}
 
 	return &ChartRepository{
@@ -90,7 +90,7 @@ func (r *ChartRepository) Load() error {
 		return err
 	}
 	if !dirInfo.IsDir() {
-		return errors.Errorf("%q is not a directory", r.Config.Name)
+		return fmt.Errorf("%q is not a directory", r.Config.Name)
 	}
 
 	// FIXME: Why are we recursively walking directories?
@@ -265,11 +265,11 @@ func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName,
 	}
 	cv, err := repoIndex.Get(chartName, chartVersion)
 	if err != nil {
-		return "", errors.Errorf("%s not found in %s repository", errMsg, repoURL)
+		return "", fmt.Errorf("%s not found in %s repository", errMsg, repoURL)
 	}
 
 	if len(cv.URLs) == 0 {
-		return "", errors.Errorf("%s has no downloadable URLs", errMsg)
+		return "", fmt.Errorf("%s has no downloadable URLs", errMsg)
 	}
 
 	chartURL := cv.URLs[0]

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -18,6 +18,7 @@ package repo
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -218,7 +219,7 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 			return ver, nil
 		}
 	}
-	return nil, errors.Errorf("no chart version found for %s-%s", name, version)
+	return nil, fmt.Errorf("no chart version found for %s-%s", name, version)
 }
 
 // WriteFile writes an index file to the given destination path.

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -26,9 +26,10 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"errors"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/internal/fileutil"
@@ -110,7 +111,7 @@ func LoadIndexFile(path string) (*IndexFile, error) {
 	}
 	i, err := loadIndex(b, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error loading %s", path)
+		return nil, githubErrors.Wrapf(err, "error loading %s", path)
 	}
 	return i, nil
 }
@@ -126,7 +127,7 @@ func (i IndexFile) MustAdd(md *chart.Metadata, filename, baseURL, digest string)
 		md.APIVersion = chart.APIVersionV1
 	}
 	if err := md.Validate(); err != nil {
-		return errors.Wrapf(err, "validate failed for %s", filename)
+		return githubErrors.Wrapf(err, "validate failed for %s", filename)
 	}
 
 	u := filename
@@ -320,7 +321,7 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 			return index, err
 		}
 		if err := index.MustAdd(c.Metadata, fname, parentURL, hash); err != nil {
-			return index, errors.Wrapf(err, "failed adding to %s to index", fname)
+			return index, githubErrors.Wrapf(err, "failed adding to %s to index", fname)
 		}
 	}
 	return index, nil

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -18,11 +18,11 @@ package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,7 +121,7 @@ func (cfgmaps *ConfigMaps) Query(labels map[string]string) ([]*rspb.Release, err
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
-			return nil, errors.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
+			return nil, fmt.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
 		}
 		ls[k] = v
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -18,6 +18,7 @@ package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -113,7 +114,7 @@ func (secrets *Secrets) Query(labels map[string]string) ([]*rspb.Release, error)
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
-			return nil, errors.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
+			return nil, fmt.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
 		}
 		ls[k] = v
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -17,10 +17,9 @@ limitations under the License.
 package storage // import "helm.sh/helm/v3/pkg/storage"
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	rspb "helm.sh/helm/v3/pkg/release"
 	relutil "helm.sh/helm/v3/pkg/releaseutil"
@@ -213,7 +212,7 @@ func (s *Storage) removeLeastRecent(name string, max int) error {
 	case 1:
 		return errs[0]
 	default:
-		return errors.Errorf("encountered %d deletion errors. First is: %s", c, errs[0])
+		return fmt.Errorf("encountered %d deletion errors. First is: %s", c, errs[0])
 	}
 }
 
@@ -235,7 +234,7 @@ func (s *Storage) Last(name string) (*rspb.Release, error) {
 		return nil, err
 	}
 	if len(h) == 0 {
-		return nil, errors.Errorf("no revision for release %q", name)
+		return nil, fmt.Errorf("no revision for release %q", name)
 	}
 
 	relutil.Reverse(h, relutil.SortByRevision)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package storage // import "helm.sh/helm/v3/pkg/storage"
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	rspb "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"

--- a/pkg/strvals/literal_parser.go
+++ b/pkg/strvals/literal_parser.go
@@ -102,7 +102,7 @@ func (t *literalParser) key(data map[string]interface{}, nestedNameLevel int) (r
 			if len(key) == 0 {
 				return err
 			}
-			return errors.Errorf("key %q has no value", string(key))
+			return fmt.Errorf("key %q has no value", string(key))
 
 		case lastRune == '=':
 			// found end of key: swallow the '=' and get the value
@@ -129,7 +129,7 @@ func (t *literalParser) key(data map[string]interface{}, nestedNameLevel int) (r
 			// recurse on sub-tree with remaining data
 			err := t.key(inner, nestedNameLevel)
 			if err == nil && len(inner) == 0 {
-				return errors.Errorf("key map %q has no value", string(key))
+				return fmt.Errorf("key map %q has no value", string(key))
 			}
 			if len(inner) != 0 {
 				set(data, string(key), inner)
@@ -178,7 +178,7 @@ func (t *literalParser) listItem(list []interface{}, i, nestedNameLevel int) ([]
 
 	switch key, lastRune, err := runesUntilLiteral(t.sc, stop); {
 	case len(key) > 0:
-		return list, errors.Errorf("unexpected data at end of array index: %q", key)
+		return list, fmt.Errorf("unexpected data at end of array index: %q", key)
 
 	case err != nil:
 		return list, err
@@ -233,7 +233,7 @@ func (t *literalParser) listItem(list []interface{}, i, nestedNameLevel int) ([]
 		return setIndex(list, i, list2)
 
 	default:
-		return nil, errors.Errorf("parse error: unexpected token %v", lastRune)
+		return nil, fmt.Errorf("parse error: unexpected token %v", lastRune)
 	}
 }
 

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -18,13 +18,14 @@ package strvals
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
+	githubErrors "github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -196,7 +197,7 @@ func (t *parser) key(data map[string]interface{}, nestedNameLevel int) (reterr e
 			// We are in a list index context, so we need to set an index.
 			i, err := t.keyIndex()
 			if err != nil {
-				return errors.Wrap(err, "error parsing index")
+				return githubErrors.Wrap(err, "error parsing index")
 			}
 			kk := string(k)
 			// Find or create target list
@@ -394,7 +395,7 @@ func (t *parser) listItem(list []interface{}, i, nestedNameLevel int) ([]interfa
 		// now we have a nested list. Read the index and handle.
 		nextI, err := t.keyIndex()
 		if err != nil {
-			return list, errors.Wrap(err, "error parsing index")
+			return list, githubErrors.Wrap(err, "error parsing index")
 		}
 		var crtList []interface{}
 		if len(list) > i {

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -189,7 +189,7 @@ func (t *parser) key(data map[string]interface{}, nestedNameLevel int) (reterr e
 			if len(k) == 0 {
 				return err
 			}
-			return errors.Errorf("key %q has no value", string(k))
+			return fmt.Errorf("key %q has no value", string(k))
 			//set(data, string(k), "")
 			//return err
 		case last == '[':
@@ -261,7 +261,7 @@ func (t *parser) key(data map[string]interface{}, nestedNameLevel int) (reterr e
 		case last == ',':
 			// No value given. Set the value to empty string. Return error.
 			set(data, string(k), "")
-			return errors.Errorf("key %q has no value (cannot end with ,)", string(k))
+			return fmt.Errorf("key %q has no value (cannot end with ,)", string(k))
 		case last == '.':
 			// Check value name is within the maximum nested name level
 			nestedNameLevel++
@@ -278,7 +278,7 @@ func (t *parser) key(data map[string]interface{}, nestedNameLevel int) (reterr e
 			// Recurse
 			e := t.key(inner, nestedNameLevel)
 			if e == nil && len(inner) == 0 {
-				return errors.Errorf("key map %q has no value", string(k))
+				return fmt.Errorf("key map %q has no value", string(k))
 			}
 			if len(inner) != 0 {
 				set(data, string(k), inner)
@@ -339,7 +339,7 @@ func (t *parser) listItem(list []interface{}, i, nestedNameLevel int) ([]interfa
 	stop := runeSet([]rune{'[', '.', '='})
 	switch k, last, err := runesUntil(t.sc, stop); {
 	case len(k) > 0:
-		return list, errors.Errorf("unexpected data at end of array index: %q", k)
+		return list, fmt.Errorf("unexpected data at end of array index: %q", k)
 	case err != nil:
 		return list, err
 	case last == '=':
@@ -430,7 +430,7 @@ func (t *parser) listItem(list []interface{}, i, nestedNameLevel int) ([]interfa
 		}
 		return setIndex(list, i, inner)
 	default:
-		return nil, errors.Errorf("parse error: unexpected token %v", last)
+		return nil, fmt.Errorf("parse error: unexpected token %v", last)
 	}
 }
 

--- a/pkg/uploader/chart_uploader.go
+++ b/pkg/uploader/chart_uploader.go
@@ -20,8 +20,6 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"helm.sh/helm/v3/pkg/pusher"
 	"helm.sh/helm/v3/pkg/registry"
 )
@@ -42,7 +40,7 @@ type ChartUploader struct {
 func (c *ChartUploader) UploadTo(ref, remote string) error {
 	u, err := url.Parse(remote)
 	if err != nil {
-		return errors.Errorf("invalid chart URL format: %s", remote)
+		return fmt.Errorf("invalid chart URL format: %s", remote)
 	}
 
 	if u.Scheme == "" {

--- a/pkg/uploader/chart_uploader_test.go
+++ b/pkg/uploader/chart_uploader_test.go
@@ -1,0 +1,30 @@
+package uploader
+
+import (
+	"fmt"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/registry"
+)
+
+func TestUploadTo_InvalidFormatError(t *testing.T) {
+	c := ChartUploader{}
+	remote := "0.google.com:443/abc"
+	got := c.UploadTo("", remote).Error()
+	want := fmt.Errorf("invalid chart URL format: %s", remote).Error()
+
+	if got != want {
+		t.Errorf("expected error to be equal to %v, got %v", want, got)
+	}
+}
+
+func TestUploadTo_SchemaPrefixMissingError(t *testing.T) {
+	c := ChartUploader{}
+	remote := "www.github.com/helm/helm"
+	got := c.UploadTo("", remote).Error()
+	want := fmt.Errorf("scheme prefix missing from remote (e.g. \"%s://\")", registry.OCIScheme).Error()
+
+	if got != want {
+		t.Errorf("expected error to be equal to %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refs #11994 and removes the package `github.com/pkg/errors` from many parts of the code base, aside from the instances of `errors.Wrap`, `errors.Wrapf`, and `errors.Cause` from `github.com/pkg/errors`. I'm unsure how the Helm team might want to solve the replacement of `Wrap(f)`, so maybe we can discuss that in another issue. 

**Special notes for your reviewer**:
1. Replaced `githubErrors.Errorf` with `fmt.Errorf`
2. Replaced `githubErrors.New` with `errors.New`
3. Replaced `githubErrors.Is` with `errors.Is`


**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
