### PR TITLE
Cleanup `repotest.Server` constructors

### DIFF
--- a/cmd/helm/dependency_build_test.go
+++ b/cmd/helm/dependency_build_test.go
@@ -29,11 +29,11 @@ import (
 )
 
 func TestDependencyBuildCmd(t *testing.T) {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz"),
+	)
 	defer srv.Stop()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	rootDir := srv.Root()
 	srv.LinkIndices()

--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -32,10 +32,10 @@ import (
 )
 
 func TestDependencyUpdateCmd(t *testing.T) {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz"),
+	)
 	defer srv.Stop()
 	t.Logf("Listening on directory %s", srv.Root())
 
@@ -151,10 +151,10 @@ func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 	defer resetEnv()()
 	ensure.HelmHome(t)
 
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz"),
+	)
 	defer srv.Stop()
 	t.Logf("Listening on directory %s", srv.Root())
 
@@ -248,10 +248,10 @@ func TestDependencyUpdateCmd_WithRepoThatWasNotAdded(t *testing.T) {
 }
 
 func setupMockRepoServer(t *testing.T) *repotest.Server {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz"),
+	)
 
 	t.Logf("Listening on directory %s", srv.Root())
 

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -27,18 +27,12 @@ import (
 )
 
 func TestInstall(t *testing.T) {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+		repotest.WithMiddleware(repotest.BasicAuthMiddleware(t)),
+	)
 	defer srv.Stop()
