### PR TITLE
Recreate immutable resources on upgrade

### DIFF
--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -85,6 +85,7 @@ func newRollbackCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.WaitForJobs, "wait-for-jobs", false, "if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this rollback when rollback fails")
 	f.IntVar(&client.MaxHistory, "history-max", settings.MaxHistory, "limit the maximum number of revisions saved per release. Use 0 for no limit")
+	f.BoolVar(&client.RecreateImmutableResources, "recreate-immutable-resources", false, "On status code 422, try to delete and create the resource again")
 
 	return cmd
 }

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -76,6 +76,11 @@ func TestRollbackCmd(t *testing.T) {
 		golden:    "output/rollback-no-args.txt",
 		rels:      rels,
 		wantError: true,
+	}, {
+		name:   "rollback a release with recreate-immutable-resources option ",
+		cmd:    "rollback funny-honey 1 --recreate-immutable-resources",
+		golden: "output/rollback.txt",
+		rels:   rels,
 	}}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -246,6 +246,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.Recreate, "recreate-pods", false, "performs pods restart for the resource if applicable")
 	f.MarkDeprecated("recreate-pods", "functionality will no longer be updated. Consult the documentation for other methods to recreate pods")
 	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")
+	f.BoolVar(&client.RecreateImmutableResources, "recreate-immutable-resources", false, "On status code 422, try to delete and create the resource again")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "disable pre/post upgrade hooks")
 	f.BoolVar(&client.DisableOpenAPIValidation, "disable-openapi-validation", false, "if set, the upgrade process will not validate rendered templates against the Kubernetes OpenAPI Schema")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed when an upgrade is performed with install flag enabled. By default, CRDs are installed if not already present, when an upgrade is performed with install flag enabled")

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -175,6 +175,12 @@ func TestUpgradeCmd(t *testing.T) {
 			wantError: true,
 			rels:      []*release.Release{relWithStatusMock("funny-bunny", 2, ch, release.StatusPendingInstall)},
 		},
