### PR TITLE
bugfix: Override subcharts with null values

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -237,6 +237,9 @@ func coalesceValues(printf printFn, c *chart.Chart, v map[string]interface{}, pr
 						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
 					}
 				} else {
+					// If the key is a child chart, coalesce tables with Merge set to true
+					merge := childChartMergeTrue(c, key, merge)
+
 					// Because v has higher precedence than nv, dest values override src
 					// values.
 					coalesceTablesFullKey(printf, dest, src, concatPrefix(subPrefix, key), merge)
@@ -247,6 +250,15 @@ func coalesceValues(printf printFn, c *chart.Chart, v map[string]interface{}, pr
 			v[key] = val
 		}
 	}
+}
+
+func childChartMergeTrue(chrt *chart.Chart, key string, merge bool) bool {
+	for _, subchart := range chrt.Dependencies() {
+		if subchart.Name() == key {
+			return true
+		}
+	}
+	return merge
 }
 
 // CoalesceTables merges a source map into a destination map.

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -57,6 +57,7 @@ pequod:
     nested:
       foo: true
       boat: null
+    object: null
 `)
 
 func withDeps(c *chart.Chart, deps ...*chart.Chart) *chart.Chart {
@@ -118,6 +119,7 @@ func TestCoalesceValues(t *testing.T) {
 					"name":   "ahab",
 					"boat":   true,
 					"nested": map[string]interface{}{"foo": false, "boat": true},
+					"object": map[string]interface{}{"foo": "bar"},
 				},
 			},
 		),
@@ -225,6 +227,10 @@ func TestCoalesceValues(t *testing.T) {
 
 	if _, ok := subsubchart["nested"].(map[string]interface{})["boat"]; ok {
 		t.Error("Expected sub-subchart nested boat key to be removed, still present")
+	}
+
+	if _, ok := subsubchart["object"]; ok {
+		t.Error("Expected sub-subchart object map to be removed, still present")
 	}
 
 	// CoalesceValues should not mutate the passed arguments

--- a/pkg/chartutil/coalesce_test.go
+++ b/pkg/chartutil/coalesce_test.go
@@ -51,6 +51,7 @@ pequod:
     nested:
       boat: false
       sail: true
+      foo2: null
   ahab:
     scope: whale
     boat: null
@@ -112,7 +113,7 @@ func TestCoalesceValues(t *testing.T) {
 				Metadata: &chart.Metadata{Name: "ahab"},
 				Values: map[string]interface{}{
 					"global": map[string]interface{}{
-						"nested":  map[string]interface{}{"foo": "bar"},
+						"nested":  map[string]interface{}{"foo": "bar", "foo2": "bar2"},
 						"nested2": map[string]interface{}{"l2": "ahab"},
 					},
 					"scope":  "ahab",
@@ -170,6 +171,7 @@ func TestCoalesceValues(t *testing.T) {
 		{"{{.pequod.ahab.nested.foo}}", "true"},
 		{"{{.pequod.ahab.global.name}}", "Ishmael"},
 		{"{{.pequod.ahab.global.nested.foo}}", "bar"},
+		{"{{.pequod.ahab.global.nested.foo2}}", "<no value>"},
 		{"{{.pequod.ahab.global.subject}}", "Queequeg"},
 		{"{{.pequod.ahab.global.harpooner}}", "Tashtego"},
 		{"{{.pequod.global.name}}", "Ishmael"},


### PR DESCRIPTION
This PR closes #12469  and closes #12488

Helm should allow users to not only override default values, but also completely remove any default values by setting a config to `null`. 

This works fine for regular charts, but default values within sub-charts cannot be `null`-ed.  The linked issue has a good example of this created by user "naemono." 

The reason this issue is happening is because the `coalesce` function goes over sub-chart values that are defined in a values file or with a `--set` flag twice due to the logic [here](https://github.com/helm/helm/blob/d37e2e9097f9715d4d184b2e3cc313588f106030/pkg/chartutil/coalesce.go#L100-L101).  `merge` is always set to `false` in this context, and the first time `coalesce` gets called, the null value gets removed during the `coalesceTablesFullKey` function [here.](https://github.com/helm/helm/blob/d37e2e9097f9715d4d184b2e3cc313588f106030/pkg/chartutil/coalesce.go#L279) This is fine for regular chart values, but for sub-chart values, the `coalesceDeps` function runs the logic again for every value in the subChart, so we end right back to the spot in the previous link.  But the config option that was explicitly set to null was already removed, so we end up at [this point](https://github.com/helm/helm/blob/d37e2e9097f9715d4d184b2e3cc313588f106030/pkg/chartutil/coalesce.go#L281) two lines down, which overwrites the user defined `null` config the sub-chart default value.

This problem only occurs because when the `coalesce` function is run while `merge` is `false`.  

To prevent this bug from removing sub-chart config values that are explicitly set to `null` and therefore getting overwritten when `coalesceDeps` runs through the sub-chart values a second time, I added logic to check if the key was the name of a sub-chart, and if so setting `merge` to `false` so the null config option is not deleted.
 


**Special notes for your reviewer**:
Follow-up if this PR is accepted may be to add a unit-test to confirm sub-chart nulls aren't overwritten.