-
-	srv.WithMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if !ok || username != "username" || password != "password" {
-			t.Errorf("Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
-		}
-	}))
 
 	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.FileServer(http.Dir(srv.Root())).ServeHTTP(w, r)

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -34,22 +34,21 @@ import (
 )
 
 func TestRepoAddCmd(t *testing.T) {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer srv.Stop()
 
 	// A second test server is setup to verify URL changing
-	srv2, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv2 := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer srv2.Stop()
 
 	tmpdir := filepath.Join(t.TempDir(), "path-component.yaml/data")
-	err = os.MkdirAll(tmpdir, 0777)
-	if err != nil {
+	if err := os.MkdirAll(tmpdir, 0777); err != nil {
 		t.Fatal(err)
 	}
 	repoFile := filepath.Join(tmpdir, "repositories.yaml")
@@ -81,10 +80,10 @@ func TestRepoAddCmd(t *testing.T) {
 }
 
 func TestRepoAdd(t *testing.T) {
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	rootDir := t.TempDir()
@@ -134,10 +133,10 @@ func TestRepoAdd(t *testing.T) {
 }
 
 func TestRepoAddCheckLegalName(t *testing.T) {
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 	defer resetEnv()()
 
@@ -190,10 +189,10 @@ func TestRepoAddConcurrentHiddenFile(t *testing.T) {
 }
 
 func repoAddConcurrent(t *testing.T, testName, repoFile string) {
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	var wg sync.WaitGroup
@@ -240,7 +239,11 @@ func TestRepoAddFileCompletion(t *testing.T) {
 }
 
 func TestRepoAddWithPasswordFromStdin(t *testing.T) {
-	srv := repotest.NewTempServerWithCleanupAndBasicAuth(t, "testdata/testserver/*.*")
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+		repotest.WithMiddleware(repotest.BasicAuthMiddleware(t)),
+	)
 	defer srv.Stop()
 
 	defer resetEnv()()

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 func TestRepoRemove(t *testing.T) {
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	rootDir := t.TempDir()
@@ -162,10 +162,11 @@ func testCacheFiles(t *testing.T, cacheIndexFile string, cacheChartsFile string,
 }
 
 func TestRepoRemoveCompletion(t *testing.T) {
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
+
 	defer ts.Stop()
 
 	rootDir := t.TempDir()

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -106,10 +106,11 @@ func TestUpdateCustomCacheCmd(t *testing.T) {
 	cachePath := filepath.Join(rootDir, "updcustomcache")
 	os.Mkdir(cachePath, os.ModePerm)
 
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
+
 	defer ts.Stop()
 
 	o := &repoUpdateOptions{
@@ -130,10 +131,9 @@ func TestUpdateCharts(t *testing.T) {
 	defer resetEnv()()
 	ensure.HelmHome(t)
 
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	r, err := repo.NewChartRepository(&repo.Entry{
@@ -165,10 +165,10 @@ func TestUpdateChartsFail(t *testing.T) {
 	defer resetEnv()()
 	ensure.HelmHome(t)
 
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	var invalidURL = ts.URL() + "55"
@@ -198,10 +198,10 @@ func TestUpdateChartsFailWithError(t *testing.T) {
 	defer resetEnv()()
 	ensure.HelmHome(t)
 
-	ts, err := repotest.NewTempServerWithCleanup(t, "testdata/testserver/*.*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
+	)
 	defer ts.Stop()
 
 	var invalidURL = ts.URL() + "55"

--- a/cmd/helm/show_test.go
+++ b/cmd/helm/show_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestShowPreReleaseChart(t *testing.T) {
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
 	defer srv.Stop()
 
 	if err := srv.LinkIndices(); err != nil {

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -175,7 +175,11 @@ func TestIsTar(t *testing.T) {
 }
 
 func TestDownloadTo(t *testing.T) {
-	srv := repotest.NewTempServerWithCleanupAndBasicAuth(t, "testdata/*.tgz*")
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+		repotest.WithMiddleware(repotest.BasicAuthMiddleware(t)),
+	)
 	defer srv.Stop()
 	if err := srv.CreateIndex(); err != nil {
 		t.Fatal(err)
@@ -222,12 +226,11 @@ func TestDownloadTo(t *testing.T) {
 
 func TestDownloadTo_TLS(t *testing.T) {
 	// Set up mock server w/ tls enabled
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	srv.Stop()
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv.StartTLS()
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+		repotest.WithTLSConfig(repotest.MakeTestTLSConfig(t, "../../testdata")),
+	)
 	defer srv.Stop()
 	if err := srv.CreateIndex(); err != nil {
 		t.Fatal(err)
@@ -249,7 +252,13 @@ func TestDownloadTo_TLS(t *testing.T) {
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,
 		}),
-		Options: []getter.Option{},
+		Options: []getter.Option{
+			getter.WithTLSClientConfig(
+				"",
+				"",
+				filepath.Join("../../testdata/rootca.crt"),
+			),
+		},
 	}
 	cname := "test/signtest"
 	dest := srv.Root()
@@ -278,10 +287,10 @@ func TestDownloadTo_VerifyLater(t *testing.T) {
 	dest := t.TempDir()
 
 	// Set up a fake repo
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+	)
 	defer srv.Stop()
 	if err := srv.LinkIndices(); err != nil {
 		t.Fatal(err)

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -292,10 +292,10 @@ version: 0.1.0`
 
 func TestUpdateBeforeBuild(t *testing.T) {
 	// Set up a fake repo
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+	)
 	defer srv.Stop()
 	if err := srv.LinkIndices(); err != nil {
 		t.Fatal(err)
@@ -347,13 +347,11 @@ func TestUpdateBeforeBuild(t *testing.T) {
 	}
 
 	// Update before Build. see issue: https://github.com/helm/helm/issues/7101
-	err = m.Update()
-	if err != nil {
+	if err := m.Update(); err != nil {
 		t.Fatal(err)
 	}
 
-	err = m.Build()
-	if err != nil {
+	if err := m.Build(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -363,10 +361,10 @@ func TestUpdateBeforeBuild(t *testing.T) {
 // to be fetched.
 func TestUpdateWithNoRepo(t *testing.T) {
 	// Set up a fake repo
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+	)
 	defer srv.Stop()
 	if err := srv.LinkIndices(); err != nil {
 		t.Fatal(err)
@@ -422,8 +420,7 @@ func TestUpdateWithNoRepo(t *testing.T) {
 	}
 
 	// Test the update
-	err = m.Update()
-	if err != nil {
+	if err := m.Update(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -436,10 +433,10 @@ func TestUpdateWithNoRepo(t *testing.T) {
 // If each of these main fields (name, version, repository) is not supplied by dep param, default value will be used.
 func checkBuildWithOptionalFields(t *testing.T, chartName string, dep chart.Dependency) {
 	// Set up a fake repo
-	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/*.tgz*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/*.tgz*"),
+	)
 	defer srv.Stop()
 	if err := srv.LinkIndices(); err != nil {
 		t.Fatal(err)
@@ -487,14 +484,12 @@ func checkBuildWithOptionalFields(t *testing.T, chartName string, dep chart.Depe
 	}
 
 	// First build will update dependencies and create Chart.lock file.
-	err = m.Build()
-	if err != nil {
+	if err := m.Build(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Second build should be passed. See PR #6655.
-	err = m.Build()
-	if err != nil {
+	if err := m.Build(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/repo/repotest/server.go
+++ b/pkg/repo/repotest/server.go
@@ -17,6 +17,7 @@ package repotest
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"sigs.k8s.io/yaml"
 
-	"helm.sh/helm/v4/internal/tlsutil"
 	"helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/chartutil"
@@ -41,34 +41,103 @@ import (
 	"helm.sh/helm/v4/pkg/repo"
 )
 
-// NewTempServerWithCleanup creates a server inside of a temp dir.
-//
-// If the passed in string is not "", it will be treated as a shell glob, and files
-// will be copied from that path to the server's docroot.
-//
-// The caller is responsible for stopping the server.
-// The temp dir will be removed by testing package automatically when test finished.
-func NewTempServerWithCleanup(t *testing.T, glob string) (*Server, error) {
-	srv, err := NewTempServer(glob)
-	t.Cleanup(func() { os.RemoveAll(srv.docroot) })
-	return srv, err
-}
-
-// Set up a fake repo with basic auth enabled
-func NewTempServerWithCleanupAndBasicAuth(t *testing.T, glob string) *Server {
-	srv, err := NewTempServerWithCleanup(t, glob)
-	srv.Stop()
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv.WithMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+func BasicAuthMiddleware(t *testing.T) http.HandlerFunc {
+	return http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok || username != "username" || password != "password" {
 			t.Errorf("Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
 		}
-	}))
-	srv.Start()
+	})
+}
+
+type ServerOption func(*testing.T, *Server)
+
+func WithTLSConfig(tlsConfig *tls.Config) ServerOption {
+	return func(_ *testing.T, server *Server) {
+		server.tlsConfig = tlsConfig
+	}
+}
+
+func WithMiddleware(middleware http.HandlerFunc) ServerOption {
+	return func(_ *testing.T, server *Server) {
+		server.middleware = middleware
+	}
+}
+
+func WithChartSourceGlob(glob string) ServerOption {
+	return func(_ *testing.T, server *Server) {
+		server.chartSourceGlob = glob
+	}
+}
+
+// Server is an implementation of a repository server for testing.
+type Server struct {
+	docroot         string
+	srv             *httptest.Server
+	middleware      http.HandlerFunc
+	tlsConfig       *tls.Config
+	chartSourceGlob string
+}
+
+// NewTempServer creates a server inside of a temp dir.
+//
+// If the passed in string is not "", it will be treated as a shell glob, and files
+// will be copied from that path to the server's docroot.
+//
+// The server is started automatically. The caller is responsible for stopping
+// the server.
+//
+// The temp dir will be removed by testing package automatically when test finished.
+func NewTempServer(t *testing.T, options ...ServerOption) *Server {
+
+	docrootTempDir, err := os.MkdirTemp("", "helm-repotest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newServer(t, docrootTempDir, options...)
+
+	t.Cleanup(func() { os.RemoveAll(srv.docroot) })
+
+	if srv.chartSourceGlob != "" {
+		if _, err := srv.CopyCharts(srv.chartSourceGlob); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	return srv
+}
+
+// Create the server, but don't yet start it
+func newServer(t *testing.T, docroot string, options ...ServerOption) *Server {
+	absdocroot, err := filepath.Abs(docroot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{
+		docroot: absdocroot,
+	}
+
+	for _, option := range options {
+		option(t, s)
+	}
+
+	s.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.middleware != nil {
+			s.middleware.ServeHTTP(w, r)
+		}
+		http.FileServer(http.Dir(s.Root())).ServeHTTP(w, r)
+	}))
+
+	s.start()
+
+	// Add the testing repository as the only repo. Server must be started for the server's URL to be valid
+	if err := setTestingRepository(s.URL(), filepath.Join(s.docroot, "repositories.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	return s
 }
 
 type OCIServer struct {
@@ -239,69 +308,6 @@ func (srv *OCIServer) Run(t *testing.T, opts ...OCIServerOpt) {
 		result.Chart.Digest, result.Chart.Size)
 }
 
-// NewTempServer creates a server inside of a temp dir.
-//
-// If the passed in string is not "", it will be treated as a shell glob, and files
-// will be copied from that path to the server's docroot.
-//
-// The caller is responsible for destroying the temp directory as well as stopping
-// the server.
-//
-// Deprecated: use NewTempServerWithCleanup
-func NewTempServer(glob string) (*Server, error) {
-	tdir, err := os.MkdirTemp("", "helm-repotest-")
-	if err != nil {
-		return nil, err
-	}
-	srv := NewServer(tdir)
-
-	if glob != "" {
-		if _, err := srv.CopyCharts(glob); err != nil {
-			srv.Stop()
-			return srv, err
-		}
-	}
-
-	return srv, nil
-}
-
-// NewServer creates a repository server for testing.
-//
-// docroot should be a temp dir managed by the caller.
-//
-// This will start the server, serving files off of the docroot.
-//
-// Use CopyCharts to move charts into the repository and then index them
-// for service.
-func NewServer(docroot string) *Server {
-	root, err := filepath.Abs(docroot)
-	if err != nil {
-		panic(err)
-	}
-	srv := &Server{
-		docroot: root,
-	}
-	srv.Start()
-	// Add the testing repository as the only repo.
-	if err := setTestingRepository(srv.URL(), filepath.Join(root, "repositories.yaml")); err != nil {
-		panic(err)
-	}
-	return srv
-}
-
-// Server is an implementation of a repository server for testing.
-type Server struct {
-	docroot    string
-	srv        *httptest.Server
-	middleware http.HandlerFunc
-}
-
-// WithMiddleware injects middleware in front of the server. This can be used to inject
-// additional functionality like layering in an authentication frontend.
-func (s *Server) WithMiddleware(middleware http.HandlerFunc) {
-	s.middleware = middleware
-}
-
 // Root gets the docroot for the server.
 func (s *Server) Root() string {
 	return s.docroot
@@ -348,50 +354,12 @@ func (s *Server) CreateIndex() error {
 	return os.WriteFile(ifile, d, 0644)
 }
 
-func (s *Server) Start() {
-	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.middleware != nil {
-			s.middleware.ServeHTTP(w, r)
-		}
-		http.FileServer(http.Dir(s.docroot)).ServeHTTP(w, r)
-	}))
-}
-
-func (s *Server) StartTLS() {
-	cd := "../../testdata"
-	ca, pub, priv := filepath.Join(cd, "rootca.crt"), filepath.Join(cd, "crt.pem"), filepath.Join(cd, "key.pem")
-	insecure := false
-
-	s.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.middleware != nil {
-			s.middleware.ServeHTTP(w, r)
-		}
-		http.FileServer(http.Dir(s.Root())).ServeHTTP(w, r)
-	}))
-	tlsConf, err := tlsutil.NewTLSConfig(
-		tlsutil.WithInsecureSkipVerify(insecure),
-		tlsutil.WithCertKeyPairFiles(pub, priv),
-		tlsutil.WithCAFile(ca),
-	)
-	if err != nil {
-		panic(err)
-	}
-	tlsConf.ServerName = "helm.sh"
-	s.srv.TLS = tlsConf
-	s.srv.StartTLS()
-
-	// Set up repositories config with ca file
-	repoConfig := filepath.Join(s.Root(), "repositories.yaml")
-
-	r := repo.NewFile()
-	r.Add(&repo.Entry{
-		Name:   "test",
-		URL:    s.URL(),
-		CAFile: filepath.Join("../../testdata", "rootca.crt"),
-	})
-
-	if err := r.WriteFile(repoConfig, 0600); err != nil {
-		panic(err)
+func (s *Server) start() {
+	if s.tlsConfig != nil {
+		s.srv.TLS = s.tlsConfig
+		s.srv.StartTLS()
+	} else {
+		s.srv.Start()
 	}
 }
 
@@ -411,6 +379,10 @@ func (s *Server) URL() string {
 	return s.srv.URL
 }
 
+func (s *Server) Client() *http.Client {
+	return s.srv.Client()
+}
+
 // LinkIndices links the index created with CreateIndex and makes a symbolic link to the cache index.
 //
 // This makes it possible to simulate a local cache of a repository.
@@ -422,6 +394,10 @@ func (s *Server) LinkIndices() error {
 
 // setTestingRepository sets up a testing repository.yaml with only the given URL.
 func setTestingRepository(url, fname string) error {
+	if url == "" {
+		panic("no url")
+	}
+
 	r := repo.NewFile()
 	r.Add(&repo.Entry{
 		Name: "test",

--- a/pkg/repo/repotest/tlsconfig.go
+++ b/pkg/repo/repotest/tlsconfig.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repotest
+
+import (
+	"crypto/tls"
+	"path/filepath"
+	"testing"
+
+	"helm.sh/helm/v4/internal/tlsutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func MakeTestTLSConfig(t *testing.T, path string) *tls.Config {
+	ca, pub, priv := filepath.Join(path, "rootca.crt"), filepath.Join(path, "crt.pem"), filepath.Join(path, "key.pem")
+
+	insecure := false
+	tlsConf, err := tlsutil.NewTLSConfig(
+		tlsutil.WithInsecureSkipVerify(insecure),
+		tlsutil.WithCertKeyPairFiles(pub, priv),
+		tlsutil.WithCAFile(ca),
+	)
+	//require.Nil(t, err, err.Error())
+	require.Nil(t, err)
+
+	tlsConf.ServerName = "helm.sh"
+
+	return tlsConf
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
1. Replace the deprecated `repotest.NewTempServer` with `repotest.NewTempServerWithCleanup` (ie. delete `repotest.NewTempServer` and rename `repotest.NewTempServerWithCleanup` -> `repotest.NewTempServer`).

2. Add constructor options ie. create `WithNoAutostart()`, `WithBasicAuth()`, etc

3. Finally, require `testing.T` type to be passed into each constructor, allowing errors to immediately fail/abort tests

**Special notes for your reviewer**:
Because this is testing code, even if used externally, the disruption to any users should be minimal.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
