### PR TITLE
Increased release information key name max length.

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -137,7 +137,7 @@ func (s *SQL) ensureDBSetup() error {
 				Up: []string{
 					fmt.Sprintf(`
 						CREATE TABLE %s (
-							%s VARCHAR(67),
+							%s VARCHAR(90),
 							%s VARCHAR(64) NOT NULL,
 							%s TEXT NOT NULL,
 							%s VARCHAR(64) NOT NULL,


### PR DESCRIPTION
Helm release names are limited to 53 characters. By default, Release information is stored in Kubernetes as secrets, and the secret's name structure follows the pattern "sh.helm.release.v1.<release name up to 53 characters>.v<release revision>." However, in the case of using an SQL backend, this release information key is stored in the release_v1 table, and the table constraint currently limits the key name length to 67 characters. This limitation may not be suitable for release names that are within Helm's 53-character limit and need to accommodate the additional "sh.helm.release.v1." prefix and the release revision suffix.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
