### PR TITLE
Support Helm release data stored in multiple K8s Secrets

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -381,6 +381,10 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 
 	var store *storage.Storage
 	switch helmDriver {
+	case "multisecret", "multisecrets":
+		d := driver.NewMultiSecrets(newMultiSecretClient(lazyClient))
+		d.Log = log
+		store = storage.Init(d)
 	case "secret", "secrets", "":
 		d := driver.NewSecrets(newSecretClient(lazyClient))
 		d.Log = log

--- a/pkg/action/lazyclient.go
+++ b/pkg/action/lazyclient.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"sync"
 
-	"helm.sh/helm/v3/pkg/storage/driver"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +27,8 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 // lazyClient is a workaround to deal with Kubernetes having an unstable client API.

--- a/pkg/action/lazyclient.go
+++ b/pkg/action/lazyclient.go
@@ -52,6 +52,78 @@ func (s *lazyClient) init() error {
 	return s.clientErr
 }
 
+// multiSecretClient implements a corev1.SecretsInterface
+type multiSecretClient struct{ *lazyClient }
+
+var _ corev1.SecretInterface = (*multiSecretClient)(nil)
+
+func newMultiSecretClient(lc *lazyClient) *multiSecretClient {
+	return &multiSecretClient{lazyClient: lc}
+}
+
+func (s *multiSecretClient) Create(ctx context.Context, secret *v1.Secret, opts metav1.CreateOptions) (result *v1.Secret, err error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, opts)
+}
+
+func (s *multiSecretClient) Update(ctx context.Context, secret *v1.Secret, opts metav1.UpdateOptions) (*v1.Secret, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, opts)
+}
+
+func (s *multiSecretClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	if err := s.init(); err != nil {
+		return err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Delete(ctx, name, opts)
+}
+
+func (s *multiSecretClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	if err := s.init(); err != nil {
+		return err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).DeleteCollection(ctx, opts, listOpts)
+}
+
+func (s *multiSecretClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Secret, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Get(ctx, name, opts)
+}
+
+func (s *multiSecretClient) List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).List(ctx, opts)
+}
+
+func (s *multiSecretClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Watch(ctx, opts)
+}
+
+func (s *multiSecretClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*v1.Secret, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Patch(ctx, name, pt, data, opts, subresources...)
+}
+
+func (s *multiSecretClient) Apply(ctx context.Context, secretConfiguration *applycorev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (*v1.Secret, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s.client.CoreV1().Secrets(s.namespace).Apply(ctx, secretConfiguration, opts)
+}
+
 // secretClient implements a corev1.SecretsInterface
 type secretClient struct{ *lazyClient }
 

--- a/pkg/action/lazyclient.go
+++ b/pkg/action/lazyclient.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"helm.sh/helm/v3/pkg/storage/driver"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -93,7 +94,11 @@ func (s *multiSecretClient) Get(ctx context.Context, name string, opts metav1.Ge
 	if err := s.init(); err != nil {
 		return nil, err
 	}
-	return s.client.CoreV1().Secrets(s.namespace).Get(ctx, name, opts)
+	namespace := s.namespace
+	if v, ok := driver.GetNamespaceFromContext(ctx); ok {
+		namespace = v
+	}
+	return s.client.CoreV1().Secrets(namespace).Get(ctx, name, opts)
 }
 
 func (s *multiSecretClient) List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error) {

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -154,7 +154,6 @@ func (secrets *MultiSecrets) List(filter func(*rspb.Release) bool) ([]*rspb.Rele
 // Query fetches all releases that match the provided map of labels.
 // An error is returned if the secret fails to retrieve the releases.
 func (secrets *MultiSecrets) Query(labels map[string]string) ([]*rspb.Release, error) {
-	const firstchunk = 1
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
@@ -365,7 +364,7 @@ func newMultiSecretsObject(key string, rls *rspb.Release, lbs labels, chunkSizeE
 					Data: map[string][]byte{"release": []byte(str), "chunk": []byte(fmt.Sprintf("%d", i)), "chunks": []byte(fmt.Sprintf("%d", len(slices)))},
 				})
 			}
-			i += 1
+			i++
 		}
 	} else {
 		// No chunking required, create 100% BWC Secret

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -1,0 +1,432 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Supports both single and multiple Secrets to hold a Helm release.
+
+// TODO
+// Arch
+//   - Consider implementing chunk support as v2 driver?
+// Code
+//   - Complete the remove code duplication of chunking code
+//     See loadRemainingChunks() not currently working b/c no access to secrets.impl.Get()
+//   - Likely remove HELM_DRIVER_CHUNKSIZE setting and fix size at ~1MB
+//   - Tests
+
+package driver // import "helm.sh/helm/v3/pkg/storage/driver"
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kblabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	rspb "helm.sh/helm/v3/pkg/release"
+)
+
+var _ Driver = (*MultiSecrets)(nil)
+
+// MultiSecretsDriverName is the string name of the driver.
+const MultiSecretsDriverName = "MultiSecret"
+
+// MultiSecrets is a wrapper around an implementation of a kubernetes
+// SecretsInterface.
+type MultiSecrets struct {
+	impl corev1.SecretInterface
+	Log  func(string, ...interface{})
+	//	loadRemainingChunks func(string, ...interface{}) ([]byte, error)
+}
+
+// NewMultiSecrets initializes a new Secrets wrapping an implementation of
+// the kubernetes SecretsInterface.
+func NewMultiSecrets(impl corev1.SecretInterface) *MultiSecrets {
+	return &MultiSecrets{
+		impl: impl,
+		Log:  func(_ string, _ ...interface{}) {},
+		//		loadRemainingChunks: func(_ string, _ ...interface{}) (_ []byte, _ error) {},
+	}
+}
+
+// Name returns the name of the driver.
+func (secrets *MultiSecrets) Name() string {
+	return MultiSecretsDriverName
+}
+
+// Get fetches the release named by key. The corresponding release is returned
+// or error if not found.
+func (secrets *MultiSecrets) Get(key string) (*rspb.Release, error) {
+	// fetch the secret holding the release named by key
+	obj, err := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, ErrReleaseNotFound
+		}
+		return nil, errors.Wrapf(err, "get: failed to get %q", key)
+	}
+
+	// Add remaining chunks; use single function
+	// obj.Data["release"], _ = secrets.loadRemainingChunks(key, obj)
+	// Let decode release fail if release contains incorrect data?
+
+	// Add remaining chunks; duplicated code
+
+	chunks, _ := strconv.Atoi(string(obj.Data["chunks"]))
+	for chunk := 2; chunk <= chunks; chunk++ {
+		key := fmt.Sprintf("%s.%d", obj.ObjectMeta.Name, chunk)
+		chunkobj, _ := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, ErrReleaseNotFound
+			}
+			return nil, errors.Wrapf(err, "get: failed to get %q", key)
+		}
+		obj.Data["release"] = append(obj.Data["release"], chunkobj.Data["release"]...)
+	}
+
+	// found the secret, decode the base64 data string
+	r, err := decodeRelease(string(obj.Data["release"]))
+	return r, errors.Wrapf(err, "get: failed to decode data %q", key)
+}
+
+// List fetches all releases and returns the list releases such
+// that filter(release) == true. An error is returned if the
+// secret fails to retrieve the releases.
+func (secrets *MultiSecrets) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
+	lsel := kblabels.Set{"owner": "helm"}.AsSelector()
+	opts := metav1.ListOptions{LabelSelector: lsel.String()}
+
+	list, err := secrets.impl.List(context.Background(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "list: failed to list")
+	}
+
+	var results []*rspb.Release
+
+	// iterate over the secrets object list
+	// and decode each release
+	for _, item := range list.Items {
+		// If chunked, add remaining chunks
+		chunk, err := strconv.Atoi(string(item.Data["chunk"]))
+		if err == nil && chunk > 1 {
+			continue
+		} else {
+			chunks, _ := strconv.Atoi(string(item.Data["chunks"]))
+			for chunk := 2; chunk <= chunks; chunk++ {
+				key := fmt.Sprintf("%s.%d", item.ObjectMeta.Name, chunk)
+				chunkobj, _ := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil, ErrReleaseNotFound
+					}
+					return nil, errors.Wrapf(err, "get: failed to get %q", key)
+				}
+				item.Data["release"] = append(item.Data["release"], chunkobj.Data["release"]...)
+			}
+		}
+
+		rls, err := decodeRelease(string(item.Data["release"]))
+		if err != nil {
+			secrets.Log("list: failed to decode release: %v: %s", item, err)
+			continue
+		}
+
+		rls.Labels = item.ObjectMeta.Labels
+
+		if filter(rls) {
+			results = append(results, rls)
+		}
+	}
+	return results, nil
+}
+
+// Query fetches all releases that match the provided map of labels.
+// An error is returned if the secret fails to retrieve the releases.
+func (secrets *MultiSecrets) Query(labels map[string]string) ([]*rspb.Release, error) {
+	const firstchunk = 1
+	ls := kblabels.Set{}
+	for k, v := range labels {
+		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
+			return nil, errors.Errorf("invalid label value: %q: %s", v, strings.Join(errs, "; "))
+		}
+		ls[k] = v
+	}
+
+	opts := metav1.ListOptions{LabelSelector: ls.AsSelector().String()}
+
+	list, err := secrets.impl.List(context.Background(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "query: failed to query with labels")
+	}
+
+	if len(list.Items) == 0 {
+		return nil, ErrReleaseNotFound
+	}
+
+	var results []*rspb.Release
+	for _, item := range list.Items {
+		// If chunked, add remaining chunks
+		chunks, _ := strconv.Atoi(string(item.Data["chunks"]))
+		for chunk := 2; chunk <= chunks; chunk++ {
+			key := fmt.Sprintf("%s.%d", item.ObjectMeta.Name, chunk)
+			chunkobj, _ := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, ErrReleaseNotFound
+				}
+				return nil, errors.Wrapf(err, "get: failed to get %q", key)
+			}
+			item.Data["release"] = append(item.Data["release"], chunkobj.Data["release"]...)
+		}
+
+		rls, err := decodeRelease(string(item.Data["release"]))
+		if err != nil {
+			secrets.Log("query: failed to decode release: %s", err)
+			continue
+		}
+		results = append(results, rls)
+	}
+	return results, nil
+}
+
+// Create creates a new Secret holding the release. If the
+// Secret already exists, ErrReleaseExists is returned.
+func (secrets *MultiSecrets) Create(key string, rls *rspb.Release) error {
+	// set labels for secrets object meta data
+	var lbs labels
+
+	lbs.init()
+	lbs.set("createdAt", strconv.Itoa(int(time.Now().Unix())))
+
+	// create a new secret to hold the release
+	objs, err := newMultiSecretsObject(key, rls, lbs, 1)
+	if err != nil {
+		return errors.Wrapf(err, "create: failed to encode release %q", rls.Name)
+	}
+	// push the secret object out into the kubiverse
+	for _, obj := range *objs {
+		if _, err := secrets.impl.Create(context.Background(), &obj, metav1.CreateOptions{}); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return ErrReleaseExists
+			}
+
+			return errors.Wrap(err, "create: failed to create")
+		}
+	}
+	return nil
+}
+
+// Update updates the Secret holding the release. If not found
+// the Secret is created to hold the release.
+func (secrets *MultiSecrets) Update(key string, rls *rspb.Release) error {
+	// Get release 1st to check if chunked or not
+	obj, err := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "get: release not found %q", rls.Name)
+		}
+		return errors.Wrapf(err, "get: failed to get %q", key)
+	}
+	chunks, err := strconv.Atoi(string(obj.Data["chunks"]))
+	if err != nil {
+		chunks = 0
+	}
+
+	// set labels for secrets object meta data
+	var lbs labels
+
+	lbs.init()
+	lbs.set("modifiedAt", strconv.Itoa(int(time.Now().Unix())))
+
+	// create a new secret object to hold the release
+	objs, err := newMultiSecretsObject(key, rls, lbs, chunks)
+	if err != nil {
+		return errors.Wrapf(err, "update: failed to encode release %q", rls.Name)
+	}
+	// push the secret object out into the kubiverse
+	for _, obj := range *objs {
+		if _, err = secrets.impl.Update(context.Background(), &obj, metav1.UpdateOptions{}); err != nil {
+			return errors.Wrap(err, "update: failed to update")
+		}
+	}
+	return nil
+}
+
+// Delete deletes the Secret holding the release named by key.
+func (secrets *MultiSecrets) Delete(key string) (rls *rspb.Release, err error) {
+	// fetch the secret holding the release named by key
+	obj, err := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, ErrReleaseNotFound
+		}
+		return nil, errors.Wrapf(err, "get: failed to get %q", key)
+	}
+	chunks, err := strconv.Atoi(string(obj.Data["chunks"]))
+	if err != nil {
+		chunks = 0
+	}
+
+	// fetch the release to check existence
+	if rls, err = secrets.Get(key); err != nil {
+		return nil, err
+	}
+
+	// delete the release
+	err = secrets.impl.Delete(context.Background(), key, metav1.DeleteOptions{})
+	// delete remaining chunks if any
+	for chunk := 2; chunk <= chunks; chunk++ {
+		err = secrets.impl.Delete(context.Background(), fmt.Sprintf("%s.%d", key, chunk), metav1.DeleteOptions{})
+	}
+	return rls, err
+}
+
+// newSecretsObject constructs a kubernetes Secret object
+// to store a release. Each secret data entry is the base64
+// encoded gzipped string of a release.
+//
+// The following labels are used within each secret:
+//
+//	"modifiedAt"    - timestamp indicating when this secret was last modified. (set in Update)
+//	"createdAt"     - timestamp indicating when this secret was created. (set in Create)
+//	"version"        - version of the release.
+//	"status"         - status of the release (see pkg/release/status.go for variants)
+//	"owner"          - owner of the secret, currently "helm".
+//	"name"           - name of the release.
+func newMultiSecretsObject(key string, rls *rspb.Release, lbs labels, chunks int) (*[]v1.Secret, error) {
+	const owner = "helm"
+	const maxChunkSize = (1024 * 1000) // approx 1MB in bytes
+
+	// encode the release
+	s, err := encodeRelease(rls)
+	if err != nil {
+		return nil, err
+	}
+
+	if lbs == nil {
+		lbs.init()
+	}
+
+	// apply labels
+	lbs.set("name", rls.Name)
+	lbs.set("owner", owner)
+	lbs.set("status", rls.Info.Status.String())
+	lbs.set("version", strconv.Itoa(rls.Version))
+
+	// create and return secret object.
+	// Helm 3 introduced setting the 'Type' field
+	// in the Kubernetes storage object.
+	// Helm defines the field content as follows:
+	// <helm_domain>/<helm_object>.v<helm_object_version>
+	// Type field for Helm 3: helm.sh/release.v1
+	// Note: Version starts at 'v1' for Helm 3 and
+	// should be incremented if the release object
+	// metadata is modified.
+	// This would potentially be a breaking change
+	// and should only happen between major versions.
+
+	objs := []v1.Secret{}
+	if chunks > 0 {
+		origData := s
+
+		chunkSize := maxChunkSize
+		sz := strings.TrimSpace(os.Getenv("HELM_DRIVER_CHUNKSIZE"))
+		if sz != "" {
+			size, err := strconv.Atoi(sz)
+			if err == nil && size < maxChunkSize {
+				chunkSize = size
+			} else {
+				return nil, errors.Wrapf(err, "newSecretsObject: cannot use chunk size: %s", sz)
+			}
+		}
+		lbs.set("chunksize", strconv.Itoa(chunkSize))
+
+		slices := []string{}
+		lastIndex := 0
+		lastI := 0
+		for i := range origData {
+			if i-lastIndex > chunkSize {
+				slices = append(slices, origData[lastIndex:lastI])
+				lastIndex = lastI
+			}
+			lastI = i
+		}
+		// handle the leftovers at the end
+		if len(origData)-lastIndex > chunkSize {
+			slices = append(slices, origData[lastIndex:lastIndex+chunkSize], origData[lastIndex+chunkSize:])
+		} else {
+			slices = append(slices, origData[lastIndex:])
+		}
+
+		i := 1
+		for _, str := range slices {
+			{
+				var lbs2 labels
+				lbs2.init()
+				lbs2.set("chunk", strconv.Itoa(i))
+				lbs2.set("chunks", strconv.Itoa(len(slices)))
+				instanceName := key
+				if i > 1 {
+					instanceName = fmt.Sprintf("%s.%d", key, i)
+				}
+				objs = append(objs, v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   instanceName,
+						Labels: kblabels.Merge(lbs.toMap(), lbs2.toMap()),
+					},
+					Type: "helm.sh/release.v1",
+					Data: map[string][]byte{"release": []byte(str), "chunk": []byte(fmt.Sprintf("%d", i)), "chunks": []byte(fmt.Sprintf("%d", len(slices)))},
+				})
+			}
+			i += 1
+		}
+	} else {
+		objs = append(objs, v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   key,
+				Labels: lbs.toMap(),
+			},
+			Type: "helm.sh/release.v1",
+			Data: map[string][]byte{"release": []byte(s)},
+		})
+	}
+	return &objs, nil
+}
+
+// Load remaining chunks given a key and 1st release Secret
+//func (secrets *Secrets) loadRemainingChunks(key string, obj *v1.Secret) ([]byte, error) {
+//	chunks, _ := strconv.Atoi(string(obj.Data["chunks"]))
+//	for chunk := 2 ; chunk <= chunks ; chunk++ {
+//			key := fmt.Sprintf("%s.%d", obj.ObjectMeta.Name, chunk)
+//			chunkobj, err := secrets.impl.Get(context.Background(), key, metav1.GetOptions{})
+//			if err != nil {
+//				if apierrors.IsNotFound(err) {
+//					return nil, ErrReleaseNotFound
+//				}
+//				return nil, errors.Wrapf(err, "get: failed to get %q", key)
+//			}
+//			obj.Data["release"] = append(obj.Data["release"], chunkobj.Data["release"]...)
+//	}
+//	return obj.Data["release"], nil
+//}

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -16,14 +16,6 @@ limitations under the License.
 
 // Supports both single and multiple Secrets to hold a Helm release.
 
