### PR TITLE
Fix chart install error when CWD contains files or dirs of same name as chart

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -737,7 +737,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 
-	if _, err := os.Stat(name); err == nil {
+	if chartAtPath(name) {
 		abs, err := filepath.Abs(name)
 		if err != nil {
 			return abs, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR introduces a more exhaustive check for the presence, in the current working directory of a local copy of the chart being installed. 

Previously this detection was done with a simple `os.Stat()` call which would yield false positives even when an empty file of the same name as the chart was present, which leads to the installation failing.

These changes preserve the original behaviour that prioritises the local copy over the remote one.

**Special notes for your reviewer**:

Fixes issue #13008 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
