### PR TITLE
Replace the splitManifests regex

### DIFF
--- a/pkg/releaseutil/manifest_test.go
+++ b/pkg/releaseutil/manifest_test.go
@@ -18,6 +18,7 @@ package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -37,10 +38,51 @@ spec:
     cmd: fake-command
 `
 
-const expectedManifest = `apiVersion: v1
+const expectedManifest1 = `apiVersion: v1
 kind: Pod
 metadata:
   name: finding-nemo,
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: nemo-test
+    image: fake-image
+    cmd: fake-command`
+
+const mockManifestFile2 = `
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: finding-nemo,
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: nemo-test
+    image: fake-image
+    cmd: fake-command
+
+---apiVersion: v1
+kind: Pod
+metadata:
+  name: finding-nemo-2,
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: nemo-test
+    image: fake-image
+    cmd: fake-command
+`
+
+const expectedManifest2 = `apiVersion: v1
+kind: Pod
+metadata:
+  name: finding-nemo-2,
   annotations:
     "helm.sh/hook": test
 spec:
@@ -54,8 +96,53 @@ func TestSplitManifest(t *testing.T) {
 	if len(manifests) != 1 {
 		t.Errorf("Expected 1 manifest, got %v", len(manifests))
 	}
-	expected := map[string]string{"manifest-0": expectedManifest}
+	expected := map[string]string{"manifest-0": expectedManifest1}
 	if !reflect.DeepEqual(manifests, expected) {
-		t.Errorf("Expected %v, got %v", expected, manifests)
+		t.Errorf("Expected \n%v\n got: \n%v", expected, manifests)
 	}
+}
+
+func TestSplitManifestDocBreak(t *testing.T) {
+	manifests := SplitManifests(mockManifestFile2)
+	if len(manifests) != 2 {
+		t.Errorf("Expected 2 manifest, got %v", len(manifests))
+	}
+	expected := map[string]string{"manifest-0": expectedManifest1, "manifest-1": expectedManifest2}
+	if !reflect.DeepEqual(manifests, expected) {
+		t.Errorf("Expected \n%v\n got: \n%v", expected, manifests)
+	}
+
+}
+
+func TestSplitManifestNoDocBreak(t *testing.T) {
+	manifests := SplitManifests(expectedManifest1)
+	if len(manifests) != 1 {
+		t.Errorf("Expected 1 manifest, got %v", len(manifests))
+	}
+	expected := map[string]string{"manifest-0": expectedManifest1}
+	if !reflect.DeepEqual(manifests, expected) {
+		t.Errorf("Expected \n%v\n got: \n%v", expected, manifests)
+	}
+
+}
+
+func createManifest() string {
+	sb := strings.Builder{}
+	for i := 0; i < 10000; i++ {
+		sb.WriteString(expectedManifest2)
+		sb.WriteString("\n---")
+	}
+	return sb.String()
+}
+
+var BenchmarkSplitManifestsResult map[string]string
+var largeManifest = createManifest()
+
+func BenchmarkSplitManifests(b *testing.B) {
+	var r map[string]string
+	for n := 0; n < b.N; n++ {
+		r = SplitManifests(largeManifest)
+	}
+
+	BenchmarkSplitManifestsResult = r
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**What this PR does / why we need it**:
The regex is slow, we use helm in a gitops repo and template a lot of helm in our CI steps and it is getting quite slow because i've profiled helm itself and found true bottlenecks:

1. Splitting the yaml output (this part)
2. Sorting the yaml output because it has to parse the source
3. Reading the chart index in the chart downloader

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
