### PR TITLE
feat(chart_downloader): Use cached chart if possible in chart_downloader.go

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -99,20 +99,25 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 
 	c.Options = append(c.Options, getter.WithAcceptHeader("application/gzip,application/octet-stream"))
 
-	data, err := g.Get(u.String(), c.Options...)
-	if err != nil {
-		return "", nil, err
-	}
-
 	name := filepath.Base(u.Path)
+
 	if u.Scheme == registry.OCIScheme {
 		idx := strings.LastIndexByte(name, ':')
 		name = fmt.Sprintf("%s-%s.tgz", name[:idx], name[idx+1:])
 	}
 
 	destfile := filepath.Join(dest, name)
-	if err := fileutil.AtomicWriteFile(destfile, data, 0644); err != nil {
-		return destfile, nil, err
+
+	// If the file does not exist locally, fetch it from the remote source.
+	if _, err := os.Stat(destfile); err != nil {
+		data, err := g.Get(u.String(), c.Options...)
+		if err != nil {
+			return "", nil, err
+		}
+
+		if err := fileutil.AtomicWriteFile(destfile, data, 0644); err != nil {
+			return destfile, nil, err
+		}
 	}
 
 	// If provenance is requested, verify it.


### PR DESCRIPTION
closes https://github.com/helm/helm/issues/13211

**What this PR does / why we need it**:
It prevents a chart from loading if it has already been loaded

**If applicable**:
- [Y] this PR contains unit tests
