### PR TITLE
Update debug to have timestamps

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -45,7 +45,8 @@ func init() {
 
 func debug(format string, v ...interface{}) {
 	if settings.Debug {
-		format = fmt.Sprintf("[debug] %s\n", format)
+		timeNow := time.Now().UTC().String()
+		format = fmt.Sprintf("%s [debug] %s\n", timeNow, format)
 		log.Output(2, fmt.Sprintf(format, v...))
 	}
 }

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
resuming https://github.com/helm/helm/pull/6337
having a good timestamp in the output is always great for debug

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
