### PR TITLE
Make the authorizer and registry authorizer configurable

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -175,6 +175,26 @@ func ClientOptWriter(out io.Writer) ClientOption {
 	}
 }
 
+// ClientOptAuthorizer returns a function that sets the authorizer setting on a client options set. This
+// can be used to override the default authorization mechanism.
+//
+// Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
+func ClientOptAuthorizer(authorizer auth.Client) ClientOption {
+	return func(client *Client) {
+		client.authorizer = authorizer
+	}
+}
+
+// ClientOptRegistryAuthorizer returns a function that sets the registry authorizer setting on a client options set. This
+// can be used to override the default authorization mechanism.
+//
+// Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
+func ClientOptRegistryAuthorizer(registryAuthorizer *registryauth.Client) ClientOption {
+	return func(client *Client) {
+		client.registryAuthorizer = registryAuthorizer
+	}
+}
+
 // ClientOptCredentialsFile returns a function that sets the credentialsFile setting on a client options set
 func ClientOptCredentialsFile(credentialsFile string) ClientOption {
 	return func(client *Client) {


### PR DESCRIPTION
Fixes: #12584

This change makes the authorizer and registryAuthorizer of the registry client configurable via options. This allows Go SDK users to override the authentication behavior of the client.

This PR makes both the authorizer and registryAuthorizer configurable because depending on the exact scenario that may be needed. The default registryAuthorizer only supports a specific implementation of the authorizer.

**What this PR does / why we need it**:

This PR ports #12588 to the dev-v3 branch. I'm opening this per-request after it was merged to v4/main https://github.com/helm/helm/pull/12588#issuecomment-2492867470

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
