### PR TITLE
Fix: uninstall action resource namespace

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -368,6 +368,7 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 // Init initializes the action configuration
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
+	kc.Namespace = namespace
 	kc.Log = log
 
 	lazyClient := &lazyClient{


### PR DESCRIPTION
closes#12766

At init configuration the kubeclient namespace is not set. When the uninstall action is triggered, if the release has been installed in a non-default namespace, the resource without any namespace provided (which are installed in the release's namespace) are not deleted since it tries to delete resources in the namespace "".