### PR TITLE
Fix linting error for pr 12876

### DIFF
--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -108,7 +108,7 @@ func fakeClientWith(code int, gv schema.GroupVersion, body string) *fake.RESTCli
 	return &fake.RESTClient{
 		GroupVersion:         gv,
 		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		Client: fake.CreateHTTPClient(func(_ *http.Request) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Content-Type", runtime.ContentTypeJSON)
 			return &http.Response{


### PR DESCRIPTION
golangci-lint passed when last commit was made on #12876, but has since failed:
https://github.com/helm/helm/actions/runs/10394125027/job/28783206110

This is probably because the linter has since updated.

I ran locally with the same version of golangci-lint we run in GH Actions, and this is the only error now (an additional linting error in pkg/action/package.go since #12876 has already been fixed).

```sh
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.58.1

./bin/golangci-lint run pkg/action/...

./bin/golangci-lint run ./...
```

we should be good now.

Signed-off-by: Scott Rigby <scott@r6by.com>