+		{
+			name:   "upgrade a release with --recreate-immutable-resources flag",
+			cmd:    fmt.Sprintf("upgrade funny-bunny '%s' --recreate-immutable-resources", chartPath),
+			golden: "output/upgrade.txt",
+			rels:   []*release.Release{relMock("funny-bunny", 2, ch)},
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -439,7 +439,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	if len(toBeAdopted) == 0 && len(resources) > 0 {
 		_, err = i.cfg.KubeClient.Create(resources)
 	} else if len(resources) > 0 {
-		_, err = i.cfg.KubeClient.Update(toBeAdopted, resources, i.Force)
+		_, err = i.cfg.KubeClient.Update(toBeAdopted, resources, i.Force, false)
 	}
 	if err != nil {
 		return rel, err

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -187,7 +187,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to set metadata visitor from target release")
 	}
-	results, err := r.cfg.KubeClient.Update(current, target, r.Force)
+	results, err := r.cfg.KubeClient.Update(current, target, r.Force, false)
 
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -35,16 +35,17 @@ import (
 type Rollback struct {
 	cfg *Configuration
 
-	Version       int
-	Timeout       time.Duration
-	Wait          bool
-	WaitForJobs   bool
-	DisableHooks  bool
-	DryRun        bool
-	Recreate      bool // will (if true) recreate pods after a rollback.
-	Force         bool // will (if true) force resource upgrade through uninstall/recreate if needed
-	CleanupOnFail bool
-	MaxHistory    int // MaxHistory limits the maximum number of revisions saved per release
+	Version                    int
+	Timeout                    time.Duration
+	Wait                       bool
+	WaitForJobs                bool
+	DisableHooks               bool
+	DryRun                     bool
+	Recreate                   bool // will (if true) recreate pods after a rollback.
+	Force                      bool // will (if true) force resource upgrade through uninstall/recreate if needed
+	CleanupOnFail              bool
+	MaxHistory                 int  // MaxHistory limits the maximum number of revisions saved per release
+	RecreateImmutableResources bool // will (if true) try to delete and recreate immutable resources on 422 status code
 }
 
 // NewRollback creates a new Rollback object with the given configuration.
@@ -187,7 +188,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to set metadata visitor from target release")
 	}
-	results, err := r.cfg.KubeClient.Update(current, target, r.Force, false)
+	results, err := r.cfg.KubeClient.Update(current, target, r.Force, r.RecreateImmutableResources)
 
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -78,6 +78,8 @@ type Upgrade struct {
 	//
 	// This should be used with caution.
 	Force bool
+	// Recreate resources will try to delete and create resources ONLY during upgrade if it receives statusError with code 422
+	RecreateImmutableResources bool
 	// ResetValues will reset the values to the chart's built-ins rather than merging with existing.
 	ResetValues bool
 	// ReuseValues will re-use the user's last supplied values.
@@ -405,7 +407,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 		u.cfg.Log("upgrade hooks disabled for %s", upgradedRelease.Name)
 	}
 
-	results, err := u.cfg.KubeClient.Update(current, target, u.Force)
+	results, err := u.cfg.KubeClient.Update(current, target, u.Force, u.RecreateImmutableResources)
 	if err != nil {
 		u.cfg.recordRelease(originalRelease)
 		u.reportToPerformUpgrade(c, upgradedRelease, results.Created, err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -513,6 +513,7 @@ func (u *Upgrade) failRelease(rel *release.Release, created kube.ResourceList, e
 		rollin.Recreate = u.Recreate
 		rollin.Force = u.Force
 		rollin.Timeout = u.Timeout
+		rollin.RecreateImmutableResources = u.RecreateImmutableResources
 		if rollErr := rollin.Run(rel.Name); rollErr != nil {
 			return rel, errors.Wrapf(rollErr, "an error occurred while rolling back the release. original upgrade error: %s", err)
 		}

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -107,11 +107,11 @@ func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.
 }
 
 // Update returns the configured error if set or prints
-func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
+func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool, alsoIgnoreMe bool) (*kube.Result, error) {
 	if f.UpdateError != nil {
 		return &kube.Result{}, f.UpdateError
 	}
-	return f.PrintingKubeClient.Update(r, modified, ignoreMe)
+	return f.PrintingKubeClient.Update(r, modified, ignoreMe, alsoIgnoreMe)
 }
 
 // Build returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -90,7 +90,7 @@ func (p *PrintingKubeClient) WatchUntilReady(resources kube.ResourceList, _ time
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool) (*kube.Result, error) {
+func (p *PrintingKubeClient) Update(_, modified kube.ResourceList, _ bool, _ bool) (*kube.Result, error) {
 	_, err := io.Copy(p.Out, bufferize(modified))
 	if err != nil {
 		return nil, err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -54,7 +54,7 @@ type Interface interface {
 
 	// Update updates one or more resources or creates the resource
 	// if it doesn't exist.
-	Update(original, target ResourceList, force bool) (*Result, error)
+	Update(original, target ResourceList, force bool, recreateImmutableResources bool) (*Result, error)
 
 	// Build creates a resource list from a Reader.
 	//


### PR DESCRIPTION
Closes #7082 

**What this PR does / why we need it**: This PR tries to solve the recreation resources problem in minimalistic way by adding new `--recreate-immutable-resources` argument to command line for `helm upgrade` only.
It should be mentioned that I read the whole discussion about the issues and I understand why maintainers are not eager to merge it, but I thought I will give it a try.
In my solution I would like to mark this feature as experimental (which I was not sure how to do) or just explicitly mention that if it would be used, bad things may happen (like example with deleting PVC).
However - as a helm user - I would like to use it myself in non-critical workflows where for example I change labels for my deployment.

**Special notes for your reviewer**: I am pretty sure reviewers are familiar with this problem. I didn't want to introduce the breaking change and I thought additional function parameter in `Update` is not breaking, but I may be wrong. If you think MR is worth to work on, I am happy to spend some more time on it, however if you think merging this would be very difficult or this is not really the feature you are looking for, information would also be appreciated.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Signed-off-by: Jakub Domanski <vegetto_sys@yahoo.com>
