### PR TITLE
Mention absolute error line for YAML parse errors

### DIFF
--- a/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
+++ b/cmd/helm/testdata/output/template-with-invalid-yaml-debug.txt
@@ -10,4 +10,4 @@ spec:
     image: "alpine:3.9"
     command: ["/bin/sleep","9000"]
 invalid
-Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
+Error: YAML parse error on line 13 of complete output: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'

--- a/cmd/helm/testdata/output/template-with-invalid-yaml.txt
+++ b/cmd/helm/testdata/output/template-with-invalid-yaml.txt
@@ -1,3 +1,3 @@
-Error: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
+Error: YAML parse error on line 13 of complete output: YAML parse error on chart-with-template-with-invalid-yaml/templates/alpine-pod.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
 
 Use --debug flag to render out invalid YAML


### PR DESCRIPTION
**What this PR does / why we need it**:
For YAML syntax errors, calculate the absolute line number of the problem line in the aggregate output. Wrap the existing document-relative line number in another error mentioning this line number.

Helm renders template documents individually. Templates that produce invalid YAML bubble up an error that mentions the problem line (roughly, due to the addition of headers after) relative to the start of that document's output. Charts often have many template documents, and finding the problem line by finding the document and manually counting an offset is tedious. This seeks to simplify debugging by also mentioning the absolute line number in `--debug` stdout.

For example:

```
$ go run ./cmd/helm template ana /tmp/bup --debug 2> /dev/null | cat -n | grep -C2 28
    26	# im a yaml comment
    27	apiVersion: apps/v1
    28			foo # broken because it starts with a tab
    29	kind: Deploymentmetadata:
    30	  name: ana-bup

$ go run ./cmd/helm template ana /tmp/bup --debug > /dev/null                 
install.go:214: [debug] Original chart version: ""
install.go:231: [debug] CHART PATH: /tmp/bup

Error: YAML parse error on line 28 of complete output: YAML parse error on bup/templates/deployment.yaml: error converting YAML to JSON: yaml: line 3: found a tab character that violates indentation
helm.go:84: [debug] YAML parse error on line 28 of complete output: YAML parse error on bup/templates/deployment.yaml: error converting YAML to JSON: yaml: line 3: found a tab character that violates indentation
exit status 1
```
with [bup.tar.gz](https://github.com/helm/helm/files/13756730/bup.tar.gz). The line number may vary because the template parse order is random, but it's correct for the current run.

**Special notes for your reviewer**:

I also considered prefixing template output with document-relative line numbers, but this feels less convenient overall and means output cannot be copied into an external YAML linter.

I don't love the magic strings and positional number extraction to find and parse the expected error string, but didn't find string constants in sigs.k8s.io/yaml to try and make it more reliable. Line calculation will break if Helm errors stop reporting the problem filename or if sigs.k8s.io/yaml stops using `line <line number>` in its error output. `renderResources()` excludes the error if it cannot find them, so future version breakage should be caught by the golden tests.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
