### PR TITLE
Fixing release labelling in rollback

### DIFF
--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -120,4 +122,45 @@ func TestRollbackFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "rollback", false)
 	checkFileCompletion(t, "rollback myrelease", false)
 	checkFileCompletion(t, "rollback myrelease 1", false)
+}
+
+func TestRollbackWithLabels(t *testing.T) {
+	labels1 := map[string]string{"operation": "install", "firstLabel": "firstValue"}
+	labels2 := map[string]string{"operation": "upgrade", "secondLabel": "secondValue"}
+
+	releaseName := "funny-bunny-labels"
+	rels := []*release.Release{
+		{
+			Name:    releaseName,
+			Info:    &release.Info{Status: release.StatusSuperseded},
+			Chart:   &chart.Chart{},
+			Version: 1,
+			Labels:  labels1,
+		},
+		{
+			Name:    releaseName,
+			Info:    &release.Info{Status: release.StatusDeployed},
+			Chart:   &chart.Chart{},
+			Version: 2,
+			Labels:  labels2,
+		},
+	}
+	storage := storageFixture()
+	for _, rel := range rels {
+		if err := storage.Create(rel); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, _, err := executeActionCommandC(storage, fmt.Sprintf("rollback %s 1", releaseName))
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := storage.Get(releaseName, 3)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+
+	if !reflect.DeepEqual(updatedRel.Labels, labels1) {
+		t.Errorf("Expected {%v}, got {%v}", labels1, updatedRel.Labels)
+	}
 }

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -151,6 +151,7 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 			Description: fmt.Sprintf("Rollback to %d", previousVersion),
 		},
 		Version:  currentRelease.Version + 1,
+		Labels:   previousRelease.Labels,
 		Manifest: previousRelease.Manifest,
 		Hooks:    previousRelease.Hooks,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

refs https://github.com/helm/helm/issues/12521

This is a proposed solution for issue https://github.com/helm/helm/issues/12521:

Fix the problem of missing labeling in the rollback release secret. The labels are copied from the rollback target release.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [*] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
