### PR TITLE
Format chart name

### DIFF
--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -136,7 +136,7 @@ func getHistory(client *action.History, name string) (releaseHistory, error) {
 func getReleaseHistory(rls []*release.Release) (history releaseHistory) {
 	for i := len(rls) - 1; i >= 0; i-- {
 		r := rls[i]
-		c := formatChartname(r.Chart)
+		c := formatChartName(r.Chart)
 		s := r.Info.Status.String()
 		v := r.Version
 		d := r.Info.Description
@@ -159,7 +159,7 @@ func getReleaseHistory(rls []*release.Release) (history releaseHistory) {
 	return history
 }
 
-func formatChartname(c *chart.Chart) string {
+func formatChartName(c *chart.Chart) string {
 	if c == nil || c.Metadata == nil {
 		// This is an edge case that has happened in prod, though we don't
 		// know how: https://github.com/helm/helm/issues/1347

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -156,7 +156,7 @@ func newReleaseListWriter(releases []*release.Release, timeFormat string, noHead
 			Namespace:  r.Namespace,
 			Revision:   strconv.Itoa(r.Version),
 			Status:     r.Info.Status.String(),
-			Chart:      formatChartname(r.Chart),
+			Chart:      formatChartName(r.Chart),
 			AppVersion: formatAppVersion(r.Chart),
 		}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR renames the variable formatChartname to formatChartName to maintain naming consistency across the codebase. Consistent naming conventions improve code readability and maintainability.

**Special notes for your reviewer**:
Nothing

Closes: https://github.com/helm/helm/pull/13310

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
