### PR TITLE
feat: add httproute from gateway-api to create chart template

### DIFF
--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -54,8 +54,8 @@ const (
 	IgnorefileName = ".helmignore"
 	// IngressFileName is the name of the example ingress file.
 	IngressFileName = TemplatesDir + sep + "ingress.yaml"
-	// HttpRouteFileName is the name of the example HTTPRoute file.
-	HttpRouteFileName = TemplatesDir + sep + "httproute.yaml"
+	// HTTPRouteFileName is the name of the example HTTPRoute file.
+	HTTPRouteFileName = TemplatesDir + sep + "httproute.yaml"
 	// DeploymentName is the name of the example deployment file.
 	DeploymentName = TemplatesDir + sep + "deployment.yaml"
 	// ServiceName is the name of the example service file.
@@ -335,7 +335,7 @@ spec:
 {{- end }}
 `
 
-const defaultHttpRoute = `{{- if .Values.httpRoute.enabled -}}
+const defaultHTTPRoute = `{{- if .Values.httpRoute.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
@@ -755,8 +755,8 @@ func Create(name, dir string) (string, error) {
 		},
 		{
 			// httproute.yaml
-			path:    filepath.Join(cdir, HttpRouteFileName),
-			content: transform(defaultHttpRoute, name),
+			path:    filepath.Join(cdir, HTTPRouteFileName),
+			content: transform(defaultHTTPRoute, name),
 		},
 		{
 			// deployment.yaml

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -179,7 +179,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-# -- How the service is exposed via gateway-apis HTTPRoute.
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed incluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
 httpRoute:
   # -- HTTPRoute enabled.
   enabled: false

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -338,11 +338,7 @@ spec:
 const defaultHTTPRoute = `{{- if .Values.httpRoute.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
 apiVersion: gateway.networking.k8s.io/v1
-{{- else -}}
-apiVersion: gateway.networking.k8s.io/v1alpha2
-{{- end }}
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -54,6 +54,8 @@ const (
 	IgnorefileName = ".helmignore"
 	// IngressFileName is the name of the example ingress file.
 	IngressFileName = TemplatesDir + sep + "ingress.yaml"
+	// HttpRouteFileName is the name of the example HTTPRoute file.
+	HttpRouteFileName = TemplatesDir + sep + "httproute.yaml"
 	// DeploymentName is the name of the example deployment file.
 	DeploymentName = TemplatesDir + sep + "deployment.yaml"
 	// ServiceName is the name of the example service file.
@@ -177,6 +179,41 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- How the service is exposed via gateway-apis HTTPRoute.
+httpRoute:
+  # -- HTTPRoute enabled.
+  enabled: false
+  # -- HTTPRoute annotations.
+  annotations: {}
+  # -- Which Gateways this Route is attached to
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  # -- Hostnames matching HTTP header.
+  hostnames:
+  - "example.com"
+  # -- List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /headers
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -293,6 +330,50 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
+    {{- end }}
+{{- end }}
+`
+
+const defaultHttpRoute = `{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "<CHARTNAME>.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else -}}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
     {{- end }}
 {{- end }}
 `
@@ -657,6 +738,11 @@ func Create(name, dir string) (string, error) {
 			// ingress.yaml
 			path:    filepath.Join(cdir, IngressFileName),
 			content: transform(defaultIngress, name),
+		},
+		{
+			// httproute.yaml
+			path:    filepath.Join(cdir, HttpRouteFileName),
+			content: transform(defaultHttpRoute, name),
 		},
 		{
 			// deployment.yaml

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -192,7 +192,7 @@ httpRoute:
     # namespace: default
   # -- Hostnames matching HTTP header.
   hostnames:
-  - "example.com"
+  - chart-example.local
   # -- List of rules and filters applied.
   rules:
   - matches:

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -180,22 +180,22 @@ ingress:
   #      - chart-example.local
 
 # -- Expose the service via gateway-api HTTPRoute
-# Requires Gateway API resources and suitable controller installed incluster
+# Requires Gateway API resources and suitable controller installed within the cluster
 # (see: https://gateway-api.sigs.k8s.io/guides/)
 httpRoute:
-  # -- HTTPRoute enabled.
+  # HTTPRoute enabled.
   enabled: false
-  # -- HTTPRoute annotations.
+  # HTTPRoute annotations.
   annotations: {}
-  # -- Which Gateways this Route is attached to
+  # Which Gateways this Route is attached to.
   parentRefs:
   - name: gateway
     sectionName: http
     # namespace: default
-  # -- Hostnames matching HTTP header.
+  # Hostnames matching HTTP header.
   hostnames:
   - chart-example.local
-  # -- List of rules and filters applied.
+  # List of rules and filters applied.
   rules:
   - matches:
     - path:

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -105,7 +105,7 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 9
+	expectedNumberOfTemplates := 10
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}
@@ -173,7 +173,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 		t.Errorf("Wrong API version: %q", c.Metadata.APIVersion)
 	}
 
-	expectedNumberOfTemplates := 9
+	expectedNumberOfTemplates := 10
 	if l := len(c.Templates); l != expectedNumberOfTemplates {
 		t.Errorf("Expected %d templates, got %d", expectedNumberOfTemplates, l)
 	}


### PR DESCRIPTION
This closes #12603

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds the HTTPRoute from [gateway-api](https://gateway-api.sigs.k8s.io/reference/spec/) to the example getting started chart. 
It is disabled by default, just like ingress.  
Adding the resource will make helm charts future-proof for the gateway-api and may also increase its adoption rate.

**Special notes for your reviewer**:

If enabled, the via `httpRoute.enabled: true`, it will produce a valid `HTTPRoute` but it will not route real traffic since a `Gateway` must be installed and configured which is in the responsibility of the cluster admin, just like ingress-controller.

The gateway api is still quite young and the gateway-api CRDs are not yet part of a default k8s installation. They currently have to be installed separably with `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml`.  
~~The template checks if the `v1` or the `v1alpha2` version is installed and sets the api version accordingly.  
If the CRDs are missing the installation fails.~~

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
