### PR TITLE
fix: Bind repotest server to `localhost`

### DIFF
--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -113,7 +113,7 @@ func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
 		t.Fatalf("error finding free port for test registry")
 	}
 
-	config.HTTP.Addr = fmt.Sprintf(":%d", port)
+	config.HTTP.Addr = fmt.Sprintf("127.0.0.1:%d", port)
 	config.HTTP.DrainTimeout = time.Duration(10) * time.Second
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	config.Auth = configuration.Auth{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently, `repotest.Server` is binding to all interfaces (empty "host" in the servers "Addr"). This causes the server to also bind to the hosts `0.0.0.0` interface, and as such enables the server to be accessed over the network.

This is perhaps a (very minor) security problem. But annoyingly, on my MacBook I get security popups when running "unit" tests, asking if I want to allow `helm.test` and `registry.test` to "Accept incoming connections?" (see screenshot below).

Instead, bind the server to local interface. Avoiding these popups, as the server is for testing and only needs to accept local connections.

**Special notes for your reviewer**:
Binding to `127.0.0.1` is fine, see `httptest.NewServer` implementation:
https://cs.opensource.google/go/go/+/refs/tags/go1.23.5:src/net/http/httptest/server.go;l=68

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

<img width="268" alt="image" src="https://github.com/user-attachments/assets/d906adeb-24e7-4b38-96aa-6603aff431e8" />
