### PR TITLE
Add --print-file-path flag to helm install command

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -172,6 +172,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	// it is added separately
 	f := cmd.Flags()
 	f.BoolVar(&client.HideSecret, "hide-secret", false, "hide Kubernetes Secrets when also using the --dry-run flag")
+	f.BoolVar(&client.PrintFilePath, "print-file-path", false, "print the file path specified by the --print-file-path flag")
 	bindOutputFlag(cmd, &outfmt)
 	bindPostRenderFlag(cmd, &client.PostRenderer)
 
@@ -243,6 +244,11 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	}
 
 	debug("CHART PATH: %s\n", cp)
+
+	if client.PrintFilePath {
+		fmt.Println(cp)
+		return nil, nil
+	}
 
 	p := getter.All(settings)
 	vals, err := valueOpts.MergeValues(p)

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -274,6 +274,11 @@ func TestInstall(t *testing.T) {
 			wantError: true,
 			golden:    "output/install-hide-secret.txt",
 		},
+		{
+			name:   "install with print-file-path",
+			cmd:    "install printpath testdata/testcharts/alpine --print-file-path",
+			golden: "output/install-print-file-path.txt",
+		},
 	}
 
 	runTestCmd(t, tests)


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/helm/helm/pull/13528?shareId=2ab9ae29-4b9b-4b79-b861-900b79ef0469).