### PR TITLE
Add enhanced proxy

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -62,6 +62,7 @@ type repoAddOptions struct {
 
 	// Deprecated, but cannot be removed until Helm 4
 	deprecatedNoUpdate bool
+	repoProxyUrl       string
 }
 
 func newRepoAddCmd(out io.Writer) *cobra.Command {
@@ -94,7 +95,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&o.insecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the repository")
 	f.BoolVar(&o.allowDeprecatedRepos, "allow-deprecated-repos", false, "by default, this command will not allow adding official repos that have been permanently deleted. This disables that behavior")
 	f.BoolVar(&o.passCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
-
+	f.StringVar(&o.repoProxyUrl, "repo-proxy-url", "", "proxy for accessing the repository and its URL format follows the global option --proxy-url")
 	return cmd
 }
 
@@ -165,15 +166,17 @@ func (o *repoAddOptions) run(out io.Writer) error {
 	}
 
 	c := repo.Entry{
-		Name:                  o.name,
-		URL:                   o.url,
-		Username:              o.username,
-		Password:              o.password,
-		PassCredentialsAll:    o.passCredentialsAll,
-		CertFile:              o.certFile,
-		KeyFile:               o.keyFile,
-		CAFile:                o.caFile,
-		InsecureSkipTLSverify: o.insecureSkipTLSverify,
+		Name:                        o.name,
+		URL:                         o.url,
+		Username:                    o.username,
+		Password:                    o.password,
+		PassCredentialsAll:          o.passCredentialsAll,
+		CertFile:                    o.certFile,
+		KeyFile:                     o.keyFile,
+		CAFile:                      o.caFile,
+		InsecureSkipTLSverify:       o.insecureSkipTLSverify,
+		RepoProxyUrl:                o.repoProxyUrl,
+		DoNotUseEnvSettingsProxyUrl: settings.ProxyUrl,
 	}
 
 	// Check if the repo name is legal

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -71,7 +71,7 @@ Environment variables:
 | $HELM_KUBETLS_SERVER_NAME          | set the server name used to validate the Kubernetes API server certificate                                 |
 | $HELM_BURST_LIMIT                  | set the default burst limit in the case the server contains many CRDs (default 100, -1 to disable)         |
 | $HELM_QPS                          | set the Queries Per Second in cases where a high number of calls exceed the option for higher burst values |
-
+| $HELM_PROXY_URL                    | set the proxy url use this parameter to specify a proxy server URL for accessing the Helm repository       |
 Helm stores cache, configuration, and data based on the following configuration order:
 
 - If a HELM_*_HOME environment variable is set, it will be used

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -806,7 +806,9 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	} else {
 		dl.Options = append(dl.Options, getter.WithBasicAuth(c.Username, c.Password))
 	}
-
+	if settings.ProxyUrl != "" {
+		dl.Options = append(dl.Options, getter.WithProxyUrl(settings.ProxyUrl))
+	}
 	if err := os.MkdirAll(settings.RepositoryCache, 0755); err != nil {
 		return "", err
 	}

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -88,6 +88,8 @@ type EnvSettings struct {
 	BurstLimit int
 	// QPS is queries per second which may be used to avoid throttling.
 	QPS float32
+	// Proxy proxy url
+	ProxyUrl string
 }
 
 func New() *EnvSettings {
@@ -108,6 +110,7 @@ func New() *EnvSettings {
 		RepositoryCache:           envOr("HELM_REPOSITORY_CACHE", helmpath.CachePath("repository")),
 		BurstLimit:                envIntOr("HELM_BURST_LIMIT", defaultBurstLimit),
 		QPS:                       envFloat32Or("HELM_QPS", defaultQPS),
+		ProxyUrl:                  os.Getenv("HELM_PROXY_URL"),
 	}
 	env.Debug, _ = strconv.ParseBool(os.Getenv("HELM_DEBUG"))
 
@@ -159,6 +162,7 @@ func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RepositoryCache, "repository-cache", s.RepositoryCache, "path to the file containing cached repository indexes")
 	fs.IntVar(&s.BurstLimit, "burst-limit", s.BurstLimit, "client-side default throttling limit")
 	fs.Float32Var(&s.QPS, "qps", s.QPS, "queries per second used when communicating with the Kubernetes API, not including bursting")
