### PR TITLE
Add missing with clause to release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3.6.0
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@4.1.0


### PR DESCRIPTION
Fix missing with statement. Not sure why this missing passed an `act release -n`. 