### PR TITLE
Add json support for index.yaml file #10542

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -52,6 +52,8 @@ var (
 	ErrNoChartName = errors.New("no chart name found")
 	// ErrEmptyIndexYaml indicates that the content of index.yaml is empty.
 	ErrEmptyIndexYaml = errors.New("empty index.yaml file")
+	// ErrEmptyIndexJson indicates that the content of index.json is empty.
+	ErrEmptyIndexJson = errors.New("empty index.json file")
 )
 
 // ChartVersions is a list of versioned chart references.
@@ -332,14 +334,18 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 // This will fail if API Version is not set (ErrNoAPIVersion) or if the unmarshal fails.
 func loadIndex(data []byte, source string) (*IndexFile, error) {
 	i := &IndexFile{}
+	isjson := strings.HasSuffix(source, ".json")
 
 	// TODO : add error for empty json
 	if len(data) == 0 {
-		return i, ErrEmptyIndexYaml
+		if isjson {
+			return i, ErrEmptyIndexJson
+		} else {
+			return i, ErrEmptyIndexYaml
+		}
 	}
 
-	// TODO : check file type, if json, unmarshal with json.
-	if strings.HasSuffix(source, ".json") {
+	if isjson {
 		if err := json.Unmarshal(data, i); err != nil {
 			return i, err
 		}

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -334,7 +334,10 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 // This will fail if API Version is not set (ErrNoAPIVersion) or if the unmarshal fails.
 func loadIndex(data []byte, source string) (*IndexFile, error) {
 	i := &IndexFile{}
-	isjson := strings.HasSuffix(source, ".json")
+	var isJSON bool
+	if fileExt := filepath.Ext(source); fileExt == ".json" {
+		isJSON = true
+	}
 
 	// TODO : add error for empty json
 	if len(data) == 0 {

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -18,6 +18,7 @@ package repo
 
 import (
 	"bytes"
+	"encoding/json"
 	"log"
 	"os"
 	"path"
@@ -332,12 +333,20 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 func loadIndex(data []byte, source string) (*IndexFile, error) {
 	i := &IndexFile{}
 
+	// TODO : add error for empty json
 	if len(data) == 0 {
 		return i, ErrEmptyIndexYaml
 	}
 
-	if err := yaml.UnmarshalStrict(data, i); err != nil {
-		return i, err
+	// TODO : check file type, if json, unmarshal with json.
+	if strings.HasSuffix(source, ".json") {
+		if err := json.Unmarshal(data, i); err != nil {
+			return i, err
+		}
+	} else {
+		if err := yaml.UnmarshalStrict(data, i); err != nil {
+			return i, err
+		}
 	}
 
 	for name, cvs := range i.Entries {

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	testfile            = "testdata/local-index.yaml"
+	jsontestfile        = "testdata/local-index-json.json"
 	annotationstestfile = "testdata/local-index-annotations.yaml"
 	chartmuseumtestfile = "testdata/chartmuseum-index.yaml"
 	unorderedTestfile   = "testdata/local-index-unordered.yaml"
@@ -144,6 +145,10 @@ func TestLoadIndex(t *testing.T) {
 		{
 			Name:     "chartmuseum index file",
 			Filename: chartmuseumtestfile,
+		},
+		{
+			Name:     "json index file",
+			Filename: jsontestfile,
 		},
 	}
 

--- a/pkg/repo/testdata/local-index-json.json
+++ b/pkg/repo/testdata/local-index-json.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion": "v1",
+  "entries": {
+      "nginx": [
+          {
+              "urls": [
+                  "https://charts.helm.sh/stable/nginx-0.2.0.tgz"
+              ],
+              "name": "nginx",
+              "description": "string",
+              "version": "0.2.0",
+              "home": "https://github.com/something/else",
+              "digest": "sha256:1234567890abcdef",
+              "keywords": [
+                  "popular",
+                  "web server",
+                  "proxy"
+              ],
+              "apiVersion": "v2"
+          },
+          {
+              "urls": [
+                  "https://charts.helm.sh/stable/nginx-0.1.0.tgz"
+              ],
+              "name": "nginx",
+              "description": "string",
+              "version": "0.1.0",
+              "home": "https://github.com/something",
+              "digest": "sha256:1234567890abcdef",
+              "keywords": [
+                  "popular",
+                  "web server",
+                  "proxy"
+              ],
+              "apiVersion": "v2"
+          }
+      ],
+      "alpine": [
+          {
+              "urls": [
+                  "https://charts.helm.sh/stable/alpine-1.0.0.tgz",
+                  "http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz"
+              ],
+              "name": "alpine",
+              "description": "string",
+              "version": "1.0.0",
+              "home": "https://github.com/something",
+              "keywords": [
+                  "linux",
+                  "alpine",
+                  "small",
+                  "sumtin"
+              ],
+              "digest": "sha256:1234567890abcdef",
+              "apiVersion": "v2"
+          }
+      ],
+      "chartWithNoURL": [
+          {
+              "name": "chartWithNoURL",
+              "description": "string",
+              "version": "1.0.0",
+              "home": "https://github.com/something",
+              "keywords": [
+                  "small",
+                  "sumtin"
+              ],
+              "digest": "sha256:1234567890abcdef",
+              "apiVersion": "v2"
+          }
+      ]
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

This is a fix to solve Issue 10542. Resolves https://github.com/helm/helm/issues/10542. With these changes one can use json formatted index file instead of yaml. the code now looks for index.json file as default and switches to index.yaml if not found. 