### PR TITLE
ref(create): don't render empty resource fields

### DIFF
--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -327,24 +327,34 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "<CHARTNAME>.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR adds conditions for `podSecurityContext `, `securityContext`, `livenessProbe`, `readinessProbe` and `resources` to not render resource field if it's empty. It aligns  with the logic used for other template fields.

**Special notes for your reviewer**:

Before changes
```shell
helm template foo . --set livenessProbe=null --set readinessProbe=null --show-only templates/deployment.yaml
```
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
  labels:
    helm.sh/chart: foo-0.1.0
    app.kubernetes.io/name: foo
    app.kubernetes.io/instance: foo
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: foo
      app.kubernetes.io/instance: foo
  template:
    metadata:
      labels:
        helm.sh/chart: foo-0.1.0
        app.kubernetes.io/name: foo
        app.kubernetes.io/instance: foo
        app.kubernetes.io/version: "1.16.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: foo
      securityContext:
        {}
      containers:
        - name: foo
          securityContext:
            {}
          image: "nginx:1.16.0"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
          livenessProbe:
            null
          readinessProbe:
            null
          resources:
            {}
```

After changes
```shell
helm template foo . --set livenessProbe=null --set readinessProbe=null --show-only templates/deployment.yaml
```
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
  labels:
    helm.sh/chart: foo-0.1.0
    app.kubernetes.io/name: foo
    app.kubernetes.io/instance: foo
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: foo
      app.kubernetes.io/instance: foo
  template:
    metadata:
      labels:
        helm.sh/chart: foo-0.1.0
        app.kubernetes.io/name: foo
        app.kubernetes.io/instance: foo
        app.kubernetes.io/version: "1.16.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: foo
      containers:
        - name: foo
          image: "nginx:1.16.0"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
