### PR TITLE
Fix typo "re-use" to "reuse"

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -184,7 +184,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.Lookup("dry-run").NoOptDefVal = "client"
 	f.BoolVar(&client.Force, "force", false, "force resource updates through a replacement strategy")
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during install")
-	f.BoolVar(&client.Replace, "replace", false, "re-use the given name, only if that name is a deleted release which remains in the history. This is unsafe in production")
+	f.BoolVar(&client.Replace, "replace", false, "reuse the given name, only if that name is a deleted release which remains in the history. This is unsafe in production")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
 	f.BoolVar(&client.WaitForJobs, "wait-for-jobs", false, "if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout")

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -96,7 +96,7 @@ func TestInstall(t *testing.T) {
 			golden:    "output/install-no-args.txt",
 			wantError: true,
 		},
-		// Install, re-use name
+		// Install, reuse name
 		{
 			name:   "install and replace release",
 			cmd:    "install aeneas testdata/testcharts/empty --replace",

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -394,8 +394,8 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 		if cfg.Releases != nil {
 			if mem, ok := cfg.Releases.Driver.(*driver.Memory); ok {
 				// This function can be called more than once (e.g., helm list --all-namespaces).
-				// If a memory driver was already initialized, re-use it but set the possibly new namespace.
-				// We re-use it in case some releases where already created in the existing memory driver.
+				// If a memory driver was already initialized, reuse it but set the possibly new namespace.
+				// We reuse it in case some releases where already created in the existing memory driver.
 				d = mem
 			}
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -450,7 +450,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	}
 
 	// At this point, we can do the install. Note that before we were detecting whether to
-	// do an update, but it's not clear whether we WANT to do an update if the re-use is set
+	// do an update, but it's not clear whether we WANT to do an update if the reuse is set
 	// to true, since that is basically an upgrade operation.
 	if len(toBeAdopted) == 0 && len(resources) > 0 {
 		_, err = i.cfg.KubeClient.Create(resources)
@@ -544,7 +544,7 @@ func (i *Install) availableName() error {
 	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed) {
 		return nil
 	}
-	return errors.New("cannot re-use a name that is still in use")
+	return errors.New("cannot reuse a name that is still in use")
 }
 
 // createRelease creates a new release object
@@ -574,7 +574,7 @@ func (i *Install) recordRelease(r *release.Release) error {
 
 // replaceRelease replaces an older release with this one
 //
-// This allows us to re-use names by superseding an existing release with a new one
+// This allows us to reuse names by superseding an existing release with a new one
 func (i *Install) replaceRelease(rel *release.Release) error {
 	hist, err := i.cfg.Releases.History(rel.Name)
 	if err != nil || len(hist) == 0 {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -83,7 +83,7 @@ type Upgrade struct {
 	Force bool
 	// ResetValues will reset the values to the chart's built-ins rather than merging with existing.
 	ResetValues bool
-	// ReuseValues will re-use the user's last supplied values.
+	// ReuseValues will reuse the user's last supplied values.
 	ReuseValues bool
 	// ResetThenReuseValues will reset the values to the chart's built-ins then merge with user's last supplied values.
 	ResetThenReuseValues bool


### PR DESCRIPTION
**What this PR does / why we need it**: There is a mix of "re-use" and "reuse" in the repo. The correct spelling is "reuse". I replaced all the "re-use" with "reuse".

**Special notes for your reviewer**: n/a

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
