### PR TITLE
Create omitted template function

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -68,6 +68,8 @@ func funcMap() template.FuncMap {
 		"fromJson":      fromJSON,
 		"fromJsonArray": fromJSONArray,
 
+		"omitted": omitted,
+
 		// Duration helpers
 		"mustToDuration":       mustToDuration,
 		"durationSeconds":      durationSeconds,
@@ -268,6 +270,12 @@ func fromJSONArray(str string) []any {
 	}
 	return a
 }
+
+func omitted(a, b interface{}) interface{} {
+	if b == nil {
+		return a
+	}
+	return b
 
 // -----------------------------------------------------------------------------
 // Duration helpers (numeric and time.Duration returns)

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -68,6 +68,8 @@ func funcMap() template.FuncMap {
 		"fromJson":      fromJSON,
 		"fromJsonArray": fromJSONArray,
 
+		"omitted": omitted,
+
 		// Duration helpers
 		"mustToDuration":       mustToDuration,
 		"durationSeconds":      durationSeconds,
@@ -267,6 +269,12 @@ func fromJSONArray(str string) []any {
 	}
 	return a
 }
+
+func omitted(a, b interface{}) interface{} {
+	if b == nil {
+		return a
+	}
+	return b
 
 // -----------------------------------------------------------------------------
 // Duration helpers (numeric and time.Duration returns)

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -126,6 +126,14 @@ keyInElement1 = "valueInElement1"`,
 		expect: `[error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go value of type []interface {}]`,
 		vars:   `hello: world`,
 	}, {
+		tpl:    `{{ .hello | omitted 'yes' }}`,
+		expect: `false`,
+		vars:   map[string]bool{"hello": false},
+	}, {
+		tpl:    `{{ .value | omitted 'yes' }}`,
+		expect: `yes`,
+		vars:   map[string]bool{"hello": false},
+	}, {
 		// This should never result in a network lookup. Regression for #7955
 		tpl:    `{{ lookup "v1" "Namespace" "" "unlikelynamespace99999999" }}`,
 		expect: `map[]`,


### PR DESCRIPTION
**What this PR does / why we need it**:
The current function `default` doesn't behave the way it's logically expected.

From #12781:

values.yaml:
```
exampleKey: false
```

in template:
```
{{ default true .Values.exampleKey }}
```

I would expect this template to write `false` because `false` as a string is `false` and `exampleKey` is not omitted with its `false` value. However that block outputs `true`.

See also: #12863

This PR attempts to create a working option for that which behaves with the same API as `default` but actually tests for an omitted value.

It's assumed that being `Nil` means omitted for the purposes of this API. Given all examples shown and best practices of Helm work on top of hierarchical information contained in maps, 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

closes #12863
fixes #12781