### PR TITLE
fix: remove download logs in templates

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -268,7 +268,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 			err = errors.Wrap(err, "An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies")
 			if client.DependencyUpdate {
 				man := &downloader.Manager{
-					Out:              out,
+					Out:              os.Stderr,
 					ChartPath:        cp,
 					Keyring:          client.ChartPathOptions.Keyring,
 					SkipUpdate:       false,


### PR DESCRIPTION
**What this PR does / why we need it**:

`helm template --dependency-update` prints the manifest and logs on stdout making the yaml output unusable:
```
Saving 2 charts
Downloading datadog-operator from repo https://helm.datadoghq.com
Deleting outdated charts
---
# Source: datadog-operator/charts/datadog-operator/templates/service_account.yaml
apiVersion: v1
kind: ServiceAccount
...
```
 