### PR TITLE
adding check-latest:true

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@5.0.2
         with:
-          go-version: '1.22.7'
+          go-version: '1.22'
+          check-latest: true
       - name: Test source headers are present
         run: make test-source-headers
       - name: Run unit tests

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: '1.22'
+          check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 #pin@6.1.0
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@5.0.2
         with:
-          go-version: '1.22.7'
+          go-version: '1.22'
+          check-latest: true
       - name: govulncheck
         uses: golang/govulncheck-action@dd0578b371c987f96d1185abb54344b44352bd58 # pin@1.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@5.0.2
         with:
-          go-version: '1.22.7'
+          go-version: '1.22'
+          check-latest: true
 
       - name: Run unit tests
         run: make test-coverage


### PR DESCRIPTION
I am fixing the go setup to check for latest. Based on the docs [here](https://github.com/actions/setup-go).

tested it with my actions and it resolves correctly:
`Run actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
Setup go version spec 1.22
Attempting to resolve the latest version from the manifest...
matching 1.22...
Resolved as '1.22.[7](https://github.com/robertsirc/helm/actions/runs/10835235498/job/30066292590#step:3:8)'`

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
