### PR TITLE
Add flag to add labels to created namespace

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -85,7 +85,7 @@ set for a key called 'foo', the 'newbar' value would take precedence:
 
     $ helm install --set foo=bar --set foo=newbar  myredis ./redis
 
-Similarly, in the following example 'foo' is set to '["four"]': 
+Similarly, in the following example 'foo' is set to '["four"]':
 
     $ helm install --set-json='foo=["one", "two", "three"]' --set-json='foo=["four"]' myredis ./redis
 
@@ -167,6 +167,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
 	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
+	f.StringVar(&client.CreateNamespaceMetadata, "create-namespace-metadata", "", "Add namespace metadata as json-formatted string when creating the namespace with --create-namespace.")
 	// --dry-run options with expected outcome:
 	// - Not set means no dry run and server is contacted.
 	// - Set with no value, a value of client, or a value of true and the server is not contacted

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -79,6 +79,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	valueOpts := &values.Options{}
 	var outfmt output.Format
 	var createNamespace bool
+	var createNamespaceMetadata string
 
 	cmd := &cobra.Command{
 		Use:   "upgrade [RELEASE] [CHART]",
@@ -123,6 +124,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					}
 					instClient := action.NewInstall(cfg)
 					instClient.CreateNamespace = createNamespace
+					instClient.CreateNamespaceMetadata = createNamespaceMetadata
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.Force = client.Force
 					instClient.DryRun = client.DryRun
@@ -239,6 +241,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
+	f.StringVar(&createNamespaceMetadata, "create-namespace-metadata", "", "Add namespace metadata as json-formatted string when creating the namespace with --create-namespace.")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.StringVar(&client.DryRunOption, "dry-run", "", "simulate an install. If --dry-run is set with no option being specified or as '--dry-run=client', it will not attempt cluster connections. Setting '--dry-run=server' allows attempting cluster connections.")

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -19,6 +19,7 @@ package action
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -72,6 +73,7 @@ type Install struct {
 	ClientOnly               bool
 	Force                    bool
 	CreateNamespace          bool
+	CreateNamespaceMetadata  string
 	DryRun                   bool
 	DryRunOption             string
 	DisableHooks             bool
@@ -359,6 +361,11 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 					"name": i.Namespace,
 				},
 			},
+		}
+		if len(i.CreateNamespaceMetadata) > 0 {
+			if err := json.Unmarshal([]byte(i.CreateNamespaceMetadata), &ns.ObjectMeta); err != nil {
+				return nil, errors.Wrap(err, "unable to unmarshal namespace metadata")
+			}
 		}
 		buf, err := yaml.Marshal(ns)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

What:

~Add the ability to specify namespace labels with a new flag for `--create-namespace`.~
Add the ability to specify a namespace's metadata with a new flag: `--create-namespace-metadata`.

Why:

If your Kubernetes global config enforces restricted pod security level and the workload you are trying to install with helm needs a higher level, the workloads won't run.
Currently there is a use-case, where an etcd-backup helm chart needs privileged pod security level and the global config will be set to enforce restricted.

New Use Case:

```bash
helm upgrade --install cronjob-etcd-backup ./cronjob-etcd-backup \
  --namespace system-etcd-backup \
  --create-namespace \
  --create-namespace-metadata `{"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/warn": "privileged", "pod-security.kubernetes.io/audit": "privileged"}`
```

~Previous Use Case:~

```bash
helm upgrade --install cronjob-etcd-backup ./cronjob-etcd-backup \
  --namespace system-etcd-backup \
  --create-namespace \
  --add-namespace-label "pod-security.kubernetes.io/enforce=privileged" \
  --add-namespace-label "pod-security.kubernetes.io/warn=privileged" \
  --add-namespace-label "pod-security.kubernetes.io/audit=privileged"
```

Ref:

- https://github.com/helm/helm/issues/11194
- [Pod Security Admission - Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
- [Pod Security Standards - Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- ["Global Config", Configure the Admission Controller - Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/#configure-the-admission-controller)

**Special notes for your reviewer**:

I can add docs and tests, if the concept of a new flag is approved.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
