### PR TITLE
fix(storage): filter out system labels from custom labels apply

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -79,7 +79,7 @@ func (cfgmaps *ConfigMaps) Get(key string) (*rspb.Release, error) {
 		cfgmaps.Log("get: failed to decode data %q: %s", key, err)
 		return nil, err
 	}
-	r.Labels = filterSystemLabels(obj.ObjectMeta.Labels)
+	r.Labels = obj.ObjectMeta.Labels
 	// return the release object
 	return r, nil
 }

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -245,9 +245,9 @@ func newConfigMapsObject(key string, rls *rspb.Release, lbs labels) (*v1.ConfigM
 	}
 
 	// apply custom labels
-	lbs.fromMap(rls.Labels)
+	lbs.fromMap(filterSystemLabels(rls.Labels))
 
-	// apply labels
+	// apply system labels
 	lbs.set("name", rls.Name)
 	lbs.set("owner", owner)
 	lbs.set("status", rls.Info.Status.String())

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -46,6 +46,7 @@ func TestConfigMapGet(t *testing.T) {
 		t.Fatalf("Failed to get release: %s", err)
 	}
 	// compare fetched release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -78,6 +79,7 @@ func TestUncompressedConfigMapGet(t *testing.T) {
 		t.Fatalf("Failed to get release: %s", err)
 	}
 	// compare fetched release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -185,6 +187,7 @@ func TestConfigMapCreate(t *testing.T) {
 	}
 
 	// compare created release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -239,6 +242,7 @@ func TestConfigMapDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete release with key %q: %s", key, err)
 	}
+	rls.Labels = filterSystemLabels(rls.Labels)
 	if !reflect.DeepEqual(rel, rls) {
 		t.Errorf("Expected {%v}, got {%v}", rel, rls)
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -227,9 +227,9 @@ func newSecretsObject(key string, rls *rspb.Release, lbs labels) (*v1.Secret, er
 	}
 
 	// apply custom labels
-	lbs.fromMap(rls.Labels)
+	lbs.fromMap(filterSystemLabels(rls.Labels))
 
-	// apply labels
+	// apply system labels
 	lbs.set("name", rls.Name)
 	lbs.set("owner", owner)
 	lbs.set("status", rls.Info.Status.String())

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -73,7 +73,7 @@ func (secrets *Secrets) Get(key string) (*rspb.Release, error) {
 	}
 	// found the secret, decode the base64 data string
 	r, err := decodeRelease(string(obj.Data["release"]))
-	r.Labels = filterSystemLabels(obj.ObjectMeta.Labels)
+	r.Labels = obj.ObjectMeta.Labels
 	return r, errors.Wrapf(err, "get: failed to decode data %q", key)
 }
 

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -46,6 +46,7 @@ func TestSecretGet(t *testing.T) {
 		t.Fatalf("Failed to get release: %s", err)
 	}
 	// compare fetched release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -78,6 +79,7 @@ func TestUNcompressedSecretGet(t *testing.T) {
 		t.Fatalf("Failed to get release: %s", err)
 	}
 	// compare fetched release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -184,7 +186,12 @@ func TestSecretCreate(t *testing.T) {
 		t.Fatalf("Failed to get release with key %q: %s", key, err)
 	}
 
+	// check release has actually been created
+	if _, exists := got.Labels["createdAt"]; !exists {
+		t.Errorf("Expected field %s", "createdAt")
+	}
 	// compare created release with original
+	got.Labels = filterSystemLabels(got.Labels)
 	if !reflect.DeepEqual(rel, got) {
 		t.Errorf("Expected {%v}, got {%v}", rel, got)
 	}
@@ -217,6 +224,9 @@ func TestSecretUpdate(t *testing.T) {
 	if rel.Info.Status != got.Info.Status {
 		t.Errorf("Expected status %s, got status %s", rel.Info.Status.String(), got.Info.Status.String())
 	}
+	if _, exists := got.Labels["modifiedAt"]; !exists {
+		t.Errorf("Expected field %s", "modifiedAt")
+	}
 }
 
 func TestSecretDelete(t *testing.T) {
@@ -239,6 +249,7 @@ func TestSecretDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete release with key %q: %s", key, err)
 	}
+	rls.Labels = filterSystemLabels(rls.Labels)
 	if !reflect.DeepEqual(rel, rls) {
 		t.Errorf("Expected {%v}, got {%v}", rel, rls)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Storage drivers including secrets and cfgmaps had wrong custom labels applied on resource creation that included system labels from previous release which was erasing field `modifiedAt`

**Special notes for your reviewer**:
Bug was noticeable starting from helm v3.13.2 with this commit:
- https://github.com/helm/helm/pull/12447/commits/250f0bd46eb543a22a3dfd7e48def58c2597189c

And it was previously wrongly configured with this commit:
- https://github.com/helm/helm/commit/512970ab40b150faef23058452d4849b9d9a4106

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
