### PR TITLE
fix(LocateChart): Fixed install.LocateChart func to support remote chart while local folder with the same name exists

### DIFF
--- a/cmd/helm/testdata/output/upgrade-with-bad-dependencies.txt
+++ b/cmd/helm/testdata/output/upgrade-with-bad-dependencies.txt
@@ -1,1 +1,1 @@
-Error: cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
+Error: repo testdata not found

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -755,7 +755,10 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 				return "", err
 			}
 		}
-		return abs, nil
+
+		if isChartDir, _ := chartutil.IsChartDir(abs); isChartDir {
+			return abs, nil
+		}
 	}
 	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
 		return name, errors.Errorf("path %q not found", name)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -745,21 +745,28 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 
-	if _, err := os.Stat(name); err == nil {
+	if fileInfo, err := os.Stat(name); err == nil {
 		abs, err := filepath.Abs(name)
 		if err != nil {
 			return abs, err
 		}
+
 		if c.Verify {
 			if _, err := downloader.VerifyChart(abs, c.Keyring); err != nil {
 				return "", err
 			}
 		}
 
-		if isChartDir, _ := chartutil.IsChartDir(abs); isChartDir {
+		if fileInfo.IsDir() {
+			// If a local directory is not a chart, we'll try to use remote chart
+			if isChartDir, _ := chartutil.IsChartDir(abs); isChartDir {
+				return abs, nil
+			}
+		} else {
 			return abs, nil
 		}
 	}
+
 	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
 		return name, errors.Errorf("path %q not found", name)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes this issue https://github.com/GoogleContainerTools/skaffold/issues/9347 when you want to install remote chart, but you have a local folder with the chart name. 

**Steps to reproduce the behavior**
1. git clone https://github.com/google/turbinia.git
2. from the root of the repo execute `helm install dev-release turbinia --repo https://google.github.io/osdfir-infrastructure/`
3. Note: the git repo contains a folder named **turbinia** which is the same as the chart name

**It will output**

> Error: INSTALLATION FAILED: Chart.yaml file is missing