### PR TITLE
doc(helm): Adjusted unclear error about table destination to match ya…

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -114,7 +114,7 @@ func coalesceDeps(printf printFn, chrt *chart.Chart, dest map[string]interface{}
 			dvmap := dv.(map[string]interface{})
 			subPrefix := concatPrefix(prefix, chrt.Metadata.Name)
 			// Get globals out of dest and merge them into dvmap.
-			coalesceGlobals(printf, dvmap, dest, subPrefix, merge)
+			coalesceGlobals(printf, dvmap, dest, subPrefix)
 			// Now coalesce the rest of the values.
 			var err error
 			dest[subchart.Name()], err = coalesce(printf, subchart, dvmap, subPrefix, merge)
@@ -129,20 +129,20 @@ func coalesceDeps(printf printFn, chrt *chart.Chart, dest map[string]interface{}
 // coalesceGlobals copies the globals out of src and merges them into dest.
 //
 // For convenience, returns dest.
-func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix string, merge bool) {
+func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix string) {
 	var dg, sg map[string]interface{}
 
 	if destglob, ok := dest[GlobalKey]; !ok {
 		dg = make(map[string]interface{})
 	} else if dg, ok = destglob.(map[string]interface{}); !ok {
-		printf("warning: skipping globals because destination %s is not a table.", GlobalKey)
+		printf("warning: skipping globals because destination %s is not a mapping.", GlobalKey)
 		return
 	}
 
 	if srcglob, ok := src[GlobalKey]; !ok {
 		sg = make(map[string]interface{})
 	} else if sg, ok = srcglob.(map[string]interface{}); !ok {
-		printf("warning: skipping globals because source %s is not a table.", GlobalKey)
+		printf("warning: skipping globals because source %s is not a mapping.", GlobalKey)
 		return
 	}
 
@@ -158,7 +158,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix st
 				dg[key] = vv
 			} else {
 				if destvmap, ok := destv.(map[string]interface{}); !ok {
-					printf("Conflict: cannot merge map onto non-map for %q. Skipping.", key)
+					printf("Conflict: cannot merge mapping onto non-mapping for %q. Skipping.", key)
 				} else {
 					// Basically, we reverse order of coalesce here to merge
 					// top-down.
@@ -172,7 +172,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix st
 			}
 		} else if dv, ok := dg[key]; ok && istable(dv) {
 			// It's not clear if this condition can actually ever trigger.
-			printf("key %s is table. Skipping", key)
+			printf("key %s is mapping. Skipping", key)
 		} else {
 			// TODO: Do we need to do any additional checking on the value?
 			dg[key] = val
@@ -195,7 +195,7 @@ func copyMap(src map[string]interface{}) map[string]interface{} {
 func coalesceValues(printf printFn, c *chart.Chart, v map[string]interface{}, prefix string, merge bool) {
 	subPrefix := concatPrefix(prefix, c.Metadata.Name)
 
-	// Using c.Values directly when coalescing a table can cause problems where
+	// Using c.Values directly when coalescing a map can cause problems where
 	// the original c.Values is altered. Creating a deep copy stops the problem.
 	// This section is fault-tolerant as there is no ability to return an error.
 	valuesCopy, err := copystructure.Copy(c.Values)
@@ -228,13 +228,13 @@ func coalesceValues(printf printFn, c *chart.Chart, v map[string]interface{}, pr
 				// remove incompatible keys from any previous chart, file, or set values.
 				delete(v, key)
 			} else if dest, ok := value.(map[string]interface{}); ok {
-				// if v[key] is a table, merge nv's val table into v[key].
+				// if v[key] is a map, merge nv's val map into v[key].
 				src, ok := val.(map[string]interface{})
 				if !ok {
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: Not a map.", subPrefix, key)
 					}
 				} else {
 					// Because v has higher precedence than nv, dest values override src
@@ -283,10 +283,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]interface{}, pref
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]interface{}), val.(map[string]interface{}), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite mapping with non mapping for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a mapping. Ignoring non-mapping value (%v)", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -234,7 +234,7 @@ func coalesceValues(printf printFn, c *chart.Chart, v map[string]interface{}, pr
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a map.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: Not a mapping.", subPrefix, key)
 					}
 				} else {
 					// Because v has higher precedence than nv, dest values override src

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -688,9 +688,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a mapping.")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a mapping. Ignoring non-mapping value (true)")
+	assert.Contains(t, warnings, "warning: cannot overwrite mapping with non mapping for level1.level2.level3.spear.sail (map[cotton:true])")
 
 }
 


### PR DESCRIPTION
…ml terminology

Updated all warning messages to use mapping to match the yaml spec: https://yaml.org/spec/1.2.2/#mapping

Closes: #11118

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR addresses issue #11118 by changing warning messages to match the [yml spec](https://yaml.org/spec/1.2.2/#mapping).  Also, I ran make test which pointed out a style error in coalesce.go which is why I removed the merge parameter from coalesceGlobals.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ x ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
