### PR TITLE
Fix: add proxy support when mTLS configured on helm install/upgrade

### DIFF
--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -156,6 +156,7 @@ func NewRegistryClientWithTLS(out io.Writer, certFile, keyFile, caFile string, i
 		ClientOptHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConf,
+				Proxy:           http.ProxyFromEnvironment,
 			},
 		}),
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes `helm install/upgrade` to respect `HTTPS_PROXY/NO_PROXY` etc. when you also specify any cert auth/mTLS arguments (e.g. `--ca-file`, `--cert-file`, etc.).

closes #13116.

**Special notes for your reviewer**:
Should be pretty similar in spirit to https://github.com/helm/helm/pull/12761

