### PR TITLE
Only show CRDs for subcharts that are enabled in values

### DIFF
--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -137,6 +137,10 @@ func (s *Show) Run(chartpath string) (string, error) {
 	}
 
 	if s.OutputFormat == ShowCRDs || s.OutputFormat == ShowAll {
+		if err := chartutil.ProcessDependencies(s.chart, s.chart.Values); err != nil {
+			return "", errors.Wrap(err, "error processing chart dependencies")
+		}
+
 		crds := s.chart.CRDObjects()
 		if len(crds) > 0 {
 			if s.OutputFormat == ShowAll && !bytes.HasPrefix(crds[0].File.Data, []byte("---")) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Process chart dependencies (as done in Install process) and only show CRDs that would be included by default.

closes #11852

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
