### PR TITLE
update to oldest supported version skew

### DIFF
--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -32,7 +32,7 @@ var (
 	// The Kubernetes version can be set by LDFLAGS. In order to do that the value
 	// must be a string.
 	k8sVersionMajor = "1"
-	k8sVersionMinor = "20"
+	k8sVersionMinor = "25"
 
 	// DefaultVersionSet is the default version set, which includes only Core V1 ("v1").
 	DefaultVersionSet = allKnownVersions()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Update to a more sane default version.  This value is typically overwritten via https://github.com/helm/helm/blob/v3.13.3/Makefile#L62.

**Special notes for your reviewer**:
Version Skew was taken from https://helm.sh/docs/topics/version_skew/

nix package manager repository, https://github.com/NixOS/nixpkgs/issues/277657, is not doing that replacement and causing an issue where the default is 1.20.  Work around is to use the  `--kube-version`.

In my opinion, the workflow that updates the k8s client lib version should also manage this versioning.  Moving this to a more declarative approach and reducing total complexity at build time.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
