### PR TITLE
feat: add formatting for errors to make multiline stacktraces in helm templates

### DIFF
--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -446,7 +446,9 @@ func TestInstallReleaseIncorrectTemplate_DryRun(t *testing.T) {
 	instAction.DryRun = true
 	vals := map[string]interface{}{}
 	_, err := instAction.Run(buildChart(withSampleIncludingIncorrectTemplates()), vals)
-	expectedErr := "\"hello/templates/incorrect\" at <.Values.bad.doh>: nil pointer evaluating interface {}.doh"
+	expectedErr := `hello/templates/incorrect:1:10
+  executing "hello/templates/incorrect" at <.Values.bad.doh>: 
+    nil pointer evaluating interface {}.doh`
 	if err == nil {
 		t.Fatalf("Install should fail containing error: %s", expectedErr)
 	}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -447,7 +447,7 @@ func TestInstallReleaseIncorrectTemplate_DryRun(t *testing.T) {
 	vals := map[string]interface{}{}
 	_, err := instAction.Run(buildChart(withSampleIncludingIncorrectTemplates()), vals)
 	expectedErr := `hello/templates/incorrect:1:10
-  executing "hello/templates/incorrect" at <.Values.bad.doh>: 
+  executing "hello/templates/incorrect" at <.Values.bad.doh>:
     nil pointer evaluating interface {}.doh`
 	if err == nil {
 		t.Fatalf("Install should fail containing error: %s", expectedErr)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -312,7 +312,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 		vals["Template"] = chartutil.Values{"Name": filename, "BasePath": tpls[filename].basePath}
 		var buf strings.Builder
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
-			return map[string]string{}, cleanupExecError(filename, err)
+			return map[string]string{}, reformatExecErrorMsg(filename, err)
 		}
 
 		// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
@@ -347,7 +347,14 @@ type TraceableError struct {
 func (t TraceableError) String() string {
 	return t.location + "\n  " + t.executedFunction + "\n    " + t.message + "\n"
 }
-func cleanupExecError(filename string, err error) error {
+
+// reformatExecErrorMsg takes an error message for template rendering and formats it into a formatted
+// multi-line error string
+func reformatExecErrorMsg(filename string, err error) error {
+	// This function matches the error message against regex's for the text/template package.
+	// If the regex's can parse out details from that error message such as the line number, template it failed on,
+	// and error description, then it will construct a new error that displays these details in a structured way.
+	// If there are issues with parsing the error message, the err passed into the function should return instead.
 	if _, isExecError := err.(template.ExecError); !isExecError {
 		return err
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -340,6 +340,35 @@ func (t TraceableError) String() string {
 	return t.location + "\n  " + t.executedFunction + "\n    " + t.message + "\n"
 }
 
+func (t TraceableError) ExtractExecutedFunction() (TraceableError, error) {
+	executionLocationRegex, regexFindErr := regexp.Compile(`executing "[^\"]*" at <[^\<\>]*>:?\s*`)
+	if regexFindErr != nil {
+		return t, regexFindErr
+	}
+	byteArrayMsg := []byte(t.message)
+	executionLocations := executionLocationRegex.FindAll(byteArrayMsg, -1)
+	t.executedFunction = string(executionLocations[0])
+	t.message = strings.ReplaceAll(t.message, t.executedFunction, "")
+	return t, nil
+}
+
+func (t TraceableError) FilterLocation() TraceableError {
+	if strings.Contains(t.message, t.location) {
+		t.message = strings.ReplaceAll(t.message, t.location, "")
+	}
+	return t
+}
+
+func (t TraceableError) FilterUnnecessaryWords() TraceableError {
+	if strings.Contains(t.message, "template:") {
+		t.message = strings.TrimSpace(strings.ReplaceAll(t.message, "template:", ""))
+	}
+	if strings.HasPrefix(t.message, ": ") {
+		t.message = strings.TrimSpace(strings.TrimPrefix(t.message, ": "))
+	}
+	return t
+}
+
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
 		return err
@@ -389,33 +418,24 @@ func cleanupExecError(filename string, err error) error {
 		prevMessage = currentMsg
 	}
 
-	for i := len(fileLocations) - 1; i >= 0; i-- {
-		if strings.Contains(fileLocations[i].message, fileLocations[i].location) {
-			fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, fileLocations[i].location, "")
-		}
+	for i, fileLocation := range fileLocations {
+		t := fileLocation.FilterLocation()
+		fileLocations[i] = t
 	}
 
-	for i := len(fileLocations) - 1; i >= 0; i-- {
-		if strings.Contains(fileLocations[i].message, "template:") {
-			fileLocations[i].message = strings.TrimSpace(strings.ReplaceAll(fileLocations[i].message, "template:", ""))
-		}
-		if strings.HasPrefix(fileLocations[i].message, ": ") {
-			fileLocations[i].message = strings.TrimSpace(strings.TrimPrefix(fileLocations[i].message, ": "))
-		}
+	for i, fileLocation := range fileLocations {
+		fileLocations[i] = fileLocation.FilterUnnecessaryWords()
 	}
 
-	for i := len(fileLocations) - 1; i >= 0; i-- {
-		if fileLocations[i].message == "" {
+	for i, fileLocation := range fileLocations {
+		if fileLocation.message == "" {
 			continue
 		}
-		executionLocationRegex, regexFindErr := regexp.Compile(`executing "[^\"]*" at <[^\<\>]*>:?\s*`)
-		if regexFindErr != nil {
+		t, extractionErr := fileLocation.ExtractExecutedFunction()
+		if extractionErr != nil {
 			continue
 		}
-		byteArrayMsg := []byte(fileLocations[i].message)
-		executionLocations := executionLocationRegex.FindAll(byteArrayMsg, -1)
-		fileLocations[i].executedFunction = string(executionLocations[0])
-		fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, fileLocations[i].executedFunction, "")
+		fileLocations[i] = t
 	}
 
 	finalErrorString := ""

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -408,7 +408,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 		fmt.Fprintf(&finalErrorString, "%s", fileLocation.String())
 	}
 
-	return fmt.Errorf("%s", finalErrorString.String())
+	return errors.New(finalErrorString.String())
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -422,17 +422,17 @@ func cleanupExecError(filename string, err error) error {
 		current = errors.Unwrap(current)
 	}
 
-	finalErrorString := ""
+	var finalErrorString strings.Builder
 	for _, fileLocation := range fileLocations {
-		finalErrorString = finalErrorString + fileLocation.String()
+		fmt.Fprintf(&finalErrorString, "%s", fileLocation.String())
 	}
 
-	if strings.TrimSpace(finalErrorString) == "" {
+	if strings.TrimSpace(finalErrorString.String()) == "" {
 		// Fallback to original error message if nothing was extracted
 		return err
 	}
 
-	return fmt.Errorf("%s", finalErrorString)
+	return fmt.Errorf("%s", finalErrorString.String())
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -330,6 +330,11 @@ func cleanupParseError(filename string, err error) error {
 	return fmt.Errorf("parse error at (%s): %s", string(location), errMsg)
 }
 
+type TraceableError struct {
+	location string
+	message  string
+}
+
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
 		return err
@@ -349,8 +354,51 @@ func cleanupExecError(filename string, err error) error {
 	if len(parts) >= 2 {
 		return fmt.Errorf("execution error at (%s): %s", string(location), parts[1])
 	}
+	current := err
+	fileLocations := []TraceableError{}
+	for {
+		if current == nil {
+			break
+		}
+		tokens = strings.SplitN(current.Error(), ": ", 3)
+		location = tokens[1]
+		traceable := TraceableError{
+			location: location,
+			message:  current.Error(),
+		}
+		fileLocations = append(fileLocations, traceable)
+		current = errors.Unwrap(current)
+	}
 
-	return err
+	prevMessage := ""
+	for i := len(fileLocations) - 1; i >= 0; i-- {
+		currentMsg := fileLocations[i].message
+		if i == len(fileLocations)-1 {
+			prevMessage = currentMsg
+			continue
+		}
+
+		if strings.Contains(currentMsg, prevMessage) {
+			fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, prevMessage, "")
+		}
+		prevMessage = currentMsg
+	}
+
+	for i := len(fileLocations) - 1; i >= 0; i-- {
+		if strings.Contains(fileLocations[i].message, fileLocations[i].location) {
+			fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, fileLocations[i].location, "")
+		}
+	}
+
+	finalErrorString := ""
+	for _, i := range fileLocations {
+		if i.message == "" {
+			continue
+		}
+		finalErrorString = finalErrorString + "\n" + i.location + " " + i.message
+	}
+
+	return fmt.Errorf("%s\n\n\n\nError: %s", finalErrorString, err.Error())
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -392,7 +392,7 @@ func determineIfFormattedErrorIsAcceptable(formattedErr error, originalErr error
 	if equivalenceRating >= 80 {
 		return formattedErr
 	}
-	return originalErr
+	return fmt.Errorf("%s", originalErr.Error())
 }
 
 func cleanupExecError(filename string, err error) error {
@@ -416,7 +416,8 @@ func cleanupExecError(filename string, err error) error {
 	}
 	current := err
 	fileLocations := []TraceableError{}
-	for {
+	maxIterations := 100
+	for i := 0; i < maxIterations && current != nil; i++ {
 		if current == nil {
 			break
 		}
@@ -428,6 +429,9 @@ func cleanupExecError(filename string, err error) error {
 		}
 		fileLocations = append(fileLocations, traceable)
 		current = errors.Unwrap(current)
+	}
+	if current != nil {
+		return fmt.Errorf("%s", err.Error())
 	}
 
 	prevMessage := ""

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -437,8 +437,12 @@ func cleanupExecError(filename string, err error) error {
 		}
 		finalErrorString = finalErrorString + fileLocation.String()
 	}
+	if strings.TrimSpace(finalErrorString) == "" {
+		// Fallback to original error message if nothing was extracted
+		return fmt.Errorf("%s", err.Error())
+	}
 
-	return fmt.Errorf("NEW ERROR FORMAT: \n%s\n\n\nORIGINAL ERROR:\n%s", finalErrorString, err.Error())
+	return fmt.Errorf("%s", finalErrorString)
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -382,8 +382,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 		}
 
 		var traceable TraceableError
-		if execErrFmt.MatchString(current.Error()) {
-			matches := execErrFmt.FindStringSubmatch(current.Error())
+		if matches := execErrFmt.FindStringSubmatch(current.Error()); matches != nil {
 			templateName := matches[execErrFmt.SubexpIndex("templateName")]
 			functionName := matches[execErrFmt.SubexpIndex("functionName")]
 			locationName := matches[execErrFmt.SubexpIndex("location")]
@@ -393,8 +392,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 				message:          errMsg,
 				executedFunction: "executing " + functionName + " at " + locationName + ":",
 			}
-		} else if execErrFmtWithoutTemplate.MatchString(current.Error()) {
-			matches := execErrFmt.FindStringSubmatch(current.Error())
+		} else if matches := execErrFmtWithoutTemplate.FindStringSubmatch(current.Error()); matches != nil {
 			templateName := matches[execErrFmt.SubexpIndex("templateName")]
 			errMsg := matches[execErrFmt.SubexpIndex("errMsg")]
 			traceable = TraceableError{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -421,11 +421,6 @@ func cleanupExecError(filename string, err error) error {
 		fmt.Fprintf(&finalErrorString, "%s", fileLocation.String())
 	}
 
-	if strings.TrimSpace(finalErrorString.String()) == "" {
-		// Fallback to original error message if nothing was extracted
-		return err
-	}
-
 	return fmt.Errorf("%s", finalErrorString.String())
 }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -389,7 +389,6 @@ func determineIfFormattedErrorIsAcceptable(formattedErr error, originalErr error
 	}
 
 	equivalenceRating := (float64(matchCount) / float64(len(formattedErrTokens))) * 100
-	fmt.Printf("Rating: %f\n", equivalenceRating)
 	if equivalenceRating >= 80 {
 		return formattedErr
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -419,8 +419,7 @@ func cleanupExecError(filename string, err error) error {
 	}
 
 	for i, fileLocation := range fileLocations {
-		t := fileLocation.FilterLocation()
-		fileLocations[i] = t
+		fileLocations[i] = fileLocation.FilterLocation()
 	}
 
 	for i, fileLocation := range fileLocations {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -431,11 +431,11 @@ func cleanupExecError(filename string, err error) error {
 	}
 
 	finalErrorString := ""
-	for _, i := range fileLocations {
-		if i.message == "" {
+	for _, fileLocation := range fileLocations {
+		if fileLocation.message == "" {
 			continue
 		}
-		finalErrorString = finalErrorString + i.String()
+		finalErrorString = finalErrorString + fileLocation.String()
 	}
 
 	return fmt.Errorf("NEW ERROR FORMAT: \n%s\n\n\nORIGINAL ERROR:\n%s", finalErrorString, err.Error())

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -395,7 +395,7 @@ func determineIfFormattedErrorIsAcceptable(formattedErr error, originalErr error
 	if equivalenceRating >= 80 {
 		return formattedErr
 	}
-	return fmt.Errorf("%s", originalErr.Error())
+	return originalErr
 }
 
 func cleanupExecError(filename string, err error) error {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -413,7 +413,7 @@ func cleanupExecError(filename string, err error) error {
 		current = errors.Unwrap(current)
 	}
 	if current != nil {
-		return fmt.Errorf("%s", err.Error())
+		return err
 	}
 
 	var prev TraceableError
@@ -439,7 +439,7 @@ func cleanupExecError(filename string, err error) error {
 	}
 	if strings.TrimSpace(finalErrorString) == "" {
 		// Fallback to original error message if nothing was extracted
-		return fmt.Errorf("%s", err.Error())
+		return err
 	}
 
 	return fmt.Errorf("%s", finalErrorString)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -33,6 +33,14 @@ import (
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 )
 
+// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=141
+// > "template: %s: executing %q at <%s>: %s"
+var execErrFmt = regexp.MustCompile(`^template: (?P<templateName>(?U).+): executing (?P<functionName>(?U).+) at (?P<location>(?U).+): (?P<errMsg>(?U).+)(?P<nextErr>( template:.*)?)$`)
+
+// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=138
+// > "template: %s: %s"
+var execErrFmtWithoutTemplate = regexp.MustCompile(`^template: (?P<templateName>(?U).+): (?P<errMsg>.*)(?P<nextErr>( template:.*)?)$`)
+
 // Engine is an implementation of the Helm rendering implementation for templates.
 type Engine struct {
 	// If strict is enabled, template rendering will fail if a template references
@@ -341,20 +349,6 @@ func (t TraceableError) String() string {
 }
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
-		return err
-	}
-
-	// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=138
-	// > "template: %s: %s"
-	// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=141
-	// > "template: %s: executing %q at <%s>: %s"
-
-	execErrFmt, compileErr := regexp.Compile(`^template: (?P<templateName>(?U).+): executing (?P<functionName>(?U).+) at (?P<location>(?U).+): (?P<errMsg>(?U).+)(?P<nextErr>( template:.*)?)$`)
-	if compileErr != nil {
-		return err
-	}
-	execErrFmtWithoutTemplate, compileErr := regexp.Compile(`^template: (?P<templateName>(?U).+): (?P<errMsg>.*)(?P<nextErr>( template:.*)?)$`)
-	if compileErr != nil {
 		return err
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -419,7 +419,7 @@ func cleanupExecError(filename string, err error) error {
 	}
 
 	for i, fileLocation := range fileLocations {
-		fileLocations[i] = fileLocation.FilterLocation().FilterUnnecessaryWords()
+		fileLocation = fileLocation.FilterLocation().FilterUnnecessaryWords()
 		if fileLocation.message == "" {
 			continue
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -426,7 +426,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 		fmt.Fprintf(&finalErrorString, "%s", fileLocation.String())
 	}
 
-	return errors.New(finalErrorString.String())
+	return errors.New(strings.TrimSpace(finalErrorString.String()))
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -419,14 +419,7 @@ func cleanupExecError(filename string, err error) error {
 	}
 
 	for i, fileLocation := range fileLocations {
-		fileLocations[i] = fileLocation.FilterLocation()
-	}
-
-	for i, fileLocation := range fileLocations {
-		fileLocations[i] = fileLocation.FilterUnnecessaryWords()
-	}
-
-	for i, fileLocation := range fileLocations {
+		fileLocations[i] = fileLocation.FilterLocation().FilterUnnecessaryWords()
 		if fileLocation.message == "" {
 			continue
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -339,67 +339,22 @@ type TraceableError struct {
 func (t TraceableError) String() string {
 	return t.location + "\n  " + t.executedFunction + "\n    " + t.message + "\n"
 }
-
-func (t TraceableError) ExtractExecutedFunction() (TraceableError, error) {
-	executionLocationRegex, regexFindErr := regexp.Compile(`executing "[^\"]*" at <[^\<\>]*>:?\s*`)
-	if regexFindErr != nil {
-		return t, regexFindErr
-	}
-	byteArrayMsg := []byte(t.message)
-	executionLocations := executionLocationRegex.FindAll(byteArrayMsg, -1)
-	if len(executionLocations) == 0 {
-		return t, nil
-	}
-	t.executedFunction = string(executionLocations[0])
-	t.message = strings.ReplaceAll(t.message, t.executedFunction, "")
-	return t, nil
-}
-
-func (t TraceableError) FilterLocation() TraceableError {
-	if strings.Contains(t.message, t.location) {
-		t.message = strings.ReplaceAll(t.message, t.location, "")
-	}
-	return t
-}
-
-func (t TraceableError) FilterUnnecessaryWords() TraceableError {
-	if strings.Contains(t.message, "template:") {
-		t.message = strings.TrimSpace(strings.ReplaceAll(t.message, "template:", ""))
-	}
-	if strings.HasPrefix(t.message, ": ") {
-		t.message = strings.TrimSpace(strings.TrimPrefix(t.message, ": "))
-	}
-	return t
-}
-
-// In the process of formatting the error, we want to ensure that the formatted version of the error
-// is not losing any necessary information. This function will tokenize and compare the two strings
-// and if the formatted error doesn't meet the threshold, it will fallback to the originalErr
-func determineIfFormattedErrorIsAcceptable(formattedErr error, originalErr error) error {
-	formattedErrTokens := strings.Fields(formattedErr.Error())
-	originalErrTokens := strings.Fields(originalErr.Error())
-
-	tokenSet := make(map[string]struct{})
-	for _, token := range originalErrTokens {
-		tokenSet[token] = struct{}{}
-	}
-
-	matchCount := 0
-	for _, token := range formattedErrTokens {
-		if _, exists := tokenSet[token]; exists {
-			matchCount++
-		}
-	}
-
-	equivalenceRating := (float64(matchCount) / float64(len(formattedErrTokens))) * 100
-	if equivalenceRating >= 80 {
-		return formattedErr
-	}
-	return originalErr
-}
-
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
+		return err
+	}
+
+	// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=138
+	// > "template: %s: %s"
+	// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=141
+	// > "template: %s: executing %q at <%s>: %s"
+
+	execErrFmt, compileErr := regexp.Compile(`^template: (?P<templateName>(?U).+): executing (?P<functionName>(?U).+) at (?P<location>(?U).+): (?P<errMsg>(?U).+)(?P<nextErr>( template:.*)?)$`)
+	if compileErr != nil {
+		return err
+	}
+	execErrFmtWithoutTemplate, compileErr := regexp.Compile(`^template: (?P<templateName>(?U).+): (?P<errMsg>.*)(?P<nextErr>( template:.*)?)$`)
+	if compileErr != nil {
 		return err
 	}
 
@@ -424,16 +379,35 @@ func cleanupExecError(filename string, err error) error {
 		if current == nil {
 			break
 		}
-		tokens = strings.SplitN(current.Error(), ": ", 3)
-		if len(tokens) == 1 {
-			// For cases where the error message doesn't contain a colon
-			location = tokens[0]
+
+		var traceable TraceableError
+		if execErrFmt.MatchString(current.Error()) {
+			matches := execErrFmt.FindStringSubmatch(current.Error())
+			templateIndex := execErrFmt.SubexpIndex("templateName")
+			templateName := matches[templateIndex]
+			functionNameIndex := execErrFmt.SubexpIndex("functionName")
+			functionName := matches[functionNameIndex]
+			locationNameIndex := execErrFmt.SubexpIndex("location")
+			locationName := matches[locationNameIndex]
+			errMsgIndex := execErrFmt.SubexpIndex("errMsg")
+			errMsg := matches[errMsgIndex]
+			traceable = TraceableError{
+				location:         templateName,
+				message:          errMsg,
+				executedFunction: "executing " + functionName + " at " + locationName + ":",
+			}
+		} else if execErrFmtWithoutTemplate.MatchString(current.Error()) {
+			matches := execErrFmt.FindStringSubmatch(current.Error())
+			templateIndex := execErrFmt.SubexpIndex("templateName")
+			templateName := matches[templateIndex]
+			errMsgIndex := execErrFmt.SubexpIndex("errMsg")
+			errMsg := matches[errMsgIndex]
+			traceable = TraceableError{
+				location: templateName,
+				message:  errMsg,
+			}
 		} else {
-			location = tokens[1]
-		}
-		traceable := TraceableError{
-			location: location,
-			message:  current.Error(),
+			return err
 		}
 		fileLocations = append(fileLocations, traceable)
 		current = errors.Unwrap(current)
@@ -442,30 +416,18 @@ func cleanupExecError(filename string, err error) error {
 		return fmt.Errorf("%s", err.Error())
 	}
 
-	prevMessage := ""
+	var prev TraceableError
 	for i := len(fileLocations) - 1; i >= 0; i-- {
-		currentMsg := fileLocations[i].message
+		current := fileLocations[i]
 		if i == len(fileLocations)-1 {
-			prevMessage = currentMsg
+			prev = current
 			continue
 		}
 
-		if strings.Contains(currentMsg, prevMessage) {
-			fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, prevMessage, "")
+		if current.message == prev.message && current.location == prev.location && current.executedFunction == prev.executedFunction {
+			fileLocations[i].message = ""
 		}
-		prevMessage = currentMsg
-	}
-
-	for i, fileLocation := range fileLocations {
-		fileLocation = fileLocation.FilterLocation().FilterUnnecessaryWords()
-		if fileLocation.message == "" {
-			continue
-		}
-		t, extractionErr := fileLocation.ExtractExecutedFunction()
-		if extractionErr != nil {
-			continue
-		}
-		fileLocations[i] = t
+		prev = current
 	}
 
 	finalErrorString := ""
@@ -480,7 +442,7 @@ func cleanupExecError(filename string, err error) error {
 		return fmt.Errorf("%s", err.Error())
 	}
 
-	return determineIfFormattedErrorIsAcceptable(fmt.Errorf("%s", finalErrorString), err)
+	return fmt.Errorf("%s", finalErrorString)
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -384,14 +384,10 @@ func reformatExecErrorMsg(filename string, err error) error {
 		var traceable TraceableError
 		if execErrFmt.MatchString(current.Error()) {
 			matches := execErrFmt.FindStringSubmatch(current.Error())
-			templateIndex := execErrFmt.SubexpIndex("templateName")
-			templateName := matches[templateIndex]
-			functionNameIndex := execErrFmt.SubexpIndex("functionName")
-			functionName := matches[functionNameIndex]
-			locationNameIndex := execErrFmt.SubexpIndex("location")
-			locationName := matches[locationNameIndex]
-			errMsgIndex := execErrFmt.SubexpIndex("errMsg")
-			errMsg := matches[errMsgIndex]
+			templateName := matches[execErrFmt.SubexpIndex("templateName")]
+			functionName := matches[execErrFmt.SubexpIndex("functionName")]
+			locationName := matches[execErrFmt.SubexpIndex("location")]
+			errMsg := matches[execErrFmt.SubexpIndex("errMsg")]
 			traceable = TraceableError{
 				location:         templateName,
 				message:          errMsg,
@@ -399,10 +395,8 @@ func reformatExecErrorMsg(filename string, err error) error {
 			}
 		} else if execErrFmtWithoutTemplate.MatchString(current.Error()) {
 			matches := execErrFmt.FindStringSubmatch(current.Error())
-			templateIndex := execErrFmt.SubexpIndex("templateName")
-			templateName := matches[templateIndex]
-			errMsgIndex := execErrFmt.SubexpIndex("errMsg")
-			errMsg := matches[errMsgIndex]
+			templateName := matches[execErrFmt.SubexpIndex("templateName")]
+			errMsg := matches[execErrFmt.SubexpIndex("errMsg")]
 			traceable = TraceableError{
 				location: templateName,
 				message:  errMsg,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -331,8 +331,9 @@ func cleanupParseError(filename string, err error) error {
 }
 
 type TraceableError struct {
-	location string
-	message  string
+	location         string
+	message          string
+	executedFunction string
 }
 
 func cleanupExecError(filename string, err error) error {
@@ -390,12 +391,35 @@ func cleanupExecError(filename string, err error) error {
 		}
 	}
 
+	for i := len(fileLocations) - 1; i >= 0; i-- {
+		if strings.Contains(fileLocations[i].message, "template:") {
+			fileLocations[i].message = strings.TrimSpace(strings.ReplaceAll(fileLocations[i].message, "template:", ""))
+		}
+		if strings.HasPrefix(fileLocations[i].message, ": ") {
+			fileLocations[i].message = strings.TrimSpace(strings.TrimPrefix(fileLocations[i].message, ": "))
+		}
+	}
+
+	for i := len(fileLocations) - 1; i >= 0; i-- {
+		if fileLocations[i].message == "" {
+			continue
+		}
+		executionLocationRegex, regexFindErr := regexp.Compile(`executing "[^\"]*" at <[^\<\>]*>:?\s*`)
+		if regexFindErr != nil {
+			continue
+		}
+		byteArrayMsg := []byte(fileLocations[i].message)
+		executionLocations := executionLocationRegex.FindAll(byteArrayMsg, -1)
+		fileLocations[i].executedFunction = string(executionLocations[0])
+		fileLocations[i].message = strings.ReplaceAll(fileLocations[i].message, fileLocations[i].executedFunction, "")
+	}
+
 	finalErrorString := ""
 	for _, i := range fileLocations {
 		if i.message == "" {
 			continue
 		}
-		finalErrorString = finalErrorString + "\n" + i.location + " " + i.message
+		finalErrorString = finalErrorString + "\n" + i.location + "\n  " + i.executedFunction + "\n    " + i.message
 	}
 
 	return fmt.Errorf("NEW ERROR FORMAT: \n%s\n\n\nORIGINAL ERROR:\n%s", finalErrorString, err.Error())

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -369,6 +369,33 @@ func (t TraceableError) FilterUnnecessaryWords() TraceableError {
 	return t
 }
 
+// In the process of formatting the error, we want to ensure that the formatted version of the error
+// is not losing any necessary information. This function will tokenize and compare the two strings
+// and if the formatted error doesn't meet the threshold, it will fallback to the originalErr
+func determineIfFormattedErrorIsAcceptable(formattedErr error, originalErr error) error {
+	formattedErrTokens := strings.Fields(formattedErr.Error())
+	originalErrTokens := strings.Fields(originalErr.Error())
+
+	tokenSet := make(map[string]struct{})
+	for _, token := range originalErrTokens {
+		tokenSet[token] = struct{}{}
+	}
+
+	matchCount := 0
+	for _, token := range formattedErrTokens {
+		if _, exists := tokenSet[token]; exists {
+			matchCount++
+		}
+	}
+
+	equivalenceRating := (float64(matchCount) / float64(len(formattedErrTokens))) * 100
+	fmt.Printf("Rating: %f\n", equivalenceRating)
+	if equivalenceRating >= 80 {
+		return formattedErr
+	}
+	return originalErr
+}
+
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
 		return err
@@ -442,7 +469,7 @@ func cleanupExecError(filename string, err error) error {
 		return fmt.Errorf("%s", err.Error())
 	}
 
-	return fmt.Errorf("%s", finalErrorString)
+	return determineIfFormattedErrorIsAcceptable(fmt.Errorf("%s", finalErrorString), err)
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -397,14 +397,9 @@ func reformatExecErrorMsg(filename string, err error) error {
 		} else {
 			return err
 		}
-		if len(fileLocations) > 0 {
-			lastErr := fileLocations[len(fileLocations)-1]
-			if lastErr == traceable {
-				current = errors.Unwrap(current)
-				continue
-			}
+		if len(fileLocations) == 0 || fileLocations[len(fileLocations)-1] != traceable {
+			fileLocations = append(fileLocations, traceable)
 		}
-		fileLocations = append(fileLocations, traceable)
 		current = errors.Unwrap(current)
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -379,6 +379,9 @@ func cleanupExecError(filename string, err error) error {
 		if current == nil {
 			break
 		}
+		if i == maxIterations-1 {
+			return err
+		}
 
 		var traceable TraceableError
 		if execErrFmt.MatchString(current.Error()) {
@@ -409,34 +412,24 @@ func cleanupExecError(filename string, err error) error {
 		} else {
 			return err
 		}
+		if len(fileLocations) > 0 {
+			lastErr := fileLocations[len(fileLocations)-1]
+			if lastErr.message == traceable.message &&
+				lastErr.location == traceable.location &&
+				lastErr.executedFunction == traceable.executedFunction {
+				current = errors.Unwrap(current)
+				continue
+			}
+		}
 		fileLocations = append(fileLocations, traceable)
 		current = errors.Unwrap(current)
-	}
-	if current != nil {
-		return err
-	}
-
-	var prev TraceableError
-	for i := len(fileLocations) - 1; i >= 0; i-- {
-		current := fileLocations[i]
-		if i == len(fileLocations)-1 {
-			prev = current
-			continue
-		}
-
-		if current.message == prev.message && current.location == prev.location && current.executedFunction == prev.executedFunction {
-			fileLocations[i].message = ""
-		}
-		prev = current
 	}
 
 	finalErrorString := ""
 	for _, fileLocation := range fileLocations {
-		if fileLocation.message == "" {
-			continue
-		}
 		finalErrorString = finalErrorString + fileLocation.String()
 	}
+
 	if strings.TrimSpace(finalErrorString) == "" {
 		// Fallback to original error message if nothing was extracted
 		return err

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -398,7 +398,7 @@ func cleanupExecError(filename string, err error) error {
 		finalErrorString = finalErrorString + "\n" + i.location + " " + i.message
 	}
 
-	return fmt.Errorf("%s\n\n\n\nError: %s", finalErrorString, err.Error())
+	return fmt.Errorf("NEW ERROR FORMAT: \n%s\n\n\nORIGINAL ERROR:\n%s", finalErrorString, err.Error())
 }
 
 func sortTemplates(tpls map[string]renderable) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -376,9 +376,6 @@ func cleanupExecError(filename string, err error) error {
 	fileLocations := []TraceableError{}
 	maxIterations := 100
 	for i := 0; i < maxIterations && current != nil; i++ {
-		if current == nil {
-			break
-		}
 		if i == maxIterations-1 {
 			return err
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -347,6 +347,9 @@ func (t TraceableError) ExtractExecutedFunction() (TraceableError, error) {
 	}
 	byteArrayMsg := []byte(t.message)
 	executionLocations := executionLocationRegex.FindAll(byteArrayMsg, -1)
+	if len(executionLocations) == 0 {
+		return t, nil
+	}
 	t.executedFunction = string(executionLocations[0])
 	t.message = strings.ReplaceAll(t.message, t.executedFunction, "")
 	return t, nil
@@ -422,7 +425,12 @@ func cleanupExecError(filename string, err error) error {
 			break
 		}
 		tokens = strings.SplitN(current.Error(), ": ", 3)
-		location = tokens[1]
+		if len(tokens) == 1 {
+			// For cases where the error message doesn't contain a colon
+			location = tokens[0]
+		} else {
+			location = tokens[1]
+		}
 		traceable := TraceableError{
 			location: location,
 			message:  current.Error(),

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -336,6 +336,10 @@ type TraceableError struct {
 	executedFunction string
 }
 
+func (t TraceableError) String() string {
+	return t.location + "\n  " + t.executedFunction + "\n    " + t.message + "\n"
+}
+
 func cleanupExecError(filename string, err error) error {
 	if _, isExecError := err.(template.ExecError); !isExecError {
 		return err
@@ -419,7 +423,7 @@ func cleanupExecError(filename string, err error) error {
 		if i.message == "" {
 			continue
 		}
-		finalErrorString = finalErrorString + "\n" + i.location + "\n  " + i.executedFunction + "\n    " + i.message
+		finalErrorString = finalErrorString + i.String()
 	}
 
 	return fmt.Errorf("NEW ERROR FORMAT: \n%s\n\n\nORIGINAL ERROR:\n%s", finalErrorString, err.Error())

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -375,12 +375,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 	}
 	current := err
 	fileLocations := []TraceableError{}
-	maxIterations := 100
-	for i := 0; i < maxIterations && current != nil; i++ {
-		if i == maxIterations-1 {
-			return err
-		}
-
+	for current != nil {
 		var traceable TraceableError
 		if matches := execErrFmt.FindStringSubmatch(current.Error()); matches != nil {
 			templateName := matches[execErrFmt.SubexpIndex("templateName")]

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -399,9 +399,7 @@ func reformatExecErrorMsg(filename string, err error) error {
 		}
 		if len(fileLocations) > 0 {
 			lastErr := fileLocations[len(fileLocations)-1]
-			if lastErr.message == traceable.message &&
-				lastErr.location == traceable.location &&
-				lastErr.executedFunction == traceable.executedFunction {
+			if lastErr == traceable {
 				current = errors.Unwrap(current)
 				continue
 			}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -18,12 +18,13 @@ package engine
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"strings"
 	"sync"
 	"testing"
 	"text/template"
+
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1314,13 +1314,13 @@ func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
 	}
 
 	expectedErrorMessage := `NestedHelperFunctions/templates/svc.yaml:1:9
-  executing "NestedHelperFunctions/templates/svc.yaml" at <include "nested_helper.name" .>: 
+  executing "NestedHelperFunctions/templates/svc.yaml" at <include "nested_helper.name" .>:
     error calling include:
 NestedHelperFunctions/templates/_helpers_1.tpl:1:39
-  executing "nested_helper.name" at <include "common.names.get_name" .>: 
+  executing "nested_helper.name" at <include "common.names.get_name" .>:
     error calling include:
 NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:50
-  executing "common.names.get_name" at <.Release.Name>: 
+  executing "common.names.get_name" at <.Release.Name>:
     nil pointer evaluating interface {}.Name
 `
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
 
 	"github.com/stretchr/testify/assert"
 
@@ -1291,16 +1290,11 @@ func TestRenderTplMissingKeyString(t *testing.T) {
 		t.Errorf("Expected error, got %v", out)
 		return
 	}
-	switch err.(type) {
-	case (template.ExecError):
-		errTxt := fmt.Sprint(err)
-		if !strings.Contains(errTxt, "noSuchKey") {
-			t.Errorf("Expected error to contain 'noSuchKey', got %s", errTxt)
-		}
-	default:
-		// Some unexpected error.
-		t.Fatal(err)
+	errTxt := fmt.Sprint(err)
+	if !strings.Contains(errTxt, "noSuchKey") {
+		t.Errorf("Expected error to contain 'noSuchKey', got %s", errTxt)
 	}
+
 }
 
 func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1318,6 +1318,17 @@ func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
 		},
 	}
 
+	expectedErrorMessage := `NestedHelperFunctions/templates/svc.yaml:1:9
+  executing "NestedHelperFunctions/templates/svc.yaml" at <include "nested_helper.name" .>: 
+    error calling include:
+NestedHelperFunctions/templates/_helpers_1.tpl:1:39
+  executing "nested_helper.name" at <include "common.names.get_name" .>: 
+    error calling include:
+NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:50
+  executing "common.names.get_name" at <.Release.Name>: 
+    nil pointer evaluating interface {}.Name
+`
+
 	v := chartutil.Values{}
 
 	val, _ := chartutil.CoalesceValues(c, v)
@@ -1327,9 +1338,7 @@ func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
 	_, err := Render(c, vals)
 
 	assert.NotNil(t, err)
-	if err != nil {
-		t.Errorf("Failed to render templates: %s", err)
-	}
+	assert.Equal(t, expectedErrorMessage, err.Error())
 }
 
 func TestRenderCustomTemplateFuncs(t *testing.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1309,7 +1309,7 @@ func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
 				`{{- define "nested_helper.name" -}}{{- include "common.names.get_name" . -}}{{- end -}}`,
 			)},
 			{Name: "charts/common/templates/_helpers_2.tpl", Data: []byte(
-				`{{- define "common.names.get_name" -}}{{- .Release.Name | trunc 63 | trimSuffix "-" -}}{{- end -}}`,
+				`{{- define "common.names.get_name" -}}{{- .Values.nonexistant.key | trunc 63 | trimSuffix "-" -}}{{- end -}}`,
 			)},
 		},
 	}
@@ -1320,9 +1320,9 @@ func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
 NestedHelperFunctions/templates/_helpers_1.tpl:1:39
   executing "nested_helper.name" at <include "common.names.get_name" .>:
     error calling include:
-NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:50
-  executing "common.names.get_name" at <.Release.Name>:
-    nil pointer evaluating interface {}.Name`
+NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:49
+  executing "common.names.get_name" at <.Values.nonexistant.key>:
+    nil pointer evaluating interface {}.key`
 
 	v := chartutil.Values{}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -18,6 +18,8 @@ package engine
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"path"
 	"strings"
 	"sync"
@@ -1299,6 +1301,25 @@ func TestRenderTplMissingKeyString(t *testing.T) {
 		// Some unexpected error.
 		t.Fatal(err)
 	}
+}
+
+func TestSometimesJesseJustBe(t *testing.T) {
+	c, _ := loader.Load("/home/jesse/code/camunda-platform-helm/charts/camunda-platform-8.5")
+
+	v, _ := chartutil.ReadValuesFile("/home/jesse/code/helm/values.yaml")
+	val, _ := chartutil.CoalesceValues(c, v)
+	vals := map[string]interface{}{
+		"Values": val.AsMap(),
+	}
+	out, err := Render(c, vals)
+
+	if err != nil {
+		t.Errorf("Failed to render templates: %s", err)
+	}
+	assert.NotNil(t, out)
+	data := strings.TrimSpace(out["jesse-subchart-values-hacktest/charts/keycloak/templates/ingress.yaml"])
+	fmt.Println(data)
+	assert.NotEmpty(t, data)
 }
 
 func TestRenderCustomTemplateFuncs(t *testing.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -19,7 +19,6 @@ package engine
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
-	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"path"
 	"strings"
 	"sync"
@@ -1303,23 +1302,34 @@ func TestRenderTplMissingKeyString(t *testing.T) {
 	}
 }
 
-func TestSometimesJesseJustBe(t *testing.T) {
-	c, _ := loader.Load("/home/jesse/code/camunda-platform-helm/charts/camunda-platform-8.5")
+func TestNestedHelpersProducesMultilineStacktrace(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "NestedHelperFunctions"},
+		Templates: []*chart.File{
+			{Name: "templates/svc.yaml", Data: []byte(
+				`name: {{ include "nested_helper.name" . }}`,
+			)},
+			{Name: "templates/_helpers_1.tpl", Data: []byte(
+				`{{- define "nested_helper.name" -}}{{- include "common.names.get_name" . -}}{{- end -}}`,
+			)},
+			{Name: "charts/common/templates/_helpers_2.tpl", Data: []byte(
+				`{{- define "common.names.get_name" -}}{{- .Release.Name | trunc 63 | trimSuffix "-" -}}{{- end -}}`,
+			)},
+		},
+	}
 
-	v, _ := chartutil.ReadValuesFile("/home/jesse/code/helm/values.yaml")
+	v := chartutil.Values{}
+
 	val, _ := chartutil.CoalesceValues(c, v)
 	vals := map[string]interface{}{
 		"Values": val.AsMap(),
 	}
-	out, err := Render(c, vals)
+	_, err := Render(c, vals)
 
+	assert.NotNil(t, err)
 	if err != nil {
 		t.Errorf("Failed to render templates: %s", err)
 	}
-	assert.NotNil(t, out)
-	data := strings.TrimSpace(out["jesse-subchart-values-hacktest/charts/keycloak/templates/ingress.yaml"])
-	fmt.Println(data)
-	assert.NotEmpty(t, data)
 }
 
 func TestRenderCustomTemplateFuncs(t *testing.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1322,8 +1322,7 @@ NestedHelperFunctions/templates/_helpers_1.tpl:1:39
     error calling include:
 NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:50
   executing "common.names.get_name" at <.Release.Name>:
-    nil pointer evaluating interface {}.Name
-`
+    nil pointer evaluating interface {}.Name`
 
 	v := chartutil.Values{}
 
@@ -1356,8 +1355,7 @@ func TestMultilineNoTemplateAssociatedError(t *testing.T) {
 	expectedErrorMessage := `multiline/templates/svc.yaml:1:9
   executing "multiline/templates/svc.yaml" at <include "nested_helper.name" .>:
     error calling include:
-template: no template "nested_helper.name" associated with template "gotpl"
-`
+template: no template "nested_helper.name" associated with template "gotpl"`
 
 	v := chartutil.Values{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

closes https://github.com/helm/helm/issues/13447

The purpose of this PR is to bring some structure into the error messages that helm will output. This structure is necessary so that readers of these error messages will naturally be able to identify important details like where the error occurred, and what the error actually is. For me, this problem comes about when you have complicated logic inside _helpers files, and is made worse when those _helpers call other _helpers.

This PR addresses this problem by adding whitespace to parts of the error message.  The structure of this format is : 
```
fileLocation:lineNumber:colNumber
  functionCallWithinFile
    contentOfError
```
and in the unit test I added, a real world example would look like this:
```
        NestedHelperFunctions/templates/svc.yaml:1:9
          executing "NestedHelperFunctions/templates/svc.yaml" at <include "nested_helper.name" .>: 
            error calling include:
        NestedHelperFunctions/templates/_helpers_1.tpl:1:39
          executing "nested_helper.name" at <include "common.names.get_name" .>: 
            error calling include:
        NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:50
          executing "common.names.get_name" at <.Release.Name>: 
            nil pointer evaluating interface {}.Name
```

This change may introduce some risk that any added formatting logic may delete important parts of the error message.  As an attempt to address this, I use regex's to match against the known error messages from the parent golang text/template library, and if there is any part of the error that doesn't match those regex's,  the unformatted error message will be returned.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
