### PR TITLE
ci: Run the build CI check on Linux/OSX ARM64

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, openeuler-6cpu-14gb]
+    runs-on:  ${{ matrix.os }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4.2.1


### PR DESCRIPTION
**What this PR does / why we need it**:

There are several [issues](https://github.com/helm/helm/issues?q=is%3Aissue+is%3Aclose+arm) related with problems on ARM64.
I think it would be good to have CI checks for Linux & OSX ARM64.

For Linux ARM64 it will use `openeuler-6cpu-14gb` (VMs provided by CNCF Infra team)
For OSX ARM64 use the Github hosted `macos-14` runners

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
