### PR TITLE
fix: ignore error when command don't need registry client.

### DIFF
--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -87,6 +87,9 @@ By default, the default directories depend on the Operating System. The defaults
 | Windows          | %TEMP%\helm               | %APPDATA%\helm                 | %APPDATA%\helm          |
 `
 
+// CMDNeedRegistryClient Any new command need RegistryClient should be added to this list.
+var CMDNeedRegistryClient = []string{"show", "template", "install", "upgrade", "pull", "registry", "dependency", "dep", "push", "package"}
+
 func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:          "helm",
@@ -155,7 +158,13 @@ func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string
 
 	registryClient, err := newDefaultRegistryClient(false)
 	if err != nil {
-		return nil, err
+		// see issues #11009
+		debug("generate registry client failed: %v", err.Error())
+		for i := 0; len(args) > 0 && i < len(CMDNeedRegistryClient); i++ {
+			if CMDNeedRegistryClient[i] == args[0] {
+				return nil, err
+			}
+		}
 	}
 	actionConfig.RegistryClient = registryClient
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Fix: #11009
**Special notes for your reviewer**:
I try my best to search all sub command which will use `RegistryClient`, If there are any omissions，please let me know :)
- show
- template
- install
- upgrade
- pull
- registry
- dependency
- dep
- push
- package

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility