### PR TITLE
Skip update when resource has keep policy and is not in original release

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -417,6 +417,17 @@ func (c *Client) Update(original, target ResourceList, force bool) (*Result, err
 
 		originalInfo := original.Get(info)
 		if originalInfo == nil {
+			annotations, err := metadataAccessor.Annotations(info.Object)
+			if err != nil {
+				c.Log("Unable to get annotations on %q, err: %s", info.Name, err)
+			}
+
+			// Since the target resource remains due to resource policy but is not in the original release
+			if annotations != nil && annotations[ResourcePolicyAnno] == KeepPolicy {
+				c.Log("Skipping update of %q due to annotation [%s=%s]", info.Name, ResourcePolicyAnno, KeepPolicy)
+				return nil
+			}
+
 			kind := info.Mapping.GroupVersionKind.Kind
 			return errors.Errorf("no %s with the name %q found", kind, info.Name)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR skips update when a resource has `helm.sh/resource-policy: keep` annotation and is not included in the original release.

#8228 was closed but the issue still remains: Rollback to a previous revision having a resource with `helm.sh/resource-policy: keep` annotation and dynamic name resulted in the following error.

```
Error: no KIND with the name NAME found
```

For instance, some service team want to version their ConfigMap in order to avoid consuming the same configuration by both of old and new pods during deployment. Especially when applying non-backward-compatible changes to configurations.

The possible solution for Helm users is adding the annotation to ConfigMap and checksum to its name. So that new ConfigMap will be created once the configuration is changed and remaining during deployment.

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: {{ printf "%s-%s" (include "test-service.fullname" .) (.Files.Get "config.yaml" | sha256sum) }}
  labels:
    {{- include "test-service.labels" . | nindent 4 }}
    label: "test2"
  annotations:
    helm.sh/resource-policy: keep
data:
  {{- .Files.Get "config.yaml" | nindent 2 }}
immutable: true
```

However, before updating a resource, Helm checks if the resource in the target revision exists in the cluster, and then checks  if that existing resource is in the original revision. This means that rollback always fails in above case.

refs #8228

**Special notes for your reviewer**:

Did couple of tests on my environment with the following chart.

```sh
# create new chart
make build
./bin/helm create test-service

# add some files to the chart
touch test-service/templates/configmap.yaml # the same as above ConfigMap template
touch test-service/config.yaml

# check rendering result
./bin/helm template test-service
-snip-
---
# Source: test-service/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e
  labels:
    helm.sh/chart: test-service-0.1.0
    app.kubernetes.io/name: test-service
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    label: "test2"
  annotations:
    helm.sh/resource-policy: keep
data:
  foo: bar

immutable: true
-snip-
```

Case1: rollback to the resource having different name.

```sh
# deploy revision 1
cat test-service/config.yaml
foo: bar

./bin/helm upgrade -i test-service ./test-service
kubectl get cm
NAME                                                                            DATA   AGE
test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e   1      4s

# fix configuration
vim test-service/config.yaml
cat test-service/config.yaml
foo: baz

# deploy revision 2
./bin/helm upgrade -i test-service ./test-service
kubectl get cm
NAME                                                                            DATA   AGE
test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e   1      9s
test-service-608bbe835231cfdc18de1e33070ea859385ac2d1590a5bc081505a8c225b7bb9   1      2s

# rollback with the helm v3.14.0
helm version
version.BuildInfo{Version:"v3.14.0", GitCommit:"3fc9f4b2638e76f26739cd77c7017139be81d0ea", GitTreeState:"clean", GoVersion:"go1.21.6"}
helm rollback test-service
Error: no ConfigMap with the name "test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e" found

# rollback with the locally built helm
./bin/helm rollback test-service
Rollback was a success! Happy Helming!

./bin/helm get manifest test-service | grep "^data:" -2
  annotations:
    helm.sh/resource-policy: keep
data:
  foo: bar

# uninstall release
./bin/helm uninstall test-service
These resources were kept due to the resource policy:
[ConfigMap] test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e

release "test-service" uninstalled
```

Case2: rollback to the resource having the same name.

```
# deploy revision 1
./bin/helm upgrade -i test-service ./test-service
kubectl get cm
NAME                                                                            DATA   AGE
test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e   1      4s

# add label to the configmap
vim test-service/templates/configmap
cat test-service/templates/configmap
-snip-
metadata:
  name: {{ printf "%s-%s" (include "test-service.fullname" .) (.Files.Get "config.yaml" | sha256sum) }}
  labels:
    label: "label" # added
    {{- include "test-service.labels" . | nindent 4 }}
-snip-

# deploy revision 2
./bin/helm upgrade -i test-service ./test-service
kubectl get cm
NAME                                                                            DATA   AGE
test-service-1dabc4e3cbbd6a0818bd460f3a6c9855bfe95d506c74726bc0f2edb0aecb1f4e   1      32s

# rollback with the helm v3.14.0
helm rollback test-service
Rollback was a success! Happy Helming!

# rollback with the locally built helm
./bin/helm rollback test-service
Rollback was a success! Happy Helming!
```

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
