### PR TITLE
chore: Make retryingRoundTripper type public

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -36,6 +36,7 @@ import (
 
 	"helm.sh/helm/v3/internal/version"
 	"helm.sh/helm/v3/pkg/helmpath"
+	"helm.sh/helm/v3/pkg/kube"
 )
 
 // defaultMaxHistory sets the maximum number of releases to 0: unlimited
@@ -127,7 +128,7 @@ func New() *EnvSettings {
 			config.Burst = env.BurstLimit
 			config.QPS = env.QPS
 			config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-				return &retryingRoundTripper{wrapped: rt}
+				return &kube.RetryingRoundTripper{Wrapped: rt}
 			})
 			config.UserAgent = version.GetUserAgent()
 			return config

--- a/pkg/kube/roundtripper.go
+++ b/pkg/kube/roundtripper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cli
+package kube
 
 import (
 	"bytes"
@@ -24,19 +24,19 @@ import (
 	"strings"
 )
 
-type retryingRoundTripper struct {
-	wrapped http.RoundTripper
+type RetryingRoundTripper struct {
+	Wrapped http.RoundTripper
 }
 
-func (rt *retryingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rt *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rt.roundTrip(req, 1, nil)
 }
 
-func (rt *retryingRoundTripper) roundTrip(req *http.Request, retry int, prevResp *http.Response) (*http.Response, error) {
+func (rt *RetryingRoundTripper) roundTrip(req *http.Request, retry int, prevResp *http.Response) (*http.Response, error) {
 	if retry < 0 {
 		return prevResp, nil
 	}
-	resp, rtErr := rt.wrapped.RoundTrip(req)
+	resp, rtErr := rt.Wrapped.RoundTrip(req)
 	if rtErr != nil {
 		return resp, rtErr
 	}


### PR DESCRIPTION
Make `retryingRoundTripper` type public to allow it being used in other projects

closes #13052

**What this PR does / why we need it**:

Some projects use helm as a library but need to create the client outside, making this object public allows using the same functionality without having to maintain a copy.

**Special notes for your reviewer**:

none.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
