### PR TITLE
FIX Default ServiceAccount yaml

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -392,7 +392,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}
 `
 


### PR DESCRIPTION

**What this PR does / why we need it**:

As described in issue #12432 (https://github.com/helm/helm/issues/12432) the default serviceaccount yaml will be created wrong. This commit will fix this.

**Special notes for your reviewer**:
Kubernetes Docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting

