### PR TITLE
feat: Added multi-platform plugin hook support

### DIFF
--- a/cmd/helm/plugin.go
+++ b/cmd/helm/plugin.go
@@ -47,19 +47,27 @@ func newPluginCmd(out io.Writer) *cobra.Command {
 
 // runHook will execute a plugin hook.
 func runHook(p *plugin.Plugin, event string) error {
-	hook := p.Metadata.Hooks[event]
-	if hook == "" {
+	plugin.SetupPluginEnv(settings, p.Metadata.Name, p.Dir)
+
+	cmds := p.Metadata.PlatformHooks[event]
+	expandArgs := true
+	if len(cmds) == 0 && len(p.Metadata.Hooks) > 0 {
+		cmd := p.Metadata.Hooks[event]
+		if len(cmd) > 0 {
+			cmds = []plugin.PlatformCommand{{Command: "sh", Args: []string{"-c", cmd}}}
+			expandArgs = false
+		}
+	}
+
+	main, argv, err := plugin.PrepareCommands(cmds, expandArgs, []string{})
+	if err != nil {
 		return nil
 	}
 
-	prog := exec.Command("sh", "-c", hook)
-	// TODO make this work on windows
-	// I think its ... ¯\_(ツ)_/¯
-	// prog := exec.Command("cmd", "/C", p.Metadata.Hooks.Install())
+	prog := exec.Command(main, argv...)
 
 	debug("running %s hook: %s", event, prog)
 
-	plugin.SetupPluginEnv(settings, p.Metadata.Name, p.Dir)
 	prog.Stdout, prog.Stderr = os.Stdout, os.Stderr
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {

--- a/pkg/plugin/hooks.go
+++ b/pkg/plugin/hooks.go
@@ -25,5 +25,8 @@ const (
 	Update = "update"
 )
 
+// PlatformHooks is a map of events to a command for a particular operating system and architecture.
+type PlatformHooks map[string][]PlatformCommand
+
 // Hooks is a map of events to commands.
 type Hooks map[string]string

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -44,9 +44,10 @@ type Downloaders struct {
 
 // PlatformCommand represents a command for a particular operating system and architecture
 type PlatformCommand struct {
-	OperatingSystem string `json:"os"`
-	Architecture    string `json:"arch"`
-	Command         string `json:"command"`
+	OperatingSystem string   `json:"os"`
+	Architecture    string   `json:"arch"`
+	Command         string   `json:"command"`
+	Args            []string `json:"args"`
 }
 
 // Metadata describes a plugin.
@@ -65,7 +66,25 @@ type Metadata struct {
 	// Description is a long description shown in places like `helm help`
 	Description string `json:"description"`
 
-	// Command is the command, as a single string.
+	// PlatformCommand is the plugin command, with a platform selector and support for args.
+	//
+	// The command and args will be passed through environment expansion, so env vars can
+	// be present in this command. Unless IgnoreFlags is set, this will
+	// also merge the flags passed from Helm.
+	//
+	// Note that the command is not executed in a shell. To do so, we suggest
+	// pointing the command to a shell script.
+	//
+	// The following rules will apply to processing platform commands:
+	// - If PlatformCommand is present, it will be used
+	// - If both OS and Arch match the current platform, search will stop and the command will be executed
+	// - If OS matches and Arch is empty, the command will be executed
+	// - If no OS/Arch match is found, the default command will be executed
+	// - If no matches are found in platformCommand, Helm will exit with an error
+	PlatformCommand []PlatformCommand `json:"platformCommand"`
+
+	// Command is the plugin command, as a single string.
+	// Providing a command will result in an error if PlatformCommand is also set.
 	//
 	// The command will be passed through environment expansion, so env vars can
 	// be present in this command. Unless IgnoreFlags is set, this will
@@ -74,14 +93,8 @@ type Metadata struct {
 	// Note that command is not executed in a shell. To do so, we suggest
 	// pointing the command to a shell script.
 	//
-	// The following rules will apply to processing commands:
-	// - If platformCommand is present, it will be searched first
-	// - If both OS and Arch match the current platform, search will stop and the command will be executed
-	// - If OS matches and there is no more specific match, the command will be executed
-	// - If no OS/Arch match is found, the default command will be executed
-	// - If no command is present and no matches are found in platformCommand, Helm will exit with an error
-	PlatformCommand []PlatformCommand `json:"platformCommand"`
-	Command         string            `json:"command"`
+	// DEPRECATED: Use PlatformCommand instead. Remove in Helm 4.
+	Command string `json:"command"`
 
 	// IgnoreFlags ignores any flags passed in from Helm
 	//
@@ -90,7 +103,31 @@ type Metadata struct {
 	// the `--debug` flag will be discarded.
 	IgnoreFlags bool `json:"ignoreFlags"`
 
-	// Hooks are commands that will run on events.
+	// PlatformHooks are commands that will run on plugin events, with a platform selector and support for args.
+	//
+	// The command and args will be passed through environment expansion, so env vars can
+	// be present in the command.
+	//
+	// Note that the command is not executed in a shell. To do so, we suggest
+	// pointing the command to a shell script.
+	//
+	// The following rules will apply to processing platform hooks:
+	// - If PlatformHooks is present, it will be used
+	// - If both OS and Arch match the current platform, search will stop and the command will be executed
+	// - If OS matches and Arch is empty, the command will be executed
+	// - If no OS/Arch match is found, the default command will be executed
+	// - If no matches are found in platformHooks, Helm will skip the event
+	PlatformHooks PlatformHooks `json:"platformHooks"`
+
+	// Hooks are commands that will run on plugin events, as a single string.
+	// Providing a hooks will result in an error if PlatformHooks is also set.
+	//
+	// The command will be passed through environment expansion, so env vars can
+	// be present in this command.
+	//
+	// Note that the command is executed in the sh shell.
+	//
+	// DEPRECATED: Use PlatformHooks instead. Remove in Helm 4.
 	Hooks Hooks
 
 	// Downloaders field is used if the plugin supply downloader mechanism
@@ -112,60 +149,104 @@ type Plugin struct {
 	Dir string
 }
 
-// The following rules will apply to processing the Plugin.PlatformCommand.Command:
-// - If both OS and Arch match the current platform, search will stop and the command will be prepared for execution
-// - If OS matches and there is no more specific match, the command will be prepared for execution
-// - If no OS/Arch match is found, return nil
-func getPlatformCommand(cmds []PlatformCommand) []string {
-	var command []string
+// Returns command and args strings based on the following rules in priority order:
+// - From the PlatformCommand where OS and Arch match the current platform
+// - From the PlatformCommand where OS matches the current platform and Arch is empty/unspecified
+// - From the PlatformCommand where OS is empty/unspecified and Arch matches the current platform
+// - From the PlatformCommand where OS and Arch are both empty/unspecified
+// - Return nil, nil
+func getPlatformCommand(cmds []PlatformCommand) ([]string, []string) {
+	var command, args []string
+	found := false
+	foundOs := false
+
 	eq := strings.EqualFold
 	for _, c := range cmds {
-		if eq(c.OperatingSystem, runtime.GOOS) {
-			command = strings.Split(c.Command, " ")
-		}
 		if eq(c.OperatingSystem, runtime.GOOS) && eq(c.Architecture, runtime.GOARCH) {
-			return strings.Split(c.Command, " ")
+			// Return early for an exact match
+			return strings.Split(c.Command, " "), c.Args
+		}
+
+		if (len(c.OperatingSystem) > 0 && !eq(c.OperatingSystem, runtime.GOOS)) || len(c.Architecture) > 0 {
+			// Skip if OS is not empty and doesn't match or if arch is set as a set arch requires an OS match
+			continue
+		}
+
+		if !foundOs && len(c.OperatingSystem) > 0 && eq(c.OperatingSystem, runtime.GOOS) {
+			// First OS match with empty arch, can only be overridden by a direct match
+			command = strings.Split(c.Command, " ")
+			args = c.Args
+			found = true
+			foundOs = true
+		} else if !found {
+			// First empty match, can be overridden by a direct match or an OS match
+			command = strings.Split(c.Command, " ")
+			args = c.Args
+			found = true
 		}
 	}
-	return command
+
+	return command, args
 }
 
-// PrepareCommand takes a Plugin.PlatformCommand.Command, a Plugin.Command and will applying the following processing:
-// - If platformCommand is present, it will be searched first
-// - If both OS and Arch match the current platform, search will stop and the command will be prepared for execution
-// - If OS matches and there is no more specific match, the command will be prepared for execution
-// - If no OS/Arch match is found, the default command will be prepared for execution
-// - If no command is present and no matches are found in platformCommand, will exit with an error
+// PrepareCommands takes a []Plugin.PlatformCommand
+// and prepares the command and arguments for execution.
 //
 // It merges extraArgs into any arguments supplied in the plugin. It
-// returns the name of the command and an args array.
+// returns the main command and an args array.
 //
 // The result is suitable to pass to exec.Command.
-func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string, error) {
-	var parts []string
-	platCmdLen := len(p.Metadata.PlatformCommand)
-	if platCmdLen > 0 {
-		parts = getPlatformCommand(p.Metadata.PlatformCommand)
-	}
-	if platCmdLen == 0 || parts == nil {
-		parts = strings.Split(p.Metadata.Command, " ")
-	}
-	if len(parts) == 0 || parts[0] == "" {
+func PrepareCommands(cmds []PlatformCommand, expandArgs bool, extraArgs []string) (string, []string, error) {
+	cmdParts, args := getPlatformCommand(cmds)
+	if len(cmdParts) == 0 || cmdParts[0] == "" {
 		return "", nil, fmt.Errorf("no plugin command is applicable")
 	}
 
-	main := os.ExpandEnv(parts[0])
+	main := os.ExpandEnv(cmdParts[0])
 	baseArgs := []string{}
-	if len(parts) > 1 {
-		for _, cmdpart := range parts[1:] {
-			cmdexp := os.ExpandEnv(cmdpart)
-			baseArgs = append(baseArgs, cmdexp)
+	if len(cmdParts) > 1 {
+		for _, cmdPart := range cmdParts[1:] {
+			if expandArgs {
+				baseArgs = append(baseArgs, os.ExpandEnv(cmdPart))
+			} else {
+				baseArgs = append(baseArgs, cmdPart)
+			}
 		}
 	}
-	if !p.Metadata.IgnoreFlags {
+
+	for _, arg := range args {
+		if expandArgs {
+			baseArgs = append(baseArgs, os.ExpandEnv(arg))
+		} else {
+			baseArgs = append(baseArgs, arg)
+		}
+	}
+
+	if len(extraArgs) > 0 {
 		baseArgs = append(baseArgs, extraArgs...)
 	}
+
 	return main, baseArgs, nil
+}
+
+// PrepareCommand gets the correct command and arguments for a plugin.
+//
+// It merges extraArgs into any arguments supplied in the plugin. It returns the name of the command and an args array.
+//
+// The result is suitable to pass to exec.Command.
+func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string, error) {
+	var extraArgsIn []string
+
+	if !p.Metadata.IgnoreFlags {
+		extraArgsIn = extraArgs
+	}
+
+	cmds := p.Metadata.PlatformCommand
+	if len(cmds) == 0 && len(p.Metadata.Command) > 0 {
+		cmds = []PlatformCommand{{Command: p.Metadata.Command}}
+	}
+
+	return PrepareCommands(cmds, true, extraArgsIn)
 }
 
 // validPluginName is a regular expression that validates plugin names.
@@ -183,6 +264,14 @@ func validatePluginData(plug *Plugin, filepath string) error {
 		return fmt.Errorf("invalid plugin name at %q", filepath)
 	}
 	plug.Metadata.Usage = sanitizeString(plug.Metadata.Usage)
+
+	if len(plug.Metadata.PlatformCommand) > 0 && len(plug.Metadata.Command) > 0 {
+		return fmt.Errorf("both platformCommand and command are set in %q", filepath)
+	}
+
+	if len(plug.Metadata.PlatformHooks) > 0 && len(plug.Metadata.Hooks) > 0 {
+		return fmt.Errorf("both platformHooks and hooks are set in %q", filepath)
+	}
 
 	// We could also validate SemVer, executable, and other fields should we so choose.
 	return nil

--- a/pkg/plugin/testdata/plugdir/good/hello/hello.ps1
+++ b/pkg/plugin/testdata/plugdir/good/hello/hello.ps1
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+Write-Host "Hello, world!"

--- a/pkg/plugin/testdata/plugdir/good/hello/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/good/hello/plugin.yaml
@@ -3,7 +3,23 @@ version: "0.1.0"
 usage: "usage"
 description: |-
   description
-command: "$HELM_PLUGIN_DIR/hello.sh"
+platformCommand:
+  - os: linux
+    arch:
+    command: "sh"
+    args: ["-c", "${HELM_PLUGIN_DIR}/hello.sh"]
+  - os: windows
+    arch:
+    command: "pwsh"
+    args: ["-c", "${HELM_PLUGIN_DIR}/hello.ps1"]
 ignoreFlags: true
-hooks:
-  install: "echo installing..."
+platformHooks:
+  install:
+    - os: linux
+      arch: ""
+      command: "sh"
+      args: ["-c", 'echo "installing..."']
+    - os: windows
+      arch: ""
+      command: "pwsh"
+      args: ["-c", 'echo "installing..."']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR addresses #7117 to allow plugin installation on Windows in a backwards compatible way. It also adds better OS specific hook support and improved platform command logic to support args containing a space.

I've forked `helm-diff` at https://github.com/stevehipwell/helm-diff to provide an example of how this works,

**Special notes for your reviewer**:

- Closes #7117
- Docs PR https://github.com/helm/helm-www/pull/1627

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
