### PR TITLE
Support List based resources in the KindSortOrder. 

### DIFF
--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -64,7 +64,7 @@ var ResourceDependencyOrder KindSortOrder = []string{
 
 // addListKind adds the List equivalent for each resource kind in the list.
 func addListKind(resources KindSortOrder) KindSortOrder {
-	output := make(KindSortOrder, 2*len(resources))
+	output := make(KindSortOrder, 0, 2*len(resources))
 	for _, resource := range resources {
 		output = append(output, resource)
 		output = append(output, resource+"List")

--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -25,10 +25,10 @@ import (
 // KindSortOrder is an ordering of Kinds.
 type KindSortOrder []string
 
-// InstallOrder is the order in which manifests should be installed (by Kind).
+// ResourceDependencyOrder is the order in which manifests should be installed (by Kind).
 //
 // Those occurring earlier in the list get installed before those occurring later in the list.
-var InstallOrder KindSortOrder = []string{
+var ResourceDependencyOrder KindSortOrder = []string{
 	"PriorityClass",
 	"Namespace",
 	"NetworkPolicy",
@@ -38,20 +38,15 @@ var InstallOrder KindSortOrder = []string{
 	"PodDisruptionBudget",
 	"ServiceAccount",
 	"Secret",
-	"SecretList",
 	"ConfigMap",
 	"StorageClass",
 	"PersistentVolume",
 	"PersistentVolumeClaim",
 	"CustomResourceDefinition",
 	"ClusterRole",
-	"ClusterRoleList",
 	"ClusterRoleBinding",
-	"ClusterRoleBindingList",
 	"Role",
-	"RoleList",
 	"RoleBinding",
-	"RoleBindingList",
 	"Service",
 	"DaemonSet",
 	"Pod",
@@ -67,47 +62,34 @@ var InstallOrder KindSortOrder = []string{
 	"APIService",
 }
 
+// addListKind adds the List equivalent for each resource kind in the list.
+func addListKind(resources KindSortOrder) KindSortOrder {
+	output := make(KindSortOrder, 2*len(resources))
+	for _, resource := range resources {
+		output = append(output, resource)
+		output = append(output, resource+"List")
+	}
+	return output
+}
+
+// reverseKindOrder reverses the order of the KindSortOrder.
+func reverseKindOrder(resources KindSortOrder) KindSortOrder {
+	for i := 0; i < len(resources)/2; i++ {
+		j := len(resources) - i - 1
+		resources[i], resources[j] = resources[j], resources[i]
+	}
+	return resources
+}
+
+// InstallOrder is the order in which manifests should be installed (by Kind).
+//
+// Those occurring earlier in the list get installed before those occurring later in the list.
+var InstallOrder = addListKind(ResourceDependencyOrder)
+
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
 //
 // Those occurring earlier in the list get uninstalled before those occurring later in the list.
-var UninstallOrder KindSortOrder = []string{
-	"APIService",
-	"Ingress",
-	"IngressClass",
-	"Service",
-	"CronJob",
-	"Job",
-	"StatefulSet",
-	"HorizontalPodAutoscaler",
-	"Deployment",
-	"ReplicaSet",
-	"ReplicationController",
-	"Pod",
-	"DaemonSet",
-	"RoleBindingList",
-	"RoleBinding",
-	"RoleList",
-	"Role",
-	"ClusterRoleBindingList",
-	"ClusterRoleBinding",
-	"ClusterRoleList",
-	"ClusterRole",
-	"CustomResourceDefinition",
-	"PersistentVolumeClaim",
-	"PersistentVolume",
-	"StorageClass",
-	"ConfigMap",
-	"SecretList",
-	"Secret",
-	"ServiceAccount",
-	"PodDisruptionBudget",
-	"PodSecurityPolicy",
-	"LimitRange",
-	"ResourceQuota",
-	"NetworkPolicy",
-	"Namespace",
-	"PriorityClass",
-}
+var UninstallOrder = reverseKindOrder(addListKind(ResourceDependencyOrder))
 
 // sort manifests by kind.
 //

--- a/pkg/releaseutil/kind_sorter_test.go
+++ b/pkg/releaseutil/kind_sorter_test.go
@@ -181,7 +181,7 @@ func TestKindSorter(t *testing.T) {
 		expected    string
 	}{
 		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvw!"},
-		{"uninstall", UninstallOrder, "wvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
+		{"uninstall", UninstallOrder, "wvUutsxrqponmLlKkJjIi2hg1fEed3CcbAaF!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
Fix for #12896 

**What this PR does / why we need it**:

The KindSortOrder maintains 2 lists for InstallOrder and UninstallOrder, which are important to make sure that resources that have dependencies are (un)installed in the correct order without missing their dependencies.

Some List based resources are present, such as SecretList, RoleList, but many are missing such as StatefulList or IngressList.

The PR is needed so you can use List based resources without dependency problems.

**Special notes for your reviewer**:

The solution here is to automatically create a List entry for each entry of a resource in the InstallOrder.
This will make sure that List equivalents will automatically be supported in the future if new resources are to be added.
Existing List resources have been removed as those are now automatically injected.

The solution also removed the separate Uninstall list and this is now automatically the reverse order of the install list.

**If applicable**:
- This PR contains unit tests
   The existing KindSortOrder tests are sufficient. Those are testing several List based resources and those test still pass even though the InstallOrder doesn't register List resources explicitly anymore.
   The Uninstall test needed a modification as the Service resource was uninstalled before a Statefulset, but Statefulset have a dependency on a headless service and should have been deleted first.

