### PR TITLE
fix: Enable release action to update helm-latest-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           AZURE_STORAGE_CONNECTION_STRING: "${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}"
           AZURE_STORAGE_CONTAINER_NAME: "${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}"
         with:
+          overwrite: 'true'
           source_dir: _dist
           container_name: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
           connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
       - main
 
 # Note the only differences between release and canary-release jobs are:
-# - only canary passes --overwrite flag
 # - the VERSION make variable passed to 'make dist checksum' is expected to
 #   be "canary" if the job is triggered by a push to "main" branch. If the
 #   job is triggered by a tag push, VERSION should be the tag ref.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently, Helm release action (`release.yml`) does not allow updating https://get.helm.sh/helm-latest-version , which causes `get-helm-3` script to download stale versions.

Set the [overwrite](https://github.com/bacongobbler/azure-blob-storage-upload/blob/main/action.yml#L29-L31) input on the Azure upload action to enable updating the `helm-latest-version` object.

fixes: #12669

**Special notes for your reviewer**:
I also created https://github.com/helm/helm/pull/12672 with some general fixups, and to avoid passing the `overwrite` option to the binary upload 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
