### PR TITLE
bug(lint): Ensure quiet flag supresses INFO messages

### DIFF
--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -59,7 +59,7 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	}
 	result := &LintResult{}
 	for _, path := range paths {
-		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion)
+		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion, l.Quiet)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue
@@ -86,7 +86,7 @@ func HasWarningsOrErrors(result *LintResult) bool {
 	return len(result.Errors) > 0
 }
 
-func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) (support.Linter, error) {
+func lintChart(path string, vals map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion, quiet bool) (support.Linter, error) {
 	var chartPath string
 	linter := support.Linter{}
 
@@ -125,5 +125,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, kubeV
 		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
-	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion), nil
+	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion, quiet), nil
 }

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -54,7 +54,7 @@ func NewLint() *Lint {
 // Run executes 'helm Lint' against the given chart.
 func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 	lowestTolerance := support.ErrorSev
-	if l.Strict {
+	if l.Strict || l.Quiet {
 		lowestTolerance = support.WarningSev
 	}
 	result := &LintResult{}
@@ -65,11 +65,12 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 			continue
 		}
 
-		result.Messages = append(result.Messages, linter.Messages...)
 		result.TotalChartsLinted++
 		for _, msg := range linter.Messages {
+			// Unknown(0), Info(1), Warning(2), Error(3)
 			if msg.Severity >= lowestTolerance {
 				result.Errors = append(result.Errors, msg.Err)
+				result.Messages = append(result.Messages, msg)
 			}
 		}
 	}

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -126,5 +126,5 @@ func lintChart(path string, vals map[string]interface{}, namespace string, kubeV
 		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
-	return lint.AllWithKubeVersion(chartPath, vals, namespace, kubeVersion, quiet), nil
+	return lint.AllWithKubeVersionAndQuiet(chartPath, vals, namespace, kubeVersion, quiet), nil
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package action
 
 import (
-	//"fmt"
 	"testing"
 )
 
@@ -78,7 +77,7 @@ func TestLintChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil, true)
+			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil, false)
 			switch {
 			case err != nil && !tt.err:
 				t.Errorf("%s", err)

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -172,4 +172,12 @@ func TestLint_ChartWithInfo(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("should pass with INFO messages without quiet", func(t *testing.T) {
+		testCharts := []string{chart1MultipleChartLint}
+		testLint := NewLint()
+		if result := testLint.Run(testCharts, values); len(result.Errors) != 0 {
+			t.Error("expected no errors, but got", len(result.Errors))
+		}
+	})
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	//"fmt"
 	"testing"
 )
 
@@ -77,7 +78,7 @@ func TestLintChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil)
+			_, err := lintChart(tt.chartPath, map[string]interface{}{}, namespace, nil, true)
 			switch {
 			case err != nil && !tt.err:
 				t.Errorf("%s", err)
@@ -154,6 +155,20 @@ func TestLint_ChartWithWarnings(t *testing.T) {
 		testLint.Strict = true
 		if result := testLint.Run(testCharts, values); len(result.Errors) != 0 {
 			t.Error("expected no errors, but got", len(result.Errors))
+		}
+	})
+}
+
+func TestLint_ChartWithInfo(t *testing.T) {
+	t.Run("should pass with no INFO messages when quiet", func(t *testing.T) {
+		testCharts := []string{chart1MultipleChartLint}
+		testLint := NewLint()
+		testLint.Quiet = true
+		result := testLint.Run(testCharts, values)
+		for _, message := range result.Messages {
+			if message.Severity < 3 {
+				t.Error("expected no INFO(1) or UNKNOWN(0) messages, but got \nSeverity:", message.Severity, "\nError:", message.Err)
+			}
 		}
 	})
 }

