### PR TITLE
fix(uninstall): supersede deployed releases

### DIFF
--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -18,8 +18,8 @@ package action
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +28,7 @@ import (
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
 )
 
 // Rollback is the action for rolling back to a given release.
@@ -278,7 +279,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	}
 
 	deployed, err := r.cfg.Releases.DeployedAll(currentRelease.Name)
-	if err != nil && !strings.Contains(err.Error(), "has no deployed releases") {
+	if err != nil && !errors.Is(err, driver.ErrNoDeployedReleases) {
 		return nil, err
 	}
 	// Supersede all previous deployments, see issue #2941.

--- a/pkg/cmd/testdata/output/uninstall-keep-history-earlier-deployed.txt
+++ b/pkg/cmd/testdata/output/uninstall-keep-history-earlier-deployed.txt
@@ -1,0 +1,1 @@
+release "aeneas" uninstalled

--- a/pkg/cmd/uninstall_test.go
+++ b/pkg/cmd/uninstall_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"testing"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -56,6 +57,15 @@ func TestUninstall(t *testing.T) {
 			cmd:    "uninstall aeneas --keep-history",
 			golden: "output/uninstall-keep-history.txt",
 			rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "aeneas"})},
+		},
+		{
+			name:   "keep history with earlier deployed release",
+			cmd:    "uninstall aeneas --keep-history",
+			golden: "output/uninstall-keep-history-earlier-deployed.txt",
+			rels: []*release.Release{
+				release.Mock(&release.MockReleaseOptions{Name: "aeneas", Version: 1, Status: common.StatusDeployed}),
+				release.Mock(&release.MockReleaseOptions{Name: "aeneas", Version: 2, Status: common.StatusFailed}),
+			},
 		},
 		{
 			name:   "wait",


### PR DESCRIPTION
**What this PR does / why we need it**:

This ensures that when `helm uninstall` is run with `--keep-history`, any release in a `deployed` state other than the last release (e.g. due to a failed upgrade) is being marked as `superseded`.

As a by-effect, running `helm upgrade` on a release which has been uninstalled after an upgrade failure now no longer works. But instead fails with a `"<name>" has no deployed releases` error. Which is the (likely) intended behavior, and prevents other side-effects like rolling back to a release version which happened before the uninstall if `--atomic` was provided.

Fixes #12556

---

Compared to example commands from above issue:

```console
$ helm install podinfo podinfo/podinfo
NAME: podinfo
LAST DEPLOYED: Mon Nov 13 21:54:51 2023
NAMESPACE: helm-system
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl -n helm-system port-forward deploy/podinfo 8080:9898

$ helm upgrade podinfo podinfo/podinfo --set replicaCount=2 --set faults.unready=true --wait --timeout=10s 
Error: UPGRADE FAILED: context deadline exceeded

$ helm uninstall podinfo --keep-history                                                               
release "podinfo" uninstalled

$ helm history podinfo
REVISION        UPDATED                         STATUS          CHART           APP VERSION     DESCRIPTION            
1               Mon Nov 13 21:54:51 2023        superseded      podinfo-6.5.0   6.5.0           Install complete       
2               Mon Nov 13 21:55:21 2023        uninstalled     podinfo-6.5.0   6.5.0           Uninstallation complete

$ helm upgrade podinfo podinfo/podinfo --set replicaCount=2 --set faults.unready=true --wait --timeout=10s --atomic
Error: UPGRADE FAILED: "podinfo" has no deployed releases
```

**Special notes for your reviewer**:

While I added a test from the perspective of the CLI, it appears to be hard to actually validate it being updated to `superseded` there.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
