### PR TITLE
fix version retrieval of get-helm-3

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -113,7 +113,7 @@ checkDesiredVersion() {
     if [ "${HAS_CURL}" == "true" ]; then
       latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
-      latest_release_response=$( wget "$latest_release_url" -O - 2>&1 || true )
+      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
     fi
     TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
     if [ "x$TAG" == "x" ]; then


### PR DESCRIPTION
add quiet switch to prevent output  like progress information in downloaded data

**What this PR does / why we need it**:
I wasn't able to install helm using the script when I had only wget installed. The reason was that exactly on the line with the version information from the download some output from wget was inserted.

The documentation of wget states the danger of using -O to write information because it just behaves like a shell redirection.
Using -q fixed the problem for me because no output from wget occurs and therefor the version retrieval was working.

**Special notes for your reviewer**:
None

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
