### PR TITLE
Prevent error message involving CLI arguments in case there's a failure in verifySupported

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -25,6 +25,8 @@
 : ${HELM_INSTALL_DIR:="/usr/local/bin"}
 : ${GPG_PUBRING:="pubring.kbx"}
 
+EXIT_VERIFY_FAILED=2
+
 HAS_CURL="$(type "curl" &> /dev/null && echo true || echo false)"
 HAS_WGET="$(type "wget" &> /dev/null && echo true || echo false)"
 HAS_OPENSSL="$(type "openssl" &> /dev/null && echo true || echo false)"
@@ -72,30 +74,30 @@ verifySupported() {
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to https://github.com/helm/helm"
-    exit 1
+    exit $EXIT_VERIFY_FAILED
   fi
 
   if [ "${HAS_CURL}" != "true" ] && [ "${HAS_WGET}" != "true" ]; then
     echo "Either curl or wget is required"
-    exit 1
+    exit $EXIT_VERIFY_FAILED
   fi
 
   if [ "${VERIFY_CHECKSUM}" == "true" ] && [ "${HAS_OPENSSL}" != "true" ]; then
     echo "In order to verify checksum, openssl must first be installed."
     echo "Please install openssl or set VERIFY_CHECKSUM=false in your environment."
-    exit 1
+    exit $EXIT_VERIFY_FAILED
   fi
 
   if [ "${VERIFY_SIGNATURES}" == "true" ]; then
     if [ "${HAS_GPG}" != "true" ]; then
       echo "In order to verify signatures, gpg must first be installed."
       echo "Please install gpg or set VERIFY_SIGNATURES=false in your environment."
-      exit 1
+      exit $EXIT_VERIFY_FAILED
     fi
     if [ "${OS}" != "linux" ]; then
       echo "Signature verification is currently only supported on Linux."
       echo "Please set VERIFY_SIGNATURES=false or verify the signatures manually."
-      exit 1
+      exit $EXIT_VERIFY_FAILED
     fi
   fi
 
@@ -246,7 +248,9 @@ verifySignatures() {
 fail_trap() {
   result=$?
   if [ "$result" != "0" ]; then
-    if [[ -n "$INPUT_ARGUMENTS" ]]; then
+    if [[ "$result" = "$EXIT_VERIFY_FAILED" ]]; then
+      echo "The script failed the installation parameter validation"
+    elif [[ -n "$INPUT_ARGUMENTS" ]]; then
       echo "Failed to install $BINARY_NAME with the arguments provided: $INPUT_ARGUMENTS"
       help
     else


### PR DESCRIPTION
**What this PR does / why we need it**:

"need" is a strong word. You might want it in order to improve feedback when there's a missing binary like `openssl` and users ought to be able to focus on the issue rather than be confused by the CLI parameter error message when the failure is compeletely unrelated to the CLI parameter.

Missing openssl is the case in most small Docker images, like Alpine.

**Special notes for your reviewer**:
./.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
