### PR TITLE
Remove deprecated `repo add --no-update` flag

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -59,9 +59,6 @@ type repoAddOptions struct {
 
 	repoFile  string
 	repoCache string
-
-	// Deprecated, but cannot be removed until Helm 4
-	deprecatedNoUpdate bool
 }
 
 func newRepoAddCmd(out io.Writer) *cobra.Command {
@@ -92,7 +89,6 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.StringVar(&o.password, "password", "", "chart repository password")
 	f.BoolVarP(&o.passwordFromStdinOpt, "password-stdin", "", false, "read chart repository password from stdin")
 	f.BoolVar(&o.forceUpdate, "force-update", false, "replace (overwrite) the repo if it already exists")
-	f.BoolVar(&o.deprecatedNoUpdate, "no-update", false, "Ignored. Formerly, it would disabled forced updates. It is deprecated by force-update.")
 	f.StringVar(&o.certFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
 	f.StringVar(&o.keyFile, "key-file", "", "identify HTTPS client using this SSL key file")
 	f.StringVar(&o.caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -93,11 +93,10 @@ func TestRepoAdd(t *testing.T) {
 	const testRepoName = "test-name"
 
 	o := &repoAddOptions{
-		name:               testRepoName,
-		url:                ts.URL(),
-		forceUpdate:        false,
-		deprecatedNoUpdate: true,
-		repoFile:           repoFile,
+		name:        testRepoName,
+		url:         ts.URL(),
+		forceUpdate: false,
+		repoFile:    repoFile,
 	}
 	os.Setenv(xdg.CacheHomeEnvVar, rootDir)
 
@@ -148,11 +147,10 @@ func TestRepoAddCheckLegalName(t *testing.T) {
 	repoFile := filepath.Join(t.TempDir(), "repositories.yaml")
 
 	o := &repoAddOptions{
-		name:               testRepoName,
-		url:                ts.URL(),
-		forceUpdate:        false,
-		deprecatedNoUpdate: true,
-		repoFile:           repoFile,
+		name:        testRepoName,
+		url:         ts.URL(),
+		forceUpdate: false,
+		repoFile:    repoFile,
 	}
 	os.Setenv(xdg.CacheHomeEnvVar, rootDir)
 
@@ -204,11 +202,10 @@ func repoAddConcurrent(t *testing.T, testName, repoFile string) {
 		go func(name string) {
 			defer wg.Done()
 			o := &repoAddOptions{
-				name:               name,
-				url:                ts.URL(),
-				deprecatedNoUpdate: true,
-				forceUpdate:        false,
-				repoFile:           repoFile,
+				name:        name,
+				url:         ts.URL(),
+				forceUpdate: false,
+				repoFile:    repoFile,
 			}
 			if err := o.run(io.Discard); err != nil {
 				t.Error(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
There is no functionality attached to this flag, and as per comments it is deprecated.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
