### PR TITLE
fix: Use chart archive modifed time for OCI push

### DIFF
--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -90,7 +90,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		path.Join(strings.TrimPrefix(href, fmt.Sprintf("%s://", registry.OCIScheme)), meta.Metadata.Name),
 		meta.Metadata.Version)
 
-	// The time the chart was "created" is semantically the time the chart archive file was last written
+	// The time the chart was "created" is semantically the time the chart archive file was last written(modified)
 	chartArchiveFileCreatedTime := ctime.Modified(stat)
 	pushOpts = append(pushOpts, registry.PushOptCreationTime(chartArchiveFileCreatedTime.Format(time.RFC3339)))
 

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -90,8 +90,9 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		path.Join(strings.TrimPrefix(href, fmt.Sprintf("%s://", registry.OCIScheme)), meta.Metadata.Name),
 		meta.Metadata.Version)
 
-	chartCreationTime := ctime.Created(stat)
-	pushOpts = append(pushOpts, registry.PushOptCreationTime(chartCreationTime.Format(time.RFC3339)))
+	// The time the chart was "created" is semantically the time the chart archive file was last written
+	chartArchiveFileCreatedTime := ctime.Modified(stat)
+	pushOpts = append(pushOpts, registry.PushOptCreationTime(chartArchiveFileCreatedTime.Format(time.RFC3339)))
 
 	_, err = client.Push(chartBytes, ref, pushOpts...)
 	return err

--- a/pkg/time/ctime/ctime.go
+++ b/pkg/time/ctime/ctime.go
@@ -21,5 +21,9 @@ import (
 )
 
 func Created(fi os.FileInfo) time.Time {
-	return created(fi)
+	return modified(fi)
+}
+
+func Modified(fi os.FileInfo) time.Time {
+	return modified(fi)
 }

--- a/pkg/time/ctime/ctime_linux.go
+++ b/pkg/time/ctime/ctime_linux.go
@@ -23,8 +23,8 @@ import (
 	"time"
 )
 
-func created(fi os.FileInfo) time.Time {
+func modified(fi os.FileInfo) time.Time {
 	st := fi.Sys().(*syscall.Stat_t)
 	//nolint
-	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
+	return time.Unix(int64(st.Mtim.Sec), int64(st.Mtim.Nsec))
 }

--- a/pkg/time/ctime/ctime_other.go
+++ b/pkg/time/ctime/ctime_other.go
@@ -22,6 +22,6 @@ import (
 	"time"
 )
 
-func created(fi os.FileInfo) time.Time {
+func modified(fi os.FileInfo) time.Time {
 	return fi.ModTime()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helps with: https://github.com/helm/helm/issues/12973

**Special notes for your reviewer**:
- Strictly, this is changing the behavior of OCI push. But from https://github.com/helm/helm/pull/13272#issuecomment-2381977860, the current behavior incorrect/unexpectedly implemented anyway
- I changed the implementation of the `ctime.Created` function. However, this function never returned a "created" time. On Linux, it returned the "inode last updated time". And on non-linux, it returns the files "ModTime". (IMHO, we should just remove `ctime.Created`. But want/need to retain public API compatibility.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
