### PR TITLE
fix: removed additional YAML document header when rendering CRDs

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -186,10 +186,12 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
+			crdFileData := string(crd.File.Data[:])
+			crdFileData = strings.TrimPrefix(crdFileData, "---")
 			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data[:]))
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crdFileData))
 			} else {
-				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data[:]), fileWritten[crd.Filename])
+				err = writeToFile(outputDir, crd.Filename, string(crdFileData), fileWritten[crd.Filename])
 				if err != nil {
 					return hs, b, "", err
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes #12953. I have modified the way CRD file data is rendered so that no additional headers are generated in the stdout.

Output before: 
```
shruti@fedora:~/cncf/helm$ bin/helm template --include-crds cmd/helm/testdata/testcharts/subchart/ | head
---
# Source: subchart/crds/crdA.yaml
---
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: testcrds.testcrdgroups.example.com
spec:
  group: testcrdgroups.example.com
  version: v1alpha1

```
Output after:
```
shruti@fedora:~/cncf/helm$ bin/helm template --include-crds cmd/helm/testdata/testcharts/subchart/ | head
---
# Source: subchart/crds/crdA.yaml

apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: testcrds.testcrdgroups.example.com
spec:
  group: testcrdgroups.example.com
  version: v1alpha1
```