### PR TITLE
chore: HTTPGetter add default timeout

### DIFF
--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -172,9 +172,21 @@ func (p Providers) ByScheme(scheme string) (Getter, error) {
 	return nil, errors.Errorf("scheme %q not supported", scheme)
 }
 
+const (
+	// The cost timeout references curl's default connection timeout.
+	// https://github.com/curl/curl/blob/master/lib/connect.h#L40C21-L40C21
+	// The helm commands are usually executed manually. Considering the acceptable waiting time, we reduced the entire request time to 120s.
+	DefaultHTTPTimeout = 120
+)
+
+var defaultOptions = []Option{WithTimeout(time.Second * DefaultHTTPTimeout)}
+
 var httpProvider = Provider{
 	Schemes: []string{"http", "https"},
-	New:     NewHTTPGetter,
+	New: func(options ...Option) (Getter, error) {
+		options = append(options, defaultOptions...)
+		return NewHTTPGetter(options...)
+	},
 }
 
 var ociProvider = Provider{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The timeout for http requests should be added when adding or updating a repo. By default there is no timeout limit. 

Or Maybe need to add a timeout parameter to `repo add` and `repo update`?


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
