### PR TITLE
Fixed lint.Run issue so that it wont modify input param

### DIFF
--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -70,7 +70,11 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	// We could change that. For now, though, we retain that strategy, and thus can
 	// coalesce tables (like reuse-values does) instead of doing the full chart
 	// CoalesceValues
-	coalescedValues := chartutil.CoalesceTables(make(map[string]interface{}, len(overrides)), overrides)
+	overridesCopy := make(map[string]interface{})
+	for key, value := range overrides {
+		overridesCopy[key] = value
+	}
+	coalescedValues := chartutil.CoalesceTables(make(map[string]interface{}, len(overridesCopy)), overridesCopy)
 	coalescedValues = chartutil.CoalesceTables(coalescedValues, values)
 
 	ext := filepath.Ext(valuesPath)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the lint.Run issue that was modifying the input params provided to it.Used a copy of the params to avoid that modification
**Special notes for your reviewer**:
closes #12412 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
