### PR TITLE
fix(helm): Use burst limit setting for discovery

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -112,7 +112,7 @@ func New() *EnvSettings {
 	env.Debug, _ = strconv.ParseBool(os.Getenv("HELM_DEBUG"))
 
 	// bind to kubernetes config flags
-	env.config = &genericclioptions.ConfigFlags{
+	config := &genericclioptions.ConfigFlags{
 		Namespace:        &env.namespace,
 		Context:          &env.KubeContext,
 		BearerToken:      &env.KubeToken,
@@ -133,6 +133,11 @@ func New() *EnvSettings {
 			return config
 		},
 	}
+	if env.BurstLimit != defaultBurstLimit {
+		config = config.WithDiscoveryBurst(env.BurstLimit)
+	}
+	env.config = config
+
 	return env
 }
 


### PR DESCRIPTION
When `--burst-limit`/`$HELM_BURST_LIMIT` is set, the specified value is not currently used for the discovery client instantiated by [`genericclioptions`](https://github.com/kubernetes/kubernetes/blob/3f9b79fc119d064d00939f91567b48d9ada7dc43/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L281). This change sets `genericclioptions.discoveryBurst` to the value of `--burst-limit`, meaning it should now be possible to fix client-side throttling issues encountered by the discovery client.

This value is only configured if `--burst-limit` is actually set. If `--burst-limit` is set to the default value, then `discoveryBurst` should be left at its default of 300.

Closes #13128