### PR TITLE
test(lint): Tests for lint flag `--full-path`

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -149,6 +149,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&client.WithSubcharts, "with-subcharts", false, "lint dependent charts")
 	f.BoolVar(&client.Quiet, "quiet", false, "print only warnings and errors")
 	f.StringVar(&kubeVersion, "kube-version", "", "Kubernetes version used for capabilities and deprecation checks")
+	f.BoolVar(&client.EnableFullPath, "full-path", false, "print full path in warnings and errors")
 	addValueOptionsFlags(f, valueOpts)
 
 	return cmd

--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-full-paths-enabled.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-full-paths-enabled.txt
@@ -1,0 +1,7 @@
+==> Linting testdata/testcharts/chart-with-bad-subcharts
+[INFO] <full-path>/testdata/testcharts/chart-with-bad-subcharts/Chart.yaml: icon is recommended
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
+[ERROR] : unable to load chart
+	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
+
+Error: 1 chart(s) linted, 1 chart(s) failed

--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts-with-full-paths-enabled.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts-with-full-paths-enabled.txt
@@ -1,0 +1,19 @@
+==> Linting testdata/testcharts/chart-with-bad-subcharts
+[INFO] <full-path>/testdata/testcharts/chart-with-bad-subcharts/Chart.yaml: icon is recommended
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/templates/: error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
+[ERROR] : unable to load chart
+	error unpacking bad-subchart in chart-with-bad-subcharts: validation: chart.metadata.name is required
+
+==> Linting testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart/Chart.yaml: name is required
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart/Chart.yaml: apiVersion is required. The value must be either "v1" or "v2"
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart/Chart.yaml: version is required
+[INFO] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart/Chart.yaml: icon is recommended
+[ERROR] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/bad-subchart/templates/: validation: chart.metadata.name is required
+[ERROR] : unable to load chart
+	validation: chart.metadata.name is required
+
+==> Linting testdata/testcharts/chart-with-bad-subcharts/charts/good-subchart
+[INFO] <full-path>/testdata/testcharts/chart-with-bad-subcharts/charts/good-subchart/Chart.yaml: icon is recommended
+
+Error: 3 chart(s) linted, 2 chart(s) failed

--- a/cmd/helm/testdata/output/lint-quiet-with-error-with-full-paths.txt
+++ b/cmd/helm/testdata/output/lint-quiet-with-error-with-full-paths.txt
@@ -1,0 +1,8 @@
+==> Linting testdata/testcharts/chart-bad-requirements
+[ERROR] <full-path>/testdata/testcharts/chart-bad-requirements/Chart.yaml: unable to parse YAML
+	error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
+[ERROR] <full-path>/testdata/testcharts/chart-bad-requirements/templates/: cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
+[ERROR] : unable to load chart
+	cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
+
+Error: 2 chart(s) linted, 1 chart(s) failed

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -32,11 +32,12 @@ import (
 //
 // It provides the implementation of 'helm lint'.
 type Lint struct {
-	Strict        bool
-	Namespace     string
-	WithSubcharts bool
-	Quiet         bool
-	KubeVersion   *chartutil.KubeVersion
+	Strict         bool
+	Namespace      string
+	WithSubcharts  bool
+	Quiet          bool
+	KubeVersion    *chartutil.KubeVersion
+	EnableFullPath bool
 }
 
 // LintResult is the result of Lint
@@ -59,7 +60,7 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	}
 	result := &LintResult{}
 	for _, path := range paths {
-		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion)
+		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion, l.EnableFullPath)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue
@@ -86,7 +87,8 @@ func HasWarningsOrErrors(result *LintResult) bool {
 	return len(result.Errors) > 0
 }
 
-func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) (support.Linter, error) {
+func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion,
+	enableFullPath bool) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
 
@@ -125,5 +127,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, kubeV
 		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
