### PR TITLE
Fix/cannot add plugins with git fsmonitor daemon enabled

### DIFF
--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -145,7 +145,7 @@ func (i *HTTPInstaller) Install() error {
 	}
 
 	debug("copying %s to %s", src, i.Path())
-	return fs.CopyDir(src, i.Path())
+	return fs.CopyDir(src, i.Path(), []string{})
 }
 
 // Update updates a local repository

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -89,7 +89,7 @@ func (i *VCSInstaller) Install() error {
 	}
 
 	debug("copying %s to %s", i.Repo.LocalPath(), i.Path())
-	return fs.CopyDir(i.Repo.LocalPath(), i.Path())
+	return fs.CopyDir(i.Repo.LocalPath(), i.Path(), []string{".git"})
 }
 
 // Update updates a remote repository


### PR DESCRIPTION
Added parameter to optionally ignore any directories in a list.  This allows the vcs_installer to skip the .git directory that causes issues when fsmonitor = true in your gitconfig.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR is to address #12125 .  I went with adding an extra parameter to CopyDir so that the other calls were unaffected by ignoring the .git directory.  Added an extra bit to test this to an existing test.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
