### PR TITLE
Print debug-level log for DNS lookups when disabled

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -44,6 +44,8 @@ type Engine struct {
 	config *rest.Config
 	// EnableDNS tells the engine to allow DNS lookups when rendering templates
 	EnableDNS bool
+	// Log is used for printing logs.
+	Log func(string, ...interface{})
 }
 
 // New creates a new instance of Engine using the passed in rest config.
@@ -202,6 +204,9 @@ func (e Engine) initFunMap(t *template.Template, referenceTpls map[string]render
 	// an empty string.
 	if !e.EnableDNS {
 		funcMap["getHostByName"] = func(name string) string {
+			if e.Log != nil {
+				e.Log("DNS lookup is disabled by default. If you understand the security implications, check the documentation for how to enable DNS lookups in templates")
+			}
 			return ""
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**What this PR does / why we need it**:

Print debug-level log for DNS lookups when disabled.
closes #12479 

**If applicable**:
- [X] this PR has been tested for backwards compatibility (the `Log` function is only called if not `nil`)
- [X] this PR has been manually tested (the log is only printed if `--debug` is used)
