### PR TITLE
chore: remove what seems to be a dangling println

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -262,7 +262,6 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, err
 	}
 
-	fmt.Println(driver.ContainsSystemLabels(u.Labels))
 	if driver.ContainsSystemLabels(u.Labels) {
 		return nil, nil, fmt.Errorf("user suplied labels contains system reserved label name. System labels: %+v", driver.GetSystemLabels())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

this println is printing `false` to the stdout. not sure why it is there other than maybe a past debug session.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
