### PR TITLE
feat(lint): Add new flag `--full-path`

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -149,6 +149,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&client.WithSubcharts, "with-subcharts", false, "lint dependent charts")
 	f.BoolVar(&client.Quiet, "quiet", false, "print only warnings and errors")
 	f.StringVar(&kubeVersion, "kube-version", "", "Kubernetes version used for capabilities and deprecation checks")
+	f.BoolVar(&client.EnableFullPath, "full-path", false, "print full path in warnings and errors")
 	addValueOptionsFlags(f, valueOpts)
 
 	return cmd

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -32,11 +32,12 @@ import (
 //
 // It provides the implementation of 'helm lint'.
 type Lint struct {
-	Strict        bool
-	Namespace     string
-	WithSubcharts bool
-	Quiet         bool
-	KubeVersion   *chartutil.KubeVersion
+	Strict         bool
+	Namespace      string
+	WithSubcharts  bool
+	Quiet          bool
+	KubeVersion    *chartutil.KubeVersion
+	EnableFullPath bool
 }
 
 // LintResult is the result of Lint
@@ -59,7 +60,7 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	}
 	result := &LintResult{}
 	for _, path := range paths {
-		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion)
+		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion, l.EnableFullPath)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue
@@ -86,7 +87,8 @@ func HasWarningsOrErrors(result *LintResult) bool {
 	return len(result.Errors) > 0
 }
 
-func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) (support.Linter, error) {
+func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion,
+	enableFullPath bool) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
 
@@ -125,5 +127,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, kubeV
 		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
-	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion), nil
+	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion, enableFullPath), nil
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -77,7 +77,7 @@ func TestLintChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil)
+			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil, false)
 			switch {
 			case err != nil && !tt.err:
 				t.Errorf("%s", err)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -25,16 +25,20 @@ import (
 )
 
 // All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, _ bool) support.Linter {
-	return AllWithKubeVersion(basedir, values, namespace, nil)
+func All(basedir string, values map[string]interface{}, namespace string, _, enableFullPath bool) support.Linter {
+	return AllWithKubeVersion(basedir, values, namespace, nil, enableFullPath)
 }
 
 // AllWithKubeVersion runs all the available linters on the given base directory, allowing to specify the kubernetes version.
-func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) support.Linter {
+func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string,
+	kubeVersion *chartutil.KubeVersion, enableFullPath bool) support.Linter {
 	// Using abs path to get directory context
 	chartDir, _ := filepath.Abs(basedir)
 
-	linter := support.Linter{ChartDir: chartDir}
+	linter := support.Linter{
+		ChartDir:       chartDir,
+		EnableFullPath: enableFullPath,
+	}
 	rules.Chartfile(&linter)
 	rules.ValuesWithOverrides(&linter, values)
 	rules.TemplatesWithKubeVersion(&linter, values, namespace, kubeVersion)

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -38,7 +38,7 @@ const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
 
 func TestBadChart(t *testing.T) {
-	m := All(badChartDir, values, namespace, strict).Messages
+	m := All(badChartDir, values, namespace, strict, false).Messages
 	if len(m) != 8 {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)
@@ -82,7 +82,7 @@ func TestBadChart(t *testing.T) {
 }
 
 func TestInvalidYaml(t *testing.T) {
-	m := All(badYamlFileDir, values, namespace, strict).Messages
+	m := All(badYamlFileDir, values, namespace, strict, false).Messages
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -92,7 +92,7 @@ func TestInvalidYaml(t *testing.T) {
 }
 
 func TestBadValues(t *testing.T) {
-	m := All(badValuesFileDir, values, namespace, strict).Messages
+	m := All(badValuesFileDir, values, namespace, strict, false).Messages
 	if len(m) < 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -102,7 +102,7 @@ func TestBadValues(t *testing.T) {
 }
 
 func TestGoodChart(t *testing.T) {
-	m := All(goodChartDir, values, namespace, strict).Messages
+	m := All(goodChartDir, values, namespace, strict, false).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {
@@ -126,7 +126,7 @@ func TestHelmCreateChart(t *testing.T) {
 
 	// Note: we test with strict=true here, even though others have
 	// strict = false.
-	m := All(createdChart, values, namespace, true).Messages
+	m := All(createdChart, values, namespace, true, false).Messages
 	if ll := len(m); ll != 1 {
 		t.Errorf("All should have had exactly 1 error. Got %d", ll)
 		for i, msg := range m {
@@ -140,7 +140,7 @@ func TestHelmCreateChart(t *testing.T) {
 // lint ignores import-values
 // See https://github.com/helm/helm/issues/9658
 func TestSubChartValuesChart(t *testing.T) {
-	m := All(subChartValuesDir, values, namespace, strict).Messages
+	m := All(subChartValuesDir, values, namespace, strict, false).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {
@@ -156,7 +156,7 @@ func TestMalformedTemplate(t *testing.T) {
 	ch := make(chan int, 1)
 	var m []support.Message
 	go func() {
-		m = All(malformedTemplate, values, namespace, strict).Messages
+		m = All(malformedTemplate, values, namespace, strict, false).Messages
 		ch <- 1
 	}()
 	select {

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -36,6 +36,11 @@ func Chartfile(linter *support.Linter) {
 	chartFileName := "Chart.yaml"
 	chartPath := filepath.Join(linter.ChartDir, chartFileName)
 
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		chartFileName = chartPath
+	}
+
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartYamlNotDirectory(chartPath))
 
 	chartFile, err := chartutil.LoadChartfile(chartPath)

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -54,6 +54,11 @@ func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interfac
 	fpath := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		fpath = templatesPath + string(filepath.Separator)
+	}
+
 	templatesDirExist := linter.RunLinterRule(support.WarningSev, fpath, validateTemplatesDir(templatesPath))
 
 	// Templates directory is optional for now
@@ -116,6 +121,11 @@ func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interfac
 	for _, template := range chart.Templates {
 		fileName, data := template.Name, template.Data
 		fpath = fileName
+
+		// When flag is enabled, update the file name with full path
+		if linter.EnableFullPath {
+			fpath = templatesPath + string(filepath.Separator) + fileName
+		}
 
 		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 		// These are v3 specific checks to make sure and warn people if their

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -42,6 +42,12 @@ func Values(linter *support.Linter) {
 func ValuesWithOverrides(linter *support.Linter, values map[string]interface{}) {
 	file := "values.yaml"
 	vf := filepath.Join(linter.ChartDir, file)
+
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		file = vf
+	}
+
 	fileExists := linter.RunLinterRule(support.InfoSev, file, validateValuesFileExistence(vf))
 
 	if !fileExists {

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -39,6 +39,8 @@ type Linter struct {
 	// The highest severity of all the failing lint rules
 	HighestSeverity int
 	ChartDir        string
+	// EnableFullPath enables printing full path of file in messages
+	EnableFullPath bool
 }
 
 // Message describes an error encountered while linting.


### PR DESCRIPTION
**What this PR does / why we need it**:

The flag `--full-path` enables printing full paths in `helm lint` warnings and errors.

Closes #11365

**Special notes for your reviewer**:

Excluded tests as the PR becomes `size/XXL` with them. So moved it to #12923 which should be merged on top of this. Please review both.

CC: @tillig @joejulian

**If applicable**:
- [ ] this PR contains documentation
> The CLI flag is self-explanatory. Doesn't require documentation.
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
> Adding a new flag shouldn't break anything in Helm 2. By default, the `--full-path` will be `false`, i.e., `helm lint` will function as usual.
