### PR TITLE
fix(dependencyBuild): prevent race condition in concurrent helm dependency

### DIFF
--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -200,8 +200,9 @@ func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 		}
 	}
 
-	// Make sure tmpcharts is deleted
-	if _, err := os.Stat(filepath.Join(dir(chartname), "tmpcharts")); !os.IsNotExist(err) {
+	// Make sure tmpcharts-x is deleted
+	tmpPath := filepath.Join(dir(chartname), fmt.Sprintf("tmpcharts-%d", os.Getpid()))
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
 		t.Fatalf("tmpcharts dir still exists")
 	}
 }

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -246,7 +246,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	}
 
 	destPath := filepath.Join(m.ChartPath, "charts")
-	tmpPath := filepath.Join(m.ChartPath, "tmpcharts")
+	tmpPath := filepath.Join(m.ChartPath, fmt.Sprintf("tmpcharts-%d", os.Getpid()))
 
 	// Check if 'charts' directory is not actually a directory. If it does not exist, create it.
 	if fi, err := os.Stat(destPath); err == nil {


### PR DESCRIPTION
closes #13110

**What this PR does / why we need it**:
it fixes this issue by adding a suffix to the `tmpcharts` directory so each instance can have its own directory
> building and templating a lot of Helm charts in parallel, when some of them share a subchart using symlinks it's possible the build fails due to a race condition