### PR TITLE
Update the Go version to 1.22

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@5.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Test source headers are present
         run: make test-source-headers
       - name: Run unit tests

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@4.1.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc #pin@3.7.0
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc #pin@3.7.0
         with:
-          version: v1.55
+          version: v1.56

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@5.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Run unit tests
         run: make test-coverage
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@5.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Run unit tests
         run: make test-coverage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module helm.sh/helm/v3
 
-go 1.21
+go 1.22
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module helm.sh/helm/v3
 
-go 1.22
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
This change is to update the go version from 1.21 to 1.22 and the golangci-lint from 1.55 to 1.56.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
