### PR TITLE
Adding CI for dev-v3 branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+      - "dev-v3"
       - "release-**"
   pull_request:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - dev-v3
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - main
+      - dev-v3
   schedule:
     - cron: '29 6 * * 6'
 


### PR DESCRIPTION
When the main branch is for Helm v4, the dev-v3 branch is for Helm v3.

Note, the canary release is setup for helm v4 once the v3 branch is created and there is no canary release for v3.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: to setup the dev-v3 branch with CI

**Special notes for your reviewer**: N/A

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