-	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion), nil
+	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion, enableFullPath), nil
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -77,7 +77,7 @@ func TestLintChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil)
+			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil, false)
 			switch {
 			case err != nil && !tt.err:
 				t.Errorf("%s", err)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -25,16 +25,20 @@ import (
 )
 
 // All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, _ bool) support.Linter {
-	return AllWithKubeVersion(basedir, values, namespace, nil)
+func All(basedir string, values map[string]interface{}, namespace string, _, enableFullPath bool) support.Linter {
+	return AllWithKubeVersion(basedir, values, namespace, nil, enableFullPath)
 }
 
 // AllWithKubeVersion runs all the available linters on the given base directory, allowing to specify the kubernetes version.
-func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) support.Linter {
+func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string,
+	kubeVersion *chartutil.KubeVersion, enableFullPath bool) support.Linter {
 	// Using abs path to get directory context
 	chartDir, _ := filepath.Abs(basedir)
 
-	linter := support.Linter{ChartDir: chartDir}
+	linter := support.Linter{
+		ChartDir:       chartDir,
+		EnableFullPath: enableFullPath,
+	}
 	rules.Chartfile(&linter)
 	rules.ValuesWithOverrides(&linter, values)
 	rules.TemplatesWithKubeVersion(&linter, values, namespace, kubeVersion)

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -38,7 +38,7 @@ const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
 
 func TestBadChart(t *testing.T) {
-	m := All(badChartDir, values, namespace, strict).Messages
+	m := All(badChartDir, values, namespace, strict, false).Messages
 	if len(m) != 8 {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)
@@ -82,7 +82,7 @@ func TestBadChart(t *testing.T) {
 }
 
 func TestInvalidYaml(t *testing.T) {
-	m := All(badYamlFileDir, values, namespace, strict).Messages
+	m := All(badYamlFileDir, values, namespace, strict, false).Messages
 	if len(m) != 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -92,7 +92,7 @@ func TestInvalidYaml(t *testing.T) {
 }
 
 func TestBadValues(t *testing.T) {
-	m := All(badValuesFileDir, values, namespace, strict).Messages
+	m := All(badValuesFileDir, values, namespace, strict, false).Messages
 	if len(m) < 1 {
 		t.Fatalf("All didn't fail with expected errors, got %#v", m)
 	}
@@ -102,7 +102,7 @@ func TestBadValues(t *testing.T) {
 }
 
 func TestGoodChart(t *testing.T) {
-	m := All(goodChartDir, values, namespace, strict).Messages
+	m := All(goodChartDir, values, namespace, strict, false).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {
@@ -126,7 +126,7 @@ func TestHelmCreateChart(t *testing.T) {
 
 	// Note: we test with strict=true here, even though others have
 	// strict = false.
-	m := All(createdChart, values, namespace, true).Messages
+	m := All(createdChart, values, namespace, true, false).Messages
 	if ll := len(m); ll != 1 {
 		t.Errorf("All should have had exactly 1 error. Got %d", ll)
 		for i, msg := range m {
@@ -140,7 +140,7 @@ func TestHelmCreateChart(t *testing.T) {
 // lint ignores import-values
 // See https://github.com/helm/helm/issues/9658
 func TestSubChartValuesChart(t *testing.T) {
-	m := All(subChartValuesDir, values, namespace, strict).Messages
+	m := All(subChartValuesDir, values, namespace, strict, false).Messages
 	if len(m) != 0 {
 		t.Error("All returned linter messages when it shouldn't have")
 		for i, msg := range m {
@@ -156,7 +156,7 @@ func TestMalformedTemplate(t *testing.T) {
 	ch := make(chan int, 1)
 	var m []support.Message
 	go func() {
-		m = All(malformedTemplate, values, namespace, strict).Messages
+		m = All(malformedTemplate, values, namespace, strict, false).Messages
 		ch <- 1
 	}()
 	select {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lint
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ var values map[string]interface{}
 
 const namespace = "testNamespace"
 const strict = false
+const defaultEnableFullPathFlag = false
 
 const badChartDir = "rules/testdata/badchartfile"
 const badValuesFileDir = "rules/testdata/badvaluesfile"
@@ -38,76 +40,368 @@ const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
 
 func TestBadChart(t *testing.T) {
-	m := All(badChartDir, values, namespace, strict, false).Messages
-	if len(m) != 8 {
-		t.Errorf("Number of errors %v", len(m))
-		t.Errorf("All didn't fail with expected errors, got %#v", m)
+	badChartDirFullPath, err := filepath.Abs(badChartDir)
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of templates directory")
 	}
-	// There should be one INFO, and 2 ERROR messages, check for them
-	var i, e, e2, e3, e4, e5, e6 bool
-	for _, msg := range m {
-		if msg.Severity == support.InfoSev {
-			if strings.Contains(msg.Err.Error(), "icon is recommended") {
-				i = true
-			}
+
+	t.Run("bad chart", func(t *testing.T) {
+		linterMessages := All(badChartDir, values, namespace, strict, defaultEnableFullPathFlag).Messages
+		if len(linterMessages) != 8 {
+			t.Errorf("Number of errors %v", len(linterMessages))
+			t.Errorf("All didn't fail with expected errors, got %#v", linterMessages)
 		}
-		if msg.Severity == support.ErrorSev {
-			if strings.Contains(msg.Err.Error(), "version '0.0.0.0' is not a valid SemVer") {
-				e = true
-			}
-			if strings.Contains(msg.Err.Error(), "name is required") {
-				e2 = true
-			}
 
-			if strings.Contains(msg.Err.Error(), "apiVersion is required. The value must be either \"v1\" or \"v2\"") {
-				e3 = true
-			}
-
-			if strings.Contains(msg.Err.Error(), "chart type is not valid in apiVersion") {
-				e4 = true
-			}
-
-			if strings.Contains(msg.Err.Error(), "dependencies are not valid in the Chart file with apiVersion") {
-				e5 = true
-			}
-			// This comes from the dependency check, which loads dependency info from the Chart.yaml
-			if strings.Contains(msg.Err.Error(), "unable to load chart") {
-				e6 = true
-			}
+		type testCase struct {
+			name               string
+			severity           int
+			matcher            func(err error) bool
+			expectedMatchCount int
 		}
-	}
-	if !e || !e2 || !e3 || !e4 || !e5 || !i || !e6 {
-		t.Errorf("Didn't find all the expected errors, got %#v", m)
-	}
+
+		tests := []testCase{
+			{
+				name:     "info: icon is recommended",
+				severity: support.InfoSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "icon is recommended")
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     "error: version '0.0.0.0' is not a valid SemVer",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "version '0.0.0.0' is not a valid SemVer")
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     "error: validation: chart.metadata.name is required and not unable to load chart",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "validation: chart.metadata.name is required") &&
+						!strings.Contains(e.Error(), "unable to load chart")
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     `error: apiVersion is required. The value must be either "v1" or "v2"`,
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), `apiVersion is required. The value must be either "v1" or "v2"`)
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     "error: chart type is not valid in apiVersion",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "chart type is not valid in apiVersion")
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     "error: dependencies are not valid in the Chart file with apiVersion",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "dependencies are not valid in the Chart file with apiVersion")
+				},
+				expectedMatchCount: 1,
+			},
+			{
+				name:     "error: unable to load chart",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "unable to load chart")
+				},
+				expectedMatchCount: 1,
+				// This comes from the dependency check, which loads dependency info
+				// from the Chart.yaml file. Path will be empty for this.
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				matchCount := 0
+
+				for _, msg := range linterMessages {
+					if msg.Severity != tt.severity {
+						// If severity of the message doesn't match, ignore the matcher
+						continue
+					}
+
+					if !tt.matcher(msg.Err) {
+						// If error matcher func doesn't return true, ignore counting current message
+						continue
+					}
+					matchCount++
+
+					// Message shouldn't contain full path unless the flag --full-path is enabled
+					if strings.HasPrefix(msg.Path, badChartDirFullPath) {
+						t.Errorf("Full path is not expected when --full-path is disabled: %s",
+							msg.Path)
+					}
+				}
+
+				// Expected exact match count. Else, update matcher-func or count.
+				if matchCount < tt.expectedMatchCount {
+					t.Errorf("Didn't find all the expected errors")
+				} else if matchCount > tt.expectedMatchCount {
+					t.Errorf("Too many matches found for the current error-matcher-func: %d", matchCount)
+				}
+			})
+		}
+	})
+
+	t.Run("bad chart --full-path enabled", func(t *testing.T) {
+		linterMessages := All(badChartDir, values, namespace, strict, true).Messages
+		if len(linterMessages) != 8 {
+			t.Errorf("Number of errors %v", len(linterMessages))
+			t.Errorf("All didn't fail with expected errors, got %#v", linterMessages)
+		}
+
+		type testCase struct {
+			name               string
+			severity           int
+			matcher            func(err error) bool
+			expectedMatchCount int
+			checkFullPath      bool
+		}
+
+		tests := []testCase{
+			{
+				name:     "info: icon is recommended",
+				severity: support.InfoSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "icon is recommended")
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     "error: version '0.0.0.0' is not a valid SemVer",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "version '0.0.0.0' is not a valid SemVer")
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     "error: validation: chart.metadata.name is required and not unable to load chart",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "validation: chart.metadata.name is required") &&
+						!strings.Contains(e.Error(), "unable to load chart")
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     `error: apiVersion is required. The value must be either "v1" or "v2"`,
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), `apiVersion is required. The value must be either "v1" or "v2"`)
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     "error: chart type is not valid in apiVersion",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "chart type is not valid in apiVersion")
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     "error: dependencies are not valid in the Chart file with apiVersion",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "dependencies are not valid in the Chart file with apiVersion")
+				},
+				expectedMatchCount: 1,
+				checkFullPath:      true,
+			},
+			{
+				name:     "error: unable to load chart",
+				severity: support.ErrorSev,
+				matcher: func(e error) bool {
+					return strings.Contains(e.Error(), "unable to load chart")
+				},
+				expectedMatchCount: 1,
+				// This comes from the dependency check, which loads dependency info
+				// from the Chart.yaml file. Path will be empty for this.
+				checkFullPath: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				matchCount := 0
+
+				for _, msg := range linterMessages {
+					if msg.Severity != tt.severity {
+						// If severity of the message doesn't match, ignore the matcher
+						continue
+					}
+
+					if !tt.matcher(msg.Err) {
+						// If error matcher func doesn't return true, ignore counting current message
+						continue
+					}
+					matchCount++
+
+					if !tt.checkFullPath {
+						// When check for full path is disable for given matcher
+						continue
+					}
+
+					if !strings.HasPrefix(msg.Path, badChartDirFullPath) {
+						// If the message doesn't have chart directory's full path in prefix, fail the sub-test
+						t.Errorf("Absolute path missing or incorrect: %s: %v\n"+
+							"Should contain prefix: %s", msg.Path, err, badChartDirFullPath)
+					}
+				}
+
+				// Expected exact match count. Else, update matcher-func or count.
+				if matchCount < tt.expectedMatchCount {
+					t.Errorf("Didn't find all the expected errors")
+				} else if matchCount > tt.expectedMatchCount {
+					t.Errorf("Too many matches found for the current error-matcher-func: %d", matchCount)
+				}
+			})
+		}
+	})
 }
 
 func TestInvalidYaml(t *testing.T) {
-	m := All(badYamlFileDir, values, namespace, strict, false).Messages
-	if len(m) != 1 {
-		t.Fatalf("All didn't fail with expected errors, got %#v", m)
+	chartPath := badYamlFileDir
+	badYamlFileDirFullPath, err := filepath.Abs(chartPath)
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of bad YAML file's directory")
 	}
-	if !strings.Contains(m[0].Err.Error(), "deliberateSyntaxError") {
-		t.Errorf("All didn't have the error for deliberateSyntaxError")
+
+	templatesFileFullPath := filepath.Join(badYamlFileDirFullPath, "templates") +
+		string(filepath.Separator)
+
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "invalid YAML",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "invalid YAML with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := All(chartPath, values, namespace, strict, tt.enableFullPath).Messages
+			if len(m) != 1 {
+				t.Fatalf("All didn't fail with expected errors, got %#v", m)
+			}
+			if !strings.Contains(m[0].Err.Error(), "deliberateSyntaxError") {
+				t.Errorf("All didn't have the error for deliberateSyntaxError")
+			}
+
+			if tt.enableFullPath {
+				if m[0].Path != templatesFileFullPath {
+					t.Errorf("Full path is missing or incorrect\nExpected: %s\nGot     : %s",
+						templatesFileFullPath, m[0].Path)
+				}
+			}
+		})
 	}
 }
 
 func TestBadValues(t *testing.T) {
-	m := All(badValuesFileDir, values, namespace, strict, false).Messages
-	if len(m) < 1 {
-		t.Fatalf("All didn't fail with expected errors, got %#v", m)
+	chartPath := badValuesFileDir
+	valuesFileFullPath, err := filepath.Abs(filepath.Join(chartPath, "values.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of bad values file")
 	}
-	if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
-		t.Errorf("All didn't have the error for invalid key format: %s", m[0].Err)
+
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "bad values",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "bad values with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := All(chartPath, values, namespace, strict, tt.enableFullPath).Messages
+			if len(m) < 1 {
+				t.Fatalf("All didn't fail with expected errors, got %#v", m)
+			}
+
+			if !strings.Contains(m[0].Err.Error(), "unable to parse YAML") {
+				t.Errorf("All didn't have the error for invalid key format: %s", m[0].Err)
+			}
+
+			if tt.enableFullPath {
+				if m[0].Path != valuesFileFullPath {
+					t.Errorf("Full path is missing or incorrect\nExpected: %s\nGot     : %s",
+						valuesFileFullPath, m[0].Path)
+				}
+			}
+		})
 	}
 }
 
 func TestGoodChart(t *testing.T) {
-	m := All(goodChartDir, values, namespace, strict, false).Messages
-	if len(m) != 0 {
-		t.Error("All returned linter messages when it shouldn't have")
-		for i, msg := range m {
-			t.Logf("Message %d: %s", i, msg)
-		}
+	chartPath := goodChartDir
+	goodChartDirFullPath, err := filepath.Abs(chartPath)
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of good chart")
+	}
+
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "good chart",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "good chart with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := All(chartPath, values, namespace, strict, tt.enableFullPath).Messages
+			if len(m) != 0 {
+				t.Error("All returned linter messages when it shouldn't have")
+				for i, msg := range m {
+					t.Logf("Message %d: %s", i, msg)
+
+					if tt.enableFullPath {
+						// Check if the message has directory path prefixed, i.e., has full path.
+						if !strings.HasPrefix(msg.Path, goodChartDirFullPath) {
+							t.Errorf("Absolute path missing or incorrect: %s\n"+
+								"Should contain prefix: %s", msg.Path, goodChartDirFullPath)
+						}
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -124,50 +418,142 @@ func TestHelmCreateChart(t *testing.T) {
 		return
 	}
 
-	// Note: we test with strict=true here, even though others have
-	// strict = false.
-	m := All(createdChart, values, namespace, true, false).Messages
-	if ll := len(m); ll != 1 {
-		t.Errorf("All should have had exactly 1 error. Got %d", ll)
-		for i, msg := range m {
-			t.Logf("Message %d: %s", i, msg.Error())
-		}
-	} else if msg := m[0].Err.Error(); !strings.Contains(msg, "icon is recommended") {
-		t.Errorf("Unexpected lint error: %s", msg)
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "create chart and lint",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "create chart and lint with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: we test with strict=true here, even though others have
+			// strict = false.
+			m := All(createdChart, values, namespace, true, tt.enableFullPath).Messages
+			if ll := len(m); ll != 1 {
+				t.Errorf("All should have had exactly 1 error. Got %d", ll)
+				for i, msg := range m {
+					t.Logf("Message %d: %s", i, msg.Error())
+				}
+			} else if msg := m[0].Err.Error(); !strings.Contains(msg, "icon is recommended") {
+				t.Errorf("Unexpected lint error: %s", msg)
+			}
+
+			if tt.enableFullPath {
+				// Check if the message has directory path prefixed, i.e., has full path.
+				// Note: t.TempDir() returns the absolute path to temporary directory.
+				if !strings.HasPrefix(m[0].Path, dir) {
+					t.Errorf("Absolute path missing or incorrect: %s\n"+
+						"Should contain prefix: %s", m[0].Path, dir)
+				}
+			}
+		})
 	}
 }
 
 // lint ignores import-values
 // See https://github.com/helm/helm/issues/9658
 func TestSubChartValuesChart(t *testing.T) {
-	m := All(subChartValuesDir, values, namespace, strict, false).Messages
-	if len(m) != 0 {
-		t.Error("All returned linter messages when it shouldn't have")
-		for i, msg := range m {
-			t.Logf("Message %d: %s", i, msg)
-		}
+	chartPath := subChartValuesDir
+	subChartValuesDirFullPath, err := filepath.Abs(chartPath)
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of sub-chart's directory")
+	}
+
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "sub-chart values",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "sub-chart values with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := All(chartPath, values, namespace, strict, tt.enableFullPath).Messages
+			if len(m) != 0 {
+				t.Error("All returned linter messages when it shouldn't have")
+				for i, msg := range m {
+					t.Logf("Message %d: %s", i, msg)
+
+					if tt.enableFullPath {
+						// Check if the message has directory path prefixed, i.e., has full path.
+						if !strings.HasPrefix(msg.Path, subChartValuesDirFullPath) {
+							t.Errorf("Absolute path missing or incorrect: %s\n"+
+								"Should contain prefix: %s", msg.Path, subChartValuesDirFullPath)
+						}
+					}
+				}
+			}
+		})
 	}
 }
 
 // lint stuck with malformed template object
 // See https://github.com/helm/helm/issues/11391
 func TestMalformedTemplate(t *testing.T) {
-	c := time.After(3 * time.Second)
-	ch := make(chan int, 1)
-	var m []support.Message
-	go func() {
-		m = All(malformedTemplate, values, namespace, strict, false).Messages
-		ch <- 1
-	}()
-	select {
-	case <-c:
-		t.Fatalf("lint malformed template timeout")
-	case <-ch:
-		if len(m) != 1 {
-			t.Fatalf("All didn't fail with expected errors, got %#v", m)
-		}
-		if !strings.Contains(m[0].Err.Error(), "invalid character '{'") {
-			t.Errorf("All didn't have the error for invalid character '{'")
-		}
+	chartPath := malformedTemplate
+	malformedTemplateFullPath, err := filepath.Abs(chartPath)
+	if err != nil {
+		t.Fatalf("Failed to determine the full path of malformed template's directory")
+	}
+
+	tests := []struct {
+		name           string
+		enableFullPath bool
+	}{
+		{
+			name:           "malformed template",
+			enableFullPath: defaultEnableFullPathFlag,
+		},
+		{
+			name:           "malformed template with --full-path enabled",
+			enableFullPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := time.After(3 * time.Second)
+			ch := make(chan int, 1)
+			var m []support.Message
+			go func() {
+				m = All(chartPath, values, namespace, strict, tt.enableFullPath).Messages
+				ch <- 1
+			}()
+			select {
+			case <-c:
+				t.Fatalf("lint malformed template timeout")
+			case <-ch:
+				if len(m) != 1 {
+					t.Fatalf("All didn't fail with expected errors, got %#v", m)
+				}
+
+				if !strings.Contains(m[0].Err.Error(), "invalid character '{'") {
+					t.Errorf("All didn't have the error for invalid character '{'")
+				}
+
+				if tt.enableFullPath {
+					// Check if the message has directory path prefixed, i.e., has full path.
+					if !strings.HasPrefix(m[0].Path, malformedTemplateFullPath) {
+						t.Errorf("Absolute path missing or incorrect: %s\n"+
+							"Should contain prefix: %s", m[0].Path, malformedTemplateFullPath)
+					}
+				}
+			}
+		})
 	}
 }

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -36,6 +36,11 @@ func Chartfile(linter *support.Linter) {
 	chartFileName := "Chart.yaml"
 	chartPath := filepath.Join(linter.ChartDir, chartFileName)
 
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		chartFileName = chartPath
+	}
+
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartYamlNotDirectory(chartPath))
 
 	chartFile, err := chartutil.LoadChartfile(chartPath)

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -229,6 +229,54 @@ func TestChartfile(t *testing.T) {
 		}
 	})
 
