### PR TITLE
Fix: Helm chart is removed even if pre-delete hook is failing

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -97,8 +97,6 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}
 
-	cfg.recordRelease(rl)
-
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook
 	for _, h := range executingHooks {

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -66,7 +66,6 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			StartedAt: helmtime.Now(),
 			Phase:     release.HookPhaseRunning,
 		}
-		cfg.recordRelease(rl)
 
 		// As long as the implementation of WatchUntilReady does not panic, HookPhaseFailed or HookPhaseSucceeded
 		// should always be set by this function. If we fail to do that for any reason, then HookPhaseUnknown is
@@ -96,6 +95,8 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}
+
+	cfg.recordRelease(rl)
 
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -66,6 +66,7 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			StartedAt: helmtime.Now(),
 			Phase:     release.HookPhaseRunning,
 		}
+		cfg.recordRelease(rl)
 
 		// As long as the implementation of WatchUntilReady does not panic, HookPhaseFailed or HookPhaseSucceeded
 		// should always be set by this function. If we fail to do that for any reason, then HookPhaseUnknown is
@@ -95,6 +96,8 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		}
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}
+
+	cfg.recordRelease(rl)
 
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -96,8 +96,6 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}
 
-	cfg.recordRelease(rl)
-
 	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
 	// under succeeded condition. If so, then clear the corresponding resource object in each hook
 	for _, h := range executingHooks {

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -100,9 +100,6 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	}
 
 	u.cfg.Log("uninstall: Deleting %s", name)
-	rel.Info.Status = release.StatusUninstalling
-	rel.Info.Deleted = helmtime.Now()
-	rel.Info.Description = "Deletion in progress (or silently failed)"
 	res := &release.UninstallReleaseResponse{Release: rel}
 
 	if !u.DisableHooks {
@@ -115,6 +112,10 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 
 	// From here on out, the release is currently considered to be in StatusUninstalling
 	// state.
+	rel.Info.Status = release.StatusUninstalling
+	rel.Info.Deleted = helmtime.Now()
+	rel.Info.Description = "Deletion in progress (or silently failed)"
+
 	if err := u.cfg.Releases.Update(rel); err != nil {
 		u.cfg.Log("uninstall: Failed to store updated release: %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
closes #9700
**Special notes for your reviewer**:

Moved release status, deleted and description update statements to after the pre-delete hooks have succeeded. According to this comment in the code:
```
// From here on out, the release is currently considered to be in StatusUninstalling
// state.
```
It looks pretty promising that the uninstalling status should be changed only after the hooks have succeeded.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
