### PR TITLE
feat(load.go): add warning on requirements.lock

### DIFF
--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -134,6 +134,9 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			if c.Metadata == nil {
 				c.Metadata = new(chart.Metadata)
 			}
+			if c.Metadata.APIVersion != chart.APIVersionV1 {
+				log.Printf("Warning: Dependency locking is handled in Chart.lock since apiVersion \"v2\". We recommend migrating to Chart.lock.")
+			}
 			if c.Metadata.APIVersion == chart.APIVersionV1 {
 				c.Files = append(c.Files, &chart.File{Name: f.Name, Data: f.Data})
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Adds a warning when `requirements.lock` is used and the API version is not `v1`.

Partial fix for: #12853 (full fix to come when this functionality is hopefully removed in v4)

**Special notes for your reviewer**:

FYI @gjenkins8

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
