### PR TITLE
Drop unused field.

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -165,7 +165,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 	// Sort hooks, manifests, and partials. Only hooks and manifests are returned,
 	// as partials are not used after renderer.Render. Empty manifests are also
 	// removed here.
-	hs, manifests, err := releaseutil.SortManifests(files, caps.APIVersions, releaseutil.InstallOrder)
+	hs, manifests, err := releaseutil.SortManifests(files, nil, releaseutil.InstallOrder)
 	if err != nil {
 		// By catching parse errors here, we can prevent bogus releases from going
 		// to Kubernetes.

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -196,13 +196,9 @@ func joinErrors(errs []error) string {
 // deleteRelease deletes the release and returns list of delete resources and manifests that were kept in the deletion process
 func (u *Uninstall) deleteRelease(rel *release.Release) (kube.ResourceList, string, []error) {
 	var errs []error
-	caps, err := u.cfg.getCapabilities()
-	if err != nil {
-		return nil, rel.Manifest, []error{errors.Wrap(err, "could not get apiVersions from Kubernetes")}
-	}
 
 	manifests := releaseutil.SplitManifests(rel.Manifest)
-	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.UninstallOrder)
+	_, files, err := releaseutil.SortManifests(manifests, nil, releaseutil.UninstallOrder)
 	if err != nil {
 		// We could instead just delete everything in no particular order.
 		// FIXME: One way to delete at this point would be to try a label-based

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -54,7 +54,6 @@ type Capabilities struct {
 	// KubeVersion is the Kubernetes version.
 	KubeVersion KubeVersion
 	// APIVersions are supported Kubernetes API versions.
-	// This field is unused.
 	APIVersions VersionSet
 	// HelmVersion is the build information for this helm version
 	HelmVersion helmversion.BuildInfo

--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -53,7 +53,8 @@ var (
 type Capabilities struct {
 	// KubeVersion is the Kubernetes version.
 	KubeVersion KubeVersion
-	// APIversions are supported Kubernetes API versions.
+	// APIVersions are supported Kubernetes API versions.
+	// This field is unused.
 	APIVersions VersionSet
 	// HelmVersion is the build information for this helm version
 	HelmVersion helmversion.BuildInfo

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -41,7 +41,6 @@ type Manifest struct {
 type manifestFile struct {
 	entries map[string]string
 	path    string
-	apis    chartutil.VersionSet
 }
 
 // result is an intermediate structure used during sorting.
@@ -75,7 +74,7 @@ var events = map[string]release.HookEvent{
 //
 // Files that do not parse into the expected format are simply placed into a map and
 // returned.
-func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering KindSortOrder) ([]*release.Hook, []Manifest, error) {
+func SortManifests(files map[string]string, _ chartutil.VersionSet, ordering KindSortOrder) ([]*release.Hook, []Manifest, error) {
 	result := &result{}
 
 	var sortedFilePaths []string
@@ -100,7 +99,6 @@ func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering 
 		manifestFile := &manifestFile{
 			entries: SplitManifests(content),
 			path:    filePath,
-			apis:    apis,
 		}
 
 		if err := manifestFile.sort(result); err != nil {

--- a/pkg/releaseutil/manifest_sorter_test.go
+++ b/pkg/releaseutil/manifest_sorter_test.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
 )
 
@@ -139,7 +138,7 @@ metadata:
 		manifests[o.path] = o.manifest
 	}
 
-	hs, generic, err := SortManifests(manifests, chartutil.VersionSet{"v1", "v1beta1"}, InstallOrder)
+	hs, generic, err := SortManifests(manifests, nil, InstallOrder)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

it seems that `manifestFile.apis` is a write-only field, and can safely be removed.

**Special notes for your reviewer**:

The `Capabilities.APIVersions` field, while no longer used on its own by the Helm code directly, remains exposed to helm charts as part of the `.Capabilities` struct, which may well depend on it, so it must stay untouched.

Introducing new versions of functions with one less argument seems like an overkill, so I just replaced the argument names with an underscore.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
