### PR TITLE
fix: set release status to Failed when delete release failed

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -121,8 +121,13 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 
 	deletedResources, kept, errs := u.deleteRelease(rel)
 	if errs != nil {
+		rel.Info.Status = release.StatusFailed
+		if err := u.cfg.Releases.Update(rel); err != nil {
+			u.cfg.Log("uninstall: Failed to store updated release: %s", err)
+			return nil, errors.Errorf("uninstallation failed and failed to store updated release: %s", joinErrors(errs))
+		}
 		u.cfg.Log("uninstall: Failed to delete release: %s", errs)
-		return nil, errors.Errorf("failed to delete release: %s", name)
+		return nil, errors.Errorf("failed to delete release %s, %s", name, joinErrors(errs))
 	}
 
 	if kept != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
when delete release failed, should update release status and return error message, closes #12829

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
