### PR TITLE
Feat: Add Log Sanitization for Secret Kind in 'Helm Upgrade' Command

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -687,12 +687,56 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		c.Log("Patch %s %q in namespace %s", kind, target.Name, target.Namespace)
 		obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
 		if err != nil {
-			return errors.Wrapf(err, "cannot patch %q with kind %s", target.Name, kind)
+			sanitizeLog := err.Error()
+			if kind == "Secret" {
+				sanitizeLog = desensitizeLog(err.Error())
+			}
+			return errors.Wrapf(errors.New(sanitizeLog), "cannot patch %q with kind %s", target.Name, kind)
 		}
 	}
 
 	target.Refresh(obj, true)
 	return nil
+}
+
+// desensitizeLog replaces the data in a Secret with {"key": "***"}.
+// e.g. "data": {"username": "admin", "password": "password"} becomes "data": {"username": "***", "password": "***"}
+func desensitizeLog(log string) string {
+	start := strings.Index(log, `{\"apiVersion`)
+	end := strings.Index(log, `,\"kind\":\"Secret\"`)
+	if start == -1 || end == -1 {
+		return log
+	}
+
+	// Extract the JSON string and add a } at the end
+	jsonStr := log[start:end] + "}"
+	jsonStr = strings.ReplaceAll(jsonStr, "\\\"", "\"")
+
+	// Parse the JSON string into a map
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(jsonStr), &data)
+	if err != nil {
+		return log
+	}
+
+	// Desensitize the values in the data map
+	if dataMap, ok := data["data"].(map[string]interface{}); ok {
+		for k := range dataMap {
+			dataMap[k] = "***"
+		}
+	}
+
+	// Convert the map back to JSON string
+	newJsonStr, err := json.Marshal(data)
+	if err != nil {
+		return log
+	}
+
+	// Replace the original JSON string with the new one in the log
+	newJsonStr = []byte(strings.ReplaceAll(string(newJsonStr), "\"", "\\\""))
+	newLog := log[:start] + string(newJsonStr[:len(newJsonStr)-1]) + log[end:]
+
+	return newLog
 }
 
 func (c *Client) watchUntilReady(timeout time.Duration, info *resource.Info) error {

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -558,3 +558,19 @@ spec:
         ports:
         - containerPort: 80
 `
+
+func TestDesensitizeLog(t *testing.T) {
+	log := `Error: UPGRADE FAILED: cannot patch "mysecret" with kind Secret:  "" is invalid: patch: Invalid value: "{\"apiVersion\":\"v1\",\"data\":{\"mykey1\":\"hello\", \"mykey2\":\"world\"},\"kind\":\"Secret\",\"metadata\"……,\"type\":\"Opaque\"}": illegal base64 data at input byte 12`
+	expected1 := `\"mykey1\":\"***\"`
+	expected2 := `\"mykey2\":\"***\"`
+
+	result := desensitizeLog(log)
+
+	if !strings.Contains(result, expected1) {
+		t.Errorf("Expected %s to contain %s", result, expected1)
+	}
+
+	if !strings.Contains(result, expected2) {
+		t.Errorf("Expected %s to contain %s", result, expected2)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

fix #12176 #11727

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

I have thoroughly tested it locally and have written corresponding unit tests. Please take a review at this pr.

## How to Test This Modification Locally

1. Create a `secret.yaml`

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: {{ .Release.Name }}-secret
type: Opaque
data:
  secretKey: {{ .Values.secret.secretKey }}
```

2. Set secretKey in `values.yaml`

```yaml
secret:
  secretKey: "SGVsbG8gd29ybGQ="  # This is "Hello world" in base64
  # secretKey: "hello"  # This is invalid base64 string
```

3. Execute `helm install test-release .`

4. Update `values.yaml`

```yaml
secret:
  # secretKey: "SGVsbG8gd29ybGQ="  # This is "Hello world" in base64
  secretKey: "hello"  # This is invalid base64 string
```

5. Execute `helm upgrade test-release .` before changing the code

```bash
$ helm upgrade test-release .
Error: UPGRADE FAILED: cannot patch "test-release-secret" with kind Secret:  "" is invalid: patch: Invalid value: "{\"apiVersion\":\"v1\",\"data\":{\"secretKey\":\"hello\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"meta.helm.sh/release-name\":\"test-release\",\"meta.helm.sh/release-namespace\":\"default\"},\"creationTimestamp\":\"2023-07-04T06:51:10Z\",\"labels\":{\"app.kubernetes.io/managed-by\":\"Helm\"},\"managedFields\":[{\"manager\":\"helm\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-07-04T06:51:10Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:data\":{\".\":{},\"f:secretKey\":{}},\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:meta.helm.sh/release-name\":{},\"f:meta.helm.sh/release-namespace\":{}},\"f:labels\":{\".\":{},\"f:app.kubernetes.io/managed-by\":{}}},\"f:type\":{}}}],\"name\":\"test-release-secret\",\"namespace\":\"default\",\"resourceVersion\":\"4030333\",\"uid\":\"b2faa643-1711-4bc3-9219-c1f8a32306be\"},\"type\":\"Opaque\"}": illegal base64 data at input byte 4
```

Pay attention to `{\"secretKey\":\"hello\"}`

6. Execute `helm upgrade test-release .` after changing the Code

```bash
$ ./helm upgrade test-release /Users/danielhu/Work/test/test-chart
Error: UPGRADE FAILED: cannot patch "test-release-secret" with kind Secret:  "" is invalid: patch: Invalid value: "{\"apiVersion\":\"v1\",\"data\":{\"secretKey\":\"***\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"meta.helm.sh/release-name\":\"test-release\",\"meta.helm.sh/release-namespace\":\"default\"},\"creationTimestamp\":\"2023-07-04T13:42:20Z\",\"labels\":{\"app.kubernetes.io/managed-by\":\"Helm\"},\"managedFields\":[{\"manager\":\"helm\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-07-04T13:42:20Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:data\":{\".\":{},\"f:secretKey\":{}},\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:meta.helm.sh/release-name\":{},\"f:meta.helm.sh/release-namespace\":{}},\"f:labels\":{\".\":{},\"f:app.kubernetes.io/managed-by\":{}}},\"f:type\":{}}}],\"name\":\"test-release-secret\",\"namespace\":\"default\",\"resourceVersion\":\"4119312\",\"uid\":\"c90737ad-58c8-4c0e-aadf-b0f4dd4c85f8\"},\"type\":\"Opaque\"}": illegal base64 data at input byte 4
```

Pay attention to `{\"secretKey\":\"***\"}`