### PR TITLE
[dev-v3] Moving to SetOut and SetErr for Cobra

### DIFF
--- a/cmd/helm/require/args_test.go
+++ b/cmd/helm/require/args_test.go
@@ -71,7 +71,8 @@ func runTestCases(t *testing.T, testCases []testCase) {
 				Args: tc.validateFunc,
 			}
 			cmd.SetArgs(tc.args)
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			err := cmd.Execute()
 			if tc.wantError == "" {


### PR DESCRIPTION
SetOutput is deprecated. This causes it to fail linting.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
