### PR TITLE
Correct incorrect error message of invalid tag

### DIFF
--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"strings"
 	"time"
-
+	"net/url"
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/tlsutil"
@@ -45,6 +45,14 @@ func (pusher *OCIPusher) Push(chartRef, href string, options ...Option) error {
 }
 
 func (pusher *OCIPusher) push(chartRef, href string) error {
+
+	// See: https://github.com/helm/helm/issues/12728
+	u, _ := url.Parse(href)
+	hrefPath := strings.SplitN(u.Path, ":", 2)
+	if len(hrefPath) > 1 {
+			return fmt.Errorf("Version tag \"%s\" need not be passed for remote", hrefPath[1])
+	}
+	
 	stat, err := os.Stat(chartRef)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/uploader/chart_uploader.go
+++ b/pkg/uploader/chart_uploader.go
@@ -24,6 +24,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/pusher"
 	"helm.sh/helm/v3/pkg/registry"
+	"strings"
 )
 
 // ChartUploader handles uploading a chart.
@@ -48,6 +49,12 @@ func (c *ChartUploader) UploadTo(ref, remote string) error {
 	if u.Scheme == "" {
 		return fmt.Errorf("scheme prefix missing from remote (e.g. \"%s://\")", registry.OCIScheme)
 	}
+
+	// See: https://github.com/helm/helm/issues/12728
+	path := strings.SplitN(u.Path, ":", 2)
+	if len(path) > 1 {
+		return fmt.Errorf("Version tag \"%s\" need not be passed for remote", path[1])
+	} 
 
 	p, err := c.Pushers.ByScheme(u.Scheme)
 	if err != nil {

--- a/pkg/uploader/chart_uploader.go
+++ b/pkg/uploader/chart_uploader.go
@@ -24,7 +24,6 @@ import (
 
 	"helm.sh/helm/v3/pkg/pusher"
 	"helm.sh/helm/v3/pkg/registry"
-	"strings"
 )
 
 // ChartUploader handles uploading a chart.
@@ -49,12 +48,6 @@ func (c *ChartUploader) UploadTo(ref, remote string) error {
 	if u.Scheme == "" {
 		return fmt.Errorf("scheme prefix missing from remote (e.g. \"%s://\")", registry.OCIScheme)
 	}
-
-	// See: https://github.com/helm/helm/issues/12728
-	path := strings.SplitN(u.Path, ":", 2)
-	if len(path) > 1 {
-		return fmt.Errorf("Version tag \"%s\" need not be passed for remote", path[1])
-	} 
 
 	p, err := c.Pushers.ByScheme(u.Scheme)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Closes #12728 by adding a clearer error log that says `Version tag <VERSION> need not be passed for remote"`

See local run result:
<img width="763" alt="Screenshot 2024-01-21 at 2 26 37 PM" src="https://github.com/helm/helm/assets/39820442/32f08994-9379-4099-a1b3-034260ae21b9">


**Special notes for your reviewer**:
Note for local development: The strings.SplitN(...) command works only with go version >=1.18, not sure if a backwards compatible strings.Split(...) is required instead.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
