### PR TITLE
Unify behavior of includeFun in regard to nil value output

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -139,7 +139,7 @@ func includeFun(t *template.Template, includedNames map[string]int) func(string,
 		}
 		err := t.ExecuteTemplate(&buf, name, data)
 		includedNames[name]--
-		return buf.String(), err
+		return strings.ReplaceAll(buf.String(), "<no value>", ""), err
 	}
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1308,10 +1308,15 @@ func TestRenderNilValue(t *testing.T) {
 			Version: "1.2.3",
 		},
 		Templates: []*chart.File{
-			{Name: "templates/_helpers.tpl", Data: []byte(`{{- define "noval" -}}{{ and nil }}{{- end -}}`)},
+			{Name: "templates/_helpers.tpl", Data: []byte(`` +
+				`{{- define "noval" -}}{{ and nil }}{{- end -}}` +
+				`{{- define "noval_str" -}}<no value>{{- end -}}`)},
 			{Name: "templates/test_include.yaml", Data: []byte(`{{ eq (include "noval" .) "" }}`)},
 			{Name: "templates/test_tpl.yaml", Data: []byte(`{{ eq (tpl "{{ and nil }}" .) "" }}`)},
 			{Name: "templates/test_render.yaml", Data: []byte(`{{ and nil }}`)},
+			{Name: "templates/test_include_str.yaml", Data: []byte(`{{ eq (include "noval_str" .) "<no value>" }}`)},
+			{Name: "templates/test_tpl_str.yaml", Data: []byte(`{{ eq (tpl "<no value>" .) "<no value>" }}`)},
+			{Name: "templates/test_render_str.yaml", Data: []byte(`<no value>`)},
 		},
 	}
 
@@ -1321,9 +1326,12 @@ func TestRenderNilValue(t *testing.T) {
 	}
 
 	expect := map[string]string{
-		"moby/templates/test_include.yaml": "true",
-		"moby/templates/test_tpl.yaml":     "true",
-		"moby/templates/test_render.yaml":  "",
+		"moby/templates/test_include.yaml":     "true",
+		"moby/templates/test_tpl.yaml":         "true",
+		"moby/templates/test_render.yaml":      "",
+		"moby/templates/test_include_str.yaml": "true",
+		"moby/templates/test_tpl_str.yaml":     "true",
+		"moby/templates/test_render_str.yaml":  "<no value>",
 	}
 	for name, data := range expect {
 		if out[name] != data {


### PR DESCRIPTION
Unifies the behavior of `includeFun` with `tplFun` and `render` regarding rendered nil values ("\<no value>"). This is done by applying the same replaceAll function to the output as the other two functions, replacing any occurrence of "\<no value>" in the string output of `includeFun` with the empty string.

Closes #13487

Note that this is still a hack as not only an actual nil value will be rendered as the empty string, but also any actual string output of "\<no value>". Sadly, I’m not deep enough into Go Templates to come up with a proper solution, so I propose to make Helm’s behavior consistent at least.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
