### PR TITLE
Support customization of labels helm adds to every object.

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -323,7 +323,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	}
 
 	// It is safe to use "force" here because these are resources currently rendered by the chart.
-	err = resources.Visit(setMetadataVisitor(rel.Name, rel.Namespace, true))
+	err = resources.Visit(setMetadataVisitor(rel.Name, rel.Namespace, rel.Labels, true))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -184,7 +184,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	}
 
 	// It is safe to use "force" here because these are resources currently rendered by the chart.
-	err = target.Visit(setMetadataVisitor(targetRelease.Name, targetRelease.Namespace, true))
+	err = target.Visit(setMetadataVisitor(targetRelease.Name, targetRelease.Namespace, targetRelease.Labels, true))
 	if err != nil {
 		return targetRelease, errors.Wrap(err, "unable to set metadata visitor from target release")
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -311,7 +311,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 	}
 
 	// It is safe to use force only on target because these are resources currently rendered by the chart.
-	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace, true))
+	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace, upgradedRelease.Labels, true))
 	if err != nil {
 		return upgradedRelease, err
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -112,7 +112,7 @@ func requireValue(meta map[string]string, k, v string) error {
 // setMetadataVisitor adds release tracking metadata to all resources. If force is enabled, existing
 // ownership metadata will be overwritten. Otherwise an error will be returned if any resource has an
 // existing and conflicting value for the managed by label or Helm release/namespace annotations.
-func setMetadataVisitor(releaseName, releaseNamespace string, force bool) resource.VisitorFunc {
+func setMetadataVisitor(releaseName, releaseNamespace string, releaseLabels map[string]string, force bool) resource.VisitorFunc {
 	return func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
@@ -124,9 +124,8 @@ func setMetadataVisitor(releaseName, releaseNamespace string, force bool) resour
 			}
 		}
 
-		if err := mergeLabels(info.Object, map[string]string{
-			appManagedByLabel: appManagedByHelm,
-		}); err != nil {
+		releaseLabels[appManagedByLabel] = appManagedByHelm
+		if err := mergeLabels(info.Object, releaseLabels); err != nil {
 			return fmt.Errorf(
 				"%s labels could not be updated: %s",
 				resourceString(info), err,


### PR DESCRIPTION
By taking advantage of the already existing --labels flag, we can customize the labels that helm adds to every object. These can be useful for organizing and to select subsets of objects, providing better management capabilities.

refs #12314