### PR TITLE
build: set kube version via `debug.BuildInfo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,6 @@ LDFLAGS += -X helm.sh/helm/v3/internal/version.gitCommit=${GIT_COMMIT}
 LDFLAGS += -X helm.sh/helm/v3/internal/version.gitTreeState=${GIT_DIRTY}
 LDFLAGS += $(EXT_LDFLAGS)
 
-# Define constants based on the client-go version
-K8S_MODULES_VER=$(subst ., ,$(subst v,,$(shell go list -f '{{.Version}}' -m k8s.io/client-go)))
-K8S_MODULES_MAJOR_VER=$(shell echo $$(($(firstword $(K8S_MODULES_VER)) + 1)))
-K8S_MODULES_MINOR_VER=$(word 2,$(K8S_MODULES_VER))
-
-LDFLAGS += -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-
 .PHONY: all
 all: build
 

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -80,7 +80,7 @@ func TestLintCmdWithKubeVersionFlag(t *testing.T) {
 		// which is "20"
 		name:      "lint chart with deprecated api version without kube version",
 		cmd:       fmt.Sprintf("lint %s", testChart),
-		golden:    "output/lint-chart-with-deprecated-api-old-k8s.txt",
+		golden:    "output/lint-chart-with-deprecated-api.txt",
 		wantError: false,
 	}, {
 		name:      "lint chart with deprecated api version with older kube version",

--- a/cmd/helm/testdata/output/template-name-template.txt
+++ b/cmd/helm/testdata/output/template-name-template.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "foobar-ywjj-baz"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-set.txt
+++ b/cmd/helm/testdata/output/template-set.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-multiple.txt
+++ b/cmd/helm/testdata/output/template-show-only-multiple.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-show-only-one.txt
+++ b/cmd/helm/testdata/output/template-show-only-one.txt
@@ -8,8 +8,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-skip-tests.txt
+++ b/cmd/helm/testdata/output/template-skip-tests.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm-set-file.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm-set-file.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm-set.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm-set.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-subchart-cm.txt
+++ b/cmd/helm/testdata/output/template-subchart-cm.txt
@@ -80,8 +80,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-values-files.txt
+++ b/cmd/helm/testdata/output/template-values-files.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template-with-api-version.txt
+++ b/cmd/helm/testdata/output/template-with-api-version.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
     kube-api-version/test: v1
 spec:
   type: ClusterIP

--- a/cmd/helm/testdata/output/template-with-crds.txt
+++ b/cmd/helm/testdata/output/template-with-crds.txt
@@ -89,8 +89,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/cmd/helm/testdata/output/template.txt
+++ b/cmd/helm/testdata/output/template.txt
@@ -72,8 +72,8 @@ metadata:
     helm.sh/chart: "subchart-0.1.0"
     app.kubernetes.io/instance: "release-name"
     kube-version/major: "1"
-    kube-version/minor: "20"
-    kube-version/version: "v1.20.0"
+    kube-version/minor: "30"
+    kube-version/version: "v1.30.0"
 spec:
   type: ClusterIP
   ports:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,6 +19,7 @@ package version // import "helm.sh/helm/v3/internal/version"
 import (
 	"flag"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
@@ -78,4 +79,23 @@ func Get() BuildInfo {
 		v.GoVersion = ""
 	}
 	return v
+}
+
+func init() {
+	if gitCommit != "" || gitTreeState != "" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" && setting.Value != "" {
+			gitCommit = setting.Value
+		} else if setting.Key == "vcs.modified" && setting.Value == "true" {
+			gitTreeState = "dirty"
+		} else if setting.Key == "vcs.modified" && setting.Value == "false" {
+			gitTreeState = "clean"
+		}
+	}
 }

--- a/pkg/lint/rules/deprecations.go
+++ b/pkg/lint/rules/deprecations.go
@@ -28,14 +28,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
-var (
-	// This should be set in the Makefile based on the version of client-go being imported.
-	// These constants will be overwritten with LDFLAGS. The version components must be
-	// strings in order for LDFLAGS to set them.
-	k8sVersionMajor = "1"
-	k8sVersionMinor = "20"
-)
-
 // deprecatedAPIError indicates than an API is deprecated in Kubernetes
 type deprecatedAPIError struct {
 	Deprecated string
@@ -56,12 +48,8 @@ func validateNoDeprecations(resource *K8sYamlStruct, kubeVersion *chartutil.Kube
 		return nil
 	}
 
-	majorVersion := k8sVersionMajor
-	minorVersion := k8sVersionMinor
-
-	if kubeVersion != nil {
-		majorVersion = kubeVersion.Major
-		minorVersion = kubeVersion.Minor
+	if kubeVersion == nil {
+		kubeVersion = &chartutil.DefaultCapabilities.KubeVersion
 	}
 
 	runtimeObject, err := resourceToRuntimeObject(resource)
@@ -73,11 +61,11 @@ func validateNoDeprecations(resource *K8sYamlStruct, kubeVersion *chartutil.Kube
 		return err
 	}
 
-	maj, err := strconv.Atoi(majorVersion)
+	maj, err := strconv.Atoi(kubeVersion.Major)
 	if err != nil {
 		return err
 	}
-	min, err := strconv.Atoi(minorVersion)
+	min, err := strconv.Atoi(kubeVersion.Minor)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is inspired by #13174, where Homebrew built `helm` outside of the Makefile and accidentally did not set the correct ldflags for the `k8sVersion` variables (which were defaulted to `1.20` instead of `1.30`)

Instead, this uses `runtime/debug`'s [`ReadBuildInfo`](https://pkg.go.dev/runtime/debug#ReadBuildInfo) to automatically extract the correct `k8s.io/client-go` version, regardless if the Makefile was used (for example, using `go install helm.sh/helm/v3/cmd/helm@latest`). It also adds a similar fallback for the git metadata ldflags using 1.18's [`BuildSetting`](https://pkg.go.dev/runtime/debug#BuildSetting) (but respects the variables if they are already set):

```console
$ go build ./cmd/helm && ./helm version
version.BuildInfo{Version:"v3.15", GitCommit:"7af094d606aff055c1eb938775b6fd260e637158", GitTreeState:"clean", GoVersion:"go1.22.5"}
```

**Special notes for your reviewer**:

This does introduce a lot of test golden changes since tests now also run with the correct `k8s.io/client-go` version

**If applicable**:

- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
