### PR TITLE
Support for configuring OCI TLS for dependency and package commands

### DIFF
--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 
@@ -57,6 +58,15 @@ func newDependencyUpdateCmd(cfg *action.Configuration, out io.Writer) *cobra.Com
 			if len(args) > 0 {
 				chartpath = filepath.Clean(args[0])
 			}
+
+			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+				client.InsecureSkipTLSverify, client.PlainHTTP)
+			if err != nil {
+				return fmt.Errorf("missing registry client: %w", err)
+			}
+
+			cfg.RegistryClient = registryClient
+
 			man := &downloader.Manager{
 				Out:              out,
 				ChartPath:        chartpath,
@@ -79,6 +89,11 @@ func newDependencyUpdateCmd(cfg *action.Configuration, out io.Writer) *cobra.Com
 	f.BoolVar(&client.Verify, "verify", false, "verify the packages against signatures")
 	f.StringVar(&client.Keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 	f.BoolVar(&client.SkipRefresh, "skip-refresh", false, "do not refresh the local repository cache")
+	f.StringVar(&client.CertFile, "cert-file", "", "identify registry client using this SSL certificate file")
+	f.StringVar(&client.KeyFile, "key-file", "", "identify registry client using this SSL key file")
+	f.StringVar(&client.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.BoolVar(&client.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for remote sources")
+	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use insecure HTTP connections for remote sources")
 
 	return cmd
 }

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -84,6 +84,12 @@ func newPackageCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					return err
 				}
 
+				cfg.RegistryClient, err = newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+					client.InsecureSkipTLSverify, client.PlainHTTP)
+				if err != nil {
+					return fmt.Errorf("missing registry client: %w", err)
+				}
+
 				if client.DependencyUpdate {
 					downloadManager := &downloader.Manager{
 						Out:              io.Discard,
@@ -119,6 +125,11 @@ func newPackageCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.AppVersion, "app-version", "", "set the appVersion on the chart to this version")
 	f.StringVarP(&client.Destination, "destination", "d", ".", "location to write the chart.")
 	f.BoolVarP(&client.DependencyUpdate, "dependency-update", "u", false, `update dependencies from "Chart.yaml" to dir "charts/" before packaging`)
+	f.StringVar(&client.CertFile, "cert-file", "", "identify registry client using this SSL certificate file")
+	f.StringVar(&client.KeyFile, "key-file", "", "identify registry client using this SSL key file")
+	f.StringVar(&client.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.BoolVar(&client.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for remote sources")
+	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use insecure HTTP connections for remote sources")
 
 	return cmd
 }

--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -34,10 +34,15 @@ import (
 //
 // It provides the implementation of 'helm dependency' and its respective subcommands.
 type Dependency struct {
-	Verify      bool
-	Keyring     string
-	SkipRefresh bool
-	ColumnWidth uint
+	Verify                bool
+	Keyring               string
+	SkipRefresh           bool
+	ColumnWidth           uint
+	CertFile              string
+	KeyFile               string
+	CaFile                string
+	InsecureSkipTLSverify bool
+	PlainHTTP             bool
 }
 
 // NewDependency creates a new Dependency object with the given configuration.

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -35,14 +35,19 @@ import (
 //
 // It provides the implementation of 'helm package'.
 type Package struct {
-	Sign             bool
-	Key              string
-	Keyring          string
-	PassphraseFile   string
-	Version          string
-	AppVersion       string
-	Destination      string
-	DependencyUpdate bool
+	CertFile              string
+	KeyFile               string
+	CaFile                string
+	InsecureSkipTLSverify bool
+	PlainHTTP             bool
+	Sign                  bool
+	Key                   string
+	Keyring               string
+	PassphraseFile        string
+	Version               string
+	AppVersion            string
+	Destination           string
+	DependencyUpdate      bool
 
 	RepositoryConfig string
 	RepositoryCache  string


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support to bring parity as it relates to OCI registry TLS configuration options for helm `package` and `dependency` to resolve #12614 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