--- a/pkg/action/lint_test.go
+++ b/pkg/action/lint_test.go
@@ -18,6 +18,8 @@ package action
 
 import (
 	"testing"
+
+	"helm.sh/helm/v3/pkg/lint/support"
 )
 
 var (
@@ -165,7 +167,7 @@ func TestLint_ChartWithInfo(t *testing.T) {
 		testLint.Quiet = true
 		result := testLint.Run(testCharts, values)
 		for _, message := range result.Messages {
-			if message.Severity < 3 {
+			if message.Severity < support.WarningSev {
 				t.Error("expected no INFO(1) or UNKNOWN(0) messages, but got \nSeverity:", message.Severity, "\nError:", message.Err)
 			}
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -186,7 +186,7 @@ func tplFun(parent *template.Template, includedNames map[string]int, strict bool
 			return "", errors.Wrapf(err, "error during tpl function execution for %q", tpl)
 		}
 
-		// Supress INFO messages if quiet mode is enabled
+		// Suppress INFO messages if quiet mode is enabled
 		if quiet {
 			return strings.ReplaceAll(buf.String(), "[INFO]", ""), nil
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -40,6 +40,8 @@ type Engine struct {
 	Strict bool
 	// In LintMode, some 'required' template values may be missing, so don't fail
 	LintMode bool
+	// If quiet is enabled, suppress INFO messages
+	Quiet bool
 	// optional provider of clients to talk to the Kubernetes API
 	clientProvider *ClientProvider
 	// EnableDNS tells the engine to allow DNS lookups when rendering templates
@@ -145,7 +147,7 @@ func includeFun(t *template.Template, includedNames map[string]int) func(string,
 
 // As does 'tpl', so that nested calls to 'tpl' see the templates
 // defined by their enclosing contexts.
-func tplFun(parent *template.Template, includedNames map[string]int, strict bool) func(string, interface{}) (string, error) {
+func tplFun(parent *template.Template, includedNames map[string]int, strict bool, quiet bool) func(string, interface{}) (string, error) {
 	return func(tpl string, vals interface{}) (string, error) {
 		t, err := parent.Clone()
 		if err != nil {
@@ -165,7 +167,7 @@ func tplFun(parent *template.Template, includedNames map[string]int, strict bool
 		// this lets any 'define's inside tpl be 'include'd.
 		t.Funcs(template.FuncMap{
 			"include": includeFun(t, includedNames),
-			"tpl":     tplFun(t, includedNames, strict),
+			"tpl":     tplFun(t, includedNames, strict, quiet),
 		})
 
 		// We need a .New template, as template text which is just blanks
@@ -184,6 +186,11 @@ func tplFun(parent *template.Template, includedNames map[string]int, strict bool
 			return "", errors.Wrapf(err, "error during tpl function execution for %q", tpl)
 		}
 
+		// Supress INFO messages if quiet mode is enabled
+		if quiet {
+			return strings.ReplaceAll(buf.String(), "[INFO]", ""), nil
+		}
+
 		// See comment in renderWithReferences explaining the <no value> hack.
 		return strings.ReplaceAll(buf.String(), "<no value>", ""), nil
 	}
@@ -196,22 +203,26 @@ func (e Engine) initFunMap(t *template.Template) {
 
 	// Add the template-rendering functions here so we can close over t.
 	funcMap["include"] = includeFun(t, includedNames)
-	funcMap["tpl"] = tplFun(t, includedNames, e.Strict)
+	funcMap["tpl"] = tplFun(t, includedNames, e.Strict, e.Quiet)
 
 	// Add the `required` function here so we can use lintMode
 	funcMap["required"] = func(warn string, val interface{}) (interface{}, error) {
 		if val == nil {
 			if e.LintMode {
 				// Don't fail on missing required values when linting
-				log.Printf("[INFO] Missing required value: %s", warn)
-				return "", nil
+				if !e.Quiet {
+					log.Printf("[INFO] Missing required value: %s", warn)
+				}
+				return val, nil
 			}
 			return val, errors.Errorf(warnWrap(warn))
 		} else if _, ok := val.(string); ok {
 			if val == "" {
 				if e.LintMode {
 					// Don't fail on missing required values when linting
-					log.Printf("[INFO] Missing required value: %s", warn)
+					if !e.Quiet {
+						log.Printf("[INFO] Missing required value: %s", warn)
+					}
 					return "", nil
 				}
 				return val, errors.Errorf(warnWrap(warn))
@@ -224,7 +235,9 @@ func (e Engine) initFunMap(t *template.Template) {
 	funcMap["fail"] = func(msg string) (string, error) {
 		if e.LintMode {
 			// Don't fail when linting
-			log.Printf("[INFO] Fail: %s", msg)
+			if !e.Quiet { // Check if --quiet flag is not set
+				log.Printf("[INFO] Fail: %s", msg)
+			}
 			return "", nil
 		}
 		return "", errors.New(warnWrap(msg))

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -25,12 +25,17 @@ import (
 )
 
 // All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, quiet bool) support.Linter {
-	return AllWithKubeVersion(basedir, values, namespace, nil, quiet)
+func All(basedir string, values map[string]interface{}, namespace string, _ bool) support.Linter {
+	return AllWithKubeVersion(basedir, values, namespace, nil)
 }
 
 // AllWithKubeVersion runs all the available linters on the given base directory, allowing to specify the kubernetes version.
-func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion, quiet bool) support.Linter {
+func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) support.Linter {
+	return AllWithKubeVersionAndQuiet(basedir, values, namespace, kubeVersion, false)
+}
+
+// AllWithKubeVersionAndQuiet allows the quiet flag to be passed to the linter
+func AllWithKubeVersionAndQuiet(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion, quiet bool) support.Linter {
 	// Using abs path to get directory context
 	chartDir, _ := filepath.Abs(basedir)
 

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -25,19 +25,19 @@ import (
 )
 
 // All runs all of the available linters on the given base directory.
-func All(basedir string, values map[string]interface{}, namespace string, _ bool) support.Linter {
-	return AllWithKubeVersion(basedir, values, namespace, nil)
+func All(basedir string, values map[string]interface{}, namespace string, quiet bool) support.Linter {
+	return AllWithKubeVersion(basedir, values, namespace, nil, quiet)
 }
 
 // AllWithKubeVersion runs all the available linters on the given base directory, allowing to specify the kubernetes version.
-func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) support.Linter {
+func AllWithKubeVersion(basedir string, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion, quiet bool) support.Linter {
 	// Using abs path to get directory context
 	chartDir, _ := filepath.Abs(basedir)
 
 	linter := support.Linter{ChartDir: chartDir}
 	rules.Chartfile(&linter)
 	rules.ValuesWithOverrides(&linter, values)
-	rules.TemplatesWithKubeVersion(&linter, values, namespace, kubeVersion)
+	rules.TemplatesWithKubeVersion(&linter, values, namespace, kubeVersion, quiet)
 	rules.Dependencies(&linter)
 	return linter
 }

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -45,12 +45,12 @@ var (
 )
 
 // Templates lints the templates in the Linter.
-func Templates(linter *support.Linter, values map[string]interface{}, namespace string, _ bool) {
-	TemplatesWithKubeVersion(linter, values, namespace, nil)
+func Templates(linter *support.Linter, values map[string]interface{}, namespace string, quiet bool) {
+	TemplatesWithKubeVersion(linter, values, namespace, nil, quiet)
 }
 
 // TemplatesWithKubeVersion lints the templates in the Linter, allowing to specify the kubernetes version.
-func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion) {
+func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interface{}, namespace string, kubeVersion *chartutil.KubeVersion, quiet bool) {
 	fpath := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
@@ -98,6 +98,7 @@ func TemplatesWithKubeVersion(linter *support.Linter, values map[string]interfac
 	}
 	var e engine.Engine
 	e.LintMode = true
+	e.Quiet = quiet
 	renderedContentMap, err := e.Render(chart, valuesToRender)
 
 	renderOk := linter.RunLinterRule(support.ErrorSev, fpath, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
While I was using `helm lint --quiet mychart`, I saw that there were some INFO messages that shouldn't appear as the `--quiet` flag states: 
> --quiet                      print only warnings and errors

This PR makes the quiet flag to be respected.
The whole rendering of templates needs a refactor IMO, but I made the changes as minimal as possible to avoid any disrupting change :) 

**Special notes for your reviewer**:
If there's no rush, I'd like to make a common effort over the templating refactor. I might take some while to build all the context, but helm is a great project and quite widely used! 

**If applicable**:
- [n/a] this PR contains documentation
- [n/a] this PR contains unit tests
- [n/a] this PR has been tested for backwards compatibility

closes #13000