### PR TITLE
bug: add proxy support for oci getter

### DIFF
--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -119,6 +119,7 @@ func (g *OCIGetter) newRegistryClient() (*registry.Client, error) {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			Proxy:                 http.ProxyFromEnvironment,
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

OCI getter does not seem to be taking into account the proxy settings. See this example:

```go
var getters = getter.Providers{
        getter.Provider{
                Schemes: []string{"http", "https"},
                New:     getter.NewHTTPGetter,
        },
        getter.Provider{
                Schemes: []string{"oci"},
                New:     getter.NewOCIGetter,
        },
}

func main() {
        dl := downloader.ChartDownloader{
                Out:              os.Stdout,
                Getters:          getters,
                Options:          []getter.Option{},
                RepositoryConfig: "/tmp/doesntexist",
                RepositoryCache:  "/tmp",
        }
        if _, _, err := dl.DownloadTo(
                "oci://registry-1.docker.io/bitnamicharts/memcached",
                "6.6.2",
                "/tmp",
        ); err != nil {
                log.Fatal(err)
        }
        log.Println("done")
}

```

When running with http proxy env set this is the output (without the patch):

```bash
$ go build -o downloader main.go
$ http_proxy=$p https_proxy=$p ./downloader
2024/01/31 11:54:22 failed to do request: Head "https://registry-1.docker.io/v2/bitnamicharts/memcached/manifests/6.6.2": dial tcp 54.227.20.253:443: i/o timeout
$
```

When running with the patch:

```bash
$ go build -o downloader main.go
$ http_proxy=$p https_proxy=$p ./downloader
2024/01/31 11:56:04 done
$

```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