-/*
-TODO
-- Clesnup K8s Secret splitting code in newMultiSecretsObject
-- Get rid of chunksize in Secret; look at data length
-- Does chunk size need to be configurable as envvar?
-- Tests
-*/
-
 package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 
 import (

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -352,7 +352,7 @@ func newMultiSecretsObject(key string, rls *rspb.Release, lbs labels, chunkSizeE
 						Name:   instanceName,
 						Labels: kblabels.Merge(lbs.toMap(), lbs2.toMap()),
 					},
-					Type: "helm.sh/release.v1",
+					Type: "helm.sh/release-multisecret.v1",
 					Data: map[string][]byte{"release": []byte(str), "chunk": []byte(fmt.Sprintf("%d", i)), "chunks": []byte(fmt.Sprintf("%d", len(slices)))},
 				})
 			}
@@ -413,12 +413,14 @@ func getMaxChunkSize(key string, multiSecretImpl *MultiSecrets, chunkSizeExist i
 		sz = obj.ObjectMeta.Labels["chunksize"]
 		if sz != "" {
 			size, err := strconv.Atoi(sz)
-			if err == nil && size < maxChunkSize {
+			if err == nil && size <= maxChunkSize {
 				chunkSize = size
 			} else {
 				log.Fatal(errors.Wrapf(err, "newSecretsObject: cannot use chunk size: %s", sz))
 				//return nil, errors.Wrapf(err, "newSecretsObject: cannot use chunk size: %s", sz)
 			}
+		} else {
+			chunkSize = maxChunkSize
 		}
 	} else {
 		// CASE 3: use the default or the envvar
@@ -426,7 +428,7 @@ func getMaxChunkSize(key string, multiSecretImpl *MultiSecrets, chunkSizeExist i
 		sz := strings.TrimSpace(os.Getenv("MULTISECRETS_CHUNKSIZE"))
 		if sz != "" {
 			size, err := strconv.Atoi(sz)
-			if err == nil && size < maxChunkSize {
+			if err == nil && size <= maxChunkSize {
 				chunkSize = size
 			} else {
 				log.Fatal(errors.Wrapf(err, "newSecretsObject: cannot use chunk size: %s", sz))

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -383,6 +383,8 @@ func newMultiSecretsObject(key string, rls *rspb.Release, lbs labels, chunkSizeE
 // Load remaining chunks given a key and 1st release Secret
 func loadRemainingChunks(obj *v1.Secret, multiSecretImpl *MultiSecrets) ([]byte, error) {
 	chunks, _ := strconv.Atoi(string(obj.Data["chunks"]))
+	releaseData := make([]byte, 0, len(obj.Data["release"])*chunks)
+	releaseData = append(releaseData, obj.Data["release"]...)
 	for chunk := 2; chunk <= chunks; chunk++ {
 		key := fmt.Sprintf("%s.%d", obj.ObjectMeta.Name, chunk)
 		ctx := context.WithValue(context.Background(), multiSecretContextNamespace, obj.Namespace)
@@ -393,9 +395,9 @@ func loadRemainingChunks(obj *v1.Secret, multiSecretImpl *MultiSecrets) ([]byte,
 			}
 			return nil, errors.Wrapf(err, "get: failed to get %q", key)
 		}
-		obj.Data["release"] = append(obj.Data["release"], chunkobj.Data["release"]...)
+		releaseData = append(releaseData, chunkobj.Data["release"]...)
 	}
-	return obj.Data["release"], nil
+	return releaseData, nil
 }
 
 // Determine the chunk size to use

--- a/pkg/storage/driver/multisecrets.go
+++ b/pkg/storage/driver/multisecrets.go
@@ -123,12 +123,12 @@ func (secrets *MultiSecrets) List(filter func(*rspb.Release) bool) ([]*rspb.Rele
 	for _, item := range list.Items {
 		// If chunked, add remaining chunks
 		chunk, err := strconv.Atoi(string(item.Data["chunk"]))
-		if err == nil && chunk > 1 {
-			// Skip any Secret that is not 1st chunk
-			continue
-		} else {
+		if err == nil && chunk == 1 {
 			// Load any remaining chunks
 			item.Data["release"], _ = loadRemainingChunks(&item, secrets)
+		} else if err == nil && chunk > 1 {
+			// Skip any Secret that is not 1st chunk
+			continue
 		}
 		rls, err := decodeRelease(string(item.Data["release"]))
 		if err != nil {
@@ -169,12 +169,12 @@ func (secrets *MultiSecrets) Query(labels map[string]string) ([]*rspb.Release, e
 	for _, item := range list.Items {
 		// If chunked, add remaining chunks
 		chunk, err := strconv.Atoi(string(item.Data["chunk"]))
-		if err == nil && chunk > 1 {
-			// Skip any Secret that is not 1st chunk
-			continue
-		} else {
+		if err == nil && chunk == 1 {
 			// Load any remaining chunks
 			item.Data["release"], _ = loadRemainingChunks(&item, secrets)
+		} else if err == nil && chunk > 1 {
+			// Skip any Secret that is not 1st chunk
+			continue
 		}
 		rls, err := decodeRelease(string(item.Data["release"]))
 		if err != nil {

--- a/pkg/storage/driver/multisecrets_test.go
+++ b/pkg/storage/driver/multisecrets_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	rspb "helm.sh/helm/v3/pkg/release"
+)
+
+func TestMultiSecretsName(t *testing.T) {
+	c := newTestFixtureMultiSecrets(t)
+	if c.Name() != MultiSecretsDriverName {
+		t.Errorf("Expected name to be %q, got %q", MultiSecretsDriverName, c.Name())
+	}
+}
+
+func TestMultiSecretsGet(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, rspb.StatusDeployed)
+
+	secrets := newTestFixtureMultiSecrets(t, []*rspb.Release{rel}...)
+
+	// get release with key
+	got, err := secrets.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get release: %s", err)
+	}
+	// compare fetched release with original
+	if !reflect.DeepEqual(rel, got) {
+		t.Errorf("Expected {%v}, got {%v}", rel, got)
+	}
+}
+
+func TestUNcompressedMultiSecretsGet(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, rspb.StatusDeployed)
+
+	// Create a test fixture which contains an uncompressed release
+	secret, err := newSecretsObject(key, rel, nil)
+	if err != nil {
+		t.Fatalf("Failed to create secret: %s", err)
+	}
+	b, err := json.Marshal(rel)
+	if err != nil {
+		t.Fatalf("Failed to marshal release: %s", err)
+	}
+	secret.Data["release"] = []byte(base64.StdEncoding.EncodeToString(b))
+	var mock MockSecretsInterface
+	mock.objects = map[string]*v1.Secret{key: secret}
+	secrets := NewSecrets(&mock)
+
+	// get release with key
+	got, err := secrets.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get release: %s", err)
+	}
+	// compare fetched release with original
+	if !reflect.DeepEqual(rel, got) {
+		t.Errorf("Expected {%v}, got {%v}", rel, got)
+	}
+}
+
+func TestMultiSecretsList(t *testing.T) {
+	secrets := newTestFixtureMultiSecrets(t, []*rspb.Release{
+		releaseStub("key-1", 1, "default", rspb.StatusUninstalled),
+		releaseStub("key-2", 1, "default", rspb.StatusUninstalled),
+		releaseStub("key-3", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-4", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-5", 1, "default", rspb.StatusSuperseded),
+		releaseStub("key-6", 1, "default", rspb.StatusSuperseded),
+	}...)
+
+	// list all deleted releases
+	del, err := secrets.List(func(rel *rspb.Release) bool {
+		return rel.Info.Status == rspb.StatusUninstalled
+	})
+	// check
+	if err != nil {
+		t.Errorf("Failed to list deleted: %s", err)
+	}
+	if len(del) != 2 {
+		t.Errorf("Expected 2 deleted, got %d:\n%v\n", len(del), del)
+	}
+
+	// list all deployed releases
+	dpl, err := secrets.List(func(rel *rspb.Release) bool {
+		return rel.Info.Status == rspb.StatusDeployed
+	})
+	// check
+	if err != nil {
+		t.Errorf("Failed to list deployed: %s", err)
+	}
+	if len(dpl) != 2 {
+		t.Errorf("Expected 2 deployed, got %d", len(dpl))
+	}
+
+	// list all superseded releases
+	ssd, err := secrets.List(func(rel *rspb.Release) bool {
+		return rel.Info.Status == rspb.StatusSuperseded
+	})
+	// check
+	if err != nil {
+		t.Errorf("Failed to list superseded: %s", err)
+	}
+	if len(ssd) != 2 {
+		t.Errorf("Expected 2 superseded, got %d", len(ssd))
+	}
+}
+
+func TestMultiSecretsQuery(t *testing.T) {
+	secrets := newTestFixtureMultiSecrets(t, []*rspb.Release{
+		releaseStub("key-1", 1, "default", rspb.StatusUninstalled),
+		releaseStub("key-2", 1, "default", rspb.StatusUninstalled),
+		releaseStub("key-3", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-4", 1, "default", rspb.StatusDeployed),
+		releaseStub("key-5", 1, "default", rspb.StatusSuperseded),
+		releaseStub("key-6", 1, "default", rspb.StatusSuperseded),
+	}...)
+
+	rls, err := secrets.Query(map[string]string{"status": "deployed"})
+	if err != nil {
+		t.Fatalf("Failed to query: %s", err)
+	}
+	if len(rls) != 2 {
+		t.Fatalf("Expected 2 results, actual %d", len(rls))
+	}
+
+	_, err = secrets.Query(map[string]string{"name": "notExist"})
+	if err != ErrReleaseNotFound {
+		t.Errorf("Expected {%v}, got {%v}", ErrReleaseNotFound, err)
+	}
+}
+
+func TestMultiSecretsCreate(t *testing.T) {
+	secrets := newTestFixtureMultiSecrets(t)
+
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, rspb.StatusDeployed)
+
+	// store the release in a secret
+	if err := secrets.Create(key, rel); err != nil {
+		t.Fatalf("Failed to create release with key %q: %s", key, err)
+	}
+
+	// get the release back
+	got, err := secrets.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get release with key %q: %s", key, err)
+	}
+
+	// compare created release with original
+	if !reflect.DeepEqual(rel, got) {
+		t.Errorf("Expected {%v}, got {%v}", rel, got)
+	}
+}
+
+func TestMultiSecretsUpdate(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, rspb.StatusDeployed)
+
+	secrets := newTestFixtureMultiSecrets(t, []*rspb.Release{rel}...)
+
+	// modify release status code
+	rel.Info.Status = rspb.StatusSuperseded
+
+	// perform the update
+	if err := secrets.Update(key, rel); err != nil {
+		t.Fatalf("Failed to update release: %s", err)
+	}
+
+	// fetch the updated release
+	got, err := secrets.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get release with key %q: %s", key, err)
+	}
+
+	// check release has actually been updated by comparing modified fields
+	if rel.Info.Status != got.Info.Status {
+		t.Errorf("Expected status %s, got status %s", rel.Info.Status.String(), got.Info.Status.String())
+	}
+}
+
+func TestMultiSecretsDelete(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, rspb.StatusDeployed)
+
+	secrets := newTestFixtureMultiSecrets(t, []*rspb.Release{rel}...)
+
+	// perform the delete on a non-existing release
+	_, err := secrets.Delete("nonexistent")
+	if err != ErrReleaseNotFound {
+		t.Fatalf("Expected ErrReleaseNotFound, got: {%v}", err)
+	}
+
+	// perform the delete
+	rls, err := secrets.Delete(key)
+	if err != nil {
+		t.Fatalf("Failed to delete release with key %q: %s", key, err)
+	}
+	if !reflect.DeepEqual(rel, rls) {
+		t.Errorf("Expected {%v}, got {%v}", rel, rls)
+	}
+
+	// fetch the deleted release
+	_, err = secrets.Get(key)
+	if !reflect.DeepEqual(ErrReleaseNotFound, err) {
+		t.Errorf("Expected {%v}, got {%v}", ErrReleaseNotFound, err)
+	}
+}

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package driver
 
 import (


### PR DESCRIPTION
HIP PR https://github.com/helm/community/pull/256

**What this PR does / why we need it**:

This is the implementation for HIP https://github.com/helm/community/pull/256 "HIP Support Helm release data stored in multiple K8s Secrets".

(This is a continuation of inadvertently closed PR https://github.com/helm/helm/pull/11087)

It allows Helm releases to be stored in multiple K8s Secrets if the size is > (1024*1000) bytes. For more details see the HIP.

The storage driver is implemented as HELM_DRIVER=multisecret | multisecrets

If secrets are <1MB they are 100% BWC and can be processed by helm binaries that do not know of split Helm secrets.

By default, the multisecret driver splits into multiple K8s Secrets when the compressed Helm release data > 1024*1000 bytes. If a Helm upgrade for a release results in Helm release data < 1024*1000 bytes then the driver will create a single K8s Secret same as the standard secret Helm driver.

**Testing**:

To test with default split size of 1MB:
- export HELM_DRIVER=multisecret OR export HELM_DRIVER=multisecrets
- run any Helm CLI command ; if Helm release data > 1024*1000 bytes then additional K8s Secrets are created to hold the release data

To test the splitting more easily for example to create K8s Secrets that contain Helm release data <= 1024 bytes:
- export HELM_DRIVER=multisecret OR export HELM_DRIVER=multisecrets
- export MULTISECRETS_CHUNKSIZE=1024
- run any Helm CLI command

Example, this will create 8 K8s Secrets for a single revision of a Helm release:
helm create test
helm install test ./test

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility

Signed-off-by: Ralf Van Dorsselaer <ralfvandorsselaer@gmail.com>
