### PR TITLE
docs: Introduce `docs needed` label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@
 **Special notes for your reviewer**:
 
 **If applicable**:
-- [ ] this PR contains documentation
+- [ ] this PR contains user facing changes (`docs wanted` label should be applied if so)
 - [ ] this PR contains unit tests
 - [ ] this PR has been tested for backwards compatibility

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@
 **Special notes for your reviewer**:
 
 **If applicable**:
-- [ ] this PR contains user facing changes (`docs needed` label should be applied if so)
+- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
 - [ ] this PR contains unit tests
 - [ ] this PR has been tested for backwards compatibility

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@
 **Special notes for your reviewer**:
 
 **If applicable**:
-- [ ] this PR contains user facing changes (`docs wanted` label should be applied if so)
+- [ ] this PR contains user facing changes (`docs needed` label should be applied if so)
 - [ ] this PR contains unit tests
 - [ ] this PR has been tested for backwards compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
 
 Documentation PRs should be made on the docs repo: <https://github.com/helm/helm-www>. Keeping Helm's documentation up to date is highly desirable, and it is recommend all user facing changes. Accurate and helpful documentation is critical for effectively communicating Helm's behavior to a wide audience.
 
-Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs needed`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs needed` label should be applied.
+Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should apply the `docs needed` label. Larger changes associated with a HIP should track docs via that HIP. The `docs needed` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging in whether the `docs needed` label should be applied.
 
 ## The Triager
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
 
 Documentation PRs should be made on the docs repo: <https://github.com/helm/helm-www>. Keeping Helm's documentation up to date is highly desirable, and it is recommend all user facing changes. Accurate and helpful documentation is critical for effectively communicating Helm's behavior to a wide audience.
 
-Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs wanted`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs wanted` label should be applied.
+Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs needed`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs needed` label should be applied.
 
 ## The Triager
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
 
 Documentation PRs should be made on the docs repo: <https://github.com/helm/helm-www>. Keeping Helm's documentation up to date is highly desirable, and it is recommend all user facing changes. Accurate and helpful documentation is critical for effectively communicating Helm's behavior to a wide audience.
 
-Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs wanted`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs wanted` label should be applied.| `bug` | Marks an issue as a bug or a PR as a bugfix |
+Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs wanted`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs wanted` label should be applied.
 
 ## The Triager
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
 
 Documentation PRs should be made on the docs repo: <https://github.com/helm/helm-www>. Keeping Helm's documentation up to date is highly desirable, and it is recommend all user facing changes. Accurate and helpful documentation is critical for effectively communicating Helm's behavior to a wide audience.
 
-Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should apply the `docs needed` label. Larger changes associated with a HIP should track docs via that HIP. The `docs needed` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging in whether the `docs needed` label should be applied.
+Small, ad-hoc changes/PRs to Helm which introduce user facing changes, which would benefit from documentation changes, should apply the `docs needed` label. Larger changes associated with a HIP should track docs via that HIP. The `docs needed` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging in whether the `docs needed` label should be applied.
 
 ## The Triager
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,9 +262,9 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
 
 #### Documentation PRs
 
-Documentation PRs will follow the same lifecycle as other PRs. They will also be labeled with the
-`docs` label. For documentation, special attention will be paid to spelling, grammar, and clarity
-(whereas those things don't matter *as* much for comments in code).
+Documentation PRs should be made on the docs repo: <https://github.com/helm/helm-www>. Keeping Helm's documentation up to date is highly desirable, and it is recommend all user facing changes. Accurate and helpful documentation is critical for effectively communicating Helm's behavior to a wide audience.
+
+Small, ad-hoc changes/PRs to Helm which introduce user facing changes which would benefit from documentation changes should be labeled `docs wanted`. Larger changes associated with a HIP should track docs via that HIP. The `docs wanted` label doesn't block PRs, and maintainers/PR reviewers should apply discretion judging if the `docs wanted` label should be applied.| `bug` | Marks an issue as a bug or a PR as a bugfix |
 
 ## The Triager
 
@@ -307,6 +307,7 @@ The following tables define all label types used for Helm. It is split up by cat
 | `needs rebase` | Indicates a PR needs to be rebased before it can be merged |
 | `needs pick` | Indicates a PR needs to be cherry-picked into a feature branch (generally bugfix branches). Once it has been, the `picked` label should be applied and this one removed |
 | `picked` | This PR has been cherry-picked into a feature branch |
+| `docs wanted` | Tracks PRs that introduces a feature/change for which documentation update would be desirable (non-blocking). Once a suitable docs PR is created this label should be removed |
 
 #### Size labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,7 +307,7 @@ The following tables define all label types used for Helm. It is split up by cat
 | `needs rebase` | Indicates a PR needs to be rebased before it can be merged |
 | `needs pick` | Indicates a PR needs to be cherry-picked into a feature branch (generally bugfix branches). Once it has been, the `picked` label should be applied and this one removed |
 | `picked` | This PR has been cherry-picked into a feature branch |
-| `docs wanted` | Tracks PRs that introduces a feature/change for which documentation update would be desirable (non-blocking). Once a suitable docs PR is created this label should be removed |
+| `docs needed` | Tracks PRs that introduces a feature/change for which documentation update would be desirable (non-blocking). Once a suitable docs PR is created this label should be removed |
 
 #### Size labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,7 +307,7 @@ The following tables define all label types used for Helm. It is split up by cat
 | `needs rebase` | Indicates a PR needs to be rebased before it can be merged |
 | `needs pick` | Indicates a PR needs to be cherry-picked into a feature branch (generally bugfix branches). Once it has been, the `picked` label should be applied and this one removed |
 | `picked` | This PR has been cherry-picked into a feature branch |
-| `docs needed` | Tracks PRs that introduces a feature/change for which documentation update would be desirable (non-blocking). Once a suitable docs PR is created this label should be removed |
+| `docs needed` | Tracks PRs that introduces a feature/change for which documentation update would be desirable (non-blocking). Once a suitable documentation PR has been created, then this label should be removed |
 
 #### Size labels
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Introduce a new `docs needed` label, by adding its description to `CONTRIBUTING.md`. Which should be applied to PRs that would benefit from documentation.

I also updated the "Documentation PRs" section to reflect the usage of this label. And removed the text, which seemed to be from a time when documentation was in this repository(?) (rather than `helm/helm-www`).

Finally, I updated the pull request template to switch the "documentation" checkbox to "user facing change". With a reminder to apply the `docs needed` label, if the change is user facing. The rational for this change being, that rather than e.g. adding a new checkbox. Is that I read this checkbox item as pertaining to if the PR should be accompanied by a documentation change. And not that the PR contains changes to the small amount of "docs" in this repo. 

**Special notes for your reviewer**:
- Did I make the right changes to the "Documentation PRs" section and the pull request template?
- Any assistance/thoughts in updating the "Documentation PRs" section and label description welcome!

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
