### PR TITLE
helm uninstall dry run support `--ignore-not-found`

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -66,12 +66,15 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	if u.DryRun {
-		// In the dry run case, just see if the release exists
 		r, err := u.cfg.releaseContent(name, 0)
-		if err != nil {
+		switch {
+		case u.IgnoreNotFound && errors.As(err, &driver.ErrReleaseNotFound):
+			fallthrough
+		case err == nil:
+			return &release.UninstallReleaseResponse{Release: r}, nil
+		default:
 			return &release.UninstallReleaseResponse{}, err
 		}
-		return &release.UninstallReleaseResponse{Release: r}, nil
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -68,10 +68,10 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	if u.DryRun {
 		r, err := u.cfg.releaseContent(name, 0)
 		switch {
-		case u.IgnoreNotFound && errors.As(err, &driver.ErrReleaseNotFound):
-			fallthrough
 		case err == nil:
 			return &release.UninstallReleaseResponse{Release: r}, nil
+		case u.IgnoreNotFound && errors.As(err, &driver.ErrReleaseNotFound):
+			fallthrough
 		default:
 			return &release.UninstallReleaseResponse{}, err
 		}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -69,9 +69,9 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 		r, err := u.cfg.releaseContent(name, 0)
 		switch {
 		case err == nil:
-			return &release.UninstallReleaseResponse{Release: r}, nil
-		case u.IgnoreNotFound && errors.As(err, &driver.ErrReleaseNotFound):
 			fallthrough
+		case u.IgnoreNotFound && errors.As(err, &driver.ErrReleaseNotFound):
+			return &release.UninstallReleaseResponse{Release: r}, nil
 		default:
 			return &release.UninstallReleaseResponse{}, err
 		}

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -41,7 +41,7 @@ func TestUninstallRelease_dryRun_ignoreNotFound(t *testing.T) {
 
 	is := assert.New(t)
 	res, err := unAction.Run("release-non-exist")
-	is.NotNil(res)
+	is.Nil(res)
 	is.NoError(err)
 }
 

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -34,6 +34,17 @@ func uninstallAction(t *testing.T) *Uninstall {
 	return unAction
 }
 
+func TestUninstallRelease_dryRun_ignoreNotFound(t *testing.T) {
+	unAction := uninstallAction(t)
+	unAction.DryRun = true
+	unAction.IgnoreNotFound = true
+
+	is := assert.New(t)
+	res, err := unAction.Run("release-non-exist")
+	is.NotNil(res)
+	is.NoError(err)
+}
+
 func TestUninstallRelease_ignoreNotFound(t *testing.T) {
 	unAction := uninstallAction(t)
 	unAction.DryRun = false
@@ -44,7 +55,6 @@ func TestUninstallRelease_ignoreNotFound(t *testing.T) {
 	is.Nil(res)
 	is.NoError(err)
 }
-
 func TestUninstallRelease_deleteRelease(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The goal is to have the same behaviour with or without dry-run with --ignore-not-found on uninstall. 

I am developping a CD pipeline:
- on pull request, it executes a dry-run but it fails with --ignore-not-found even if the release is not found
- on merge on default branch, it executes and succeeds even if the release is not found which what we expect

The fact is the pull request will be blocked due a failed build. The dry-run does not have the same behaviour.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

refs #12970