### PR TITLE
Support loading subschemas from the schemas directory in a chart

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -46,8 +46,10 @@ type Chart struct {
 	Templates []*File `json:"templates"`
 	// Values are default config for this chart.
 	Values map[string]interface{} `json:"values"`
-	// Schema is an optional JSON schema for imposing structure on Values
+	// Schema is an optional JSON schema imposing structure on the chart values
 	Schema []byte `json:"schema"`
+	// Additional schemas are optional JSON schemas that can be referenced from the root schema
+	ExtraSchemas [][]byte `json:"extra_schemas"`
 	// Files are miscellaneous files in a chart archive,
 	// e.g. README, LICENSE, etc.
 	Files []*File `json:"files"`

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -137,7 +137,8 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if c.Metadata.APIVersion == chart.APIVersionV1 {
 				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
 			}
-
+		case strings.HasPrefix(f.Name, "schemas/"):
+			c.ExtraSchemas = append(c.ExtraSchemas, f.Data)
 		case strings.HasPrefix(f.Name, "templates/"):
 			c.Templates = append(c.Templates, &chart.File{Name: f.Name, Data: f.Data})
 		case strings.HasPrefix(f.Name, "charts/"):

--- a/pkg/chartutil/jsonschema.go
+++ b/pkg/chartutil/jsonschema.go
@@ -77,12 +77,15 @@ func ValidateAgainstSingleSchema(values Values, schemaJSON []byte, extraSchemas 
 	extraSchemasLoader := gojsonschema.NewSchemaLoader()
 	for _, extraSchema := range extraSchemas {
 		extraLoader := gojsonschema.NewBytesLoader(extraSchema)
-		extraSchemasLoader.AddSchemas(extraLoader)
+		err = extraSchemasLoader.AddSchemas(extraLoader)
+		if err != nil {
+			return fmt.Errorf("unable to load extra schema: %s", err)
+		}
 	}
 	rootSchemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
 	rootSchema, err := extraSchemasLoader.Compile(rootSchemaLoader)
 	if err != nil {
-		return fmt.Errorf("enable to compile schema: %s", err)
+		return fmt.Errorf("unable to compile schema: %s", err)
 	}
 
 	valuesLoader := gojsonschema.NewBytesLoader(valuesJSON)

--- a/pkg/chartutil/jsonschema.go
+++ b/pkg/chartutil/jsonschema.go
@@ -32,7 +32,7 @@ import (
 func ValidateAgainstSchema(chrt *chart.Chart, values map[string]interface{}) error {
 	var sb strings.Builder
 	if chrt.Schema != nil {
-		err := ValidateAgainstSingleSchema(values, chrt.Schema)
+		err := ValidateAgainstSingleSchema(values, chrt.Schema, chrt.ExtraSchemas)
 		if err != nil {
 			sb.WriteString(fmt.Sprintf("%s:\n", chrt.Name()))
 			sb.WriteString(err.Error())
@@ -55,7 +55,7 @@ func ValidateAgainstSchema(chrt *chart.Chart, values map[string]interface{}) err
 }
 
 // ValidateAgainstSingleSchema checks that values does not violate the structure laid out in this schema
-func ValidateAgainstSingleSchema(values Values, schemaJSON []byte) (reterr error) {
+func ValidateAgainstSingleSchema(values Values, schemaJSON []byte, extraSchemas [][]byte) (reterr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			reterr = fmt.Errorf("unable to validate schema: %s", r)
@@ -73,10 +73,21 @@ func ValidateAgainstSingleSchema(values Values, schemaJSON []byte) (reterr error
 	if bytes.Equal(valuesJSON, []byte("null")) {
 		valuesJSON = []byte("{}")
 	}
-	schemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
+
+	extraSchemasLoader := gojsonschema.NewSchemaLoader()
+	for _, extraSchema := range extraSchemas {
+		extraLoader := gojsonschema.NewBytesLoader(extraSchema)
+		extraSchemasLoader.AddSchemas(extraLoader)
+	}
+	rootSchemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
+	rootSchema, err := extraSchemasLoader.Compile(rootSchemaLoader)
+	if err != nil {
+		return fmt.Errorf("enable to compile schema: %s", err)
+	}
+
 	valuesLoader := gojsonschema.NewBytesLoader(valuesJSON)
 
-	result, err := gojsonschema.Validate(schemaLoader, valuesLoader)
+	result, err := rootSchema.Validate(valuesLoader)
 	if err != nil {
 		return err
 	}

--- a/pkg/chartutil/jsonschema_test.go
+++ b/pkg/chartutil/jsonschema_test.go
@@ -33,7 +33,29 @@ func TestValidateAgainstSingleSchema(t *testing.T) {
 		t.Fatalf("Error reading YAML file: %s", err)
 	}
 
-	if err := ValidateAgainstSingleSchema(values, schema); err != nil {
+	if err := ValidateAgainstSingleSchema(values, schema, make([][]byte, 0)); err != nil {
+		t.Errorf("Error validating Values against Schema: %s", err)
+	}
+}
+
+func TestValidateAgainstSchemaWithExtras(t *testing.T) {
+	values, err := ReadValuesFile("./testdata/test-values.yaml")
+	if err != nil {
+		t.Fatalf("Error reading YAML file: %s", err)
+	}
+	schema, err := os.ReadFile("./testdata/test-values-with-extra.schema.json")
+	if err != nil {
+		t.Fatalf("Error reading YAML file: %s", err)
+	}
+	extra, err := os.ReadFile("./testdata/test-values-extra.schema.json")
+	if err != nil {
+		t.Fatalf("Error reading YAML file: %s", err)
+	}
+
+	extraSchemas := make([][]byte, 1)
+	extraSchemas[0] = extra
+
+	if err := ValidateAgainstSingleSchema(values, schema, extraSchemas); err != nil {
 		t.Errorf("Error validating Values against Schema: %s", err)
 	}
 }
@@ -49,7 +71,7 @@ func TestValidateAgainstInvalidSingleSchema(t *testing.T) {
 	}
 
 	var errString string
-	if err := ValidateAgainstSingleSchema(values, schema); err == nil {
+	if err := ValidateAgainstSingleSchema(values, schema, make([][]byte, 0)); err == nil {
 		t.Fatalf("Expected an error, but got nil")
 	} else {
 		errString = err.Error()
@@ -73,7 +95,7 @@ func TestValidateAgainstSingleSchemaNegative(t *testing.T) {
 	}
 
 	var errString string
-	if err := ValidateAgainstSingleSchema(values, schema); err == nil {
+	if err := ValidateAgainstSingleSchema(values, schema, make([][]byte, 0)); err == nil {
 		t.Fatalf("Expected an error, but got nil")
 	} else {
 		errString = err.Error()

--- a/pkg/chartutil/testdata/test-values-extra.schema.json
+++ b/pkg/chartutil/testdata/test-values-extra.schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://helm.sh/schemas/addresses",
+  "type": "array",
+  "description": "List of addresses",
+  "items": {
+    "properties": {
+      "city": {
+        "type": "string"
+      },
+      "number": {
+        "type": "number"
+      },
+      "street": {
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+}

--- a/pkg/chartutil/testdata/test-values-with-extra.schema.json
+++ b/pkg/chartutil/testdata/test-values-with-extra.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "addresses": {
+      "$ref": "https://helm.sh/schemas/addresses"
+    },
+    "age": {
+      "description": "Age",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "employmentInfo": {
+      "properties": {
+        "salary": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "salary"
+      ],
+      "type": "object"
+    },
+    "firstname": {
+      "description": "First name",
+      "type": "string"
+    },
+    "lastname": {
+      "type": "string"
+    },
+    "likesCoffee": {
+      "type": "boolean"
+    },
+    "phoneNumbers": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "firstname",
+    "lastname",
+    "addresses",
+    "employmentInfo"
+  ],
+  "title": "Values",
+  "type": "object"
+}

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -18,6 +18,7 @@ package rules
 
 import (
 	"os"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -76,11 +77,46 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	ext := filepath.Ext(valuesPath)
 	schemaPath := valuesPath[:len(valuesPath)-len(ext)] + ".schema.json"
 	schema, err := os.ReadFile(schemaPath)
+
+	// Check for zero-length _before_ checking for errors, since we want schema files to be optional
 	if len(schema) == 0 {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	return chartutil.ValidateAgainstSingleSchema(coalescedValues, schema)
+
+	extraSchemas := make([][]byte, 0)
+	schemasPath := filepath.Dir(valuesPath) + "/schemas"
+	err = filepath.WalkDir(schemasPath, func(path string, dentry fs.DirEntry, err error) error {
+		if path == schemasPath && dentry == nil && err != nil {
+			// The "schemas" folder could not be opened if it doesn't exist, treat it as empty
+			if os.IsNotExist(err) {
+				return fs.SkipAll
+			} else {
+				return err
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if !dentry.IsDir() {
+			schema, err = os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			extraSchemas = append(extraSchemas, schema)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return chartutil.ValidateAgainstSingleSchema(coalescedValues, schema, extraSchemas)
 }

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -103,12 +103,12 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 		}
 
 		if !dentry.IsDir() {
-			schema, err = os.ReadFile(path)
+			extraSchema, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
 
-			extraSchemas = append(extraSchemas, schema)
+			extraSchemas = append(extraSchemas, extraSchema)
 		}
 
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to #10481.

It's often nice to be able to write JSON schemas as separate files and to reference them with the `$ref` key into the root schema (this is handy when the subschemas are not your own, or when other tools wish to integrate with part of your data model, or if you have a large schema with duplication and want to compartmentalize the various sections of configuration.

JSON schema allows `$ref` markers to point to a "canonical location" for a subschema, with the intention that the schema validator will go and fetch the subschema during compilation of the schema for a validation operation.  This is "fine" (with the usual caveats) if the canonical location is an `http(s)://` URL since the validator can go and fetch that URL when it needs to, but is less fine for a `file://` URL since that file might not be available if the Chart is published and subsequently fetched onto another machine.  Fortunately the JSONschema module that helm uses allows "pre-loading" of subschemas which can then be used to satisfy `$ref` markers without needing to fetch from the canonical location (the `$id` element of the subschema names the canonical location for cross-corelation).

Using the above, this MR allows chart authors to place subschemas into the `schemas` folder of their chart, which will be pre-loaded when processing the `values.schema.json` file.  This means that local subschemas can be named by the Chart and still be accessible when the chart is use on a second device (since the `schemas` folder will be packaged with the chart).

Schemas can still use `http(s)` references as before.

**Special notes for your reviewer**:

I've not written any documentation for this change yet, since I'm not sure having a special `schemas` folder is the right model, I considered having a list in the Chart.toml of extra schemas to load, or loading all files called `*.schema.json` in the Chart root but thought a folder would be easiest for the user.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
