### PR TITLE
Replace template with yamltemplate

### DIFF
--- a/cmd/helm/printer.go
+++ b/cmd/helm/printer.go
@@ -18,7 +18,8 @@ package main
 
 import (
 	"io"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 )
 
 func tpl(t string, vals map[string]interface{}, out io.Writer) error {

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -19,7 +19,8 @@ package main
 import (
 	"fmt"
 	"io"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/spf13/cobra"
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/foxcpp/go-mockdns v1.0.0
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.8.1
+	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp5GZKyvYY6MkjvPE8CIMlkvXFF8gA=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -27,10 +27,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/Masterminds/sprig/v3"
+
+	template "github.com/google/safetext/yamltemplate"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/chartutil/values_test.go
+++ b/pkg/chartutil/values_test.go
@@ -20,7 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"helm.sh/helm/v3/pkg/chart"
 )

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -24,7 +24,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -22,7 +22,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -20,7 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -19,7 +19,8 @@ package engine
 import (
 	"strings"
 	"testing"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Use yamltemplate from https://github.com/google/safetext instead of text/template.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
