### PR TITLE
Don't concatenate u.Path and tag if tag is already in OCI URI

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -171,7 +171,11 @@ func (c *ChartDownloader) getOciURI(ref, version string, u *url.URL) (*url.URL, 
 		}
 	}
 
-	u.Path = fmt.Sprintf("%s:%s", u.Path, tag)
+	// If the tag is already inside the OCI URI, don't concatenate u.Path with tag.
+	// Otherwise the tag gets invalid.
+	if !(strings.Contains(u.Path, ":"+tag)) {
+		u.Path = fmt.Sprintf("%s:%s", u.Path, tag)
+	}
 
 	return u, err
 }


### PR DESCRIPTION
Closes #13466.

If `helm template` is run for an OCI-based Helm chart, which has the tag already in the OCI URI, the download of the chart fails because of an invalid tag.

