### PR TITLE
Consider full GroupVersionKind when matching resources

### DIFF
--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -81,5 +81,5 @@ func (r ResourceList) Intersect(rs ResourceList) ResourceList {
 
 // isMatchingInfo returns true if infos match on Name and GroupVersionKind.
 func isMatchingInfo(a, b *resource.Info) bool {
-	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind && a.Mapping.GroupVersionKind.Group == b.Mapping.GroupVersionKind.Group
+	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind == b.Mapping.GroupVersionKind
 }

--- a/pkg/kube/resource_test.go
+++ b/pkg/kube/resource_test.go
@@ -59,3 +59,42 @@ func TestResourceList(t *testing.T) {
 		t.Error("expected intersect to return bar")
 	}
 }
+
+func TestIsMatchingInfo(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "group1", Version: "version1", Kind: "pod"}
+	resourceInfo := resource.Info{Name: "name1", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvk}}
+
+	gvkDiffGroup := schema.GroupVersionKind{Group: "diff", Version: "version1", Kind: "pod"}
+	resourceInfoDiffGroup := resource.Info{Name: "name1", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvkDiffGroup}}
+	if isMatchingInfo(&resourceInfo, &resourceInfoDiffGroup) {
+		t.Error("expected resources not equal")
+	}
+
+	gvkDiffVersion := schema.GroupVersionKind{Group: "group1", Version: "diff", Kind: "pod"}
+	resourceInfoDiffVersion := resource.Info{Name: "name1", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvkDiffVersion}}
+	if isMatchingInfo(&resourceInfo, &resourceInfoDiffVersion) {
+		t.Error("expected resources not equal")
+	}
+
+	gvkDiffKind := schema.GroupVersionKind{Group: "group1", Version: "version1", Kind: "deployment"}
+	resourceInfoDiffKind := resource.Info{Name: "name1", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvkDiffKind}}
+	if isMatchingInfo(&resourceInfo, &resourceInfoDiffKind) {
+		t.Error("expected resources not equal")
+	}
+
+	resourceInfoDiffName := resource.Info{Name: "diff", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvk}}
+	if isMatchingInfo(&resourceInfo, &resourceInfoDiffName) {
+		t.Error("expected resources not equal")
+	}
+
+	resourceInfoDiffNamespace := resource.Info{Name: "name1", Namespace: "diff", Mapping: &meta.RESTMapping{GroupVersionKind: gvk}}
+	if isMatchingInfo(&resourceInfo, &resourceInfoDiffNamespace) {
+		t.Error("expected resources not equal")
+	}
+
+	gvkEqual := schema.GroupVersionKind{Group: "group1", Version: "version1", Kind: "pod"}
+	resourceInfoEqual := resource.Info{Name: "name1", Namespace: "namespace1", Mapping: &meta.RESTMapping{GroupVersionKind: gvkEqual}}
+	if !isMatchingInfo(&resourceInfo, &resourceInfoEqual) {
+		t.Error("expected resources to be equal")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This change shall take Group, Version and Kind from GroupVersionKind into consideration instead of the current behavior of only considering the Kind when matching resources.
This is needed as resources with different apiVersion are being considered the same.

Closes: #12578


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
