### PR TITLE
feat(helm): flag to update all plugins

### DIFF
--- a/cmd/helm/plugin_update_test.go
+++ b/cmd/helm/plugin_update_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginUpdateArgs(t *testing.T) {
+	o := pluginUpdateOptions{
+		all: true,
+	}
+	assert.Nil(t, o.args([]string{}))
+	assert.Error(t, o.args([]string{"foo"}))
+	o = pluginUpdateOptions{
+		all: false,
+	}
+	assert.Error(t, o.args([]string{}))
+	assert.Nil(t, o.args([]string{"foo"}))
+}
+
+func TestPluginFindSelectedPlugins(t *testing.T) {
+	settings.PluginsDirectory = "testdata/helmhome/helm/plugins"
+	o := pluginUpdateOptions{
+		all: true,
+	}
+	assert.Nil(t, o.findSelectedPlugins([]string{}))
+	assert.Len(t, o.plugins, 5)
+	var names []string
+	for _, plugin := range o.plugins {
+		names = append(names, plugin.Metadata.Name)
+	}
+	assert.ElementsMatch(t, []string{"args", "echo", "env", "exitwith", "fullenv"}, names)
+
+	o = pluginUpdateOptions{
+		all: false,
+	}
+	assert.Error(t, o.findSelectedPlugins([]string{"args", "foo"}))
+
+	o = pluginUpdateOptions{
+		all: false,
+	}
+	assert.Nil(t, o.findSelectedPlugins([]string{"args", "exitwith"}))
+	names = []string{}
+	for _, plugin := range o.plugins {
+		names = append(names, plugin.Metadata.Name)
+	}
+	assert.ElementsMatch(t, []string{"args", "exitwith"}, names)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

add a new flag to helm plugin update to update all plugins at once
```
Usage:
  helm plugin update <plugin>... [flags]

Aliases:
  update, up

Flags:
  -a, --all    Update all installed plugins
  -h, --help   help for update
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
