### PR TITLE
feat: add support for --disable-openapi-validation flag in uninstall and hook

### DIFF
--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -77,6 +77,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.IgnoreNotFound, "ignore-not-found", false, `Treat "release not found" as a successful uninstall`)
 	f.BoolVar(&client.KeepHistory, "keep-history", false, "remove all associated resources and mark the release as deleted, but retain the release history")
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
+	f.BoolVar(&client.DisableOpenAPIValidation, "disable-openapi-validation", false, "if set, the uninstallation process will not validate rendered templates against the Kubernetes OpenAPI Schema")
 	f.StringVar(&client.DeletionPropagation, "cascade", "background", "Must be \"background\", \"orphan\", or \"foreground\". Selects the deletion cascading strategy for the dependents. Defaults to background.")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.StringVar(&client.Description, "description", "", "add a custom description")

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -27,7 +27,7 @@ import (
 )
 
 // execHook executes all of the hooks for the given hook event.
-func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout time.Duration) error {
+func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, timeout time.Duration, openAPIValidation bool) error {
 	executingHooks := []*release.Hook{}
 
 	for _, h := range rl.Hooks {
@@ -55,7 +55,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			return err
 		}
 
-		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), true)
+		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), openAPIValidation)
 		if err != nil {
 			return errors.Wrapf(err, "unable to build kubernetes object for %s hook %s", hook, h.Path)
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -428,7 +428,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	var err error
 	// pre-install hooks
 	if !i.DisableHooks {
-		if err := i.cfg.execHook(rel, release.HookPreInstall, i.Timeout); err != nil {
+		if err := i.cfg.execHook(rel, release.HookPreInstall, i.Timeout, !i.DisableOpenAPIValidation); err != nil {
 			return rel, fmt.Errorf("failed pre-install: %s", err)
 		}
 	}
@@ -457,7 +457,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	}
 
 	if !i.DisableHooks {
-		if err := i.cfg.execHook(rel, release.HookPostInstall, i.Timeout); err != nil {
+		if err := i.cfg.execHook(rel, release.HookPostInstall, i.Timeout, !i.DisableOpenAPIValidation); err != nil {
 			return rel, fmt.Errorf("failed post-install: %s", err)
 		}
 	}

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -94,7 +94,7 @@ func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
 		rel.Hooks = executingHooks
 	}
 
-	if err := r.cfg.execHook(rel, release.HookTest, r.Timeout); err != nil {
+	if err := r.cfg.execHook(rel, release.HookTest, r.Timeout, false); err != nil {
 		rel.Hooks = append(skippedHooks, rel.Hooks...)
 		r.cfg.Releases.Update(rel)
 		return rel, err

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -175,7 +175,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 
 	// pre-rollback hooks
 	if !r.DisableHooks {
-		if err := r.cfg.execHook(targetRelease, release.HookPreRollback, r.Timeout); err != nil {
+		if err := r.cfg.execHook(targetRelease, release.HookPreRollback, r.Timeout, false); err != nil {
 			return targetRelease, err
 		}
 	} else {
@@ -242,7 +242,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 
 	// post-rollback hooks
 	if !r.DisableHooks {
-		if err := r.cfg.execHook(targetRelease, release.HookPostRollback, r.Timeout); err != nil {
+		if err := r.cfg.execHook(targetRelease, release.HookPostRollback, r.Timeout, false); err != nil {
 			return targetRelease, err
 		}
 	}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -37,14 +37,15 @@ import (
 type Uninstall struct {
 	cfg *Configuration
 
-	DisableHooks        bool
-	DryRun              bool
-	IgnoreNotFound      bool
-	KeepHistory         bool
-	Wait                bool
-	DeletionPropagation string
-	Timeout             time.Duration
-	Description         string
+	DisableHooks             bool
+	DryRun                   bool
+	IgnoreNotFound           bool
+	KeepHistory              bool
+	Wait                     bool
+	DeletionPropagation      string
+	DisableOpenAPIValidation bool
+	Timeout                  time.Duration
+	Description              string
 }
 
 // NewUninstall creates a new Uninstall object with the given configuration.
@@ -106,7 +107,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	res := &release.UninstallReleaseResponse{Release: rel}
 
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(rel, release.HookPreDelete, u.Timeout); err != nil {
+		if err := u.cfg.execHook(rel, release.HookPreDelete, u.Timeout, !u.DisableOpenAPIValidation); err != nil {
 			return res, err
 		}
 	} else {
@@ -139,7 +140,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(rel, release.HookPostDelete, u.Timeout); err != nil {
+		if err := u.cfg.execHook(rel, release.HookPostDelete, u.Timeout, !u.DisableOpenAPIValidation); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -222,7 +223,7 @@ func (u *Uninstall) deleteRelease(rel *release.Release) (kube.ResourceList, stri
 		builder.WriteString("\n---\n" + file.Content)
 	}
 
-	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), false)
+	resources, err := u.cfg.KubeClient.Build(strings.NewReader(builder.String()), !u.DisableOpenAPIValidation)
 	if err != nil {
 		return nil, "", []error{errors.Wrap(err, "unable to build kubernetes objects for delete")}
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -399,7 +399,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 	// pre-upgrade hooks
 
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.Timeout); err != nil {
+		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.Timeout, !u.DisableOpenAPIValidation); err != nil {
 			u.reportToPerformUpgrade(c, upgradedRelease, kube.ResourceList{}, fmt.Errorf("pre-upgrade hooks failed: %s", err))
 			return
 		}
@@ -445,7 +445,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 
 	// post-upgrade hooks
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(upgradedRelease, release.HookPostUpgrade, u.Timeout); err != nil {
+		if err := u.cfg.execHook(upgradedRelease, release.HookPostUpgrade, u.Timeout, !u.DisableOpenAPIValidation); err != nil {
 			u.reportToPerformUpgrade(c, upgradedRelease, results.Created, fmt.Errorf("post-upgrade hooks failed: %s", err))
 			return
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Helm already support `--disable-openapi-validation` flag for install and upgrade, but some hooks also validate scheme. In some case, we don't need validate OpenAPI scheme for hook.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
