### PR TITLE
fix: --disable-openapi-validation option was never applied

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -73,7 +73,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		h.LastRun.Phase = release.HookPhaseUnknown
 
 		// Create hook resources
-		if _, err := cfg.KubeClient.Create(resources); err != nil {
+		if _, err := cfg.KubeClient.Create(resources, false); err != nil {
 			h.LastRun.CompletedAt = helmtime.Now()
 			h.LastRun.Phase = release.HookPhaseFailed
 			return errors.Wrapf(err, "warning: Hook %s %s failed", hook, h.Path)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -161,7 +161,7 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 		}
 
 		// Send them to Kube
-		if _, err := i.cfg.KubeClient.Create(res); err != nil {
+		if _, err := i.cfg.KubeClient.Create(res, !i.DisableOpenAPIValidation); err != nil {
 			// If the error is CRD already exists, continue.
 			if apierrors.IsAlreadyExists(err) {
 				crdName := res[0].Name
@@ -368,7 +368,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		if err != nil {
 			return nil, err
 		}
-		if _, err := i.cfg.KubeClient.Create(resourceList); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := i.cfg.KubeClient.Create(resourceList, !i.DisableOpenAPIValidation); err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, err
 		}
 	}
@@ -437,9 +437,9 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	// do an update, but it's not clear whether we WANT to do an update if the re-use is set
 	// to true, since that is basically an upgrade operation.
 	if len(toBeAdopted) == 0 && len(resources) > 0 {
-		_, err = i.cfg.KubeClient.Create(resources)
+		_, err = i.cfg.KubeClient.Create(resources, !i.DisableOpenAPIValidation)
 	} else if len(resources) > 0 {
-		_, err = i.cfg.KubeClient.Update(toBeAdopted, resources, i.Force)
+		_, err = i.cfg.KubeClient.Update(toBeAdopted, resources, i.Force, !i.DisableOpenAPIValidation)
 	}
 	if err != nil {
 		return rel, err

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -187,7 +187,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to set metadata visitor from target release")
 	}
-	results, err := r.cfg.KubeClient.Update(current, target, r.Force)
+	results, err := r.cfg.KubeClient.Update(current, target, r.Force, false)
 
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -405,7 +405,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 		u.cfg.Log("upgrade hooks disabled for %s", upgradedRelease.Name)
 	}
 
-	results, err := u.cfg.KubeClient.Update(current, target, u.Force)
+	results, err := u.cfg.KubeClient.Update(current, target, u.Force, !u.DisableOpenAPIValidation)
 	if err != nil {
 		u.cfg.recordRelease(originalRelease)
 		u.reportToPerformUpgrade(c, upgradedRelease, results.Created, err)

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -166,7 +166,7 @@ func TestUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := c.Update(first, second, false)
+	result, err := c.Update(first, second, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func TestReal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Create(resources); err != nil {
+	if _, err := c.Create(resources, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -358,7 +358,7 @@ func TestReal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Create(resources); err != nil {
+	if _, err := c.Create(resources, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -50,11 +50,11 @@ type FailingKubeClient struct {
 }
 
 // Create returns the configured error if set or prints
-func (f *FailingKubeClient) Create(resources kube.ResourceList) (*kube.Result, error) {
+func (f *FailingKubeClient) Create(resources kube.ResourceList, validate bool) (*kube.Result, error) {
 	if f.CreateError != nil {
 		return nil, f.CreateError
 	}
-	return f.PrintingKubeClient.Create(resources)
+	return f.PrintingKubeClient.Create(resources, validate)
 }
 
 // Get returns the configured error if set or prints
@@ -107,11 +107,11 @@ func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.
 }
 
 // Update returns the configured error if set or prints
-func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
+func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool, validate bool) (*kube.Result, error) {
 	if f.UpdateError != nil {
 		return &kube.Result{}, f.UpdateError
 	}
-	return f.PrintingKubeClient.Update(r, modified, ignoreMe)
+	return f.PrintingKubeClient.Update(r, modified, ignoreMe, validate)
 }
 
 // Build returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -41,7 +41,7 @@ func (p *PrintingKubeClient) IsReachable() error {
 }
 
 // Create prints the values of what would be created with a real KubeClient.
-func (p *PrintingKubeClient) Create(resources kube.ResourceList) (*kube.Result, error) {
+func (p *PrintingKubeClient) Create(resources kube.ResourceList, _ bool) (*kube.Result, error) {
 	_, err := io.Copy(p.Out, bufferize(resources))
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (p *PrintingKubeClient) WatchUntilReady(resources kube.ResourceList, _ time
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kube.Result, error) {
+func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool, _ bool) (*kube.Result, error) {
 	_, err := io.Copy(p.Out, bufferize(modified))
 	if err != nil {
 		return nil, err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -30,7 +30,7 @@ import (
 // A KubernetesClient must be concurrency safe.
 type Interface interface {
 	// Create creates one or more resources.
-	Create(resources ResourceList) (*Result, error)
+	Create(resources ResourceList, validate bool) (*Result, error)
 
 	// Wait waits up to the given timeout for the specified resources to be ready.
 	Wait(resources ResourceList, timeout time.Duration) error
@@ -54,7 +54,7 @@ type Interface interface {
 
 	// Update updates one or more resources or creates the resource
 	// if it doesn't exist.
-	Update(original, target ResourceList, force bool) (*Result, error)
+	Update(original, target ResourceList, force bool, validate bool) (*Result, error)
 
 	// Build creates a resource list from a Reader.
 	//


### PR DESCRIPTION
**Why we need it**:

Currently there is an issue with openapi validation in Helm.
Here is the problem description.
Let's take a pod definition with a problem, the spec.toto field does not exist:
```yaml
apiVersion: v1
kind: Pod
metadata:
  namespace: mynamespace
  name: mypod
spec:
  toto: tutu
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
```

First I try to create it using kubectl, with no specific option:
```bash
$ kubectl apply -f pod.yaml 
Error from server (BadRequest): error when creating "pod.yaml": Pod in version "v1" cannot be handled as a Pod: strict decoding error: unknown field "spec.toto"
```
Then I try different options of --validate:
```bash
$ kubectl apply -f pod.yaml --validate=strict
Error from server (BadRequest): error when creating "pod.yaml": Pod in version "v1" cannot be handled as a Pod: strict decoding error: unknown field "spec.toto"

$ kubectl apply -f pod.yaml --validate=ignore
pod/mypod created
```

This is okay and this is the kubectl behavior.

Now the same thing with Helm.
First test with no option:
```bash
$ helm install testchart .
W1018 10:43:09.834267  122282 warnings.go:70] unknown field "spec.toto"
NAME: testchart
LAST DEPLOYED: Wed Oct 18 10:43:09 2023
NAMESPACE: mynamespace
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
Here I just have a warning but the resource is created. This is not normal.

Then with different values of the option:
```bash
$ helm upgrade testchart . --disable-openapi-validation
W1018 10:44:48.986008  122562 warnings.go:70] unknown field "spec.toto"
Release "testchart" has been upgraded. Happy Helming!
NAME: testchart
LAST DEPLOYED: Wed Oct 18 10:44:48 2023
NAMESPACE: mynamespace
STATUS: deployed
REVISION: 2
TEST SUITE: None
```
and:
```bash
$ helm upgrade testchart . --disable-openapi-validation=false
W1018 10:45:05.128872  122606 warnings.go:70] unknown field "spec.toto"
Release "testchart" has been upgraded. Happy Helming!
NAME: testchart
LAST DEPLOYED: Wed Oct 18 10:45:04 2023
NAMESPACE: mynamespace
STATUS: deployed
REVISION: 3
TEST SUITE: None
```

So currently the option `--disable-openapi-validation` of Helm does not change anything.

The source of the problem is:
Currently we validate the manifest in the prepareUpgrade here:
https://github.com/helm/helm/blob/main/pkg/action/upgrade.go#L290
Then the validation direct is calculated here:
https://github.com/helm/helm/blob/main/pkg/kube/client.go#L344-L347
and then given to the kube client.
And in the kube client the validation apply client-side only if the ServerSideFieldValidation is disabled on the api-server, as described here: https://kubernetes.io/blog/2023/04/24/openapi-v3-field-validation-ga/#server-side-field-validation
```kubectl will skip client side validation and will automatically use server side field validation in Strict mode```
But in the `prepareUpgrade` step, no creation is done, so no server-side validation is applied neither client-side validation.

Then after the `prepareUpgrade` step we go to the `performUpgrade` step and here we really do the Update, here:
https://github.com/helm/helm/blob/main/pkg/action/upgrade.go#L408
if we take a look deeper into the Update func of our client, the real update is done here:
https://github.com/helm/helm/blob/main/pkg/kube/client.go#L424
and here is the way we instanciate the Helper that will be used for the patch:
https://github.com/helm/helm/blob/main/pkg/kube/client.go#L665

If we compare this to the way kubectl instanciate the Helper, there is a big difference:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go#L559-L562
In kubectl there are adding the line:
```go
WithFieldValidation(o.ValidationDirective)
```
and this line configure the client to add the validate field with strict or ignore value.
So in our case we never give the validationDirective value to the API when we do the update, and so the defaut value applies:
https://kubernetes.io/blog/2023/04/24/openapi-v3-field-validation-ga/#server-side-field-validation
```
If the parameter is not passed, server side field validation is in Warn mode by default.
```
That's why in the different tests you always see a Warning but the resources are always created, even when there is an error in the manifest.

**What this PR does**:

So my PR forward the validation boolean in client and add the validationDirective in the the create/update.
I also chose to set the default value to "Warn" instead of "Strict", because it's the current behavior and I didn't want to break it.

Let me know what you think about all this! 

**Result:**

After my changes I have the following behavior with differents values of the --disable-openapi-validation parameter:
when enabling the validation I still have the same warning as previously:
```bash
$ /home/denouche/workspace/src/github.com/denouche/helm/bin/helm upgrade testchart . --disable-openapi-validation=false
W1018 11:15:15.140002  126116 warnings.go:70] unknown field "spec.toto"
Release "testchart" has been upgraded. Happy Helming!
NAME: testchart
LAST DEPLOYED: Wed Oct 18 11:15:14 2023
NAMESPACE: mynamespace
STATUS: deployed
REVISION: 2
TEST SUITE: None
```

and when disabling, no warning anymore:
```bash
$ /home/denouche/workspace/src/github.com/denouche/helm/bin/helm upgrade testchart . --disable-openapi-validation=true
Release "testchart" has been upgraded. Happy Helming!
NAME: testchart
LAST DEPLOYED: Wed Oct 18 11:15:20 2023
NAMESPACE: mynamespace
STATUS: deployed
REVISION: 3
TEST SUITE: None
```


Closes #12470 
