### PR TITLE
fix: oci getter with version option and ref version

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -145,6 +145,14 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 	var tag string
 	var err error
 
+	if strings.Contains(u.Path, ":") {
+		v := strings.Split(u.Path, ":")[1]
+		if version != "" && v != version {
+			return nil, errors.Errorf("chart ref version mismatch: %s, %s", version, v)
+		}
+		return u, nil
+	}
+
 	// Evaluate whether an explicit version has been provided. Otherwise, determine version to use
 	_, errSemVer := semver.NewVersion(version)
 	if errSemVer == nil {

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -53,6 +53,8 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "full URL, file", ref: "file:///foo-1.2.3.tgz", fail: true},
 		{name: "invalid", ref: "invalid-1.2.3", fail: true},
 		{name: "not found", ref: "nosuchthing/invalid-1.2.3", fail: true},
+		{name: "ref with tag", ref: "oci://example.com/helm-charts/nginx:15.4.2", expect: "oci://example.com/helm-charts/nginx:15.4.2"},
+		{name: "oci ref", ref: "oci://example.com/helm-charts/nginx", version: "15.4.2", expect: "oci://example.com/helm-charts/nginx:15.4.2"},
 	}
 
 	c := ChartDownloader{

--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -57,7 +58,9 @@ func (g *OCIGetter) get(href string) (*bytes.Buffer, error) {
 	}
 
 	ref := strings.TrimPrefix(href, fmt.Sprintf("%s://", registry.OCIScheme))
-
+	if version := g.opts.version; version != "" && !strings.Contains(path.Base(ref), ":") {
+		ref = fmt.Sprintf("%s:%s", ref, version)
+	}
 	var pullOpts []registry.PullOption
 	requestingProv := strings.HasSuffix(ref, ".prov")
 	if requestingProv {


### PR DESCRIPTION
**What this PR does / why we need it**:
- currently ocigetter WithTagName option didn't take effect
- current chartDownloader can not handle oci chart reference with tag

The above 2 situation is some conflict, since I can not use WithTagName option, I must contain tag in chart reference, but after the chartDownloader's ResolveChartVersion function, I got the ref as: oci://example.com/helm-charts/nginx:15.4.2:15.4.2, we can see it in chart_downloader_test.go

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
