### PR TITLE
Allow post-renderer to process hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	k8s.io/kubectl v0.33.2
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/controller-runtime v0.21.0
+	sigs.k8s.io/kustomize/kyaml v0.19.0
 	sigs.k8s.io/yaml v1.5.0
 )
 
@@ -175,7 +176,6 @@ require (
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -241,8 +241,8 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 		// them back into a map of filename -> content.
 
 		// Merge files as stream of documents for sending to post renderer
-		var merged string
-		if merged, err = annotateAndMerge(files); err != nil {
+		merged, err := annotateAndMerge(files)
+		if err != nil {
 			return hs, b, notes, fmt.Errorf("error merging manifests: %w", err)
 		}
 
@@ -253,7 +253,8 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 		}
 
 		// Use the file list and contents received from the post renderer
-		if files, err = splitAndDeannotate(postRendered.String()); err != nil {
+		files, err = splitAndDeannotate(postRendered.String())
+		if err != nil {
 			return hs, b, notes, fmt.Errorf("error while parsing post rendered output: %w", err)
 		}
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -128,9 +128,9 @@ func annotateAndMerge(files map[string]string) (string, error) {
 	return merged, nil
 }
 
-// SplitAndDeannotate reconstructs individual files from a merged YAML stream,
+// splitAndDeannotate reconstructs individual files from a merged YAML stream,
 // removing filename annotations and grouping documents by their original filenames.
-func SplitAndDeannotate(postrendered string) (map[string]string, error) {
+func splitAndDeannotate(postrendered string) (map[string]string, error) {
 	manifests, err := kio.ParseAll(postrendered)
 	if err != nil {
 		return nil, fmt.Errorf("re-parsing merged buffer: %w", err)
@@ -253,7 +253,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 		}
 
 		// Use the file list and contents received from the post renderer
-		if files, err = SplitAndDeannotate(postRendered.String()); err != nil {
+		if files, err = splitAndDeannotate(postRendered.String()); err != nil {
 			return hs, b, notes, fmt.Errorf("error while parsing post rendered files: %w", err)
 		}
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -99,9 +99,9 @@ const (
 	filenameAnnotation = "helm-postrender-filename"
 )
 
-// AnnotateAndMerge combines multiple YAML files into a single stream of documents,
+// annotateAndMerge combines multiple YAML files into a single stream of documents,
 // adding filename annotations to each document for later reconstruction.
-func AnnotateAndMerge(files map[string]string) (string, error) {
+func annotateAndMerge(files map[string]string) (string, error) {
 	var combinedManifests []*kyaml.RNode
 	for fname, content := range files {
 		// Skip partials and empty files.
@@ -242,7 +242,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 
 		// Merge files as stream of documents for sending to post renderer
 		var merged string
-		if merged, err = AnnotateAndMerge(files); err != nil {
+		if merged, err = annotateAndMerge(files); err != nil {
 			return hs, b, notes, fmt.Errorf("error merging manifests: %w", err)
 		}
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -96,7 +96,7 @@ type Configuration struct {
 const (
 	// filenameAnnotation is the annotation key used to store the original filename
 	// information in manifest annotations for post-rendering reconstruction.
-	filenameAnnotation = "helm-postrender-filename"
+	filenameAnnotation = "postrenderer.helm.sh/postrender-filename"
 )
 
 // annotateAndMerge combines multiple YAML files into a single stream of documents,

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"text/template"
@@ -103,7 +105,12 @@ const (
 // adding filename annotations to each document for later reconstruction.
 func annotateAndMerge(files map[string]string) (string, error) {
 	var combinedManifests []*kyaml.RNode
-	for fname, content := range files {
+
+	// Get sorted filenames to ensure result is deterministic
+	fnames := slices.Sorted(maps.Keys(files))
+
+	for _, fname := range fnames {
+		content := files[fname]
 		// Skip partials and empty files.
 		if strings.HasPrefix(path.Base(fname), "_") || strings.TrimSpace(content) == "" {
 			continue

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -94,9 +94,9 @@ type Configuration struct {
 }
 
 const (
-	// FilenameAnnotation is the annotation key used to store the original filename
+	// filenameAnnotation is the annotation key used to store the original filename
 	// information in manifest annotations for post-rendering reconstruction.
-	FilenameAnnotation = "helm-postrender-filename"
+	filenameAnnotation = "helm-postrender-filename"
 )
 
 // AnnotateAndMerge combines multiple YAML files into a single stream of documents,
@@ -114,7 +114,7 @@ func AnnotateAndMerge(files map[string]string) (string, error) {
 			return "", fmt.Errorf("parsing %s: %w", fname, err)
 		}
 		for _, manifest := range manifests {
-			if err := manifest.PipeE(kyaml.SetAnnotation(FilenameAnnotation, fname)); err != nil {
+			if err := manifest.PipeE(kyaml.SetAnnotation(filenameAnnotation, fname)); err != nil {
 				return "", fmt.Errorf("annotating %s: %w", fname, err)
 			}
 			combinedManifests = append(combinedManifests, manifest)
@@ -142,11 +142,11 @@ func SplitAndDeannotate(postrendered string) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting metadata: %w", err)
 		}
-		fname := meta.Annotations[FilenameAnnotation]
+		fname := meta.Annotations[filenameAnnotation]
 		if fname == "" {
 			fname = fmt.Sprintf("generated-by-postrender-%d.yaml", i)
 		}
-		if err := manifest.PipeE(kyaml.ClearAnnotation(FilenameAnnotation)); err != nil {
+		if err := manifest.PipeE(kyaml.ClearAnnotation(filenameAnnotation)); err != nil {
 			return nil, fmt.Errorf("clearing filename annotation: %w", err)
 		}
 		manifestsByFilename[fname] = append(manifestsByFilename[fname], manifest)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -133,7 +133,7 @@ func annotateAndMerge(files map[string]string) (string, error) {
 func splitAndDeannotate(postrendered string) (map[string]string, error) {
 	manifests, err := kio.ParseAll(postrendered)
 	if err != nil {
-		return nil, fmt.Errorf("re-parsing merged buffer: %w", err)
+		return nil, fmt.Errorf("error parsing YAML: %w", err)
 	}
 
 	manifestsByFilename := make(map[string][]*kyaml.RNode)
@@ -254,7 +254,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 
 		// Use the file list and contents received from the post renderer
 		if files, err = splitAndDeannotate(postRendered.String()); err != nil {
-			return hs, b, notes, fmt.Errorf("error while parsing post rendered files: %w", err)
+			return hs, b, notes, fmt.Errorf("error while parsing post rendered output: %w", err)
 		}
 	}
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
@@ -89,6 +91,76 @@ type Configuration struct {
 	HookOutputFunc func(namespace, pod, container string) io.Writer
 
 	mutex sync.Mutex
+}
+
+const (
+	// FilenameAnnotation is the annotation key used to store the original filename
+	// information in manifest annotations for post-rendering reconstruction.
+	FilenameAnnotation = "helm-postrender-filename"
+)
+
+// AnnotateAndMerge combines multiple YAML files into a single stream of documents,
+// adding filename annotations to each document for later reconstruction.
+func AnnotateAndMerge(files map[string]string) (string, error) {
+	var combinedManifests []*kyaml.RNode
+	for fname, content := range files {
+		// Skip partials and empty files.
+		if strings.HasPrefix(path.Base(fname), "_") || strings.TrimSpace(content) == "" {
+			continue
+		}
+
+		manifests, err := kio.ParseAll(content)
+		if err != nil {
+			return "", fmt.Errorf("parsing %s: %w", fname, err)
+		}
+		for _, manifest := range manifests {
+			if err := manifest.PipeE(kyaml.SetAnnotation(FilenameAnnotation, fname)); err != nil {
+				return "", fmt.Errorf("annotating %s: %w", fname, err)
+			}
+			combinedManifests = append(combinedManifests, manifest)
+		}
+	}
+
+	merged, err := kio.StringAll(combinedManifests)
+	if err != nil {
+		return "", fmt.Errorf("writing merged docs: %w", err)
+	}
+	return merged, nil
+}
+
+// SplitAndDeannotate reconstructs individual files from a merged YAML stream,
+// removing filename annotations and grouping documents by their original filenames.
+func SplitAndDeannotate(postrendered string) (map[string]string, error) {
+	manifests, err := kio.ParseAll(postrendered)
+	if err != nil {
+		return nil, fmt.Errorf("re-parsing merged buffer: %w", err)
+	}
+
+	manifestsByFilename := make(map[string][]*kyaml.RNode)
+	for i, manifest := range manifests {
+		meta, err := manifest.GetMeta()
+		if err != nil {
+			return nil, fmt.Errorf("getting metadata: %w", err)
+		}
+		fname := meta.Annotations[FilenameAnnotation]
+		if fname == "" {
+			fname = fmt.Sprintf("generated-by-postrender-%d.yaml", i)
+		}
+		if err := manifest.PipeE(kyaml.ClearAnnotation(FilenameAnnotation)); err != nil {
+			return nil, fmt.Errorf("clearing filename annotation: %w", err)
+		}
+		manifestsByFilename[fname] = append(manifestsByFilename[fname], manifest)
+	}
+
+	reconstructed := make(map[string]string, len(manifestsByFilename))
+	for fname, docs := range manifestsByFilename {
+		fileContents, err := kio.StringAll(docs)
+		if err != nil {
+			return nil, fmt.Errorf("re-writing %s: %w", fname, err)
+		}
+		reconstructed[fname] = fileContents
+	}
+	return reconstructed, nil
 }
 
 // renderResources renders the templates in a chart
@@ -160,6 +232,32 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 	}
 	notes := notesBuffer.String()
 
+	if pr != nil {
+		// We need to send files to the post-renderer before sorting and splitting
+		// hooks from manifests. The post-renderer interface expects a stream of
+		// manifests (similar to what tools like Kustomize and kubectl expect), whereas
+		// the sorter uses filenames.
+		// Here, we merge the documents into a stream, post-render them, and then split
+		// them back into a map of filename -> content.
+
+		// Merge files as stream of documents for sending to post renderer
+		var merged string
+		if merged, err = AnnotateAndMerge(files); err != nil {
+			return hs, b, notes, fmt.Errorf("error merging manifests: %w", err)
+		}
+
+		// Run the post renderer
+		postRendered, err := pr.Run(bytes.NewBufferString(merged))
+		if err != nil {
+			return hs, b, notes, fmt.Errorf("error while running post render on files: %w", err)
+		}
+
+		// Use the file list and contents received from the post renderer
+		if files, err = SplitAndDeannotate(postRendered.String()); err != nil {
+			return hs, b, notes, fmt.Errorf("error while parsing post rendered files: %w", err)
+		}
+	}
+
 	// Sort hooks, manifests, and partials. Only hooks and manifests are returned,
 	// as partials are not used after renderer.Render. Empty manifests are also
 	// removed here.
@@ -217,13 +315,6 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 				return hs, b, "", err
 			}
 			fileWritten[m.Name] = true
-		}
-	}
-
-	if pr != nil {
-		b, err = pr.Run(b)
-		if err != nil {
-			return hs, b, notes, fmt.Errorf("error while running post render on files: %w", err)
 		}
 	}
 

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -675,7 +675,7 @@ data:
 		{
 			name:          "invalid yaml input",
 			input:         "invalid: yaml: content:",
-			expectedError: "re-parsing merged buffer",
+			expectedError: "error parsing YAML: MalformedYAMLError",
 		},
 		{
 			name: "manifest without filename annotation",
@@ -885,7 +885,7 @@ func TestRenderResources_PostRenderer_SplitError(t *testing.T) {
 	)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error while parsing post rendered files")
+	assert.Contains(t, err.Error(), "error while parsing post rendered output: error parsing YAML: MalformedYAMLError:")
 }
 
 func TestRenderResources_PostRenderer_Integration(t *testing.T) {

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -536,7 +536,7 @@ metadata:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			merged, err := AnnotateAndMerge(tt.files)
+			merged, err := annotateAndMerge(tt.files)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)
@@ -749,7 +749,7 @@ data:
 	}
 
 	// Merge and annotate
-	merged, err := AnnotateAndMerge(originalFiles)
+	merged, err := annotateAndMerge(originalFiles)
 	require.NoError(t, err)
 
 	// Split and deannotate

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -419,7 +419,7 @@ kind: ConfigMap
 metadata:
   name: test-cm
   annotations:
-    helm-postrender-filename: 'templates/configmap.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/configmap.yaml'
 data:
   key: value
 `,
@@ -445,7 +445,7 @@ kind: ConfigMap
 metadata:
   name: test-cm
   annotations:
-    helm-postrender-filename: 'templates/configmap.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/configmap.yaml'
 data:
   key: value
 ---
@@ -454,7 +454,7 @@ kind: Secret
 metadata:
   name: test-secret
   annotations:
-    helm-postrender-filename: 'templates/secret.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/secret.yaml'
 data:
   password: dGVzdA==
 `,
@@ -481,7 +481,7 @@ kind: ConfigMap
 metadata:
   name: test-cm1
   annotations:
-    helm-postrender-filename: 'templates/multi.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/multi.yaml'
 data:
   key: value1
 ---
@@ -490,7 +490,7 @@ kind: ConfigMap
 metadata:
   name: test-cm2
   annotations:
-    helm-postrender-filename: 'templates/multi.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/multi.yaml'
 data:
   key: value2
 `,
@@ -514,7 +514,7 @@ kind: ConfigMap
 metadata:
   name: test-cm1
   annotations:
-    helm-postrender-filename: 'templates/cm.yaml'
+    postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 `,
 		},
 		{
@@ -564,7 +564,7 @@ kind: ConfigMap
 metadata:
   name: test-cm
   annotations:
-    helm-postrender-filename: templates/configmap.yaml
+    postrenderer.helm.sh/postrender-filename: templates/configmap.yaml
 data:
   key: value`,
 			expectedFiles: map[string]string{
@@ -584,7 +584,7 @@ kind: ConfigMap
 metadata:
   name: test-cm
   annotations:
-    helm-postrender-filename: templates/configmap.yaml
+    postrenderer.helm.sh/postrender-filename: templates/configmap.yaml
 data:
   key: value
 ---
@@ -593,7 +593,7 @@ kind: Secret
 metadata:
   name: test-secret
   annotations:
-    helm-postrender-filename: templates/secret.yaml
+    postrenderer.helm.sh/postrender-filename: templates/secret.yaml
 data:
   password: dGVzdA==`,
 			expectedFiles: map[string]string{
@@ -620,7 +620,7 @@ kind: ConfigMap
 metadata:
   name: test-cm1
   annotations:
-    helm-postrender-filename: templates/multi.yaml
+    postrenderer.helm.sh/postrender-filename: templates/multi.yaml
 data:
   key: value1
 ---
@@ -629,7 +629,7 @@ kind: ConfigMap
 metadata:
   name: test-cm2
   annotations:
-    helm-postrender-filename: templates/multi.yaml
+    postrenderer.helm.sh/postrender-filename: templates/multi.yaml
 data:
   key: value2`,
 			expectedFiles: map[string]string{
@@ -656,7 +656,7 @@ kind: ConfigMap
 metadata:
   name: test-cm
   annotations:
-    helm-postrender-filename: templates/configmap.yaml
+    postrenderer.helm.sh/postrender-filename: templates/configmap.yaml
     other-annotation: should-remain
 data:
   key: value`,

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -699,7 +699,7 @@ data:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			files, err := SplitAndDeannotate(tt.input)
+			files, err := splitAndDeannotate(tt.input)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)
@@ -753,7 +753,7 @@ data:
 	require.NoError(t, err)
 
 	// Split and deannotate
-	reconstructed, err := SplitAndDeannotate(merged)
+	reconstructed, err := splitAndDeannotate(merged)
 	require.NoError(t, err)
 
 	// Compare the results


### PR DESCRIPTION
closes #7891

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Allow post-renderer to receive and process manifests with hook annotations.

**Special notes for your reviewer**:
In order to avoid dealing with YAML comments or reconciling file contents back to their filenames, this MR calls the post-renderer right after the templates are rendered and before they get split into hooks, manifests and partials lists.

**If applicable**:
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
