### PR TITLE
fix(pkg/lint): unmarshals Chart.yaml strictly

### DIFF
--- a/pkg/chart/v2/util/chartfile.go
+++ b/pkg/chart/v2/util/chartfile.go
@@ -33,6 +33,17 @@ func LoadChartfile(filename string) (*chart.Metadata, error) {
 		return nil, err
 	}
 	y := new(chart.Metadata)
+	err = yaml.Unmarshal(b, y)
+	return y, err
+}
+
+// StrictLoadChartFile loads a Chart.yaml into a *chart.Metadata using a strict unmarshaling
+func StrictLoadChartfile(filename string) (*chart.Metadata, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	y := new(chart.Metadata)
 	err = yaml.UnmarshalStrict(b, y)
 	return y, err
 }

--- a/pkg/chart/v2/util/chartfile.go
+++ b/pkg/chart/v2/util/chartfile.go
@@ -33,7 +33,7 @@ func LoadChartfile(filename string) (*chart.Metadata, error) {
 		return nil, err
 	}
 	y := new(chart.Metadata)
-	err = yaml.Unmarshal(b, y)
+	err = yaml.UnmarshalStrict(b, y)
 	return y, err
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -35,6 +35,7 @@ const badYamlFileDir = "rules/testdata/albatross"
 const goodChartDir = "rules/testdata/goodone"
 const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
+const invalidChartFileDir = "rules/testdata/invalidchartfile"
 
 func TestBadChart(t *testing.T) {
 	m := RunAll(badChartDir, values, namespace).Messages
@@ -87,6 +88,16 @@ func TestInvalidYaml(t *testing.T) {
 	}
 	if !strings.Contains(m[0].Err.Error(), "deliberateSyntaxError") {
 		t.Errorf("All didn't have the error for deliberateSyntaxError")
+	}
+}
+
+func TestInvalidChartYaml(t *testing.T) {
+	m := All(invalidChartFileDir, values, namespace, strict).Messages
+	if len(m) != 1 {
+		t.Fatalf("All didn't fail with expected errors, got %#v", m)
+	}
+	if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
+		t.Errorf("All didn't have the error for duplicate YAML keys")
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -96,7 +96,7 @@ func TestInvalidChartYaml(t *testing.T) {
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
-	if !strings.Contains(m[0].Err.Error(), "failed to strictly parse chartfile") {
+	if !strings.Contains(m[0].Err.Error(), "failed to strictly parse chart metadata file") {
 		t.Errorf("All didn't have the error for duplicate YAML keys")
 	}
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -96,7 +96,7 @@ func TestInvalidChartYaml(t *testing.T) {
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
-	if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
+	if !strings.Contains(m[0].Err.Error(), "failed to strictly parse chartfile") {
 		t.Errorf("All didn't have the error for duplicate YAML keys")
 	}
 }

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -92,7 +92,7 @@ func TestInvalidYaml(t *testing.T) {
 }
 
 func TestInvalidChartYaml(t *testing.T) {
-	m := All(invalidChartFileDir, values, namespace, strict).Messages
+	m := RunAll(invalidChartFileDir, values, namespace).Messages
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -46,6 +46,9 @@ func Chartfile(linter *support.Linter) {
 		return
 	}
 
+	_, err = chartutil.StrictLoadChartfile(chartPath)
+	linter.RunLinterRule(support.WarningSev, chartFileName, validateChartYamlStrictFormat(err))
+
 	// type check for Chart.yaml . ignoring error as any parse
 	// errors would already be caught in the above load function
 	chartFileForTypeCheck, _ := loadChartFileForTypeCheck(chartPath)
@@ -98,6 +101,13 @@ func validateChartYamlNotDirectory(chartPath string) error {
 func validateChartYamlFormat(chartFileError error) error {
 	if chartFileError != nil {
 		return errors.Errorf("unable to parse YAML\n\t%s", chartFileError.Error())
+	}
+	return nil
+}
+
+func validateChartYamlStrictFormat(chartFileError error) error {
+	if chartFileError != nil {
+		return errors.Errorf("failed to strictly parse chartfile\n\t%s", chartFileError.Error())
 	}
 	return nil
 }

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -107,7 +107,7 @@ func validateChartYamlFormat(chartFileError error) error {
 
 func validateChartYamlStrictFormat(chartFileError error) error {
 	if chartFileError != nil {
-		return errors.Errorf("failed to strictly parse chartfile\n\t%s", chartFileError.Error())
+		return errors.Errorf("failed to strictly parse chart metadata file\n\t%s", chartFileError.Error())
 	}
 	return nil
 }

--- a/pkg/lint/rules/testdata/invalidchartfile/Chart.yaml
+++ b/pkg/lint/rules/testdata/invalidchartfile/Chart.yaml
@@ -1,0 +1,5 @@
+name: some-chart
+apiVersion: v2
+apiVersion: v1
+description: A Helm chart for Kubernetes
+version: 1.3.0

--- a/pkg/lint/rules/testdata/invalidchartfile/Chart.yaml
+++ b/pkg/lint/rules/testdata/invalidchartfile/Chart.yaml
@@ -3,3 +3,4 @@ apiVersion: v2
 apiVersion: v1
 description: A Helm chart for Kubernetes
 version: 1.3.0
+icon: http://example.com


### PR DESCRIPTION
When "helm lint" is run, it now errors on invalid Chart.yaml files, e.g. those with duplicate keys

Closes #12381

**What this PR does / why we need it**: Fixes a bug with the current `helm lint` command, where it does not error on Chart.yaml with duplicate mapping keys

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
