### PR TITLE
[bugfix] Custom or Unstructed Resource not update when helm upgrade

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -609,27 +609,29 @@ func deleteResource(info *resource.Info, policy metav1.DeletionPropagation) erro
 	return err
 }
 
-func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.PatchType, error) {
+func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.PatchType, bool, error) {
+	isCRDOrUnstructured := false
+
 	oldData, err := json.Marshal(current)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing current configuration")
+		return nil, types.StrategicMergePatchType, isCRDOrUnstructured, errors.Wrap(err, "serializing current configuration")
 	}
 	newData, err := json.Marshal(target.Object)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing target configuration")
+		return nil, types.StrategicMergePatchType, isCRDOrUnstructured, errors.Wrap(err, "serializing target configuration")
 	}
 
 	// Fetch the current object for the three way merge
 	helper := resource.NewHelper(target.Client, target.Mapping).WithFieldManager(getManagedFieldsManager())
 	currentObj, err := helper.Get(target.Namespace, target.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, types.StrategicMergePatchType, errors.Wrapf(err, "unable to get data for current object %s/%s", target.Namespace, target.Name)
+		return nil, types.StrategicMergePatchType, isCRDOrUnstructured, errors.Wrapf(err, "unable to get data for current object %s/%s", target.Namespace, target.Name)
 	}
 
 	// Even if currentObj is nil (because it was not found), it will marshal just fine
 	currentData, err := json.Marshal(currentObj)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "serializing live configuration")
+		return nil, types.StrategicMergePatchType, isCRDOrUnstructured, errors.Wrap(err, "serializing live configuration")
 	}
 
 	// Get a versioned object
@@ -647,16 +649,17 @@ func createPatch(target *resource.Info, current runtime.Object) ([]byte, types.P
 	if isUnstructured || isCRD {
 		// fall back to generic JSON merge patch
 		patch, err := jsonpatch.CreateMergePatch(oldData, newData)
-		return patch, types.MergePatchType, err
+		isCRDOrUnstructured = true
+		return patch, types.MergePatchType, isCRDOrUnstructured, err
 	}
 
 	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(versionedObject)
 	if err != nil {
-		return nil, types.StrategicMergePatchType, errors.Wrap(err, "unable to create patch metadata from object")
+		return nil, types.StrategicMergePatchType, isCRDOrUnstructured, errors.Wrap(err, "unable to create patch metadata from object")
 	}
 
 	patch, err := strategicpatch.CreateThreeWayMergePatch(oldData, newData, currentData, patchMeta, true)
-	return patch, types.StrategicMergePatchType, err
+	return patch, types.StrategicMergePatchType, isCRDOrUnstructured, err
 }
 
 func updateResource(c *Client, target *resource.Info, currentObj runtime.Object, force bool) error {
@@ -675,7 +678,7 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 		}
 		c.Log("Replaced %q with kind %s for kind %s", target.Name, currentObj.GetObjectKind().GroupVersionKind().Kind, kind)
 	} else {
-		patch, patchType, err := createPatch(target, currentObj)
+		patch, patchType, isCRDOrUnstructured, err := createPatch(target, currentObj)
 		if err != nil {
 			return errors.Wrap(err, "failed to create patch")
 		}
@@ -690,8 +693,14 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 			return nil
 		}
 		// send patch to server
-		c.Log("Patch %s %q in namespace %s", kind, target.Name, target.Namespace)
-		obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
+		if isCRDOrUnstructured {
+			// CRDs and Unstructured resources do not support strategic merge patch, so just replace it
+			c.Log("Custom or Unstructured Resouce Replace %s %q in namespace %s ", kind, target.Name, target.Namespace)
+			obj, err = helper.Replace(target.Namespace, target.Name, true, target.Object)
+		} else {
+			c.Log("Patch %s %q in namespace %s", kind, target.Name, target.Namespace)
+			obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
+		}
 		if err != nil {
 			return errors.Wrapf(err, "cannot patch %q with kind %s", target.Name, kind)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

refs #12827

**What this PR does / why we need it**:
The CR resource defined in the chart cannot be updated as expected, due to the different behavior when the custom resource and the native resource are updated.

Issue Situation:
Someone edit CR `amonitor `from CRD monitoring.coreos.com/v1/PodMonitor with `kubectl edit`.  `amonitor` is defined in ChartA. I have upgrade ChartA but `amonitor` is not expected defined in ChartA status, it still in `kubectl edit` status.

The Reason:
pkg/kube/client.go: createPatch
```
	// Unstructured objects, such as CRDs, may not have an not registered error
	// returned from ConvertToVersion. Anything that's unstructured should
	// use the jsonpatch.CreateMergePatch. Strategic Merge Patch is not supported
	// on objects like CRDs.
	_, isUnstructured := versionedObject.(runtime.Unstructured)

	// On newer K8s versions, CRDs aren't unstructured but has this dedicated type
	_, isCRD := versionedObject.(*apiextv1beta1.CustomResourceDefinition)

	if isUnstructured || isCRD {
		// fall back to generic JSON merge patch
		patch, err := jsonpatch.CreateMergePatch(oldData, newData)
		return patch, types.MergePatchType, err
	}
```
follow that logical oldData is the CR in release, newData is the CR in target. When I edit CR with `kubectl`, the oldData and the newData is not change, and the patch is created by jsonDiff, so it will be empty. There some ways to fix it. Firstly, threeWayMergePath is the better choice, but `k8s.io/apimachinery/pkg/util/strategicpatch` is not implemented. Secondly, just use `replace`, it's too violent so that some **immutable** field will cause the fails . Thirdly, `server-side-apply` with force, it will be gracefully.

**Special notes for your reviewer**:
Is there a better solution than SSA

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
