### PR TITLE
Add error details when a dependent chart's version cannot be found in a repo

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -77,7 +77,6 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 			continue
 		}
 		if strings.HasPrefix(d.Repository, "file://") {
-
 			chartpath, err := GetLocalPath(d.Repository, r.chartpath)
 			if err != nil {
 				return nil, err
@@ -95,7 +94,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 			}
 
 			if !constraint.Check(v) {
-				missing = append(missing, d.Name)
+				missing = append(missing, fmt.Sprintf("%q (repository %q, version %q)", d.Name, d.Repository, d.Version))
 				continue
 			}
 
@@ -189,11 +188,11 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 		}
 
 		if !found {
-			missing = append(missing, d.Name)
+			missing = append(missing, fmt.Sprintf("%q (repository %q, version %q)", d.Name, d.Repository, d.Version))
 		}
 	}
 	if len(missing) > 0 {
-		return nil, errors.Errorf("can't get a valid version for repositories %s. Try changing the version constraint in Chart.yaml", strings.Join(missing, ", "))
+		return nil, errors.Errorf("can't get a valid version for %d subchart(s): %s. Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml", len(missing), strings.Join(missing, ", "))
 	}
 
 	digest, err := HashReq(reqs, locked)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is about the error in case a chart version does not (yet) exist in the repo. Example:

```
dependencies:
  - name: abcd
    version: "0.18.0-does-not-exist"
    repository: "https://example.com/helmrepo"
```

Before:

```
$ helm dependency update
[...]
Error: can't get a valid version for repositories abcd. Try changing the version constraint in Chart.yaml
```

The error message mistakenly refers to "repositories", but the printed value is a _chart name_. Also, since `abcd` here isn't quoted, it could be mistaken as being a regular word in the error message sentence.

After:

```
$ helm dependency update
[...]
Error: can't get a valid version for 1 subchart(s): "abcd" (repository "https://example.com/helmrepo", version "0.18.0-does-not-exist"). Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml
```

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
