### PR TITLE
bugfix: Fix subchart values not overriding with null when `-f` is used

### DIFF
--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -196,7 +196,6 @@ func TestInstall(t *testing.T) {
 			name:      "install with schema file, extra values from yaml, with errors",
 			cmd:       "install schema testdata/testcharts/chart-with-schema -f testdata/testcharts/chart-with-schema/extra-values.yaml",
 			wantError: true,
-			golden:    "output/schema-negative.txt",
 		},
 		// Install, values from yaml, extra values from cli, schematized with errors
 		{

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -142,6 +142,12 @@ func TestTemplateCmd(t *testing.T) {
 			golden: "output/issue-9027.txt",
 		},
 		{
+			// Same as above, but ensures this still works when '-f' is used: https://github.com/helm/helm/issues/12488
+			name:   "ensure nil/null values pass to subcharts delete values when '-f' is used",
+			cmd:    fmt.Sprintf("template '%s' -f %s/values.yaml", deletevalchart, deletevalchart),
+			golden: "output/issue-9027.txt",
+		},
+		{
 			// Ensure that parent chart values take precedence over imported values
 			name:   "template with imported subchart values ensuring import",
 			cmd:    fmt.Sprintf("template '%s' --set configmap.enabled=true --set subchartb.enabled=true", chartPath),

--- a/cmd/helm/testdata/output/issue-9027.txt
+++ b/cmd/helm/testdata/output/issue-9027.txt
@@ -2,11 +2,15 @@
 # Source: issue-9027/charts/subchart/templates/values.yaml
 global:
   hash:
+    key1: null
+    key2: null
     key3: 13
     key4: 4
     key5: 5
     key6: 6
 hash:
+  key1: null
+  key2: null
   key3: 13
   key4: 4
   key5: 5
@@ -21,11 +25,15 @@ global:
 subchart:
   global:
     hash:
+      key1: null
+      key2: null
       key3: 13
       key4: 4
       key5: 5
       key6: 6
   hash:
+    key1: null
+    key2: null
     key3: 13
     key4: 4
     key5: 5

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -158,7 +158,7 @@ func ToRenderValuesWithSchemaValidation(chrt *chart.Chart, chrtVals map[string]i
 		},
 	}
 
-	vals, err := CoalesceValues(chrt, chrtVals)
+	vals, err := MergeValues(chrt, chrtVals)
 	if err != nil {
 		return top, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

closes https://github.com/helm/helm/issues/12488 (bug was also noted here: <https://github.com/helm/helm/pull/12162#issuecomment-1740885539>)
related: https://github.com/helm/helm/pull/12879

This is another attempt at fixing issue <https://github.com/helm/helm/issues/12488>.

Upgrading Argo CD from v2.8.21 → v2.9.22 upgrades helm from v3.12.1 → v3.13.2, which is a version in which this bug was introduced. 

This caused applications to break because of the difference in rendering behavior for the charts, and so the upgrade was rolled back. 

The test reproduces one of the major issues that caused us to roll back, and the change makes the test pass.

**Special notes for your reviewer**:

While this does fix what is (at least from what I can tell) a bug, this also changes the behavior of the original `ToRenderValuesWithSchemaValidation` to render with `MergeValues` instead of `CoalesceValues` which does change the rendered output, at least back to what it was in v3.12.1. This seems like the original behavior before my PR may have been unintentionally introduced in https://github.com/helm/helm/pull/12162 but ideally @mattfarina if you could let me know if i'm missing something that would be fantastic

**If applicable**:
- this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
