### PR TITLE
feat: Add --log functionality for additional commands and resources 

### DIFF
--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -90,7 +90,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 
 	f := cmd.Flags()
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
-	f.BoolVar(&outputLogs, "logs", false, "dump the logs from test pods (this runs after all tests are complete, but before any cleanup)")
+	f.BoolVar(&outputLogs, "logs", false, "dump the logs from test jobs or pods (this runs after all tests are complete, but before any cleanup)")
 	f.StringSliceVar(&filter, "filter", []string{}, "specify tests by attribute (currently \"name\") using attribute=value syntax or '!attribute=value' to exclude a test (can specify multiple or separate values with commas: name=test1,name=test2)")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in test output. Does not affect presence in chart metadata")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- Jobs with the `"helm.sh/hook": "test"` annotation will now work with `helm test --logs`. This previously caused helm to error due to searching for a pod with the same name as the job.
- Upgrades that have Pods or Jobs that contain an upgrade annotation (e.g. `"helm.sh/hook": pre-upgrade`) can now run with `--logs` to print the logs once the upgrade completes.

This is important because the cause of the hook related upgrade failures is not possible to determine with the helm output, and requires investigating kubernetes job logs.

**Special notes for your reviewer**:

I'm unsure if this code is possible to unit test because it relies on the output of annotated pods. If there is an integration test framework for helm, I will add tests to that. I was able to manually test with the following helm single-file chart:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: post-install
  annotations:
    "helm.sh/hook": post-install
    "helm.sh/hook-delete-policy": before-hook-creation
spec:
  template:
    spec:
      containers:
      - name: test
        image: ubuntu
        command: ["echo",  "hello world"]
      restartPolicy: Never
  backoffLimit: 1
---
apiVersion: batch/v1
kind: Job
metadata:
  name: test
  annotations:
    "helm.sh/hook": test
spec:
  template:
    spec:
      containers:
      - name: test
        image: ubuntu
        command: ["echo",  "I'm a test!"]
      restartPolicy: Never
  backoffLimit: 1
---
apiVersion: v1
kind: Pod
metadata:
  name: backwards-compatible
  annotations:
    "helm.sh/hook": test
spec:
  containers:
  - name: test
    image: ubuntu
    command: ["echo",  "I'm a test pod!"]
  restartPolicy: Never
```

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
