### PR TITLE
Support for using custom template functions when helm is used as a library

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -44,6 +44,11 @@ type Engine struct {
 	config *rest.Config
 	// EnableDNS tells the engine to allow DNS lookups when rendering templates
 	EnableDNS bool
+	// WithCustomFuncs allows you to provide a template.FuncMap containing custom template functions to be added or
+	// overridden. It is typically used as a configuration option to extend the default set of template functions with
+	// custom ones. The provided template.FuncMap can extend the default template functions, and the resulting
+	// FuncMap is used by the template engine.
+	WithCustomFuncs func(funcs template.FuncMap) template.FuncMap
 }
 
 // New creates a new instance of Engine using the passed in rest config.
@@ -204,6 +209,10 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 		funcMap["getHostByName"] = func(name string) string {
 			return ""
 		}
+	}
+
+	if e.WithCustomFuncs != nil {
+		funcMap = e.WithCustomFuncs(funcMap)
 	}
 
 	t.Funcs(funcMap)


### PR DESCRIPTION
**What this PR does / why we need it**:

#### Changes Made
- Added new engine config param `WithCustomFuncs` to the Engine package.

#### Motivation

Helm is widely used as a package manager for Kubernetes, but it can also be leveraged as a library for programmatic use. This PR aims to enhance Helm's flexibility by enabling users to define and configure their own custom template functions when using Helm programmatically.

#### Usage Example

```go
e := Engine{
        WithCustomFuncs: func(funcs template.FuncMap) template.FuncMap {
            // Add custom template functions
            funcs["myFunc"] = myFunc,
            // Add other custom functions as needed
            return funcs
        },
    }
```

**If applicable**:
- [x] this PR contains unit tests