### PR TITLE
Support overwritting values from `import-values` dependencies

### DIFF
--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -66,6 +66,31 @@ func (d *Dependency) Validate() error {
 	if d.Alias != "" && !aliasNameFormat.MatchString(d.Alias) {
 		return ValidationErrorf("dependency %q has disallowed characters in the alias", d.Name)
 	}
+	for _, riv := range d.ImportValues {
+		switch iv := riv.(type) {
+		case map[string]interface{}:
+			for k, v := range iv {
+				switch k {
+				case "child":
+					if _, ok := v.(string); !ok {
+						return ValidationErrorf("dependency %q has invalid importValues; child must be a string", d.Name)
+					}
+				case "parent":
+					if _, ok := v.(string); !ok {
+						return ValidationErrorf("dependency %q has invalid importValues; parent must be a string", d.Name)
+					}
+				case "overwrite":
+					if _, ok := v.(bool); !ok {
+						return ValidationErrorf("dependency %q has invalid importValues; overwrite must be a boolean", d.Name)
+					}
+				}
+			}
+		case string:
+			// String is always valid
+		default:
+			return ValidationErrorf("dependency %q has invalid importValues of type %T", d.Name, iv)
+		}
+	}
 	return nil
 }
 

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -190,6 +190,15 @@ func TestProcessDependencyImportValues(t *testing.T) {
 	e["overridden-chart1.SC1string"] = "pollywog"
 	e["overridden-chart1.SPextra2"] = "42"
 
+	// These values are imported from the child chart to the parent. Parent values are present.
+	// Child is configred to take precedence
+	e["child-overridden-chart1.SC1bool"] = "true"
+	e["child-overridden-chart1.SC1float"] = "3.14"
+	e["child-overridden-chart1.SC1int"] = "100"
+	e["child-overridden-chart1.SC1string"] = "dollywood"
+	e["child-overridden-chart1.SC1extra1"] = "11"
+	e["child-overridden-chart1.SPextra2"] = "42"
+
 	e["overridden-chartA.SCAbool"] = "true"
 	e["overridden-chartA.SCAfloat"] = "41.3"
 	e["overridden-chartA.SCAint"] = "808"

--- a/pkg/chartutil/testdata/subpop/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/Chart.yaml
@@ -15,6 +15,9 @@ dependencies:
         parent: imported-chart1
       - child: SC1data
         parent: overridden-chart1
+      - child: SC1data
+        parent: child-overridden-chart1
+        overwrite: true
       - child: imported-chartA
         parent: imported-chartA
       - child: imported-chartA-B

--- a/pkg/chartutil/testdata/subpop/values.yaml
+++ b/pkg/chartutil/testdata/subpop/values.yaml
@@ -10,6 +10,12 @@ overridden-chart1:
   SC1string: "pollywog"
   SPextra2: 42
 
+child-overridden-chart1:
+  SC1bool: false
+  SC1float: 3.141592
+  SC1int: 99
+  SC1string: "pollywog"
+  SPextra2: 42
 
 imported-chartA:
   SPextra3: 1.337


### PR DESCRIPTION
**What this PR does / why we need it**:
Alternative to https://github.com/helm/helm/issues/12466

This allows the above requirement to be implemented in terms of existing Helm functionality. Instead of built in support for a "bundled value set", a chart can expose a dependency on a chart which provides some sets of values. These can be conditionally enabled with `import-values` and `conditions` on the dependency.

The one gap in this approach is the parent values take precedence. This allows a user to *opt in* to making children high precedence.

Additionally, a unit test and additional validation for the field is added.

Note: overall, this is a worse experience than #12466 could provide for this use case. So I would prefer to still do that if feasible. However, this is a low-cost approach

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation - NO, I can send a PR to helm-www if this merges though
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
