### PR TITLE
Deep Copy Helm Globals

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -152,7 +152,8 @@ func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix st
 	// tables in globals.
 	for key, val := range sg {
 		if istable(val) {
-			vv := copyMap(val.(map[string]interface{}))
+			valCopy, _ := copystructure.Copy(val)
+			vv := valCopy.(map[string]interface{})
 			if destv, ok := dg[key]; !ok {
 				// Here there is no merge. We're just adding.
 				dg[key] = vv
@@ -179,14 +180,6 @@ func coalesceGlobals(printf printFn, dest, src map[string]interface{}, prefix st
 		}
 	}
 	dest[GlobalKey] = dg
-}
-
-func copyMap(src map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{}, len(src))
-	for k, v := range src {
-		m[k] = v
-	}
-	return m
 }
 
 // coalesceValues builds up a values map for a particular chart.


### PR DESCRIPTION
**What this PR does / why we need it**:

If a Helm Chart defines globals as follows:

```
global:
  foo:
    bar:
      baz: 1

subcharta:
  global:
    foo:
      bar:
        qux: 2

subchartb:
  a: true
```

Then subchartb may incorrectly see global.foo.bar.qux set to 2, even though that definition is scoped to subcharta.

This is caused by a lack of deep copy of globals when performing colesce.

I think this should close #12181

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
