### PR TITLE
Make the authorizer and registry authorizer configurable

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -175,6 +175,26 @@ func ClientOptWriter(out io.Writer) ClientOption {
 	}
 }
 
+// ClientOptAuthorizer returns a function that sets the authorizer setting on a client options set. This
+// can be used to override the default authorization mechanism.
+//
+// Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
+func ClientOptAuthorizer(authorizer auth.Client) ClientOption {
+	return func(client *Client) {
+		client.authorizer = authorizer
+	}
+}
+
+// ClientOptRegistryAuthorizer returns a function that sets the registry authorizer setting on a client options set. This
+// can be used to override the default authorization mechanism.
+//
+// Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
+func ClientOptRegistryAuthorizer(registryAuthorizer *registryauth.Client) ClientOption {
+	return func(client *Client) {
+		client.registryAuthorizer = registryAuthorizer
+	}
+}
+
 // ClientOptCredentialsFile returns a function that sets the credentialsFile setting on a client options set
 func ClientOptCredentialsFile(credentialsFile string) ClientOption {
 	return func(client *Client) {


### PR DESCRIPTION
Fixes: #12584



**What this PR does / why we need it**:

This change makes the authorizer and registryAuthorizer of the registry client configurable via options. This allows Go SDK users to override the authentication behavior of the client.

In my use-case we're doing programmatic pulls of a public chart stored on ghcr.io. We've found that many users logged into ghcr.io a long time ago and never logged out. This results in our pull getting rejected (on our public chart) because the user has cached/stored credentials. This is a common problem for ghcr.io because they don't use subdomains (`ghcr.io/my-project` not `myproject.ghcr.io`) so the scope of a login is all of ghcr.io.


**Special notes for your reviewer**:

This PR makes both the authorizer and registryAuthorizer configurable because depending on the exact scenario that may be needed. The default registryAuthorizer only supports a specific implementation of the authorizer.

I wasn't able to find any unit tests for the these features. Please advise on what you think would be helpful to cover and I can add more tests.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
