### PR TITLE
Write latest version to get.helm.sh bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3.6.0
+        fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@4.1.0
@@ -32,6 +33,10 @@ jobs:
         run: |
           make build-cross
           make dist checksum VERSION="${{ github.ref_name }}"
+      
+      - name: Set latest version
+          # Push the latest semver tag, excluding prerelease tags
+          git tag | sort -r --version-sort | grep '^v[0-9]' | grep -v '-' | head -n1 > _dist/helm-latest-version
 
       - name: Upload Binaries
         uses: bacongobbler/azure-blob-storage-upload@50f7d898b7697e864130ea04c303ca38b5751c50 # pin@3.0.0


### PR DESCRIPTION
The purpose of this change is leverage this output for the get-helm script.

It will provide the following benefits:
- Use true semver so a future release of a patch version so a future release of a patch version does not cause an unexpected minor/major version downgrade

- Avoid reliance on the github api which has rate limiting. This will also increase availability by reducing the number of systems the get-helm script depends on.

- Simplify the script so parsing json is not necessary

- Increase uptime by only requiring the Azure CDN to be available

https://github.com/helm/helm/issues/12351