### PR TITLE
Remove `GoFish` from package managers for installing  the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ If you want to use a package manager:
 - [Homebrew](https://brew.sh/) users can use `brew install helm`.
 - [Chocolatey](https://chocolatey.org/) users can use `choco install kubernetes-helm`.
 - [Scoop](https://scoop.sh/) users can use `scoop install helm`.
-- [GoFish](https://gofi.sh/) users can use `gofish install helm`.
 - [Snapcraft](https://snapcraft.io/) users can use `snap install helm --classic`
 
 To rapidly get Helm up and running, start with the [Quick Start Guide](https://helm.sh/docs/intro/quickstart/).


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove `GoFish` from package managers for installing the binary in README.

`GoFish` is being archived and it's not good to recommend now.
https://github.com/fishworks/gofish#this-project-is-being-archived


**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
