### PR TITLE
fix(lint): Extend --skip-schema-validation for lint command

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -57,6 +57,7 @@ func RunAll(baseDir string, values map[string]interface{}, namespace string, opt
 	}
 
 	rules.Chartfile(&result)
+	rules.ValuesWithOverridesWithSkipSchemaValidation(&result, values, lo.SkipSchemaValidation)
 	rules.ValuesWithOverrides(&result, values)
 	rules.TemplatesWithSkipSchemaValidation(&result, values, namespace, lo.KubeVersion, lo.SkipSchemaValidation)
 	rules.Dependencies(&result)

--- a/pkg/lint/rules/values_test.go
+++ b/pkg/lint/rules/values_test.go
@@ -67,7 +67,7 @@ func TestValidateValuesFileWellFormed(t *testing.T) {
 	`
 	tmpdir := ensure.TempFile(t, "values.yaml", []byte(badYaml))
 	valfile := filepath.Join(tmpdir, "values.yaml")
-	if err := validateValuesFile(valfile, map[string]interface{}{}); err == nil {
+	if err := validateValuesFile(valfile, map[string]interface{}{}, false); err == nil {
 		t.Fatal("expected values file to fail parsing")
 	}
 }
@@ -78,7 +78,7 @@ func TestValidateValuesFileSchema(t *testing.T) {
 	createTestingSchema(t, tmpdir)
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
-	if err := validateValuesFile(valfile, map[string]interface{}{}); err != nil {
+	if err := validateValuesFile(valfile, map[string]interface{}{}, false); err != nil {
 		t.Fatalf("Failed validation with %s", err)
 	}
 }
@@ -91,12 +91,26 @@ func TestValidateValuesFileSchemaFailure(t *testing.T) {
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
 
-	err := validateValuesFile(valfile, map[string]interface{}{})
+	err := validateValuesFile(valfile, map[string]interface{}{}, false)
 	if err == nil {
 		t.Fatal("expected values file to fail parsing")
 	}
 
 	assert.Contains(t, err.Error(), "Expected: string, given: integer", "integer should be caught by schema")
+}
+
+func TestValidateValuesFileSchemaFailureButWithSkipSchemaValidation(t *testing.T) {
+	// 1234 is an int, not a string. This should fail.
+	yaml := "username: 1234\npassword: swordfish"
+	tmpdir := ensure.TempFile(t, "values.yaml", []byte(yaml))
+	createTestingSchema(t, tmpdir)
+
+	valfile := filepath.Join(tmpdir, "values.yaml")
+
+	err := validateValuesFile(valfile, map[string]interface{}{}, true)
+	if err != nil {
+		t.Fatal("expected values file to pass parsing because of skipSchemaValidation")
+	}
 }
 
 func TestValidateValuesFileSchemaOverrides(t *testing.T) {
@@ -108,7 +122,7 @@ func TestValidateValuesFileSchemaOverrides(t *testing.T) {
 	createTestingSchema(t, tmpdir)
 
 	valfile := filepath.Join(tmpdir, "values.yaml")
-	if err := validateValuesFile(valfile, overrides); err != nil {
+	if err := validateValuesFile(valfile, overrides, false); err != nil {
 		t.Fatalf("Failed validation with %s", err)
 	}
 }
@@ -145,7 +159,7 @@ func TestValidateValuesFile(t *testing.T) {
 
 			valfile := filepath.Join(tmpdir, "values.yaml")
 
-			err := validateValuesFile(valfile, tt.overrides)
+			err := validateValuesFile(valfile, tt.overrides, false)
 
 			switch {
 			case err != nil && tt.errorMessage == "":


### PR DESCRIPTION
closes #13413 

**What this PR does / why we need it**:
Added full support of `--skip-schema-validation` for the `lint` command

**If applicable**:
- [x] this PR contains unit tests
