### PR TITLE
Fix issues when verify generation readiness was merged

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -90,13 +90,6 @@ type ReadyChecker struct {
 // IsReady will fetch the latest state of the object from the server prior to
 // performing readiness checks, and it will return any error encountered.
 func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, error) {
-	var (
-		// This defaults to true, otherwise we get to a point where
-		// things will always return false unless one of the objects
-		// that manages pods has been hit
-		ok  = true
-		err error
-	)
 	switch value := AsVersioned(v).(type) {
 	case *corev1.Pod:
 		pod, err := c.client.CoreV1().Pods(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})

--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -283,7 +283,7 @@ func Test_ReadyChecker_statefulSetReady(t *testing.T) {
 		{
 			name: "statefulset is ready when current revision for current replicas does not match update revision for updated replicas when using partition !=0",
 			args: args{
-				sts: newStatefulSetWithUpdateRevision("foo", 3, 2, 3, 3, "foo-bbbbbbb"),
+				sts: newStatefulSetWithUpdateRevision("foo", 3, 2, 3, 3, "foo-bbbbbbb", true),
 			},
 			want: true,
 		},
@@ -461,6 +461,12 @@ func Test_ReadyChecker_volumeReady(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newStatefulSetWithUpdateRevision(name string, replicas, partition, readyReplicas, updatedReplicas int, updateRevision string, generationInSync bool) *appsv1.StatefulSet {
+	ss := newStatefulSet(name, replicas, partition, readyReplicas, updatedReplicas, generationInSync)
+	ss.Status.UpdateRevision = updateRevision
+	return ss
 }
 
 func newDaemonSet(name string, maxUnavailable, numberReady, desiredNumberScheduled, updatedNumberScheduled int, generationInSync bool) *appsv1.DaemonSet {


### PR DESCRIPTION
CI, tests, and building failed after #10920 was merged. This change fixes the issues that were introduced.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: CI, building, testing, and linting are failing on master due to issues introduced in a PR where CI passed. This change fixes the codebase.

**Special notes for your reviewer**: The issue here is blocking the release of the RC for Helm 3.14.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
