### PR TITLE
Return an error instead of panicing if OCI registry client is not provided

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -164,6 +164,10 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	}
 
 	if registry.IsOCI(u.String()) {
+		if c.RegistryClient == nil {
+			return nil, fmt.Errorf("unable to resolve chart version for %s, missing registry client", ref)
+		}
+
 		return c.RegistryClient.ValidateReference(ref, version, u)
 	}
 

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -70,7 +70,7 @@ func TestResolveChartRef(t *testing.T) {
 		Out:              os.Stderr,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
-		RegistryClient: registryClient,
+		RegistryClient:   registryClient,
 		Getters: getter.All(&cli.EnvSettings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"helm.sh/helm/v4/internal/test/ensure"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/getter"
+	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/repo"
 	"helm.sh/helm/v4/pkg/repo/repotest"
 )
@@ -61,10 +63,14 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "oci ref with sha256 and version mismatch", ref: "oci://example.com/install/by/sha:0.1.1@sha256:d234555386402a5867ef0169fefe5486858b6d8d209eaf32fd26d29b16807fd6", version: "0.1.2", fail: true},
 	}
 
+	registryClient, err := registry.NewClient()
+	require.NoError(t, err)
+
 	c := ChartDownloader{
 		Out:              os.Stderr,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
+		RegistryClient: registryClient,
 		Getters: getter.All(&cli.EnvSettings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"helm.sh/helm/v4/internal/test/ensure"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/getter"
@@ -322,6 +324,22 @@ func TestDownloadTo_VerifyLater(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dest, cname+".prov")); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDownloadTo_MissingRegistryClient(t *testing.T) {
+	c := ChartDownloader{
+		Getters: getter.Providers{
+			getter.Provider{
+				Schemes: []string{"oci"},
+				New:     getter.NewOCIGetter,
+			},
+		},
+	}
+
+	ref := "oci://someurl"
+	version := "latest"
+	_, _, err := c.DownloadTo(ref, version, t.TempDir())
+	assert.Error(t, err)
 }
 
 func TestScanReposForURL(t *testing.T) {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -790,6 +790,7 @@ func (c *Client) Tags(ref string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	repository.PlainHTTP = c.plainHTTP
 	repository.Client = c.authorizer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: https://github.com/helm/helm/issues/13435

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
