### PR TITLE
chore: remove unuse untar option

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -35,7 +35,6 @@ type options struct {
 	certFile              string
 	keyFile               string
 	caFile                string
-	unTar                 bool
 	insecureSkipVerifyTLS bool
 	username              string
 	password              string
@@ -112,12 +111,6 @@ func WithTagName(tagname string) Option {
 func WithRegistryClient(client *registry.Client) Option {
 	return func(opts *options) {
 		opts.registryClient = client
-	}
-}
-
-func WithUntar() Option {
-	return func(opts *options) {
-		opts.unTar = true
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
[`getter.options`](https://github.com/helm/helm/blob/14d363669f8cc257f0413995d42237e673422d81/pkg/getter/getter.go#L33) has parameters [`untar`](https://github.com/helm/helm/blob/14d363669f8cc257f0413995d42237e673422d81/pkg/getter/getter.go#L38) and its setting function [`WithUntar()`]( https://github.com/helm/helm/blob/14d363669f8cc257f0413995d42237e673422d81/pkg/getter/getter.go#L118C6-L118C15).
But it's not used anywhere, not even in the tests.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
