### PR TITLE
Consolidate and refactor chart repository functions into FindChartInA…

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -789,7 +789,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		dl.Verify = downloader.VerifyAlways
 	}
 	if c.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthRepoURL(c.RepoURL, c.Username, c.Password, name, version,
+		chartURL, err := repo.FindChartRepoURL(c.RepoURL, c.Username, c.Password, name, version,
 			c.CertFile, c.KeyFile, c.CaFile, c.InsecureSkipTLSverify, c.PassCredentialsAll, getter.All(settings))
 		if err != nil {
 			return "", err

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -809,7 +809,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 
 		// Host on URL (returned from url.Parse) contains the port if present.
 		// This check ensures credentials are not passed between different
-		// services on different ports.
+		// services on different ports
 		if c.PassCredentialsAll || (u1.Scheme == u2.Scheme && u1.Host == u2.Host) {
 			dl.Options = append(dl.Options, getter.WithBasicAuth(c.Username, c.Password))
 		} else {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -789,7 +789,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		dl.Verify = downloader.VerifyAlways
 	}
 	if c.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(c.RepoURL, c.Username, c.Password, name, version,
+		chartURL, err := repo.FindChartInAuthRepoURL(c.RepoURL, c.Username, c.Password, name, version,
 			c.CertFile, c.KeyFile, c.CaFile, c.InsecureSkipTLSverify, c.PassCredentialsAll, getter.All(settings))
 		if err != nil {
 			return "", err

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -117,7 +117,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version,
+		chartURL, err := repo.FindChartRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version,
 			p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings))
 		if err != nil {
 			return out.String(), err

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -117,7 +117,8 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings))
+		chartURL, err := repo.FindChartInAuthRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version,
+			p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings))
 		if err != nil {
 			return out.String(), err
 		}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -742,7 +742,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
-	url, err = repo.FindChartInRepoURL(repoURL, name, version, certFile, keyFile, caFile, m.Getters)
+	url, err = repo.FindChartInAuthRepoURL(repoURL, "", "", name, version, certFile, keyFile, caFile, false, false, m.Getters)
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -742,7 +742,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
-	url, err = repo.FindChartInAuthRepoURL(repoURL, "", "", name, version, certFile, keyFile, caFile, false, false, m.Getters)
+	url, err = repo.FindChartRepoURL(repoURL, "", "", name, version, certFile, keyFile, caFile, false, false, m.Getters)
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
 	}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -196,9 +196,9 @@ func (r *ChartRepository) generateIndex() error {
 	return nil
 }
 
-// FindChartInAuthRepoURL finds chart in chart repository pointed by repoURL
+// FindChartRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories, and supports authentication, TLS settings, and optional passing of credentials to other domains.
-func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers) (string, error) {
+func FindChartRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers) (string, error) {
 	// Download and write the index file to a temporary location
 	buf := make([]byte, 20)
 	rand.Read(buf)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -290,7 +290,7 @@ func startLocalTLSServerForTests(handler http.Handler) (*httptest.Server, error)
 	return httptest.NewTLSServer(handler), nil
 }
 
-func TestChartInAuthRepoURL(t *testing.T) {
+func TestChartInRepoURL(t *testing.T) {
 	srv, err := startLocalTLSServerForTests(nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -290,14 +290,14 @@ func startLocalTLSServerForTests(handler http.Handler) (*httptest.Server, error)
 	return httptest.NewTLSServer(handler), nil
 }
 
-func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
+func TestChartInAuthRepoURL(t *testing.T) {
 	srv, err := startLocalTLSServerForTests(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -306,7 +306,7 @@ func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
 	}
 
 	// If the insecureSkipTLSVerify is false, it will return an error that contains "x509: certificate signed by unknown authority".
-	_, err = FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
+	_, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	// Go communicates with the platform and different platforms return different messages. Go itself tests darwin
 	// differently for its message. On newer versions of Darwin the message includes the "Acme Co" portion while older
 	// versions of Darwin do not. As there are people developing Helm using both old and new versions of Darwin we test
@@ -327,7 +327,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -335,7 +335,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 		t.Errorf("%s is not the valid URL", chartURL)
 	}
 
-	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{}))
+	chartURL, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -350,7 +350,7 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 		RepositoryCache: t.TempDir(),
 	})
 
-	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", g); err == nil {
+	if _, err := FindChartInAuthRepoURL("http://someserver/something", "", "", "nginx", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
 	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
@@ -362,19 +362,19 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "", "", "", "", g); err == nil {
+	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx1", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "0.1.0", "", "", "", g); err == nil {
+	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx1", "0.1.0", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" version "0.1.0" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInRepoURL(srv.URL, "chartWithNoURL", "", "", "", "", g); err == nil {
+	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "chartWithNoURL", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for no chart URLs available, but did not get any errors")
 	} else if err.Error() != `chart "chartWithNoURL" has no downloadable URLs` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -297,7 +297,7 @@ func TestChartInAuthRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -306,7 +306,7 @@ func TestChartInAuthRepoURL(t *testing.T) {
 	}
 
 	// If the insecureSkipTLSVerify is false, it will return an error that contains "x509: certificate signed by unknown authority".
-	_, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
+	_, err = FindChartRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	// Go communicates with the platform and different platforms return different messages. Go itself tests darwin
 	// differently for its message. On newer versions of Darwin the message includes the "Acme Co" portion while older
 	// versions of Darwin do not. As there are people developing Helm using both old and new versions of Darwin we test
@@ -327,7 +327,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
+	chartURL, err := FindChartRepoURL(srv.URL, "", "", "nginx", "", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -335,7 +335,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 		t.Errorf("%s is not the valid URL", chartURL)
 	}
 
-	chartURL, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
+	chartURL, err = FindChartRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -350,7 +350,7 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 		RepositoryCache: t.TempDir(),
 	})
 
-	if _, err := FindChartInAuthRepoURL("http://someserver/something", "", "", "nginx", "", "", "", "", false, false, g); err == nil {
+	if _, err := FindChartRepoURL("http://someserver/something", "", "", "nginx", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
 	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
@@ -362,19 +362,19 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx1", "", "", "", "", false, false, g); err == nil {
+	if _, err = FindChartRepoURL(srv.URL, "", "", "nginx1", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "nginx1", "0.1.0", "", "", "", false, false, g); err == nil {
+	if _, err = FindChartRepoURL(srv.URL, "", "", "nginx1", "0.1.0", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" version "0.1.0" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInAuthRepoURL(srv.URL, "", "", "chartWithNoURL", "", "", "", "", false, false, g); err == nil {
+	if _, err = FindChartRepoURL(srv.URL, "", "", "chartWithNoURL", "", "", "", "", false, false, g); err == nil {
 		t.Errorf("Expected error for no chart URLs available, but did not get any errors")
 	} else if err.Error() != `chart "chartWithNoURL" has no downloadable URLs` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
FindChartRepoURL functions into a single consolidated function, FindChartInAuthRepoURL, which supports enhanced flexibility for chart lookup. The change ensures more efficient code by unifying the logic for fetching charts from the repository with authentication, TLS settings, and optional credentials for different domains. 

**Special notes for your reviewer**:


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
