### PR TITLE
fix: (toToml) renders int as float

### DIFF
--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -22,6 +22,18 @@ import (
 	"testing"
 )
 
+func TestTemplateCmdWithToml(t *testing.T) {
+
+	tests := []cmdTestCase{
+		{
+			name:   "check toToml function rendering",
+			cmd:    fmt.Sprintf("template '%s'", "testdata/testcharts/issue-totoml"),
+			golden: "output/issue-totoml.txt",
+		},
+	}
+	runTestCmd(t, tests)
+}
+
 var chartPath = "testdata/testcharts/subchart"
 
 func TestTemplateCmd(t *testing.T) {

--- a/cmd/helm/testdata/output/issue-totoml.txt
+++ b/cmd/helm/testdata/output/issue-totoml.txt
@@ -1,0 +1,8 @@
+---
+# Source: issue-totoml/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: issue-totoml
+data: |
+  key = 13

--- a/cmd/helm/testdata/testcharts/issue-totoml/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: issue-totoml
+version: 0.1.0

--- a/cmd/helm/testdata/testcharts/issue-totoml/templates/configmap.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: issue-totoml
+data: |
+  {{ .Values.global | toToml }}

--- a/cmd/helm/testdata/testcharts/issue-totoml/values.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/values.yaml
@@ -1,0 +1,2 @@
+global:
+  key: 13

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -19,12 +19,13 @@ package loader
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/pkg/errors"
 	"log"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/yaml"
 	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v4/pkg/chart"
 )

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -18,13 +18,13 @@ package loader
 
 import (
 	"bytes"
+	"encoding/json"
+	"github.com/pkg/errors"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
+	"strings"
 
 	"helm.sh/helm/v4/pkg/chart"
 )
@@ -104,7 +104,10 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			}
 		case f.Name == "values.yaml":
 			c.Values = make(map[string]interface{})
-			if err := yaml.Unmarshal(f.Data, &c.Values); err != nil {
+			if err := yaml.Unmarshal(f.Data, &c.Values, func(d *json.Decoder) *json.Decoder {
+				d.UseNumber()
+				return d
+			}); err != nil {
 				return c, errors.Wrap(err, "cannot load values.yaml")
 			}
 		case f.Name == "values.schema.json":

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -15,8 +15,10 @@ limitations under the License.
 package chartutil
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -237,9 +239,24 @@ func TestProcessDependencyImportValues(t *testing.T) {
 			if b := strconv.FormatBool(pv); b != vv {
 				t.Errorf("failed to match imported bool value %v with expected %v for key %q", b, vv, kk)
 			}
+		case json.Number:
+			if fv, err := pv.Float64(); err == nil {
+				if sfv := strconv.FormatFloat(fv, 'f', -1, 64); sfv != vv {
+					t.Errorf("failed to match imported float value %v with expected %v for key %q", sfv, vv, kk)
+				}
+			}
+			if iv, err := pv.Int64(); err == nil {
+				if siv := strconv.FormatInt(iv, 10); siv != vv {
+					t.Errorf("failed to match imported int value %v with expected %v for key %q", siv, vv, kk)
+				}
+			}
+			if pv.String() != vv {
+				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
+			}
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
+				t.Error(reflect.TypeOf(pv))
 			}
 		}
 	}
@@ -309,9 +326,14 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 			if s := strconv.FormatFloat(pv, 'f', -1, 64); s != vv {
 				t.Errorf("failed to match imported float value %v with expected %v", s, vv)
 			}
+		case json.Number:
+			if pv.String() != vv {
+				t.Errorf("failed to match imported string value %q with expected %q", pv, vv)
+			}
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q", pv, vv)
+				t.Error(reflect.TypeOf(pv))
 			}
 		}
 	}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -256,7 +255,6 @@ func TestProcessDependencyImportValues(t *testing.T) {
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
-				t.Error(reflect.TypeOf(pv))
 			}
 		}
 	}
@@ -333,7 +331,6 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q", pv, vv)
-				t.Error(reflect.TypeOf(pv))
 			}
 		}
 	}

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -19,11 +19,12 @@ package chartutil
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v4/pkg/chart"
 )

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,13 +17,13 @@ limitations under the License.
 package chartutil
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"os"
-	"strings"
-
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
+	"strings"
 
 	"helm.sh/helm/v4/pkg/chart"
 )
@@ -105,7 +105,10 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals)
+	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
+		d.UseNumber()
+		return d
+	})
 	if len(vals) == 0 {
 		vals = Values{}
 	}


### PR DESCRIPTION
This commit fixes the issue where the `yaml.Unmarshaller` converts all int values into float64; this passes an option to the decoder, enabling int conversion into.

closes #12987 #6539 #2474 

Signed-off-by: Althaf M <althafm@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is required so that helm function toToml prints out the integer values as integers rather than floats. Without this, it prints it as float strings, appending a .0 to the end.

Currently, 

Assuming values.yaml 
```
global:
  key: 13
```

if we have a template that renders using `toToml` function, like 

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: issue-totoml
data: |
  {{ .Values.global | toToml }}
```

Will get rendered as 

```
# Source: issue-totoml/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: issue-totoml
data: |
  key = 13.0
```

With this PR, it will be rendered as integer as expected : 

```
# Source: issue-totoml/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: issue-totoml
data: |
  key = 13
```


**Special notes for your reviewer**:

Why does this happen only in the `toToml` function?

The [library](https://github.com/BurntSushi/toml) we use to convert to the TOML uses the reflection to identify the type of elements or values and prints them out based on the type. Other libraries, like YAML and JSON, ignore the element type. This causes the output to be printed out as a float rather than as an integer. The root cause is that when using the `yaml.Unmarshal` library, we are parsing all the integers as float64 values.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
