### PR TITLE
Avoiding leaking goroutines in Upgrade/Install RunWithContext when context is cancelled

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -412,6 +412,8 @@ func (i *Install) performInstallCtx(ctx context.Context, rel *release.Release, t
 	}
 	resultChan := make(chan Msg, 1)
 
+	// TODOS we are not handling context here
+	// figure out a way to handle the context
 	go func() {
 		rel, err := i.performInstall(rel, toBeAdopted, resources)
 		resultChan <- Msg{rel, err}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -363,14 +363,18 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		return upgradedRelease, nil
 	}
 
+	// TODOS here
+	// ensure that when we do a RunWithContext and the context is cancelled, we should remove all the existing go routines
 	u.cfg.Log("creating upgraded release for %s", upgradedRelease.Name)
 	if err := u.cfg.Releases.Create(upgradedRelease); err != nil {
 		return nil, err
 	}
+
 	rChan := make(chan resultMessage)
 	ctxChan := make(chan resultMessage)
 	doneChan := make(chan interface{})
 	defer close(doneChan)
+
 	go u.releasingUpgrade(rChan, upgradedRelease, current, target, originalRelease)
 	go u.handleContext(ctx, doneChan, ctxChan, upgradedRelease)
 	select {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -362,7 +362,7 @@ func (c *Client) WaitWithJobsWithContext(ctx context.Context, resources Resource
 		c:       checker,
 		log:     c.Log,
 		timeout: timeout,
-		ctx:     c.ctx,
+		ctx:     ctx,
 	}
 	return w.waitForResources(resources)
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -92,7 +92,6 @@ func New(getter genericclioptions.RESTClientGetter) *Client {
 	if getter == nil {
 		getter = genericclioptions.NewConfigFlags(true)
 	}
-
 	// Add CRDs to the scheme. They are missing by default.
 	addToScheme.Do(func() {
 		if err := apiextv1.AddToScheme(scheme.Scheme); err != nil {
@@ -103,7 +102,6 @@ func New(getter genericclioptions.RESTClientGetter) *Client {
 			panic(err)
 		}
 	})
-
 	return &Client{
 		Factory: cmdutil.NewFactory(getter),
 		Log:     nopLogger,

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -320,8 +320,39 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	return w.waitForResources(resources)
 }
 
-// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
+// WaitWithJobs wait up to the given timeout for the specified resources to be ready or until the context is Done, including jobs.
 func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) error {
+	cs, err := c.getKubeClient()
+	if err != nil {
+		return err
+	}
+	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true), CheckJobs(true))
+	w := waiter{
+		c:       checker,
+		log:     c.Log,
+		timeout: timeout,
+	}
+	return w.waitForResources(resources)
+}
+
+// WaitWithContext waits up to the given timeout for the specified resources to be ready or until the context is Done.
+func (c *Client) WaitWithContext(ctx context.Context, resources ResourceList, timeout time.Duration) error {
+	cs, err := c.getKubeClient()
+	if err != nil {
+		return err
+	}
+	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true))
+	w := waiter{
+		c:       checker,
+		log:     c.Log,
+		timeout: timeout,
+		ctx:     ctx,
+	}
+	return w.waitForResources(resources)
+}
+
+// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
+func (c *Client) WaitWithJobsWithContext(ctx context.Context, resources ResourceList, timeout time.Duration) error {
 	cs, err := c.getKubeClient()
 	if err != nil {
 		return err

--- a/pkg/kube/fake/fake.go
+++ b/pkg/kube/fake/fake.go
@@ -18,6 +18,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -80,6 +81,23 @@ func (f *FailingKubeClient) WaitWithJobs(resources kube.ResourceList, d time.Dur
 		return f.WaitError
 	}
 	return f.PrintingKubeClient.WaitWithJobs(resources, d)
+}
+
+// WaitWithContext the amount of time defined on f.WaitDuration, then returns the configured error if set or prints.
+func (f *FailingKubeClient) WaitWithContext(ctx context.Context, resources kube.ResourceList, d time.Duration) error {
+	time.Sleep(f.WaitDuration)
+	if f.WaitError != nil {
+		return f.WaitError
+	}
+	return f.PrintingKubeClient.WaitWithContext(ctx, resources, d)
+}
+
+// WaitWithJobsWithContext returns the configured error if set or prints
+func (f *FailingKubeClient) WaitWithJobsWithContext(ctx context.Context, resources kube.ResourceList, d time.Duration) error {
+	if f.WaitError != nil {
+		return f.WaitError
+	}
+	return f.PrintingKubeClient.WaitWithJobsWithContext(ctx, resources, d)
 }
 
 // WaitForDelete returns the configured error if set or prints

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"io"
 	"strings"
 	"time"
@@ -63,6 +64,16 @@ func (p *PrintingKubeClient) Wait(resources kube.ResourceList, _ time.Duration) 
 }
 
 func (p *PrintingKubeClient) WaitWithJobs(resources kube.ResourceList, _ time.Duration) error {
+	_, err := io.Copy(p.Out, bufferize(resources))
+	return err
+}
+
+func (p *PrintingKubeClient) WaitWithContext(ctx context.Context, resources kube.ResourceList, _ time.Duration) error {
+	_, err := io.Copy(p.Out, bufferize(resources))
+	return err
+}
+
+func (p *PrintingKubeClient) WaitWithJobsWithContext(ctx context.Context, resources kube.ResourceList, _ time.Duration) error {
 	_, err := io.Copy(p.Out, bufferize(resources))
 	return err
 }

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -37,6 +38,13 @@ type Interface interface {
 
 	// WaitWithJobs wait up to the given timeout for the specified resources to be ready, including jobs.
 	WaitWithJobs(resources ResourceList, timeout time.Duration) error
+
+	// WaitWithContext waits up to the given timeout for the specified resources to be ready or until the context is Done.
+	WaitWithContext(ctx context.Context, resources ResourceList, timeout time.Duration) error
+
+	// WaitWithJobsWithContext waits up to the given timeout for the specified resources to be ready or until the context is Done
+	// including jobs.
+	WaitWithJobsWithContext(ctx context.Context, resources ResourceList, timeout time.Duration) error
 
 	// Delete destroys one or more resources.
 	Delete(resources ResourceList) (*Result, []error)

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -42,6 +42,9 @@ type waiter struct {
 	c       ReadyChecker
 	timeout time.Duration
 	log     func(string, ...interface{})
+
+	// ctx used to to cancel and avoid go routines leaking
+	ctx context.Context
 }
 
 // waitForResources polls to get the current status of all pods, PVCs, Services and
@@ -49,7 +52,7 @@ type waiter struct {
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
 
-	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
+	ctx, cancel := context.WithTimeout(w.ctx, w.timeout)
 	defer cancel()
 
 	numberOfErrors := make([]int, len(created))

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -52,6 +52,10 @@ type waiter struct {
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
 
+	if w.ctx == nil {
+		w.ctx = context.Background()
+	}
+
 	ctx, cancel := context.WithTimeout(w.ctx, w.timeout)
 	defer cancel()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #13126

**What this PR does / why we need it**:
When using RunWithContext for Upgrade/Install with a Wait/WaitWithJobs/Atomic set it is possible for goroutines to leak/remain dangling when the context is cancelled prematurely.

This is due to these methods not waiting for the helm kubeclient's Wait and WaitWithJobs to complete.

With this PR I am introducing new methods in the kubeclient interface.
WaitWithContext and WaitWithJobsWithContext
This way a context is propagated and goroutines are exited solving dangling resources.

**Special notes for your reviewer**:
Snippet to try this out

```
package main

import (
	"context"
	"log"
	"time"

	"helm.sh/helm/v3/pkg/action"
)


func main() {

	installAction := action.NewInstall(&action.Configuration{
		// fill this up
		// ensure to use a logger to display the log in the dangling go routine
	})

	installAction.Wait = true
	installAction.Timeout = time.Hour

	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
	defer cancel()

	// fill up the chart and values
	go func() {
		_, err := installAction.RunWithContext(ctx, "chart", "values")
		if err != nil {
			log.Printf("encountered an error %s", err.Error())
		}
	}()

	waitChan := make(chan struct{})
	<-waitChan
}
```