### PR TITLE
fix(registry): address anonymous pull issue

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -105,12 +105,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 			if err != nil {
 				return nil, errors.New("unable to retrieve credentials")
 			}
-			// A blank returned username and password value is a bearer token
-			if username == "" && password != "" {
-				headers.Set("Authorization", fmt.Sprintf("Bearer %s", password))
-			} else {
-				headers.Set("Authorization", fmt.Sprintf("Basic %s", basicAuth(username, password)))
-			}
+			authHeader(username, password, &headers)
 		}
 
 		opts := []auth.ResolverOption{auth.WithResolverHeaders(headers)}

--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -256,3 +256,22 @@ func basicAuth(username, password string) string {
 	auth := username + ":" + password
 	return base64.StdEncoding.EncodeToString([]byte(auth))
 }
+
+// authHeader generates an HTTP authorization header based on the provided
+// username and password and sets it in the provided HTTP headers pointer.
+//
+// If both username and password are empty, no header is set.
+// If only the password is provided, a "Bearer" token is created and set in
+// the Authorization header.
+// If both username and password are provided, a "Basic" authentication token
+// is created using the basicAuth function, and set in the Authorization header.
+func authHeader(username, password string, headers *http.Header) {
+	if username == "" && password == "" {
+		return
+	}
+	if username == "" {
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", password))
+		return
+	}
+	headers.Set("Authorization", fmt.Sprintf("Basic %s", basicAuth(username, password)))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The assumption that either a username and/or password OR an error is returned appears to be wrong, and results in an error later on which looks something like the following:

```
failed to authorize: failed to fetch anonymous token: unexpected status
from GET request to https://auth.docker.io/token?scope=repository%3AXXX%2FYYY%3Apull&service=registry.docker.io:
401 Unauthorized
```

To mitigate this, confirm we actually have one of the values before setting the `Authorization` header.

Should fix #12423

**Special notes for your reviewer**:

This could (and should) really have more test coverage, but this is beyond the time I have available at present.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
