### PR TITLE
Disable warning when Kube Config is group-readable.

### DIFF
--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -49,9 +49,6 @@ func checkPerms() {
 	}
 
 	perm := fi.Mode().Perm()
-	if perm&0040 > 0 {
-		warning("Kubernetes configuration file is group-readable. This is insecure. Location: %s", kc)
-	}
 	if perm&0004 > 0 {
 		warning("Kubernetes configuration file is world-readable. This is insecure. Location: %s", kc)
 	}

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -50,7 +50,7 @@ func checkPermsStderr() (string, error) {
 func TestCheckPerms(t *testing.T) {
 	tdir := t.TempDir()
 	tfile := filepath.Join(tdir, "testconfig")
-	fh, err := os.OpenFile(tfile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0440)
+	fh, err := os.OpenFile(tfile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0404)
 	if err != nil {
 		t.Errorf("Failed to create temp file: %s", err)
 	}
@@ -59,18 +59,6 @@ func TestCheckPerms(t *testing.T) {
 	settings.KubeConfig = tfile
 	defer func() { settings.KubeConfig = tconfig }()
 
-	text, err := checkPermsStderr()
-	if err != nil {
-		t.Fatalf("could not read from stderr: %s", err)
-	}
-	expectPrefix := "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location:"
-	if !strings.HasPrefix(text, expectPrefix) {
-		t.Errorf("Expected to get a warning for group perms. Got %q", text)
-	}
-
-	if err := fh.Chmod(0404); err != nil {
-		t.Errorf("Could not change mode on file: %s", err)
-	}
 	text, err = checkPermsStderr()
 	if err != nil {
 		t.Fatalf("could not read from stderr: %s", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

`helm` warns when the kube config is group readable as it may be insecure. This is not necessarily the case and an annoying warning as discussed in #8776, #9115, #11083, and #11592 

My proposed change is to ignore the warning for group readable. Ignoring the warning for word readable would require more work to detect whether it's secure or not. I would guess it's very often insecure so I left it.

Alternatively, the whole warning feature could be removed. I understood that you want the security warning to stay because [one member said](https://github.com/helm/helm/issues/8776#issuecomment-812146980
):

> To be clear, will not accept PRs to suppress the security warning. This issue was pointed out by a security audit sponsored by the CNCF, and the warning was the security team’s recommendation.

But I had already opened the pushed my commit when I read this comment, and I kinda disagree with the idea. Sometimes security audits are not correct and I think it's fair to dismiss one of their recommendations.

**Special notes for your reviewer**:

Feel free to reject the pull request. I would understand. And thanks for your work. 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
