### PR TITLE
Ensuring the file paths are clean prior to passing to securejoin

### DIFF
--- a/pkg/chartutil/expand.go
+++ b/pkg/chartutil/expand.go
@@ -52,6 +52,9 @@ func Expand(dir string, r io.Reader) error {
 	}
 
 	// Find the base directory
+	// The directory needs to be cleaned prior to passing to SecureJoin or the location may end up
+	// being wrong or returning an error. This was introduced in v0.4.0.
+	dir = filepath.Clean(dir)
 	chartdir, err := securejoin.SecureJoin(dir, chartName)
 	if err != nil {
 		return err

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -206,6 +206,9 @@ func cleanJoin(root, dest string) (string, error) {
 	}
 
 	// SecureJoin will do some cleaning, as well as some rudimentary checking of symlinks.
+	// The directory needs to be cleaned prior to passing to SecureJoin or the location may end up
+	// being wrong or returning an error. This was introduced in v0.4.0.
+	root = filepath.Clean(root)
 	newpath, err := securejoin.SecureJoin(root, dest)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
securejoin v0.4.0 made a possibly breaking change. Only clean paths are safe to pass to SecureJoin or they could return an error or have the wrong path. The details are in the release notes for v0.4.0.

This change ensures the paths are clean prior to passing to SecureJoin.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: This is needed to ensure https://github.com/helm/helm/pull/13630 is safe to merge.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
