### PR TITLE
set the namespace on the kube client when calling Init

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -373,6 +373,7 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
 	kc.Log = log
+	kc.Namespace = namespace
 
 	lazyClient := &lazyClient{
 		namespace: namespace,


### PR DESCRIPTION
closes #8685

**What this PR does / why we need it**:
When using the Init function for an `action.Configuration` the passed in namespace is not set on the `kube.Client`. 

**Special notes for your reviewer**:

**If applicable**:
- [ X ] this PR contains documentation
- [ X ] this PR contains unit tests
- [  ] this PR has been tested for backwards compatibility
