### PR TITLE
add chart fuzz tests

### DIFF
--- a/pkg/chart/fuzz_test.go
+++ b/pkg/chart/fuzz_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chart
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzMetadataValidate(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		// Add random values to the metadata
+		md := &Metadata{}
+		err := fdp.GenerateStruct(md)
+		if err != nil {
+			t.Skip()
+		}
+		md.Validate()
+	})
+}
+
+func FuzzDependencyValidate(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		f := fuzz.NewConsumer(data)
+		// Add random values to the dependenci
+		d := &Dependency{}
+		err := f.GenerateStruct(d)
+		if err != nil {
+			t.Skip()
+		}
+		d.Validate()
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This moves the chartfuzzer upstream to Helms repository. The fuzzer currently exists [here](https://github.com/cncf/cncf-fuzzing/blob/main/projects/helm/chart_fuzzer.go). OSS-Fuzz runs this fuzzer continuously, and it is better in terms of manageability for Helm to have its fuzzers in its own repository.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
