### PR TITLE
Allow repotest OCI server to bind to localhost

### DIFF
--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -93,6 +93,10 @@ func WithDependingChart(c *chart.Chart) OCIServerOpt {
 }
 
 func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
+	return NewOCIServerWithBindAddress(t, dir, "")
+}
+
+func NewOCIServerWithBindAddress(t *testing.T, dir string, bindAddress string) (*OCIServer, error) {
 	testHtpasswdFileBasename := "authtest.htpasswd"
 	testUsername, testPassword := "username", "password"
 
@@ -113,7 +117,7 @@ func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
 		t.Fatalf("error finding free port for test registry")
 	}
 
-	config.HTTP.Addr = fmt.Sprintf(":%d", port)
+	config.HTTP.Addr = fmt.Sprintf("%s:%d", bindAddress, port)
 	config.HTTP.DrainTimeout = time.Duration(10) * time.Second
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	config.Auth = configuration.Auth{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This adds a `repotest.NewOCIServerWithBindAddress` function for building an OCI server that binds to a specific address, eg.

```go
ociServer, err := repotest.NewOCIServerWithBindAddress(t, repoDir, "localhost")
```

The current `repotest.NewOCIServer` function binds to an empty address, which means binding to all interfaces. This gets annoying when locally running tests that use repotest, as the Macos firewall dialog box will pop up every time you run tests.

I figured it would technically be backwards incompatible to just change `repotest.NewOCIServer` to bind to localhost instead of all interfaces, so I decided to split that out into a separate function. I assume most people probably don't rely on exposing the repotest server outside localhost (especially since the returned `RegistryURL` is for localhost), but someone could conceivably be depending on that.

**Special notes for your reviewer**:

I didn't see any test coverage for this function, so I'll probably need to write that if you think this change is a good idea.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
