### PR TITLE
Fix: diff against last revison, not against successful deployment

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -214,25 +214,8 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		return nil, nil, errPending
 	}
 
-	var currentRelease *release.Release
-	if lastRelease.Info.Status == release.StatusDeployed {
-		// no need to retrieve the last deployed release from storage as the last release is deployed
-		currentRelease = lastRelease
-	} else {
-		// finds the deployed release with the given name
-		currentRelease, err = u.cfg.Releases.Deployed(name)
-		if err != nil {
-			if errors.Is(err, driver.ErrNoDeployedReleases) &&
-				(lastRelease.Info.Status == release.StatusFailed || lastRelease.Info.Status == release.StatusSuperseded) {
-				currentRelease = lastRelease
-			} else {
-				return nil, nil, err
-			}
-		}
-	}
-
 	// determine if values will be reused
-	vals, err = u.reuseValues(chart, currentRelease, vals)
+	vals, err = u.reuseValues(chart, lastRelease, vals)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +230,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 
 	options := chartutil.ReleaseOptions{
 		Name:      name,
-		Namespace: currentRelease.Namespace,
+		Namespace: lastRelease.Namespace,
 		Revision:  revision,
 		IsUpgrade: true,
 	}
@@ -279,11 +262,11 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	// Store an upgraded release.
 	upgradedRelease := &release.Release{
 		Name:      name,
-		Namespace: currentRelease.Namespace,
+		Namespace: lastRelease.Namespace,
 		Chart:     chart,
 		Config:    vals,
 		Info: &release.Info{
-			FirstDeployed: currentRelease.Info.FirstDeployed,
+			FirstDeployed: lastRelease.Info.FirstDeployed,
 			LastDeployed:  Timestamper(),
 			Status:        release.StatusPendingUpgrade,
 			Description:   "Preparing upgrade", // This should be overwritten later.
@@ -298,7 +281,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		upgradedRelease.Info.Notes = notesTxt
 	}
 	err = validateManifest(u.cfg.KubeClient, manifestDoc.Bytes(), !u.DisableOpenAPIValidation)
-	return currentRelease, upgradedRelease, err
+	return lastRelease, upgradedRelease, err
 }
 
 func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedRelease *release.Release) (*release.Release, error) {


### PR DESCRIPTION
Closes  #12645

**What this PR does / why we need it**:
This will change the diff to diff against the last deployed version, not the last **successfully** deployed version. We are using `--wait`, so a pod that does not start up will mark the deployment as `failed`, although the changes have been rolled out successfully.

**Special notes for your reviewer**:
I'm not sure in which cases a deployment can go `failed` if wait is not used, maybe a more fine grained distinction is needed if a release has been deployed but did not came up or if the changes could not even be applied.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
