### PR TITLE
ActiveHelp for cmds that don't take any more args

### DIFF
--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -102,7 +102,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 		Short:             "generate autocompletion script for bash",
 		Long:              bashCompDesc,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCompletionBash(out, cmd)
 		},
@@ -114,7 +114,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 		Short:             "generate autocompletion script for zsh",
 		Long:              zshCompDesc,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCompletionZsh(out, cmd)
 		},
@@ -126,7 +126,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 		Short:             "generate autocompletion script for fish",
 		Long:              fishCompDesc,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCompletionFish(out, cmd)
 		},
@@ -138,7 +138,7 @@ func newCompletionCmd(out io.Writer) *cobra.Command {
 		Short:             "generate autocompletion script for powershell",
 		Long:              powershellCompDesc,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCompletionPowershell(out, cmd)
 		},
@@ -209,7 +209,15 @@ func runCompletionPowershell(out io.Writer, cmd *cobra.Command) error {
 	return cmd.Root().GenPowerShellCompletionWithDesc(out)
 }
 
-// Function to disable file completion
-func noCompletions(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return nil, cobra.ShellCompDirectiveNoFileComp
+// noMoreArgsCompFunc deactivates file completion when doing argument shell completion.
+// It also provides some ActiveHelp to indicate no more arguments are accepted.
+func noMoreArgsCompFunc(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return noMoreArgsComp()
+}
+
+// noMoreArgsComp deactivates file completion when doing argument shell completion.
+// It also provides some ActiveHelp to indicate no more arguments are accepted.
+func noMoreArgsComp() ([]string, cobra.ShellCompDirective) {
+	activeHelpMsg := "This command does not take any more arguments (but may accept flags)."
+	return cobra.AppendActiveHelp(nil, activeHelpMsg), cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -71,7 +71,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 				return nil, cobra.ShellCompDirectiveDefault
 			}
 			// No more completions, so disable file completion
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			o.name = args[0]

--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -58,7 +58,7 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 		Long:              docsDesc,
 		Hidden:            true,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			o.topCmd = cmd.Root()
 			return o.run(out)

--- a/cmd/helm/env.go
+++ b/cmd/helm/env.go
@@ -42,7 +42,7 @@ func newEnvCmd(out io.Writer) *cobra.Command {
 				return keys, cobra.ShellCompDirectiveNoFileComp
 			}
 
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			envVars := settings.EnvVars()

--- a/cmd/helm/get_all.go
+++ b/cmd/helm/get_all.go
@@ -43,7 +43,7 @@ func newGetAllCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -43,7 +43,7 @@ func newGetHooksCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/get_manifest.go
+++ b/cmd/helm/get_manifest.go
@@ -45,7 +45,7 @@ func newGetManifestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/get_metadata.go
+++ b/cmd/helm/get_metadata.go
@@ -42,7 +42,7 @@ func newGetMetadataCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/get_notes.go
+++ b/cmd/helm/get_notes.go
@@ -41,7 +41,7 @@ func newGetNotesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -48,7 +48,7 @@ func newGetValuesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -62,7 +62,7 @@ func newHistoryCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:    require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -68,7 +68,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              listHelp,
 		Aliases:           []string{"ls"},
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if client.AllNamespaces {
 				if err := cfg.Init(settings.RESTClientGetter(), "", os.Getenv("HELM_DRIVER"), debug); err != nil {

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -50,7 +50,7 @@ func newPluginInstallCmd(out io.Writer) *cobra.Command {
 				return nil, cobra.ShellCompDirectiveDefault
 			}
 			// No more completion once the plugin path has been specified
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			return o.complete(args)

--- a/cmd/helm/plugin_list.go
+++ b/cmd/helm/plugin_list.go
@@ -30,7 +30,7 @@ func newPluginListCmd(out io.Writer) *cobra.Command {
 		Use:               "list",
 		Aliases:           []string{"ls"},
 		Short:             "list installed Helm plugins",
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			debug("pluginDirs: %s", settings.PluginsDirectory)
 			plugins, err := plugin.FindPlugins(settings.PluginsDirectory)

--- a/cmd/helm/push.go
+++ b/cmd/helm/push.go
@@ -65,7 +65,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 				return comps, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 			}
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			registryClient, err := newRegistryClient(o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSverify, o.plainHTTP)

--- a/cmd/helm/registry_login.go
+++ b/cmd/helm/registry_login.go
@@ -53,7 +53,7 @@ func newRegistryLoginCmd(cfg *action.Configuration, out io.Writer) *cobra.Comman
 		Short:             "login to a registry",
 		Long:              registryLoginDesc,
 		Args:              require.MinimumNArgs(1),
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(_ *cobra.Command, args []string) error {
 			hostname := args[0]
 

--- a/cmd/helm/registry_logout.go
+++ b/cmd/helm/registry_logout.go
@@ -35,7 +35,7 @@ func newRegistryLogoutCmd(cfg *action.Configuration, out io.Writer) *cobra.Comma
 		Short:             "logout from a registry",
 		Long:              registryLogoutDesc,
 		Args:              require.MinimumNArgs(1),
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(_ *cobra.Command, args []string) error {
 			hostname := args[0]
 			return action.NewRegistryLogout(cfg).Run(out, hostname)

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -50,7 +50,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -68,10 +68,15 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	o := &repoAddOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "add [NAME] [URL]",
-		Short:             "add a chart repository",
-		Args:              require.ExactArgs(2),
-		ValidArgsFunction: noCompletions,
+		Use:   "add [NAME] [URL]",
+		Short: "add a chart repository",
+		Args:  require.ExactArgs(2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 1 {
+				return noMoreArgsComp()
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			o.name = args[0]
 			o.url = args[1]

--- a/cmd/helm/repo_index.go
+++ b/cmd/helm/repo_index.go
@@ -60,7 +60,7 @@ func newRepoIndexCmd(out io.Writer) *cobra.Command {
 				return nil, cobra.ShellCompDirectiveDefault
 			}
 			// No more completions, so disable file completion
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			o.dir = args[0]

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -36,7 +36,7 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 		Aliases:           []string{"ls"},
 		Short:             "list chart repositories",
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			f, _ := repo.LoadFile(settings.RepositoryConfig)
 			if len(f.Repositories) == 0 && !(outfmt == output.JSON || outfmt == output.YAML) {

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -55,7 +55,7 @@ func newRollbackCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return compListRevisions(toComplete, cfg, args[0])
 			}
 
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 1 {

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -60,18 +60,17 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	client := action.NewShowWithConfig(action.ShowAll, cfg)
 
 	showCommand := &cobra.Command{
-		Use:               "show",
-		Short:             "show information of a chart",
-		Aliases:           []string{"inspect"},
-		Long:              showDesc,
-		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions, // Disable file completion
+		Use:     "show",
+		Short:   "show information of a chart",
+		Aliases: []string{"inspect"},
+		Long:    showDesc,
+		Args:    require.NoArgs,
 	}
 
 	// Function providing dynamic auto-completion
 	validArgsFunc := func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		}
 		return compListCharts(toComplete, true)
 	}

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -60,7 +60,7 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  require.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return noMoreArgsComp()
 			}
 			return compListReleases(toComplete, args, cfg)
 		},

--- a/cmd/helm/testdata/output/empty_nofile_comp.txt
+++ b/cmd/helm/testdata/output/empty_nofile_comp.txt
@@ -1,2 +1,3 @@
+_activeHelp_ This command does not take any more arguments (but may accept flags).
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/rollback-wrong-args-comp.txt
+++ b/cmd/helm/testdata/output/rollback-wrong-args-comp.txt
@@ -1,2 +1,3 @@
+_activeHelp_ This command does not take any more arguments (but may accept flags).
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/testdata/output/status-wrong-args-comp.txt
+++ b/cmd/helm/testdata/output/status-wrong-args-comp.txt
@@ -1,2 +1,3 @@
+_activeHelp_ This command does not take any more arguments (but may accept flags).
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -97,7 +97,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if len(args) == 1 {
 				return compListCharts(toComplete, true)
 			}
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.Namespace = settings.Namespace()

--- a/cmd/helm/verify.go
+++ b/cmd/helm/verify.go
@@ -50,7 +50,7 @@ func newVerifyCmd(out io.Writer) *cobra.Command {
 				return nil, cobra.ShellCompDirectiveDefault
 			}
 			// No more completions, so disable file completion
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			err := client.Run(args[0])

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -65,7 +65,7 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 		Short:             "print the client version information",
 		Long:              versionDesc,
 		Args:              require.NoArgs,
-		ValidArgsFunction: noCompletions,
+		ValidArgsFunction: noMoreArgsCompFunc,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return o.run(out)
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR starts adding some ActiveHelp to helm for specific situations, partially addressing #13258
ActiveHelp is a framework provided by Cobra which allows a program to define messages (hints, warnings, etc) that will be printed during program usage.  Active Help is printed when the user triggers shell completion.

For more details on ActiveHelp please refer to Cobra's documentation: https://github.com/spf13/cobra/blob/main/site/content/active_help.md#active-help

**Note: ActiveHelp is only shown when doing shell completion with `bash` or `zsh` (it is simply ignored for `fish` or `powershell`)**

This PR starts by adding the ActiveHelp message: `This command does not take any more arguments (but may accept flags).` to situations where a command no longer takes any more arguments.

The result is that when doing shell completion, instead of getting no suggestions for commands that take no more arguments, the user will instead be shown an informative message:

```
$ helm list <TAB>
This command does not take any more arguments (but may accept flags).
```
The situations where this ActiveHelp message will be triggered are the following:
```
helm completion bash|zsh|fish|powershell <TAB>
helm create <name> <TAB>
helm docs <TAB>
helm env <var> <TAB>
helm get all|hooks|manifest|metadata|notes|values <release> <TAB>
helm history <release> <TAB>
helm list <TAB>
helm plugin install <path|url> <TAB>
helm plugin list <TAB>
helm push <chart> <uri> <TAB>
helm test <release> <TAB>
helm repo add <repo> <url> <TAB>
helm repo index <dir> <TAB>
helm repo list <TAB>
helm rollback <release> <revision> <TAB>
helm show all|values|chart|readme|crds <chart> <TAB>
helm status <release> <TAB>
helm upgrade <release> <chart> <TAB>
helm verify <path>
helm version <TAB>
```
**Special notes for your reviewer**:

It is possible to turn off all ActiveHelp messages by doing: `export HELM_ACTIVE_HELP=0`.  This environment variable is automatically provided by Cobra.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
