### PR TITLE
Show chart version on upgrade

### DIFF
--- a/cmd/helm/testdata/output/upgrade-with-dependency-update.txt
+++ b/cmd/helm/testdata/output/upgrade-with-dependency-update.txt
@@ -4,6 +4,9 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 3
+CHART: chart-with-subchart-update
+VERSION: 0.0.1
+APP_VERSION:
 TEST SUITE: None
 NOTES:
 PARENT NOTES

--- a/cmd/helm/testdata/output/upgrade-with-install-timeout.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install-timeout.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 2
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-install.txt
+++ b/cmd/helm/testdata/output/upgrade-with-install.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 2
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-reset-values.txt
+++ b/cmd/helm/testdata/output/upgrade-with-reset-values.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 5
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-reset-values2.txt
+++ b/cmd/helm/testdata/output/upgrade-with-reset-values2.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 6
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-timeout.txt
+++ b/cmd/helm/testdata/output/upgrade-with-timeout.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 4
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-wait-for-jobs.txt
+++ b/cmd/helm/testdata/output/upgrade-with-wait-for-jobs.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 3
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-with-wait.txt
+++ b/cmd/helm/testdata/output/upgrade-with-wait.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 3
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade.txt
+++ b/cmd/helm/testdata/output/upgrade.txt
@@ -4,4 +4,7 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 3
+CHART: testUpgradeChart
+VERSION: 0.1.3
+APP_VERSION:
 TEST SUITE: None

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -147,7 +147,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false, false, false})
+					return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false, false, true})
 				} else if err != nil {
 					return err
 				}
@@ -233,7 +233,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				fmt.Fprintf(out, "Release %q has been upgraded. Happy Helming!\n", args[0])
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false, false, false})
+			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false, false, true})
 		},
 	}
 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -92,5 +92,7 @@ func update(filename string, in []byte) error {
 }
 
 func normalize(in []byte) []byte {
-	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
+	in = bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
+	// Trim trailing space
+	return bytes.Replace(in, []byte(" \n"), []byte("\n"), -1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Always show the chart/app version during upgrade (like most (all?) package manager already do)

Before:
```
Release "foobar" has been upgraded. Happy Helming! NAME: foobar
LAST DEPLOYED: Mon Feb 26 17:18:58 2024
NAMESPACE: foobar
STATUS: deployed
REVISION: 49
TEST SUITE: None
...
```

After:
```
Release "foobar" has been upgraded. Happy Helming! NAME: foobar
LAST DEPLOYED: Mon Feb 26 17:27:34 2024
NAMESPACE: foobar
STATUS: deployed
REVISION: 51
CHART: foobar
VERSION: 1.0.69
APP_VERSION: v1.0.69
TEST SUITE: None
...
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
