### PR TITLE
feat(helm): add --namespace-labels flag to install and upgrade

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -175,6 +175,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
 	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
+	f.StringToStringVarP(&client.NamespaceLabels, "namespace-labels", "L", nil, "Labels that would be added to created namespace. Should be divided by comma. If --create-namespace is not set, this is ignored. Default is 'name=<namespace-name>'")
 	// --dry-run options with expected outcome:
 	// - Not set means no dry run and server is contacted.
 	// - Set with no value, a value of client, or a value of true and the server is not contacted

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -254,7 +254,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
-	f.StringToStringVarP(&namespaceLabels, "namespace-labels", "L", nil, "Labels that would be added to created namespace. Should be divided by comma. If --create-namespace is not set, this is ignored. Default is 'name=<namespace-name>'")
+	f.StringToStringVar(&namespaceLabels, "namespace-labels", nil, "labels to add to the created namespace. Comma separated key=value pairs. Ignored if --create-namespace is not set (default 'name=<namespace-name>'")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.StringVar(&client.DryRunOption, "dry-run", "", "simulate an install. If --dry-run is set with no option being specified or as '--dry-run=client', it will not attempt cluster connections. Setting '--dry-run=server' allows attempting cluster connections.")

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -84,6 +84,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	valueOpts := &values.Options{}
 	var outfmt output.Format
 	var createNamespace bool
+	var namespaceLabels map[string]string
 
 	cmd := &cobra.Command{
 		Use:   "upgrade [RELEASE] [CHART]",
@@ -129,6 +130,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					}
 					instClient := action.NewInstall(cfg)
 					instClient.CreateNamespace = createNamespace
+					instClient.NamespaceLabels = namespaceLabels
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.Force = client.Force
 					instClient.DryRun = client.DryRun
@@ -252,6 +254,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
+	f.StringToStringVarP(&namespaceLabels, "namespace-labels", "L", nil, "Labels that would be added to created namespace. Should be divided by comma. If --create-namespace is not set, this is ignored. Default is 'name=<namespace-name>'")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.StringVar(&client.DryRunOption, "dry-run", "", "simulate an install. If --dry-run is set with no option being specified or as '--dry-run=client', it will not attempt cluster connections. Setting '--dry-run=server' allows attempting cluster connections.")

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -72,6 +72,7 @@ type Install struct {
 	ClientOnly      bool
 	Force           bool
 	CreateNamespace bool
+	NamespaceLabels map[string]string
 	DryRun          bool
 	DryRunOption    string
 	// HideSecret can be set to true when DryRun is enabled in order to hide
@@ -357,16 +358,20 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	}
 
 	if i.CreateNamespace {
+		nsLabels := map[string]string{
+			"name": i.Namespace,
+		}
+		if i.NamespaceLabels != nil {
+			nsLabels = i.NamespaceLabels
+		}
 		ns := &v1.Namespace{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Namespace",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: i.Namespace,
-				Labels: map[string]string{
-					"name": i.Namespace,
-				},
+				Name:   i.Namespace,
+				Labels: nsLabels,
 			},
 		}
 		buf, err := yaml.Marshal(ns)


### PR DESCRIPTION
It creates the new namespace with given values to flag '--namespace-labels'. If not if provider, the default 'name=<namespace-name>' is used.

**What this PR does / why we need it**:

New namespaces may need to be created with a custom set of labels. This PR adds this capability.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
