### PR TITLE
Allow install, update action to adopt existing resources (sdk only)

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -105,7 +105,9 @@ type Install struct {
 	// Used by helm template to add the release as part of OutputDir path
 	// OutputDir/<ReleaseName>
 	UseReleaseName bool
-	PostRenderer   postrender.PostRenderer
+	// TakeOwnership will ignore the check for helm annotations and take ownership of the resources.
+	TakeOwnership bool
+	PostRenderer  postrender.PostRenderer
 	// Lock to control raceconditions when the process receives a SIGTERM
 	Lock sync.Mutex
 }
@@ -335,7 +337,11 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	// deleting the release because the manifest will be pointing at that
 	// resource
 	if !i.ClientOnly && !isUpgrade && len(resources) > 0 {
-		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace)
+		if i.TakeOwnership {
+			toBeAdopted, err = requireAdoption(resources)
+		} else {
+			toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace)
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "Unable to continue with install")
 		}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -110,6 +110,8 @@ type Upgrade struct {
 	Lock sync.Mutex
 	// Enable DNS lookups when rendering templates
 	EnableDNS bool
+	// TakeOwnership will skip the check for helm annotations and adopt all existing resources.
+	TakeOwnership bool
 }
 
 type resultMessage struct {
@@ -329,7 +331,12 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		}
 	}
 
-	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
+	var toBeUpdated kube.ResourceList
+	if u.TakeOwnership {
+		toBeUpdated, err = requireAdoption(toBeCreated)
+	} else {
+		toBeUpdated, err = existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to continue with update")
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -37,6 +37,31 @@ const (
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
 
+// requireAdoption returns the subset of resources that already exist in the cluster.
+func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
+	var requireUpdate kube.ResourceList
+
+	err := resources.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+
+		helper := resource.NewHelper(info.Client, info.Mapping)
+		_, err = helper.Get(info.Namespace, info.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
+		}
+
+		requireUpdate.Append(info)
+		return nil
+	})
+
+	return requireUpdate, err
+}
+
 func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string) (kube.ResourceList, error) {
 	var requireUpdate kube.ResourceList
 

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -26,7 +26,7 @@ func (r *ResourceList) Append(val *resource.Info) {
 	*r = append(*r, val)
 }
 
-// Visit implements resource.Visitor.
+// Visit implements resource.Visitor. The visitor stops if fn returns an error.
 func (r ResourceList) Visit(fn resource.VisitorFunc) error {
 	for _, i := range r {
 		if err := fn(i, nil); err != nil {


### PR DESCRIPTION
We use the Helm SDK in a GitOps operator and need more control over existing resources. We considered patching them with the Helm labels and annotations, but that would mean another update request per resource. Furthermore it seems wrong to apply Helm labels to resources, before the chart has actually been applied to them.

The PR introduces a new option `TakeOwnership`. If `TakeOwnership` is set, existing resources will be adopted, overwritten, etc. when installing or updating. Helm will not check for labels.

If it is not set, Helm behaves like before: adoption is only possible if they existing resources have the right labels
(`managed-by`) and annotations (`release-name`, ...).
