### PR TITLE
implement post-renderer for dependencies

### DIFF
--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -17,6 +17,11 @@ package chart
 
 import "time"
 
+type PostRendererOptions struct {
+	Command string   `json:"command" yaml:"command"`
+	Args    []string `json:"args,omitempty" yaml:"args,omitempty"`
+}
+
 // Dependency describes a chart upon which another chart depends.
 //
 // Dependencies can be used to express developer intent, or to capture the state
@@ -47,6 +52,8 @@ type Dependency struct {
 	ImportValues []interface{} `json:"import-values,omitempty" yaml:"import-values,omitempty"`
 	// Alias usable alias to be used for the chart
 	Alias string `json:"alias,omitempty" yaml:"alias,omitempty"`
+	// A post rendering operation that will be applied to the rendered outputs of this dependency
+	PostRenderer *PostRendererOptions `json:"postRenderer,omitempty" yaml:"postRenderer,omitempty"`
 }
 
 // Validate checks for common problems with the dependency datastructure in

--- a/testdata/postrender.sh
+++ b/testdata/postrender.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+s=$(tee | sed 's/5/25/')
+
+echo "${s}"


### PR DESCRIPTION
resolves #13536

e.g.
```yaml
dependencies:
- name: nginx
  version: "1.2.3"
  repository: "https://example.com/charts
  postRenderer:
    command: ytt
    args:
      - "--file"
      - "overlays/nginx/overlay.yaml"
      - "--file"
      - "-"
```

**What this PR does / why we need it**:

See https://github.com/helm/helm/issues/13536

**Special notes for your reviewer**:

The change is fairly simple

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
