### PR TITLE
Fix issue with precedence of imports. Imports in parent did not overr…

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -304,8 +304,8 @@ func processImportValues(c *chart.Chart, merge bool) error {
 		// deep copying the cvals as there are cases where pointers can end
 		// up in the cvals when they are copied onto b in ways that break things.
 		// Merge dependencies in the chart values-file first
-	    b = MergeTables(deepCopyMap(c.Values), b)
-	    // next merge sub-chart values in the chart-values merged with the dependencies
+		b = MergeTables(deepCopyMap(c.Values), b)
+		// next merge sub-chart values in the chart-values merged with the dependencies
 		c.Values = MergeTables(deepCopyMap(b), cvals)
 	} else {
 		// Trimming the nil values from cvals is needed for backwards compatibility.

--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -303,8 +303,10 @@ func processImportValues(c *chart.Chart, merge bool) error {
 	if merge {
 		// deep copying the cvals as there are cases where pointers can end
 		// up in the cvals when they are copied onto b in ways that break things.
-		cvals = deepCopyMap(cvals)
-		c.Values = MergeTables(cvals, b)
+		// Merge dependencies in the chart values-file first
+	    b = MergeTables(deepCopyMap(c.Values), b)
+	    // next merge sub-chart values in the chart-values merged with the dependencies
+		c.Values = MergeTables(deepCopyMap(b), cvals)
 	} else {
 		// Trimming the nil values from cvals is needed for backwards compatibility.
 		// Previously, the b value had been populated with cvals along with some

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -290,10 +290,19 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 	//   chart. The library chart value should be used.
 	// - app4 has a value in the app chart and does not import the value from the
 	//   library chart. The app charts value should be used.
+	// - app5 has no value in the app chart and does not import the value. Umbrella import values
+	//   The umbrella import value should be used.
+	// - app6 has null value in the app chart and does not import the value. Umbrella import values
+	//   The app umbrella import value should be used.
+	// - app7 has a value in the app chart and does not import the value. Umbrella import values
+	//   The app umbrella import value should be used.
 	e["app1.service.port"] = "3456"
 	e["app2.service.port"] = "8080"
 	e["app3.service.port"] = "9090"
 	e["app4.service.port"] = "1234"
+	e["app5.service.port"] = "9090"
+    e["app6.service.port"] = "9090"
+    e["app7.service.port"] = "9090"
 	if err := processDependencyImportValues(c, true); err != nil {
 		t.Fatalf("processing import values dependencies %v", err)
 	}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -301,8 +301,8 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 	e["app3.service.port"] = "9090"
 	e["app4.service.port"] = "1234"
 	e["app5.service.port"] = "9090"
-    e["app6.service.port"] = "9090"
-    e["app7.service.port"] = "9090"
+	e["app6.service.port"] = "9090"
+	e["app7.service.port"] = "9090"
 	if err := processDependencyImportValues(c, true); err != nil {
 		t.Fatalf("processing import values dependencies %v", err)
 	}

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/Chart.yaml
@@ -17,3 +17,18 @@ dependencies:
 - name: app4
   version: 0.1.0
   condition: app4.enabled
+- name: app5
+  version: 0.1.0
+  condition: app5.enabled
+- name: app6
+  version: 0.1.0
+  condition: app5.enabled
+- name: app7
+  version: 0.1.0
+  condition: app5.enabled
+- name: values
+  condition: profile.enabled
+  import-values:
+  - defaults
+  repository: file://charts/values
+  version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app5/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app5/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: app5
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app5/values.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app5/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port:

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app6/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app6/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: app6
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app6/values.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app6/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port: null

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app7/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app7/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: app7
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app7/values.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/app7/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port: 8080

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/values/Chart.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/values/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: values
+description: A Helm chart for Kubernetes
+type: library
+version: 0.1.0

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/values/values.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/charts/values/values.yaml
@@ -1,0 +1,14 @@
+exports:
+  defaults:
+    app5:
+      service:
+        type: ClusterIP
+        port: 9090
+    app6:
+      service:
+        type: ClusterIP
+        port: 9090
+    app7:
+      service:
+        type: ClusterIP
+        port: 9090

--- a/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/values.yaml
+++ b/pkg/chartutil/testdata/three-level-dependent-chart/umbrella/values.yaml
@@ -12,3 +12,15 @@ app3:
 
 app4:
   enabled: true
+
+app5:
+  enabled: true
+
+app6:
+  enabled: true
+
+app7:
+  enabled: true
+
+profile:
+  enabled: true


### PR DESCRIPTION
…ide values in subcharts

This pull request fixed the issue described in #12511

The value precedence for import from the parent is set higher than the sub chart values. This enables importing sets of data in the parent that is applied in the sub-charts. This has been possible in older helm versions than 3.8.2 and in 3.13.0. This fix doe not interfere with the other fixes in the value precedence - i.e backwards compatible.

Fix for these:
https://github.com/helm/helm/issues/12730
https://github.com/helm/helm/issues/12511

As an addition to these:
https://github.com/helm/helm/pull/12162
https://github.com/helm/helm/pull/12480