### PR TITLE
Add support for creating repository indexes in JSON format

### DIFF
--- a/cmd/helm/repo_index_test.go
+++ b/cmd/helm/repo_index_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -66,6 +67,28 @@ func TestRepoIndexCmd(t *testing.T) {
 	expectedVersion := "0.2.0"
 	if vs[0].Version != expectedVersion {
 		t.Errorf("expected %q, got %q", expectedVersion, vs[0].Version)
+	}
+
+	b, err := os.ReadFile(destIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if json.Valid(b) {
+		t.Error("did not expect index file to be valid json")
+	}
+
+	// Test with `--json`
+
+	c.ParseFlags([]string{"--json", "true"})
+	if err := c.RunE(c, []string{dir}); err != nil {
+		t.Error(err)
+	}
+
+	if b, err = os.ReadFile(destIndex); err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(b) {
+		t.Error("index file is not valid json")
 	}
 
 	// Test with `--merge`

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -233,6 +233,18 @@ func (i IndexFile) WriteFile(dest string, mode os.FileMode) error {
 	return fileutil.AtomicWriteFile(dest, bytes.NewReader(b), mode)
 }
 
+// WriteJSONFile writes an index file in JSON format to the given destination
+// path.
+//
+// The mode on the file is set to 'mode'.
+func (i IndexFile) WriteJSONFile(dest string, mode os.FileMode) error {
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(dest, bytes.NewReader(b), mode)
+}
+
 // Merge merges the given index file into this index.
 //
 // This merges by name and version.

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -37,6 +37,7 @@ const (
 	annotationstestfile = "testdata/local-index-annotations.yaml"
 	chartmuseumtestfile = "testdata/chartmuseum-index.yaml"
 	unorderedTestfile   = "testdata/local-index-unordered.yaml"
+	jsonTestfile        = "testdata/local-index.json"
 	testRepo            = "test-repo"
 	indexWithDuplicates = `
 apiVersion: v1
@@ -144,6 +145,10 @@ func TestLoadIndex(t *testing.T) {
 		{
 			Name:     "chartmuseum index file",
 			Filename: chartmuseumtestfile,
+		},
+		{
+			Name:     "JSON index file",
+			Filename: jsonTestfile,
 		},
 	}
 

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -19,6 +19,7 @@ package repo
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -547,6 +548,27 @@ func TestIndexWrite(t *testing.T) {
 	got, err := os.ReadFile(testpath)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "clipper-0.1.0.tgz") {
+		t.Fatal("Index files doesn't contain expected content")
+	}
+}
+
+func TestIndexJSONWrite(t *testing.T) {
+	i := NewIndexFile()
+	if err := i.MustAdd(&chart.Metadata{APIVersion: "v2", Name: "clipper", Version: "0.1.0"}, "clipper-0.1.0.tgz", "http://example.com/charts", "sha256:1234567890"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	dir := t.TempDir()
+	testpath := filepath.Join(dir, "test")
+	i.WriteJSONFile(testpath, 0600)
+
+	got, err := os.ReadFile(testpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(got) {
+		t.Fatal("Index files doesn't contain valid JSON")
 	}
 	if !strings.Contains(string(got), "clipper-0.1.0.tgz") {
 		t.Fatal("Index files doesn't contain expected content")

--- a/pkg/repo/testdata/local-index.json
+++ b/pkg/repo/testdata/local-index.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "v1",
+  "entries": {
+    "nginx": [
+      {
+        "urls": ["https://charts.helm.sh/stable/nginx-0.2.0.tgz"],
+        "name": "nginx",
+        "description": "string",
+        "version": "0.2.0",
+        "home": "https://github.com/something/else",
+        "digest": "sha256:1234567890abcdef",
+        "keywords": ["popular", "web server", "proxy"],
+        "apiVersion": "v2"
+      },
+      {
+        "urls": ["https://charts.helm.sh/stable/nginx-0.1.0.tgz"],
+        "name": "nginx",
+        "description": "string",
+        "version": "0.1.0",
+        "home": "https://github.com/something",
+        "digest": "sha256:1234567890abcdef",
+        "keywords": ["popular", "web server", "proxy"],
+        "apiVersion": "v2"
+      }
+    ],
+    "alpine": [
+      {
+        "urls": [
+          "https://charts.helm.sh/stable/alpine-1.0.0.tgz",
+          "http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz"
+        ],
+        "name": "alpine",
+        "description": "string",
+        "version": "1.0.0",
+        "home": "https://github.com/something",
+        "keywords": ["linux", "alpine", "small", "sumtin"],
+        "digest": "sha256:1234567890abcdef",
+        "apiVersion": "v2"
+      }
+    ],
+    "chartWithNoURL": [
+      {
+        "name": "chartWithNoURL",
+        "description": "string",
+        "version": "1.0.0",
+        "home": "https://github.com/something",
+        "keywords": ["small", "sumtin"],
+        "digest": "sha256:1234567890abcdef",
+        "apiVersion": "v2"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for creating an `index.yaml` in JSON format using `helm repo index [...] --json`.

Fixes #10542
Supersedes #12151

**Special notes for your reviewer**:

Given that it does not create unnecessary HTTP requests to discover `index.json` and/or `index.yaml` files hosted by a repository server, nor requires rigorous changes to the caching logic, and is fully backwards compatible due to YAML being a superset of JSON. This appears to be the least invasive way to add support for the JSON format.

Benchmark using Bitnami's infamous ["full index" archive](https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami/index.yaml):

```console
$  benchstat old.txt new.txt                                  
goos: linux
goarch: amd64
pkg: helm.sh/helm/v3/pkg/repo
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
                      │   old.txt    │               new.txt               │
                      │    sec/op    │   sec/op     vs base                │
LoadIndexFile/YAML-12     2.692 ± 1%    2.770 ± 3%        ~ (p=0.242 n=20)
LoadIndexFile/JSON-12   2318.3m ± 0%   582.6m ± 1%  -74.87% (p=0.000 n=20)
geomean                   2.498         1.270       -49.15%

                      │    old.txt    │               new.txt                │
                      │     B/op      │     B/op      vs base                │
LoadIndexFile/YAML-12    836.0Mi ± 0%   836.0Mi ± 0%        ~ (p=0.355 n=20)
LoadIndexFile/JSON-12   671.99Mi ± 0%   93.84Mi ± 0%  -86.03% (p=0.000 n=20)
geomean                  749.5Mi        280.1Mi       -62.63%

                      │   old.txt    │               new.txt               │
                      │  allocs/op   │  allocs/op   vs base                │
LoadIndexFile/YAML-12    12.03M ± 0%   12.03M ± 0%        ~ (p=0.683 n=20)
LoadIndexFile/JSON-12   10.015M ± 0%   1.078M ± 0%  -89.23% (p=0.000 n=20)
geomean                  10.98M        3.601M       -67.19%
```

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility