### PR TITLE
improve get-helm-3 GH api interaction

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -111,11 +111,19 @@ checkDesiredVersion() {
     local latest_release_url="https://api.github.com/repos/helm/helm/releases/latest"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      if [ "${GITHUB_TOKEN}" != ""]; then
+        latest_release_response=$( curl --header "Authorization: Bearer ${GITHUB_TOKEN}" -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      else
+        latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      fi
     elif [ "${HAS_WGET}" == "true" ]; then
-      latest_release_response=$( wget "$latest_release_url" -O - 2>&1 || true )
+      if [ "${GITHUB_TOKEN}" != ""]; then
+        latest_release_response=$( wget --header="Authorization: Bearer ${GITHUB_TOKEN}" "$latest_release_url" -O - 2>&1 || true )
+      else
+        latest_release_response=$( wget "$latest_release_url" -O - 2>&1 || true )
+      fi
     fi
-    TAG=$( echo "$latest_release_response" | grep '"tag_name"' | sed -E 's/.*"(v[0-9\.]+)".*/\1/g' )
+    TAG=$( echo "$latest_release_response" | grep -o '"tag_name":[[:space]]*".*"' | cut -d '"' -f 4 )
     if [ "x$TAG" == "x" ]; then
       printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
       exit 1


### PR DESCRIPTION
This commit solves two problems:  The Github API has extremely low rate-limits on requests that could cause issues if you have a large CI/CD farm behind a NAT gateway or similar that causes a large amount of requests to appear to come from the same IP.  By utilizing the environment variable GITHUB_TOKEN if present, CI/CD can pass in a GH personal access token to bypass severe rate limiting.

Additionally, the Github API is not determinisitic on the return format of its JSON -- it may or may not be compressed and/or single line.  We should try to more accurately extract the tag name value instead of assuming multi-line output.