### PR TITLE
Add annotation helm delete propagation

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -224,9 +224,9 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (kube.ResourceList, stri
 	if len(resources) > 0 {
 		if kubeClient, ok := u.cfg.KubeClient.(kube.InterfaceDeletionPropagation); ok {
 			_, errs = kubeClient.DeleteWithPropagationPolicy(resources, parseCascadingFlag(u.cfg, u.DeletionPropagation))
-			return resources, kept, errs
+		} else {
+			_, errs = u.cfg.KubeClient.Delete(resources)
 		}
-		_, errs = u.cfg.KubeClient.Delete(resources)
 	}
 	return resources, kept, errs
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -31,6 +31,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -476,7 +477,20 @@ func delete(c *Client, resources ResourceList, propagation metav1.DeletionPropag
 	mtx := sync.Mutex{}
 	err := perform(resources, func(info *resource.Info) error {
 		c.Log("Starting delete for %q %s", info.Name, info.Mapping.GroupVersionKind.Kind)
-		err := deleteResource(info, propagation)
+		object, err := resource.NewHelper(info.Client, info.Mapping).WithFieldManager(getManagedFieldsManager()).Get(info.Namespace, info.Name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if object != nil {
+			annotations, err := metadataAccessor.Annotations(object)
+			if err != nil {
+				return err
+			}
+			if prop := getAnnotationDeletePropagation(annotations); prop != "" {
+				propagation = metav1.DeletionPropagation(prop)
+			}
+		}
+		err = deleteResource(info, propagation)
 		if err == nil || apierrors.IsNotFound(err) {
 			if err != nil {
 				c.Log("Ignoring delete failure for %q %s: %v", info.Name, info.Mapping.GroupVersionKind, err)
@@ -841,4 +855,20 @@ func (c *Client) WaitAndGetCompletedPodPhase(name string, timeout time.Duration)
 	}
 
 	return v1.PodUnknown, err
+}
+
+func getAnnotationDeletePropagation(annotation map[string]string) metav1.DeletionPropagation {
+	if propagation, ok := annotation[release.HookDeletePropagationAnnotation]; ok {
+		switch metav1.DeletionPropagation(propagation) {
+		case metav1.DeletePropagationBackground:
+			return metav1.DeletePropagationBackground
+		case metav1.DeletePropagationForeground:
+			return metav1.DeletePropagationForeground
+		case metav1.DeletePropagationOrphan:
+			return metav1.DeletePropagationOrphan
+		default:
+			return ""
+		}
+	}
+	return ""
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -29,9 +29,10 @@ import (
 	"sync"
 	"time"
 
+	rspb "helm.sh/helm/v3/pkg/release"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
-	"helm.sh/helm/v3/pkg/release"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -858,7 +859,7 @@ func (c *Client) WaitAndGetCompletedPodPhase(name string, timeout time.Duration)
 }
 
 func getAnnotationDeletePropagation(annotation map[string]string) metav1.DeletionPropagation {
-	if propagation, ok := annotation[release.HookDeletePropagationAnnotation]; ok {
+	if propagation, ok := annotation[rspb.HookDeletePropagationAnnotation]; ok {
 		switch metav1.DeletionPropagation(propagation) {
 		case metav1.DeletePropagationBackground:
 			return metav1.DeletePropagationBackground

--- a/pkg/release/hook.go
+++ b/pkg/release/hook.go
@@ -59,6 +59,9 @@ const HookWeightAnnotation = "helm.sh/hook-weight"
 // HookDeleteAnnotation is the label name for the delete policy for a hook
 const HookDeleteAnnotation = "helm.sh/hook-delete-policy"
 
+// HookDeletePropagationAnnotation is the label name for the delete propagation policy for a hook
+const HookDeletePropagationAnnotation = "helm.sh/hook-delete-propagation-policy"
+
 // Hook defines a hook object.
 type Hook struct {
 	Name string `json:"name,omitempty"`

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package release
+package release // import "helm.sh/helm/v3/pkg/release"
 
 import "helm.sh/helm/v3/pkg/chart"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a feature to read the annotations helm.sh/hook-delete-propagation-policy . I think this will be necessary when the delete resource runs every time the hooks function runs and it may help to customize the propagation policy for each resource while deleting (#12082)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
