### PR TITLE
Fix bug with multi depth dependency aliases

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -120,6 +120,13 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 		md := *c.Metadata
 		out.Metadata = &md
 
+		deps := []*chart.Dependency{}
+		for _, d := range out.Metadata.Dependencies {
+			dc := *d
+			deps = append(deps, &dc)
+		}
+		out.Metadata.Dependencies = deps
+
 		if dep.Alias != "" {
 			md.Name = dep.Alias
 		}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -502,3 +502,37 @@ func TestDependentChartsWithSomeSubchartsSpecifiedInDependency(t *testing.T) {
 		t.Fatalf("expected 1 dependency specified in Chart.yaml, got %d", len(c.Metadata.Dependencies))
 	}
 }
+
+func TestMultiLevelDependentChartsWithMultipleAliases(t *testing.T) {
+	c1 := loadChart(t, "testdata/three-level-dependent-chart-multi-alias/chart1")
+
+	if err := processDependencyEnabled(c1, c1.Values, ""); err != nil {
+		t.Fatalf("expected no errors but got %q", err)
+	}
+
+	if len(c1.Dependencies()) != 2 {
+		t.Fatalf("expected 2 dependencies for chart1, but got %d", len(c1.Dependencies()))
+	}
+
+	c1DepA := c1.Dependencies()[0]
+	if c1DepA.Metadata.Name != "2a" {
+		t.Fatalf("expected chart1's first dependency name to be 2a, but got %s", c1DepA.Metadata.Name)
+	}
+
+	c1DepB := c1.Dependencies()[1]
+	if c1DepB.Metadata.Name != "2b" {
+		t.Fatalf("expected chart1's second dependency name to be 2b, but got %s", c1DepB.Metadata.Name)
+	}
+
+	for _, c2 := range c1.Dependencies() {
+		c2DepA := c2.Dependencies()[0]
+		if c2DepA.Metadata.Name != "3a" {
+			t.Fatalf("expected chart2's first dependency name to be 3a, but got %s", c2DepA.Metadata.Name)
+		}
+
+		c2DepB := c2.Dependencies()[1]
+		if c2DepB.Metadata.Name != "3b" {
+			t.Fatalf("expected chart2's second dependency name to be 3b, but got %s", c2DepB.Metadata.Name)
+		}
+	}
+}

--- a/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: chart1
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+
+dependencies:
+- name: chart2
+  version: 0.1.0
+  alias: 2a
+- name: chart2
+  version: 0.1.0
+  alias: 2b

--- a/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: chart2
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+
+dependencies:
+- name: chart3
+  version: 0.1.0
+  alias: 3a
+- name: chart3
+  version: 0.1.0
+  alias: 3b

--- a/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/charts/chart3/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/charts/chart3/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: chart3
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/charts/chart3/templates/configmap.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart-multi-alias/chart1/charts/chart2/charts/chart3/templates/configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+data: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #11484

When chart A has 2 aliased dependencies on subchart B, which in turn has aliased dependencies on subchart C, the alias resolution breaks. This is due to the way the dependency resolver reassigns `Name` from `Alias` on the parent chart's `Dependencies` objects, which results in an unintended mutation of a shared object. 

This fixes the issue by cloning `Dependency` objects (as is already done with the chart itself and its `Metadata`) when the chart is resolved by alias.

**Special notes for your reviewer**:

**If applicable**:
- [ ] ~~this PR contains documentation~~
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
