### PR TITLE
Implement helm.sh/resource-deletion-policy annotation to override deletion cascade per resource

### DIFF
--- a/pkg/kube/resource_delete_policy.go
+++ b/pkg/kube/resource_delete_policy.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube // import "helm.sh/helm/v3/pkg/kube"
+
+import (
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const ResourceDeletionPolicyAnno = "helm.sh/resource-deletion-policy"
+
+// selectDeletionPolicy allows to select an override deleteion policy per resource,
+// based on ResourceDeletionPolicyAnno.
+func selectDeletionPolicy(policyAnnotation string, defualt v1.DeletionPropagation) v1.DeletionPropagation {
+	switch policyAnnotation {
+	case strings.ToLower(string(v1.DeletePropagationBackground)):
+		return v1.DeletePropagationBackground
+	case strings.ToLower(string(v1.DeletePropagationForeground)):
+		return v1.DeletePropagationForeground
+	case strings.ToLower(string(v1.DeletePropagationOrphan)):
+		return v1.DeletePropagationOrphan
+	default:
+		return defualt
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm uninstall command allows to provider an optional `--cascade` flag to specify a deletion policy to use for all resources. In some cases this policy has to be `foreground`, to ensure the ownership resources are deleted in order, and the deletion is finished until the next hook phase is executed.

To achieve this, a new annotation is provided, `helm.sh/resource-deletion-policy`. When it is set on the resource, the policy from the value is applied on delete request, regardless of the `--cascade` flag value.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
(backwards compatibility is ensured as it is just adding an annotation. Previous releases would ignore it) 