### PR TITLE
Update architecture detection method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOBIN         = $(shell go env GOPATH)/bin
 endif
 GOX           = $(GOBIN)/gox
 GOIMPORTS     = $(GOBIN)/goimports
-ARCH          = $(shell uname -p)
+ARCH          = $(shell go env GOARCH)
 
 ACCEPTANCE_DIR:=../acceptance-testing
 # To specify the subset of acceptance tests to run. '.' means all tests


### PR DESCRIPTION
```
In some OS, obtaining the processor type from `uname - p` may fail.
For Golang programs, we should use `go env GOARCH` to obtain the architecture

=====================
$ go env GOARCH
amd64
$ uname -m
x86_64
$ uname -p
unknown
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
