### PR TITLE
use dependabot's group support for k8s.io dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+        exclude-patterns:
+          - "k8s.io/utils"
+          - "k8s.io/klog/v2"
+          - "k8s.io/kube-openapi"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

It's safer to upgrade k8s.io dependencies as a group. Dependabot has added the ability to create dependency groups. This PR enables that feature for k8s.io dependencies.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