+	t.Run("Chart.yaml basic validity issues with --full-path enabled", func(t *testing.T) {
+		linter := support.Linter{
+			ChartDir:       badChartDir,
+			EnableFullPath: true,
+		}
+
+		Chartfile(&linter)
+		msgs := linter.Messages
+		expectedNumberOfErrorMessages := 6
+
+		if len(msgs) != expectedNumberOfErrorMessages {
+			t.Errorf("Expected %d errors, got %d", expectedNumberOfErrorMessages, len(msgs))
+			return
+		}
+
+		if !strings.Contains(msgs[0].Err.Error(), "name is required") {
+			t.Errorf("Unexpected message 0: %s", msgs[0].Err)
+		}
+
+		if !strings.Contains(msgs[1].Err.Error(), "apiVersion is required. The value must be either \"v1\" or \"v2\"") {
+			t.Errorf("Unexpected message 1: %s", msgs[1].Err)
+		}
+
+		if !strings.Contains(msgs[2].Err.Error(), "version '0.0.0.0' is not a valid SemVer") {
+			t.Errorf("Unexpected message 2: %s", msgs[2].Err)
+		}
+
+		if !strings.Contains(msgs[3].Err.Error(), "icon is recommended") {
+			t.Errorf("Unexpected message 3: %s", msgs[3].Err)
+		}
+
+		if !strings.Contains(msgs[4].Err.Error(), "chart type is not valid in apiVersion") {
+			t.Errorf("Unexpected message 4: %s", msgs[4].Err)
+		}
+
+		if !strings.Contains(msgs[5].Err.Error(), "dependencies are not valid in the Chart file with apiVersion") {
+			t.Errorf("Unexpected message 5: %s", msgs[5].Err)
+		}
+
+		// Validate if full paths are returns in linter messages
+		for _, msg := range msgs {
+			if !strings.HasPrefix(msg.Path, linter.ChartDir) {
+				t.Errorf("Full path is missing or incorrect: %s\n"+
+					"Expected path prefix: %s", msg.Path, linter.ChartDir)
+			}
+		}
+	})
+
 	t.Run("Chart.yaml validity issues due to type mismatch", func(t *testing.T) {
 		linter := support.Linter{ChartDir: anotherBadChartDir}
 		Chartfile(&linter)
@@ -250,6 +298,41 @@ func TestChartfile(t *testing.T) {
 
 		if !strings.Contains(msgs[2].Err.Error(), "appVersion should be of type string") {
 			t.Errorf("Unexpected message 2: %s", msgs[2].Err)
+		}
+	})
+
+	t.Run("Chart.yaml validity issues due to type mismatch with --full-path enabled", func(t *testing.T) {
+		linter := support.Linter{
+			ChartDir:       anotherBadChartDir,
+			EnableFullPath: true,
+		}
+		Chartfile(&linter)
+		msgs := linter.Messages
+		expectedNumberOfErrorMessages := 3
+
+		if len(msgs) != expectedNumberOfErrorMessages {
+			t.Errorf("Expected %d errors, got %d", expectedNumberOfErrorMessages, len(msgs))
+			return
+		}
+
+		if !strings.Contains(msgs[0].Err.Error(), "version should be of type string") {
+			t.Errorf("Unexpected message 0: %s", msgs[0].Err)
+		}
+
+		if !strings.Contains(msgs[1].Err.Error(), "version '7.2445e+06' is not a valid SemVer") {
+			t.Errorf("Unexpected message 1: %s", msgs[1].Err)
+		}
+
+		if !strings.Contains(msgs[2].Err.Error(), "appVersion should be of type string") {
+			t.Errorf("Unexpected message 2: %s", msgs[2].Err)
+		}
+
+		// Validate if full paths are returns in linter messages
+		for _, msg := range msgs {
+			if !strings.HasPrefix(msg.Path, linter.ChartDir) {
+				t.Errorf("Full path is missing or incorrect: %s\n"+
+					"Expected path prefix: %s", msg.Path, linter.ChartDir)
+			}
 		}
 	})
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -54,6 +54,11 @@ func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interfac
 	fpath := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		fpath = templatesPath + string(filepath.Separator)
+	}
+
 	templatesDirExist := linter.RunLinterRule(support.WarningSev, fpath, validateTemplatesDir(templatesPath))
 
 	// Templates directory is optional for now
