### PR TITLE
fix: output warning message when pass-credentials are overwritten

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -233,6 +233,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 			c.Options = append(c.Options, getter.WithTLSClientConfig(rc.CertFile, rc.KeyFile, rc.CAFile))
 		}
 		if rc.Username != "" && rc.Password != "" {
+			fmt.Fprintf(c.Out, "WARNING: find the same URL repo with a configured password will override the pass-credentials parameter with PassCredentialsAll: %v.", rc.PassCredentialsAll)
 			c.Options = append(
 				c.Options,
 				getter.WithBasicAuth(rc.Username, rc.Password),
@@ -270,6 +271,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 			c.Options = append(c.Options, getter.WithTLSClientConfig(r.Config.CertFile, r.Config.KeyFile, r.Config.CAFile))
 		}
 		if r.Config.Username != "" && r.Config.Password != "" {
+			fmt.Fprintf(c.Out, "WARNING: find the same name repo with a configured password will override the pass-credentials parameter with PassCredentialsAll: %v.", r.Config.PassCredentialsAll)
 			c.Options = append(c.Options,
 				getter.WithBasicAuth(r.Config.Username, r.Config.Password),
 				getter.WithPassCredentialsAll(r.Config.PassCredentialsAll),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix:  https://github.com/helm/helm/issues/12117

The current implementation is to put the parameters of repositories.yaml after the list, which will cause the user and password to be overwritten even if we set them.
So, we put the contents of repositories.yaml at the front of the list.

**Special notes for your reviewer**:
@joejulian 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
