### PR TITLE
Do not validate metadata.name for List kind

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -261,7 +261,7 @@ func validateMetadataNameFunc(obj *K8sYamlStruct) validation.ValidateNameFunc {
 		return validation.ValidateNamespaceName
 	case "serviceaccount":
 		return validation.ValidateServiceAccountName
-	case "certificatesigningrequest":
+	case "certificatesigningrequest", "list":
 		// No validation.
 		// https://github.com/kubernetes/kubernetes/blob/v1.20.0/pkg/apis/certificates/validation/validation.go#L137-L140
 		return func(name string, prefix bool) []string { return nil }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix false-positive linter warning about missing metadata.name for List kind.

**Special notes for your reviewer**:
https://github.com/kubernetes/kubectl/issues/837#issuecomment-1342986901
https://github.com/helm/helm/issues/8439#issuecomment-1068979423

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
