### PR TITLE
Default timeout for kube.waiter

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -47,6 +47,11 @@ type waiter struct {
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
 
+	// Set a default timeout of 5 minutes
+	if w.timeout == 0 {
+		w.timeout = time.Minute * 5
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 
@@ -64,6 +69,11 @@ func (w *waiter) waitForResources(created ResourceList) error {
 // waitForDeletedResources polls to check if all the resources are deleted or a timeout is reached
 func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
 	w.log("beginning wait for %d resources to be deleted with timeout of %v", len(deleted), w.timeout)
+
+	// Set a default timeout of 5 minutes
+	if w.timeout == 0 {
+		w.timeout = time.Minute * 5
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently, if a timeout is not provided for `action.(Install|Upgrade|Uninstall|Rollback)` and `.Wait` or `.Atomic` is also set the nil value(0) for `.Timeout` will be set.  I don't see any reason for setting `.Wait` or `.Atomic` while also setting `.Timeout` to 0.  This is either done in error/misunderstanding or leaving `.Timeout` unset.  This change will pull the behavior for the Go package more in line with the command line implementation and provide a more consistent feel between the two.

Alternatively, if `.Timeout` is set to 0 or left unset it may be wise to reject it.  I fell victim to this situation and took me more time than I'd like to admit to figure out the problem 😅.  It would have been good to know, at the very least, I'm required to set a `.Timeout` for the action if also setting `.Atomic` or `.Wait`.  It was very confusing coming from using the command line implementation where a default is set.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #9761 