### PR TITLE
fix: revert OCI feature that creates breaking change

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -216,16 +216,6 @@ func ClientOptAuthorizer(authorizer auth.Client) ClientOption {
 	}
 }
 
-// ClientOptRegistryAuthorizer returns a function that sets the registry authorizer setting on a client options set. This
-// can be used to override the default authorization mechanism.
-//
-// Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
-func ClientOptRegistryAuthorizer(registryAuthorizer *registryauth.Client) ClientOption {
-	return func(client *Client) {
-		client.registryAuthorizer = registryAuthorizer
-	}
-}
-
 // ClientOptCredentialsFile returns a function that sets the credentialsFile setting on a client options set
 func ClientOptCredentialsFile(credentialsFile string) ClientOption {
 	return func(client *Client) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The addition of this method creates a breaking change because it exposes an ORAS v1 object. If this is desired, it should probably be done in a different way. It has not be released yet to my knowledge. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
