### PR TITLE
Add --take-ownership flag for install and upgrade commands

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -201,6 +201,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.StringToStringVarP(&client.Labels, "labels", "l", nil, "Labels that would be added to release metadata. Should be divided by comma.")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in install output. Does not affect presence in chart metadata")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for helm annotations and take ownership of the existing resources.")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -201,7 +201,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.StringToStringVarP(&client.Labels, "labels", "l", nil, "Labels that would be added to release metadata. Should be divided by comma.")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in install output. Does not affect presence in chart metadata")
-	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for helm annotations and take ownership of the existing resources.")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for helm annotations and take ownership of the existing resources")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -102,6 +102,12 @@ func TestInstall(t *testing.T) {
 			cmd:    "install aeneas testdata/testcharts/empty --replace",
 			golden: "output/install-and-replace.txt",
 		},
+		// Install, take ownership
+		{
+			name:   "install and replace release",
+			cmd:    "install aeneas-take-ownership testdata/testcharts/empty --take-ownership",
+			golden: "output/install-and-take-ownership.txt",
+		},
 		// Install, with timeout
 		{
 			name:   "install with a timeout",

--- a/cmd/helm/testdata/output/install-and-take-ownership.txt
+++ b/cmd/helm/testdata/output/install-and-take-ownership.txt
@@ -3,4 +3,5 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
+DESCRIPTION: Install complete
 TEST SUITE: None

--- a/cmd/helm/testdata/output/install-and-take-ownership.txt
+++ b/cmd/helm/testdata/output/install-and-take-ownership.txt
@@ -1,0 +1,6 @@
+NAME: aeneas-take-ownership
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-and-take-ownership.txt
+++ b/cmd/helm/testdata/output/upgrade-and-take-ownership.txt
@@ -1,0 +1,7 @@
+Release "funny-bunny" has been upgraded. Happy Helming!
+NAME: funny-bunny
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 3
+TEST SUITE: None

--- a/cmd/helm/testdata/output/upgrade-and-take-ownership.txt
+++ b/cmd/helm/testdata/output/upgrade-and-take-ownership.txt
@@ -4,4 +4,5 @@ LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default
 STATUS: deployed
 REVISION: 3
+DESCRIPTION: Upgrade complete
 TEST SUITE: None

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -151,6 +151,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.Labels = client.Labels
 					instClient.EnableDNS = client.EnableDNS
 					instClient.HideSecret = client.HideSecret
+					instClient.TakeOwnership = client.TakeOwnership
 
 					if isReleaseUninstalled(versions) {
 						instClient.Replace = true

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -280,6 +280,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, upgrade will ignore the check for helm annotations and take ownership of the existing resources.")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -280,7 +280,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
-	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, upgrade will ignore the check for helm annotations and take ownership of the existing resources.")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, upgrade will ignore the check for helm annotations and take ownership of the existing resources")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -115,6 +115,12 @@ func TestUpgradeCmd(t *testing.T) {
 			rels:   []*release.Release{relMock("funny-bunny", 5, ch2)},
 		},
 		{
+			name:   "upgrade a release with --take-ownership",
+			cmd:    fmt.Sprintf("upgrade funny-bunny '%s' --take-ownership", chartPath),
+			golden: "output/upgrade-and-take-ownership.txt",
+			rels:   []*release.Release{relMock("funny-bunny", 2, ch)},
+		},
+		{
 			name:   "install a release with 'upgrade --install'",
 			cmd:    fmt.Sprintf("upgrade zany-bunny -i '%s'", chartPath),
 			golden: "output/upgrade-with-install.txt",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #10304, closes #2730

**What this PR does / why we need it**:

`TakeOwnership` option was added to the Install and Upgrade actions in https://github.com/helm/helm/pull/12876. This PR allows setting this option on the CLI commands using a new `--take-ownership` flag

**Special notes for your reviewer**:

xref: https://github.com/helm/helm/issues/10304#issuecomment-2468532665

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
