### PR TITLE
feat: add pod fail details

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -38,11 +38,11 @@ import (
 	deploymentutil "helm.sh/helm/v3/internal/third_party/k8s.io/kubernetes/deployment/util"
 )
 
-type PodError struct {
-	PodName   string
-	Container string
-	Reason    string
-	Message   string
+type podError struct {
+	podName   string
+	container string
+	reason    string
+	message   string
 }
 
 // ReadyCheckerOption is a function that configures a ReadyChecker.
@@ -215,7 +215,7 @@ func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, err
 }
 
 func (c *ReadyChecker) getPodFailedError(pod *corev1.Pod) error {
-	podErrors := make([]PodError, 0)
+	podErrors := make([]podError, 0)
 	if pod.Status.Phase == corev1.PodFailed {
 		containerStatuses := pod.Status.ContainerStatuses
 		if pod.Status.InitContainerStatuses != nil {
@@ -224,18 +224,18 @@ func (c *ReadyChecker) getPodFailedError(pod *corev1.Pod) error {
 
 		for _, cs := range containerStatuses {
 			if cs.State.Terminated != nil {
-				podErrors = append(podErrors, PodError{
-					PodName:   pod.Name,
-					Container: cs.Name,
-					Reason:    cs.State.Terminated.Reason,
-					Message:   cs.State.Terminated.Message,
+				podErrors = append(podErrors, podError{
+					podName:   pod.Name,
+					container: cs.Name,
+					reason:    cs.State.Terminated.Reason,
+					message:   cs.State.Terminated.Message,
 				})
 			} else if cs.State.Waiting != nil {
-				podErrors = append(podErrors, PodError{
-					PodName:   pod.Name,
-					Container: cs.Name,
-					Reason:    cs.State.Waiting.Reason,
-					Message:   cs.State.Waiting.Message,
+				podErrors = append(podErrors, podError{
+					podName:   pod.Name,
+					container: cs.Name,
+					reason:    cs.State.Waiting.Reason,
+					message:   cs.State.Waiting.Message,
 				})
 			}
 		}

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -63,6 +63,7 @@ func (w *waiter) waitForResources(created ResourceList) error {
 			ready, err := w.c.IsReady(ctx, v)
 
 			if waitRetries > 0 && w.isRetryableError(err, v) {
+				waitRetries--
 				numberOfErrors[i]++
 				if numberOfErrors[i] > waitRetries {
 					w.log("Max number of retries reached")


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR I added details to the pod is not ready error so you can see why the release failed, it's especially useful if you pass `--atomic`, because in this case the release will be deleted and you won't be able to see what went wrong, the workaround is to start the release again and start watching pods to see what pod fails and why

Example:
> Error: INSTALLATION FAILED: release tmp failed, and has been uninstalled due to atomic being set: [{PodName:tmp-my-alpine Container:waiter Reason:Error Message:Sleep expired}]

