### PR TITLE
Update kubernetes default minor version to current supported version

### DIFF
--- a/cmd/helm/testdata/output/template-name-template.txt
+++ b/cmd/helm/testdata/output/template-name-template.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "foobar-ywjj-baz"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-set.txt
+++ b/cmd/helm/testdata/output/template-set.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "26"
-    kube-version/version: "v1.26.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "26"
+    kube-version/version: "v1.26.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-one.txt
+++ b/cmd/helm/testdata/output/template-show-only-one.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-skip-tests.txt
+++ b/cmd/helm/testdata/output/template-skip-tests.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm-set-file.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm-set-file.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm-set.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm-set.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-values-files.txt
+++ b/cmd/helm/testdata/output/template-values-files.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-with-api-version.txt
+++ b/cmd/helm/testdata/output/template-with-api-version.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -89,8 +89,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template.txt
+++ b/cmd/helm/testdata/output/template.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "26"
-    kube-version/version: "v1.26.0"
+    kube-version/minor: "28"
+    kube-version/version: "v1.28.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template.txt
+++ b/cmd/helm/testdata/output/template.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "26"
+    kube-version/version: "v1.26.0"
 spec:
   type: ClusterIP
   ports:

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -32,7 +32,7 @@ var (
 	// The Kubernetes version can be set by LDFLAGS. In order to do that the value
 	// must be a string.
 	k8sVersionMajor = "1"
-	k8sVersionMinor = "20"
+	k8sVersionMinor = "26"
 
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -32,7 +32,7 @@ var (
 	// The Kubernetes version can be set by LDFLAGS. In order to do that the value
 	// must be a string.
 	k8sVersionMajor = "1"
-	k8sVersionMinor = "26"
+	k8sVersionMinor = "28"
 
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -42,20 +42,20 @@ func TestDefaultVersionSet(t *testing.T) {
 
 func TestDefaultCapabilities(t *testing.T) {
 	kv := DefaultCapabilities.KubeVersion
-	if kv.String() != "v1.26.0" {
-		t.Errorf("Expected default KubeVersion.String() to be v1.26.0, got %q", kv.String())
+	if kv.String() != "v1.28.0" {
+		t.Errorf("Expected default KubeVersion.String() to be v1.28.0, got %q", kv.String())
 	}
-	if kv.Version != "v1.26.0" {
-		t.Errorf("Expected default KubeVersion.Version to be v1.26.0, got %q", kv.Version)
+	if kv.Version != "v1.28.0" {
+		t.Errorf("Expected default KubeVersion.Version to be v1.28.0, got %q", kv.Version)
 	}
-	if kv.GitVersion() != "v1.26.0" {
-		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.26.0, got %q", kv.Version)
+	if kv.GitVersion() != "v1.28.0" {
+		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.28.0, got %q", kv.Version)
 	}
 	if kv.Major != "1" {
 		t.Errorf("Expected default KubeVersion.Major to be 1, got %q", kv.Major)
 	}
-	if kv.Minor != "26" {
-		t.Errorf("Expected default KubeVersion.Minor to be 26, got %q", kv.Minor)
+	if kv.Minor != "28" {
+		t.Errorf("Expected default KubeVersion.Minor to be 28, got %q", kv.Minor)
 	}
 }
 

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -42,20 +42,20 @@ func TestDefaultVersionSet(t *testing.T) {
 
 func TestDefaultCapabilities(t *testing.T) {
 	kv := DefaultCapabilities.KubeVersion
-	if kv.String() != "v1.20.0" {
-		t.Errorf("Expected default KubeVersion.String() to be v1.20.0, got %q", kv.String())
+	if kv.String() != "v1.26.0" {
+		t.Errorf("Expected default KubeVersion.String() to be v1.26.0, got %q", kv.String())
 	}
-	if kv.Version != "v1.20.0" {
-		t.Errorf("Expected default KubeVersion.Version to be v1.20.0, got %q", kv.Version)
+	if kv.Version != "v1.26.0" {
+		t.Errorf("Expected default KubeVersion.Version to be v1.26.0, got %q", kv.Version)
 	}
-	if kv.GitVersion() != "v1.20.0" {
-		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.20.0, got %q", kv.Version)
+	if kv.GitVersion() != "v1.26.0" {
+		t.Errorf("Expected default KubeVersion.GitVersion() to be v1.26.0, got %q", kv.Version)
 	}
 	if kv.Major != "1" {
 		t.Errorf("Expected default KubeVersion.Major to be 1, got %q", kv.Major)
 	}
-	if kv.Minor != "20" {
-		t.Errorf("Expected default KubeVersion.Minor to be 20, got %q", kv.Minor)
+	if kv.Minor != "26" {
+		t.Errorf("Expected default KubeVersion.Minor to be 26, got %q", kv.Minor)
 	}
 }
 


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR Updates the default Kubernetes minor version to the oldest supported version.
This allows helm template to by default use the newer api versions
The older versions can be supported by passing the `--kube-version ` flag

