### PR TITLE
make the dependabot k8s.io group explicit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,13 @@ updates:
     groups:
       k8s.io:
         patterns:
-          - "k8s.io/*"
-        exclude-patterns:
-          - "k8s.io/utils"
-          - "k8s.io/klog/v2"
-          - "k8s.io/kube-openapi"
+          - "k8s.io/api"
+          - "k8s.io/apiextensions-apiserver"
+          - "k8s.io/apimachinery"
+          - "k8s.io/apiserver"
+          - "k8s.io/cli-runtime"
+          - "k8s.io/client-go"
+          - "k8s.io/kubectl"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When using a wildcard, dependabot was missing the apiextensions-apiserver dependency. This may be related to https://github.com/dependabot/dependabot-core/issues/7822. Use an explicit list.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
