### PR TITLE
Allow tests to run on loong64

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -92,6 +92,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
 				{OperatingSystem: "linux", Architecture: "ppc64le", Command: "echo -n linux-ppc64le"},
 				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
 				{OperatingSystem: "linux", Architecture: "riscv64", Command: "echo -n linux-riscv64"},
+				{OperatingSystem: "linux", Architecture: "loong64", Command: "echo -n linux-loong64"},
 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
 			},
 		},
@@ -111,6 +112,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
 		osStrCmp = "linux-s390x"
 	} else if os == "linux" && arch == "riscv64" {
 		osStrCmp = "linux-riscv64"
+	} else if os == "linux" && arch == "loong64" {
+		osStrCmp = "linux-loong64"
 	} else if os == "windows" && arch == "amd64" {
 		osStrCmp = "win-64"
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When building Helm on LoongArch-based systems, unit tests fail on `TestPlatformPrepareCommand` because it does not account for `loong64`. By applying this patch, the unit tests should run properly on the aforementioned architecture.

**Special notes for your reviewer**:

Several similar PRs have been merged, such as one for s390x (https://github.com/helm/helm/pull/7096) and another for RISC-V.
