### PR TITLE
Added toYamlPretty template function to avoid errors with the yamllint tool in pipelines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/kubectl v0.29.0
 	oras.land/oras-go v1.2.4
-	sigs.k8s.io/yaml v1.3.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -596,3 +596,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
 	"sigs.k8s.io/yaml"
+	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 // funcMap returns a mapping of all of the functions that Engine has.
@@ -49,6 +50,7 @@ func funcMap() template.FuncMap {
 	extra := template.FuncMap{
 		"toToml":        toTOML,
 		"toYaml":        toYAML,
+		"toYamlPretty":  toYAMLPretty,
 		"fromYaml":      fromYAML,
 		"fromYamlArray": fromYAMLArray,
 		"toJson":        toJSON,
@@ -86,6 +88,23 @@ func toYAML(v interface{}) string {
 		return ""
 	}
 	return strings.TrimSuffix(string(data), "\n")
+}
+
+// toYAMLPretty takes an interface, marshals it to yaml, and returns a string. It will
+// always return a string, even on marshal error (empty string).
+//
+// This is designed to be called from a template.
+func toYAMLPretty(v interface{}) string {
+	var data bytes.Buffer
+	encoder := goYaml.NewEncoder(&data)
+	encoder.SetIndent(2)
+	err := encoder.Encode(v)
+
+	if err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return strings.TrimSuffix(data.String(), "\n")
 }
 
 // fromYAML converts a YAML document into a map[string]interface{}.

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -34,6 +34,10 @@ func TestFuncs(t *testing.T) {
 		expect: `foo: bar`,
 		vars:   map[string]interface{}{"foo": "bar"},
 	}, {
+		tpl:    `{{ toYamlPretty . }}`,
+		expect: "baz:\n  - 1\n  - 2\n  - 3",
+		vars:   map[string]interface{}{"baz": []int{1, 2, 3}},
+	}, {
 		tpl:    `{{ toToml . }}`,
 		expect: "foo = \"bar\"\n",
 		vars:   map[string]interface{}{"foo": "bar"},


### PR DESCRIPTION
What this PR does / why we need it:
Currently the toYaml implementation does not indent list items, which causes issues with other tools in the YAML ecosystem such as linters and formatters. Rather than introduce a potentially breaking change to toYaml to support this, I've added a toYamlPretty function as suggested by somebody in the https://github.com/helm/helm/issues/12577.

Given a Golang map described as:

```
m := map[string]interface{} {
    "key": []int {1, 2, 3}
}
```

The toYaml function will produce:

```
key:
- 1
- 2
- 3
```
The toYamlPretty function will produce:

```
key:
  - 1
  - 2
  - 3
```
These are both syntactically correct, but other tools use an indented version which is where this function is useful.

Special notes for your reviewer:
I'm guessing this needs docs somewhere, but I'm not sure where to add them. Could somebody please point me in the right direction?

If applicable:

 

- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility