### PR TITLE
Fix hook install order

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -125,15 +125,13 @@ func (x hookByWeight) Less(i, j int) bool {
 		first, iok := ordering[x[i].Kind]
 		second, jok := ordering[x[j].Kind]
 
-		// As in https://github.com/helm/helm/blob/fe595b69d78b213ab181d98ce24dde2454a56f9d/pkg/releaseutil/kind_sorter.go#L145C15-L145C15
 		if !iok && !jok {
-			// If both are unknown then sort alphabetically by kind.
-			if x[i].Kind != x[j].Kind {
-				return x[i].Kind < x[j].Kind
+			// Sort unknown kinds alphabetically, with name as the tiebreaker.
+			if x[i].Kind == x[j].Kind {
+				return x[i].Name < x[j].Name
 			}
 
-			// Otherwise, let Stable() preserve the original order.
-			return false
+			return x[i].Kind < x[j].Kind
 		}
 
 		// Unknown kind is last.

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -115,13 +115,6 @@ func (x hookByWeight) Len() int      { return len(x) }
 func (x hookByWeight) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x hookByWeight) Less(i, j int) bool {
 	if x[i].Weight == x[j].Weight {
-		return x[i].Name < x[j].Name
-	}
-	return x[i].Weight < x[j].Weight
-}
-
-func (x hookByWeight) LessFixed(i, j int) bool {
-	if x[i].Weight == x[j].Weight {
 		ordering := make(map[string]int, len(releaseutil.InstallOrder))
 		for v, k := range releaseutil.InstallOrder {
 			ordering[k] = v

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -39,8 +39,9 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 	}
 
-	// hooke are pre-ordered by kind, so keep order stable
-	sort.Stable(hookByWeight(executingHooks))
+	// Since we want to sort by name among hooks of the same kind, we need to re-sort and can't use
+	// Stable() and rely on the existing sort by kind.
+	sort.Sort(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
 		// Set default delete policy to before-hook-creation

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -115,6 +115,7 @@ func (x hookByWeight) Len() int      { return len(x) }
 func (x hookByWeight) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x hookByWeight) Less(i, j int) bool {
 	if x[i].Weight == x[j].Weight {
+		// It's safe to assume that we can use InstallOrder as hooks will be creating resources.
 		ordering := make(map[string]int, len(releaseutil.InstallOrder))
 		for v, k := range releaseutil.InstallOrder {
 			ordering[k] = v

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -43,7 +43,7 @@ func Test_hookByWeight(t *testing.T) {
 		{Weight: 0, Kind: "Job", Name: "Job"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
-		{Weight: 1, Kind: "Pod", Name: "podA"},
+		{Weight: 1, Kind: "Pod", Name: "PodA"},
 	}
 
 	for i, hook := range hooks {

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -31,6 +31,9 @@ func TestHookByWeight(t *testing.T) {
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
 		{Weight: 0, Kind: "Job", Name: "Job"},
+		{Weight: 0, Kind: "UnknownB", Name: "UnknownB1"},
+		{Weight: 0, Kind: "UnknownB", Name: "UnknownB0"},
+		{Weight: 0, Kind: "UnknownA", Name: "UnknownA"},
 		{Weight: -1, Kind: "APIService", Name: "APIServiceB"},
 		{Weight: -1, Kind: "APIService", Name: "APIServiceA"},
 	}
@@ -41,6 +44,9 @@ func TestHookByWeight(t *testing.T) {
 		{Weight: -1, Kind: "APIService", Name: "APIServiceA"},
 		{Weight: -1, Kind: "APIService", Name: "APIServiceB"},
 		{Weight: 0, Kind: "Job", Name: "Job"},
+		{Weight: 0, Kind: "UnknownA", Name: "UnknownA"},
+		{Weight: 0, Kind: "UnknownB", Name: "UnknownB0"},
+		{Weight: 0, Kind: "UnknownB", Name: "UnknownB1"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
 		{Weight: 1, Kind: "Pod", Name: "PodA"},
@@ -62,6 +68,8 @@ func TestHookByWeight_KindSorted(t *testing.T) {
 		{Weight: -1, Kind: "Pod", Name: "podA"},
 		{Weight: 0, Kind: "Job", Name: "Job"},
 		{Weight: 1, Kind: "APIService", Name: "APIServiceA"},
+		{Weight: 0, Kind: "UnknownA", Name: "Unknown1"},
+		{Weight: 0, Kind: "UnknownB", Name: "Unknown0"},
 	}
 
 	sort.Stable(hookByWeight(hooks))
@@ -70,6 +78,8 @@ func TestHookByWeight_KindSorted(t *testing.T) {
 		{Weight: -1, Kind: "Pod", Name: "podA"},
 		{Weight: 0, Kind: "Pod", Name: "podB"},
 		{Weight: 0, Kind: "Job", Name: "Job"},
+		{Weight: 0, Kind: "UnknownA", Name: "Unknown1"},
+		{Weight: 0, Kind: "UnknownB", Name: "Unknown0"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
 		{Weight: 1, Kind: "APIService", Name: "APIServiceA"},

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -23,7 +23,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func Test_hookByWeight(t *testing.T) {
+func TestHookByWeight(t *testing.T) {
 	hooks := []*release.Hook{
 		// The previous sorter sorts by (Weight, Name) so would fail this test as
 		// "PodA" < "ServiceAccountA".
@@ -53,7 +53,7 @@ func Test_hookByWeight(t *testing.T) {
 	}
 }
 
-func Test_hookByWeight_KindSorted(t *testing.T) {
+func TestHookByWeight_KindSorted(t *testing.T) {
 	// This test assumes that the list of hooks starts off sorted by Kind.
 	hooks := []*release.Hook{
 		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"sort"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func Test_hookByWeight(t *testing.T) {
+	hooks := []*release.Hook{
+		{Weight: 1, Kind: "Pod", Name: "podA"},
+		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
+		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
+		{Weight: 0, Kind: "Job", Name: "Job"},
+		{Weight: -1, Kind: "APIService", Name: "APIServiceB"},
+		{Weight: -1, Kind: "APIService", Name: "APIServiceA"},
+	}
+
+	sort.Stable(hookByWeight(hooks))
+
+	expected := []*release.Hook{
+		{Weight: -1, Kind: "APIService", Name: "APIServiceA"},
+		{Weight: -1, Kind: "APIService", Name: "APIServiceB"},
+		{Weight: 0, Kind: "Job", Name: "Job"},
+		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountA"},
+		{Weight: 1, Kind: "ServiceAccount", Name: "ServiceAccountB"},
+		{Weight: 1, Kind: "Pod", Name: "podA"},
+	}
+
+	for i, hook := range hooks {
+		if hook.Name != expected[i].Name {
+			t.Errorf("Expected hook %d to be %s, got %s", i, expected[i].Name, hook.Name)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: closes #12414

According to [Hooks and the Release Lifecycle](https://helm.sh/docs/topics/charts_hooks/#hooks-and-the-release-lifecycle), hooks are sorted "by weight (assigning a weight of 0 by default), by resource kind and finally by name in ascending order". In practice, the current behavior is that hooks are sorted by `(Weight, Name)`.

The code currently uses `sort.Stable` under the assumption that the hooks are already sorted by Kind. However, stability only applies to elements with the same key, so since `Less` on the `hookByWeight` comparator orders based on the name of the hook too, the existing ordering by Kind is never respected.

This PR fixes the comparator so that hooks are sorted by `(Weight, Kind, Name)` as expected and adds tests for this behavior.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
