### PR TITLE
feat(dependency): Add --skip-download-if-exists into dependency build/update

### DIFF
--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -37,6 +37,7 @@ type Dependency struct {
 	Verify                bool
 	Keyring               string
 	SkipRefresh           bool
+	SkipDownloadIfExists  bool
 	ColumnWidth           uint
 	Username              string
 	Password              string

--- a/pkg/cmd/dependency.go
+++ b/pkg/cmd/dependency.go
@@ -133,4 +133,5 @@ func addDependencySubcommandFlags(f *pflag.FlagSet, client *action.Dependency) {
 	f.BoolVar(&client.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
 	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use insecure HTTP connections for the chart download")
 	f.StringVar(&client.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.BoolVar(&client.SkipDownloadIfExists, "skip-download-if-exists", false, "skip download of the chart if it already exists in the charts directory")
 }

--- a/pkg/cmd/dependency_build.go
+++ b/pkg/cmd/dependency_build.go
@@ -61,16 +61,17 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 			}
 
 			man := &downloader.Manager{
-				Out:              out,
-				ChartPath:        chartpath,
-				Keyring:          client.Keyring,
-				SkipUpdate:       client.SkipRefresh,
-				Getters:          getter.All(settings),
-				RegistryClient:   registryClient,
-				RepositoryConfig: settings.RepositoryConfig,
-				RepositoryCache:  settings.RepositoryCache,
-				ContentCache:     settings.ContentCache,
-				Debug:            settings.Debug,
+				Out:                  out,
+				ChartPath:            chartpath,
+				Keyring:              client.Keyring,
+				SkipUpdate:           client.SkipRefresh,
+				SkipDownloadIfExists: client.SkipDownloadIfExists,
+				Getters:              getter.All(settings),
+				RegistryClient:       registryClient,
+				RepositoryConfig:     settings.RepositoryConfig,
+				RepositoryCache:      settings.RepositoryCache,
+				ContentCache:         settings.ContentCache,
+				Debug:                settings.Debug,
 			}
 			if client.Verify {
 				man.Verify = downloader.VerifyIfPossible

--- a/pkg/cmd/dependency_update.go
+++ b/pkg/cmd/dependency_update.go
@@ -65,16 +65,17 @@ func newDependencyUpdateCmd(_ *action.Configuration, out io.Writer) *cobra.Comma
 			}
 
 			man := &downloader.Manager{
-				Out:              out,
-				ChartPath:        chartpath,
-				Keyring:          client.Keyring,
-				SkipUpdate:       client.SkipRefresh,
-				Getters:          getter.All(settings),
-				RegistryClient:   registryClient,
-				RepositoryConfig: settings.RepositoryConfig,
-				RepositoryCache:  settings.RepositoryCache,
-				ContentCache:     settings.ContentCache,
-				Debug:            settings.Debug,
+				Out:                  out,
+				ChartPath:            chartpath,
+				Keyring:              client.Keyring,
+				SkipUpdate:           client.SkipRefresh,
+				SkipDownloadIfExists: client.SkipDownloadIfExists,
+				Getters:              getter.All(settings),
+				RegistryClient:       registryClient,
+				RepositoryConfig:     settings.RepositoryConfig,
+				RepositoryCache:      settings.RepositoryCache,
+				ContentCache:         settings.ContentCache,
+				Debug:                settings.Debug,
 			}
 			if client.Verify {
 				man.Verify = downloader.VerifyAlways

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -351,7 +351,7 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (string, *url
 		return "", nil, err
 	}
 
-	u, err = c.appendTagToUrlIfNeeded(u, version)
+	u, err = c.appendTagToURLIfNeeded(u, version)
 	if err != nil {
 		return "", nil, err
 	}
@@ -582,7 +582,7 @@ func (c *ChartDownloader) getChartName(url string) string {
 	return name
 }
 
-func (c *ChartDownloader) appendTagToUrlIfNeeded(chartUrl *url.URL, version string) (*url.URL, error) {
+func (c *ChartDownloader) appendTagToURLIfNeeded(chartUrl *url.URL, version string) (*url.URL, error) {
 	if !registry.IsOCI(chartUrl.String()) {
 		return chartUrl, nil
 	}

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -582,24 +582,24 @@ func (c *ChartDownloader) getChartName(url string) string {
 	return name
 }
 
-func (c *ChartDownloader) appendTagToURLIfNeeded(chartUrl *url.URL, version string) (*url.URL, error) {
-	if !registry.IsOCI(chartUrl.String()) {
-		return chartUrl, nil
+func (c *ChartDownloader) appendTagToURLIfNeeded(chartURL *url.URL, version string) (*url.URL, error) {
+	if !registry.IsOCI(chartURL.String()) {
+		return chartURL, nil
 	}
 
-	refAlreadyHasTagOrDigest := strings.Contains(chartUrl.Path, ":") || strings.Contains(chartUrl.Path, "@")
+	refAlreadyHasTagOrDigest := strings.Contains(chartURL.Path, ":") || strings.Contains(chartURL.Path, "@")
 	if refAlreadyHasTagOrDigest {
-		return chartUrl, nil
+		return chartURL, nil
 	}
 
-	tag, err := c.getOciTag(chartUrl.String(), version)
+	tag, err := c.getOciTag(chartURL.String(), version)
 	if err != nil {
 		return nil, err
 	}
 
-	chartUrl.Path = fmt.Sprintf("%s:%s", chartUrl.Path, tag)
+	chartURL.Path = fmt.Sprintf("%s:%s", chartURL.Path, tag)
 
-	return chartUrl, nil
+	return chartURL, nil
 }
 
 func (c *ChartDownloader) getOciTag(ref, version string) (string, error) {

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -364,7 +364,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 				return err
 			}
 
-			u, err = dl.appendTagToUrlIfNeeded(u, version)
+			u, err = dl.appendTagToURLIfNeeded(u, version)
 			if err != nil {
 				return err
 			}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -359,8 +359,12 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		}
 
 		if m.SkipDownloadIfExists {
-			u, err := dl.parseChartURL(churl, version)
+			u, err := url.Parse(churl)
+			if err != nil {
+				return err
+			}
 
+			u, err = dl.appendTagToUrlIfNeeded(u, version)
 			if err != nil {
 				return err
 			}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -70,6 +71,8 @@ type Manager struct {
 	Keyring string
 	// SkipUpdate indicates that the repository should not be updated first.
 	SkipUpdate bool
+	// SkipDownloadIfExists indicates that the chart should not be downloaded if it already exists.
+	SkipDownloadIfExists bool
 	// Getter collection for the operation
 	Getters          []getter.Provider
 	RegistryClient   *registry.Client
@@ -273,6 +276,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	fmt.Fprintf(m.Out, "Saving %d charts\n", len(deps))
 	var saveError error
 	churls := make(map[string]struct{})
+	skippedCharts := make([]string, 0)
 	for _, dep := range deps {
 		// No repository means the chart is in charts directory
 		if dep.Repository == "" {
@@ -326,8 +330,6 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			continue
 		}
 
-		fmt.Fprintf(m.Out, "Downloading %s from repo %s\n", dep.Name, dep.Repository)
-
 		dl := ChartDownloader{
 			Out:              m.Out,
 			Verify:           m.Verify,
@@ -356,6 +358,23 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 				getter.WithTagName(version))
 		}
 
+		if m.SkipDownloadIfExists {
+			u, err := dl.parseChartURL(churl, version)
+
+			if err != nil {
+				return err
+			}
+
+			name := dl.getChartName(u.String())
+			if _, err = os.Stat(filepath.Join(destPath, name)); err == nil {
+				fmt.Fprintf(m.Out, "Already exists locally %s from repo %s\n", dep.Name, dep.Repository)
+
+				skippedCharts = append(skippedCharts, name)
+				continue
+			}
+		}
+
+		fmt.Fprintf(m.Out, "Downloading %s from repo %s\n", dep.Name, dep.Repository)
 		if _, _, err = dl.DownloadTo(churl, version, tmpPath); err != nil {
 			saveError = fmt.Errorf("could not download %s: %w", churl, err)
 			break
@@ -367,7 +386,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	// TODO: this should probably be refactored to be a []error, so we can capture and provide more information rather than "last error wins".
 	if saveError == nil {
 		// now we can move all downloaded charts to destPath and delete outdated dependencies
-		if err := m.safeMoveDeps(deps, tmpPath, destPath); err != nil {
+		if err := m.safeMoveDeps(deps, tmpPath, destPath, skippedCharts); err != nil {
 			return err
 		}
 	} else {
@@ -394,13 +413,14 @@ func parseOCIRef(chartRef string) (string, string, error) {
 // It does this by first matching the file name to an expected pattern, then loading
 // the file to verify that it is a chart.
 //
-// Any charts in dest that do not exist in source are removed (barring local dependencies)
+// Any charts in dest that do not exist in source and not in skippedCharts are removed (barring local dependencies)
+// skippedCharts is a list of charts that were skipped during the download process.
 //
 // Because it requires tar file introspection, it is more intensive than a basic move.
 //
 // This will only return errors that should stop processing entirely. Other errors
 // will emit log messages or be ignored.
-func (m *Manager) safeMoveDeps(deps []*chart.Dependency, source, dest string) error {
+func (m *Manager) safeMoveDeps(deps []*chart.Dependency, source, dest string, skippedCharts []string) error {
 	existsInSourceDirectory := map[string]bool{}
 	isLocalDependency := map[string]bool{}
 	sourceFiles, err := os.ReadDir(source)
@@ -441,7 +461,7 @@ func (m *Manager) safeMoveDeps(deps []*chart.Dependency, source, dest string) er
 	fmt.Fprintln(m.Out, "Deleting outdated charts")
 	// find all files that exist in dest that do not exist in source; delete them (outdated dependencies)
 	for _, file := range destFiles {
-		if !file.IsDir() && !existsInSourceDirectory[file.Name()] {
+		if !file.IsDir() && !existsInSourceDirectory[file.Name()] && !slices.Contains(skippedCharts, file.Name()) {
 			fname := filepath.Join(dest, file.Name())
 			ch, err := loader.LoadFile(fname)
 			if err != nil {


### PR DESCRIPTION
closes https://github.com/helm/helm/issues/13241

**What this PR does / why we need it**:
Added `--skip-download-if-exists` into `dependency build/update` commands, it allows you to specify whether charts should be downloaded if they already exist locally.  
I'll add tests if you're ok with the changes

**If applicable**:
- [Y] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [N] this PR contains unit tests
- [N] this PR has been tested for backwards compatibility
