### PR TITLE
feat: add latest version and outdated flag to plugin list command

### DIFF
--- a/pkg/cmd/plugin_list.go
+++ b/pkg/cmd/plugin_list.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/plugin/installer"
 
 	"helm.sh/helm/v4/pkg/plugin"
+	"helm.sh/helm/v4/pkg/plugin/installer"
 )
 
 type pluginListOptions struct {

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -155,6 +155,11 @@ func (i *HTTPInstaller) Update() error {
 	return errors.Errorf("method Update() not implemented for HttpInstaller")
 }
 
+// GetLatestVersion fetches the latest version of the plugin.
+func (i *HTTPInstaller) GetLatestVersion() (string, error) {
+	return "", errors.New("not supported")
+}
+
 // Path is overridden because we want to join on the plugin name not the file name
 func (i HTTPInstaller) Path() string {
 	if i.base.Source == "" {

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -40,6 +40,8 @@ type Installer interface {
 	Path() string
 	// Update updates a plugin.
 	Update() error
+	// GetLatestVersion fetches the latest version of the plugin.
+	GetLatestVersion() (string, error)
 }
 
 // Install installs a plugin.

--- a/pkg/plugin/installer/local_installer.go
+++ b/pkg/plugin/installer/local_installer.go
@@ -67,3 +67,7 @@ func (i *LocalInstaller) Update() error {
 	slog.Debug("local repository is auto-updated")
 	return nil
 }
+
+func (i *LocalInstaller) GetLatestVersion() (string, error) {
+	return "", errors.New("not supported")
+}

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -108,6 +108,26 @@ func (i *VCSInstaller) Update() error {
 	return nil
 }
 
+func (i *VCSInstaller) GetLatestVersion() (string, error) {
+	_, err := i.Repo.RunFromDir("git", "fetch", "-q", "--tags")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch tags: %w", err)
+	}
+
+	refs, err := i.Repo.Tags()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tags: %w", err)
+	}
+
+	semvers := getSemVers(refs)
+	if len(semvers) == 0 {
+		return "", fmt.Errorf("no valid semver tags found in repository")
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	return semvers[0].Original(), nil
+}
+
 func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
 	if i.Version == "" {
 		return "", nil

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,6 +16,7 @@ limitations under the License.
 package installer // import "helm.sh/helm/v4/pkg/plugin/installer"
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"sort"


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `LATEST` column to plugin list output and `--outdated` flag to show only plugins with available updates, helping users identify plugins that need updating.

example:
![image](https://github.com/user-attachments/assets/79b373b3-ef60-4138-8eee-446b62b0a62e)


**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility