### PR TITLE
Revert "fix(main): fix basic auth for helm pull or push"

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -96,23 +96,8 @@ func NewClient(options ...ClientOption) (*Client, error) {
 				return resolver, nil
 			}
 		}
-
 		headers := http.Header{}
 		headers.Set("User-Agent", version.GetUserAgent())
-		dockerClient, ok := client.authorizer.(*dockerauth.Client)
-		if ok {
-			username, password, err := dockerClient.Credential(ref.Registry)
-			if err != nil {
-				return nil, fmt.Errorf("unable to retrieve credentials: %w", err)
-			}
-			// A blank returned username and password value is a bearer token
-			if username == "" && password != "" {
-				headers.Set("Authorization", fmt.Sprintf("Bearer %s", password))
-			} else {
-				headers.Set("Authorization", fmt.Sprintf("Basic %s", basicAuth(username, password)))
-			}
-		}
-
 		opts := []auth.ResolverOption{auth.WithResolverHeaders(headers)}
 		if client.httpClient != nil {
 			opts = append(opts, auth.WithResolverClient(client.httpClient))
@@ -144,6 +129,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 				if !ok {
 					return registryauth.EmptyCredential, errors.New("unable to obtain docker client")
 				}
+
 				username, password, err := dockerClient.Credential(reg)
 				if err != nil {
 					return registryauth.EmptyCredential, errors.New("unable to retrieve credentials")
@@ -607,6 +593,7 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	if err := memoryStore.StoreManifest(parsedRef.String(), manifest, manifestData); err != nil {
 		return nil, err
 	}
+
 	remotesResolver, err := c.resolver(parsedRef)
 	if err != nil {
 		return nil, err

--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -19,7 +19,6 @@ package registry // import "helm.sh/helm/v3/pkg/registry"
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -245,14 +244,4 @@ func addToMap(inputMap map[string]string, newKey string, newValue string) map[st
 
 	return inputMap
 
-}
-
-// See 2 (end of page 4) https://www.ietf.org/rfc/rfc2617.txt
-// "To receive authorization, the client sends the userid and password,
-// separated by a single colon (":") character, within a base64
-// encoded string in the credentials."
-// It is not meant to be urlencoded.
-func basicAuth(username, password string) string {
-	auth := username + ":" + password
-	return base64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/pkg/registry/util_test.go
+++ b/pkg/registry/util_test.go
@@ -238,31 +238,3 @@ func TestGenerateOCICreatedAnnotations(t *testing.T) {
 	}
 
 }
-
-func Test_basicAuth(t *testing.T) {
-	type args struct {
-		username string
-		password string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "Basic Auth",
-			args: args{
-				username: "admin",
-				password: "passw0rd",
-			},
-			want: "YWRtaW46cGFzc3cwcmQ=",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := basicAuth(tt.args.username, tt.args.password); got != tt.want {
-				t.Errorf("basicAuth() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
This reverts commit 4a27baaffc7ae112c2f45e3cd72dd249d9563a5a.

The change to improve basic auth support caused a regression for bearer tokens. Reverting the change until we have a well understood path forward.

Note, #11129 was layered in along with this and it has been preserved with the reversion. It added to the API and we do not want to remove that.

Closes #12491

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

Note, this was created with `git revert` rather than GitHub because it was not a clean revert due to other changes that have happened since then. The original PR being reverted is #12237.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
