### PR TITLE
fix #8127, allow uninstall to keep resources

### DIFF
--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -76,6 +76,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation")
 	f.BoolVar(&client.IgnoreNotFound, "ignore-not-found", false, `Treat "release not found" as a successful uninstall`)
 	f.BoolVar(&client.KeepHistory, "keep-history", false, "remove all associated resources and mark the release as deleted, but retain the release history")
+	f.BoolVar(&client.KeepResources, "keep-resources", false, "Only mark the release as deleted, but keep all associated resources")
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
 	f.StringVar(&client.DeletionPropagation, "cascade", "background", "Must be \"background\", \"orphan\", or \"foreground\". Selects the deletion cascading strategy for the dependents. Defaults to background.")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -76,6 +76,34 @@ func TestUninstallRelease_deleteRelease(t *testing.T) {
 	is.Contains(res.Info, expected)
 }
 
+func TestUninstallRelease_keepResources(t *testing.T) {
+	is := assert.New(t)
+
+	unAction := uninstallAction(t)
+	unAction.DisableHooks = true
+	unAction.DryRun = false
+	unAction.KeepResources = true
+
+	rel := releaseStub()
+	rel.Name = "keep-resources"
+	rel.Manifest = `{
+		"apiVersion": "v1",
+		"kind": "Secret",
+		"metadata": {
+		  "name": "secret",
+		},
+		"type": "Opaque",
+		"data": {
+		  "password": "password"
+		}
+	}`
+	unAction.cfg.Releases.Create(rel)
+	res, err := unAction.Run(rel.Name)
+	is.NoError(err)
+	expected := "Associated resources were kept because --keep-resources was set"
+	is.Contains(res.Info, expected)
+}
+
 func TestUninstallRelease_Wait(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in #8127, this can be handy when migrating Helm-managed resources to ArgoCD.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