@@ -116,6 +121,11 @@ func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interfac
 	for _, template := range chart.Templates {
 		fileName, data := template.Name, template.Data
 		fpath = fileName
+
+		// When flag is enabled, update the file name with full path
+		if linter.EnableFullPath {
+			fpath = templatesPath + string(filepath.Separator) + fileName
+		}
 
 		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 		// These are v3 specific checks to make sure and warn people if their

--- a/pkg/lint/rules/values.go
+++ b/pkg/lint/rules/values.go
@@ -42,6 +42,12 @@ func Values(linter *support.Linter) {
 func ValuesWithOverrides(linter *support.Linter, values map[string]interface{}) {
 	file := "values.yaml"
 	vf := filepath.Join(linter.ChartDir, file)
+
+	// When flag is enabled, update the file name with full path
+	if linter.EnableFullPath {
+		file = vf
+	}
+
 	fileExists := linter.RunLinterRule(support.InfoSev, file, validateValuesFileExistence(vf))
 
 	if !fileExists {

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -39,6 +39,8 @@ type Linter struct {
 	// The highest severity of all the failing lint rules
 	HighestSeverity int
 	ChartDir        string
+	// EnableFullPath enables printing full path of file in messages
+	EnableFullPath bool
 }
 
 // Message describes an error encountered while linting.


### PR DESCRIPTION
**What this PR does / why we need it**:

The flag `--full-path` enables printing full paths in linter warnings and errors which is added in #12496. This PR has tests for that PR.

Related to #11365

**Special notes for your reviewer**:

Currently, this PR has the commits for both the feature and tests making it `size/XXL`. Once #12496 is merged, this can be used only for tests. Else, please review only the test commit under this PR.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
