### PR TITLE
Add precommit config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/
 vendor/
 # Ignores charts pulled for dependency build tests
 cmd/helm/testdata/testcharts/issue-7233/charts/*
+.pre-commit-config.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignores https://pre-commit.com/ config used to configure local gating checks such as golangci-lint checks and building the code before every commit.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