+	fs.StringVar(&s.ProxyUrl, "proxy-url", s.ProxyUrl, "use this parameter to specify a proxy server URL for accessing the Helm repository. The proxy URL must be in the format [scheme://][user[:password]@]host[:port], where scheme can be http, https, or socks5.")
 }
 
 func envOr(name, def string) string {
@@ -237,6 +241,7 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_KUBECAFILE":                   s.KubeCaFile,
 		"HELM_KUBEINSECURE_SKIP_TLS_VERIFY": strconv.FormatBool(s.KubeInsecureSkipTLSVerify),
 		"HELM_KUBETLS_SERVER_NAME":          s.KubeTLSServerName,
+		"HELM_PROXY_URL":                    s.ProxyUrl,
 	}
 	if s.KubeConfig != "" {
 		envvars["KUBECONFIG"] = s.KubeConfig

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -275,6 +275,9 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 				getter.WithPassCredentialsAll(r.Config.PassCredentialsAll),
 			)
 		}
+		if r.Config.RepoProxyUrl != "" {
+			c.Options = append(c.Options, getter.WithProxyUrl(r.Config.RepoProxyUrl))
+		}
 	}
 
 	// Next, we need to load the index, and actually look up the chart.

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -46,6 +46,7 @@ type options struct {
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
+	proxyUrl              string
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -121,7 +122,11 @@ func WithRegistryClient(client *registry.Client) Option {
 		opts.registryClient = client
 	}
 }
-
+func WithProxyUrl(proxyUrl string) Option {
+	return func(opts *options) {
+		opts.proxyUrl = proxyUrl
+	}
+}
 func WithUntar() Option {
 	return func(opts *options) {
 		opts.unTar = true
@@ -170,10 +175,10 @@ type Providers []Provider
 // ByScheme returns a Provider that handles the given scheme.
 //
 // If no provider handles this scheme, this will return an error.
-func (p Providers) ByScheme(scheme string) (Getter, error) {
+func (p Providers) ByScheme(scheme string, options ...Option) (Getter, error) {
 	for _, pp := range p {
 		if pp.Provides(scheme) {
-			return pp.New()
+			return pp.New(options...)
 		}
 	}
 	return nil, errors.Errorf("scheme %q not supported", scheme)

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -117,9 +117,17 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 	}
 
 	g.once.Do(func() {
+		var proxyFunc func(*http.Request) (*url.URL, error)
+		if g.opts.proxyUrl != "" {
+			proxyFunc = func(request *http.Request) (*url.URL, error) {
+				return url.Parse(g.opts.proxyUrl)
+			}
+		} else {
+			proxyFunc = http.ProxyFromEnvironment
+		}
 		g.transport = &http.Transport{
 			DisableCompression: true,
-			Proxy:              http.ProxyFromEnvironment,
+			Proxy:              proxyFunc,
 		}
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
 #13125 

Add enhanced proxy

## Requirement Description
- Add global parameter --proxy-url: Use this proxy when accessing chart repositories during pull, install, etc.
- Add HELM_PROXY_URL environment variable: Functions the same as the global parameter --proxy-url.
- Add parameter --repo-proxy-url when adding a chart repository: Used to configure a proxy for a specific chart repository.
##  Priority Order

- --repo-proxy-url: Proxy configuration for specific chart repositories.
- --proxy-url: Global parameter.
- HELM_PROXY_URL: Environment variable.
- HTTP[S]_PROXY: Environment variable.





**What this PR does / why we need it**:

Sometimes, the Helm chart repository encounters interference from the firewall and cannot be accessed directly, requiring a proxy. However, using HTTP[S]_PROXY environment variables causes conflicts with other applications. Therefore, adding this feature helps to avoid such issues.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
