### PR TITLE
Add support for encryption of Helm release body

### DIFF
--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -19,9 +19,14 @@ package driver // import "helm.sh/helm/v3/pkg/storage/driver"
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
+	"os"
 
 	rspb "helm.sh/helm/v3/pkg/release"
 )
@@ -39,12 +44,25 @@ func encodeRelease(rls *rspb.Release) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	encryptionAlgorithm := os.Getenv("HELM_RELEASE_ENCRYPTION_ALGO")
+	encryptionKey := os.Getenv("HELM_RELEASE_ENCRYPTION_KEY")
+
+	var data []byte
+
+	switch encryptionAlgorithm {
+	case "aes":
+		data, err = encryptDataAES(b, []byte(encryptionKey))
+	default:
+		data = b
+	}
+
 	var buf bytes.Buffer
 	w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	if err != nil {
 		return "", err
 	}
-	if _, err = w.Write(b); err != nil {
+	if _, err = w.Write(data); err != nil {
 		return "", err
 	}
 	w.Close()
@@ -78,12 +96,75 @@ func decodeRelease(data string) (*rspb.Release, error) {
 		b = b2
 	}
 
+	encryptionAlgorithm := os.Getenv("HELM_RELEASE_ENCRYPTION_ALGO")
+	encryptionKey := os.Getenv("HELM_RELEASE_ENCRYPTION_KEY")
+
+	var releaseBytes []byte
+
+	switch encryptionAlgorithm {
+	case "aes":
+		releaseBytes, err = decryptDataAES(b, []byte(encryptionKey))
+	default:
+		releaseBytes = b
+	}
+
 	var rls rspb.Release
 	// unmarshal release object bytes
-	if err := json.Unmarshal(b, &rls); err != nil {
+	if err := json.Unmarshal(releaseBytes, &rls); err != nil {
 		return nil, err
 	}
 	return &rls, nil
+}
+
+// encryptDataAES encrypts data using AES in Galois/Counter Mode (GCM) with the
+// provided key. The result includes both nonce and encrypted content.
+func encryptDataAES(data []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, data, nil)
+	return append(nonce, ciphertext...), nil
+}
+
+// decryptDataAES decrypts data using AES (Advanced Encryption Standard) in
+// Galois/Counter Mode (GCM). It takes encrypted data and an encryption key,
+// returning the original plaintext content.
+func decryptDataAES(encryptedData []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(encryptedData) < nonceSize {
+		return nil, fmt.Errorf("error decrypting data: ciphertext too short")
+	}
+
+	nonce, ciphertext := encryptedData[:nonceSize], encryptedData[nonceSize:]
+
+	decryptedData, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return decryptedData, nil
 }
 
 // Checks if label is system

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -53,8 +53,14 @@ func encodeRelease(rls *rspb.Release) (string, error) {
 	switch encryptionAlgorithm {
 	case "aes":
 		data, err = encryptDataAES(b, []byte(encryptionKey))
-	default:
+	case "":
 		data = b
+	default:
+		return "", fmt.Errorf("error encrypting release: unknown algorithm %v", encryptionAlgorithm)
+	}
+
+	if err != nil {
+		return "", err
 	}
 
 	var buf bytes.Buffer
@@ -104,8 +110,14 @@ func decodeRelease(data string) (*rspb.Release, error) {
 	switch encryptionAlgorithm {
 	case "aes":
 		releaseBytes, err = decryptDataAES(b, []byte(encryptionKey))
-	default:
+	case "":
 		releaseBytes = b
+	default:
+		return nil, fmt.Errorf("error decrypting release: unknown algorithm %v", encryptionAlgorithm)
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	var rls rspb.Release

--- a/pkg/storage/driver/util_test.go
+++ b/pkg/storage/driver/util_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package driver
 
 import (
+	"bytes"
+	"crypto/rand"
 	"reflect"
 	"testing"
 )
@@ -104,5 +106,28 @@ func TestContainsSystemLabels(t *testing.T) {
 		if output := ContainsSystemLabels(test.input); !reflect.DeepEqual(test.output, output) {
 			t.Errorf("Expected {%v}, got {%v}", test.output, output)
 		}
+	}
+}
+
+func TestEncryptDecryptAES(t *testing.T) {
+	encryptionKey := make([]byte, 16)
+	_, _ = rand.Read(encryptionKey)
+
+	plaintext := []byte("Dummy release data.")
+
+	encryptedData, err := encryptDataAES(plaintext, []byte(encryptionKey))
+	if err != nil {
+		t.Errorf("Error while encrypting: %v", err)
+		return
+	}
+
+	decryptedData, err := decryptDataAES(encryptedData, encryptionKey)
+	if err != nil {
+		t.Errorf("Error while decrypting: %v", err)
+		return
+	}
+
+	if !bytes.Equal(decryptedData, plaintext) {
+		t.Error("Decrypted data does not match original plaintext")
 	}
 }

--- a/pkg/storage/driver/util_test.go
+++ b/pkg/storage/driver/util_test.go
@@ -111,7 +111,11 @@ func TestContainsSystemLabels(t *testing.T) {
 
 func TestEncryptDecryptAES(t *testing.T) {
 	encryptionKey := make([]byte, 16)
-	_, _ = rand.Read(encryptionKey)
+	_, err := rand.Read(encryptionKey)
+	if err != nil {
+		t.Errorf("error generating test encryption key: %v", err)
+		return
+	}
 
 	plaintext := []byte("Dummy release data.")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: 
This PR adds the possibility to encrypt and decrypt release bodies. The encryption algorithm and key can be respectively set via the environment variables `HELM_RELEASE_ENCRYPTION_ALGO` and `HELM_RELEASE_ENCRYPTION_KEY`. 

Currently, it only supports AES encryption in Galois/Counter Mode, but the code leaves room for supporting other algorithms in the future. 

The rationale behind these changes lies in the need to secure Helm release information. Releases can contain sensitive data, such as passwords and other keys, which must be protected not only at rest, but also during transport. Encrypting the release on client side would add an additional layer of security to send and store sensitive data in a secure way - given that the encryption key is managed correctly.  

When the environment variables are unset, the behavior of the `encodeRelease` and `decodeRelease` functions is still the same as before. 



**Special notes for your reviewer**: 
Feedback is more than welcome, and if you're interested in moving forward I'm open to any suggestion to improve the proposal ☺️ 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
