### PR TITLE
Get the logs from a specified container for helm test

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
@@ -124,13 +125,24 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 				if len(r.Filters[IncludeNameFilter]) > 0 && !contains(r.Filters[IncludeNameFilter], h.Name) {
 					continue
 				}
-				req := client.CoreV1().Pods(r.Namespace).GetLogs(h.Name, &v1.PodLogOptions{})
+
+				podLogOptions := &v1.PodLogOptions{}
+
+				pod, err := client.CoreV1().Pods(r.Namespace).Get(context.Background(), h.Name, metav1.GetOptions{})
+				if container, ok := pod.Annotations["helm.sh/hook-logs-container"]; ok {
+					podLogOptions.Container = container
+				}
+
+				req := client.CoreV1().Pods(r.Namespace).GetLogs(h.Name, podLogOptions)
 				logReader, err := req.Stream(context.Background())
 				if err != nil {
 					return errors.Wrapf(err, "unable to get pod logs for %s", h.Name)
 				}
 
 				fmt.Fprintf(out, "POD LOGS: %s\n", h.Name)
+				if len(podLogOptions.Container) > 0 {
+					fmt.Fprintf(out, "CONTAINER: %s\n", podLogOptions.Container)
+				}
 				_, err = io.Copy(out, logReader)
 				fmt.Fprintln(out)
 				if err != nil {

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -129,6 +129,10 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 				podLogOptions := &v1.PodLogOptions{}
 
 				pod, err := client.CoreV1().Pods(r.Namespace).Get(context.Background(), h.Name, metav1.GetOptions{})
+				if err != nil {
+					return errors.Wrapf(err, "unable to get pod info for %s", h.Name)
+				}
+
 				if container, ok := pod.Annotations["helm.sh/hook-logs-container"]; ok {
 					podLogOptions.Container = container
 				}

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -133,7 +133,7 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 					return errors.Wrapf(err, "unable to get pod info for %s", h.Name)
 				}
 
-				if container, ok := pod.Annotations["helm.sh/hook-logs-container"]; ok {
+				if container, ok := pod.Annotations["kubectl.kubernetes.io/default-container"]; ok {
 					podLogOptions.Container = container
 				}
 


### PR DESCRIPTION
Obtain the logs for the specified container to avoid scenarios where the logs cannot be obtained because a sidecar exists.

Fixes #9995 

**What this PR does / why we need it**:

Currently only test hooks with a single container can have their logs obtained correctly. This PR allows specifying the container name for which to fetch logs while retaining the current behavior for backwards compatibility. 

**Special notes for your reviewer**:
The documentation will need to be updated to include this new annotation. 
