### PR TITLE
Introduce --disable-fetching-api-versions for install and upgrade

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -200,6 +200,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.StringToStringVarP(&client.Labels, "labels", "l", nil, "Labels that would be added to release metadata. Should be divided by comma.")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in install output. Does not affect presence in chart metadata")
+	f.BoolVar(&client.DisableFetchingAPIVersions, "disable-fetching-api-versions", false, "if set, the installation process will populate the built-in Capabilities.APIVersions template object with a default version set instead of fetching the full set from the Kubernetes API server")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -150,6 +150,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.Labels = client.Labels
 					instClient.EnableDNS = client.EnableDNS
 					instClient.HideSecret = client.HideSecret
+					instClient.DisableFetchingAPIVersions = client.DisableFetchingAPIVersions
 
 					if isReleaseUninstalled(versions) {
 						instClient.Replace = true
@@ -278,6 +279,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.DisableFetchingAPIVersions, "disable-fetching-api-versions", false, "if set, the upgrade process will populate the built-in Capabilities.APIVersions template object with a default version set instead of fetching the full set from the Kubernetes API server")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -112,6 +112,8 @@ type Install struct {
 	PostRenderer   postrender.PostRenderer
 	// Lock to control raceconditions when the process receives a SIGTERM
 	Lock sync.Mutex
+	// DisableFetchingAPIVersions controls whether Capabilities.APIVersions is fetched from the API server
+	DisableFetchingAPIVersions bool
 }
 
 // ChartPathOptions captures common options used for controlling chart paths
@@ -284,7 +286,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	// the user doesn't have to specify both
 	i.Wait = i.Wait || i.Atomic
 
-	caps, err := i.cfg.getCapabilities()
+	caps, err := i.cfg.getCapabilities(!i.DisableFetchingAPIVersions)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +312,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	rel := i.createRelease(chrt, vals, i.Labels)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithRemote, i.EnableDNS, i.HideSecret)
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithRemote, i.EnableDNS, i.HideSecret, !i.DisableFetchingAPIVersions)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -196,7 +196,7 @@ func joinErrors(errs []error) string {
 // deleteRelease deletes the release and returns list of delete resources and manifests that were kept in the deletion process
 func (u *Uninstall) deleteRelease(rel *release.Release) (kube.ResourceList, string, []error) {
 	var errs []error
-	caps, err := u.cfg.getCapabilities()
+	caps, err := u.cfg.getCapabilities(true)
 	if err != nil {
 		return nil, rel.Manifest, []error{errors.Wrap(err, "could not get apiVersions from Kubernetes")}
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -115,6 +115,8 @@ type Upgrade struct {
 	Lock sync.Mutex
 	// Enable DNS lookups when rendering templates
 	EnableDNS bool
+	// DisableFetchingAPIVersions controls whether Capabilities.APIVersions is fetched from the API server
+	DisableFetchingAPIVersions bool
 }
 
 type resultMessage struct {
@@ -254,7 +256,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		IsUpgrade: true,
 	}
 
-	caps, err := u.cfg.getCapabilities()
+	caps, err := u.cfg.getCapabilities(!u.DisableFetchingAPIVersions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -269,7 +271,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 		interactWithRemote = true
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, interactWithRemote, u.EnableDNS, u.HideSecret)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, interactWithRemote, u.EnableDNS, u.HideSecret, !u.DisableFetchingAPIVersions)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
When enabled, during the rendering process, this feature flag will populate the built-in `Capabilities.APIVersions` template object with a default version set instead of fetching the full set from the Kubernetes API server.

The motivation for this is to reduce unnecessary Kubernetes API calls when installing or upgrading charts that don't rely heavily on `Capabilities.APIVersions`. In my experience, actual usage of `Capabilities.APIVersions` is rare, yet fetching the version set on clusters supporting many CRDs is very costly.

This change is backwards-compatible.

Signed-off-by: Eric Latham ericoliverlatham@gmail.com