### PR TITLE
Fixing build issue where wrong version is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -eu -o pipefail
 
-          make build-cross
+          make build-cross VERSION="${{ github.ref_name }}"
           make dist checksum VERSION="${{ github.ref_name }}"
 
       - name: Set latest version


### PR DESCRIPTION
The release process had selected the tag to use as the version automatically. But, this presented a problem when a release candidate and final release pointed to the same commit id. For a long time it had automatically selected the final release. But, we ran into a problem where it selected the RC tag instead of the final release.

This change explicitly tells the build scripts the version to use based on the tag passed into the CI run. It should no longer try to self discover the version.

Closes #13040

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
