### PR TITLE
fix(helm): do not use local chart if --repo is provided

### DIFF
--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -63,6 +63,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 	f.BoolVar(&c.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
 	f.StringVar(&c.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 	f.BoolVar(&c.PassCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+	f.BoolVar(&c.RemoteRepo, "remote-repo", false, "force use of chart from remote repository instead of local filesystem")
 }
 
 // bindOutputFlag will add the output flag to the given command and bind the

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -252,6 +252,17 @@ func TestInstall(t *testing.T) {
 			cmd:    fmt.Sprintf("install aeneas test/reqtest --username username --password password --repository-config %s --repository-cache %s", repoFile, srv.Root()),
 			golden: "output/install.txt",
 		},
+		// Verify that a remote chart is used with --remote-repo
+		{
+			name:   "basic install with --remote-repo",
+			cmd:    "install aeneas reqtest --namespace default --repo " + srv.URL() + " --username username --password password --remote-repo",
+			golden: "output/install.txt",
+		},
+		{
+			name:      "existing local path with --remote-repo",
+			cmd:       "install aeneas testdata/testcharts/empty --namespace default --repo " + srv.URL() + " --username username --password password --remote-repo",
+			wantError: true,
+		},
 	}
 
 	runTestCmd(t, tests)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
If `--repo` is passed to `helm install` or `helm upgrade`, Helm will currently prefer a local directory with the name of the chart instead of the chart from the provided repository. This PR changes this behaviour such that the local filesystem is not checked when `--repo` is provided.

Fixes #11141

**Special notes for your reviewer**:
I considered keeping the current behaviour if the name is an absolute or relative path (i.e. it starts with `/` or `.`), but it doesn't seem correct to use a local chart if `--repo` is passed.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
