### PR TITLE
12124: Fix namespace on kubeconfig error

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -244,6 +244,9 @@ func (s *EnvSettings) Namespace() string {
 	if ns, _, err := s.config.ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}
+	if s.namespace != "" {
+		return s.namespace
+	}
 	return "default"
 }
 

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -111,6 +111,14 @@ func TestEnvSettings(t *testing.T) {
 			kubeTLSServer: "example.org",
 			kubeInsecure:  true,
 		},
+		{
+			name:       "invalid kubeconfig",
+			ns:         "testns",
+			args:       "--namespace=testns --kubeconfig=/path/to/fake/file",
+			maxhistory: defaultMaxHistory,
+			burstLimit: defaultBurstLimit,
+			qps:        defaultQPS,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes #12124 

When the kubeconfig is missing or invalid, the namespace defaults to default instead of the correct namespace. Ensure that on error reading the config, the correct namespace is still returned.

**Special notes for your reviewer**:

Copies https://github.com/helm/helm/pull/12126 but adds a unit test.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
