### PR TITLE
feat: error out when post-renderer produces no output

### DIFF
--- a/pkg/postrender/exec.go
+++ b/pkg/postrender/exec.go
@@ -67,7 +67,7 @@ func (p *execRender) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error)
 	// If the binary returned almost nothing, it's likely that it didn't
 	// successfully render anything
 	if len(bytes.TrimSpace(postRendered.Bytes())) == 0 {
-		return nil, errors.Errorf("post render binary %s did not produce any output %s", p.binaryPath, postRendered.String())
+		return nil, errors.Errorf("post-renderer %q produced empty output", p.binaryPath)
 	}
 
 	return postRendered, nil

--- a/pkg/postrender/exec.go
+++ b/pkg/postrender/exec.go
@@ -64,6 +64,12 @@ func (p *execRender) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error)
 		return nil, errors.Wrapf(err, "error while running command %s. error output:\n%s", p.binaryPath, stderr.String())
 	}
 
+	// If the binary returned almost nothing, it's likely that it didn't
+	// successfully render anything
+	if len(bytes.TrimSpace(postRendered.Bytes())) == 0 {
+		return nil, errors.Errorf("post render binary %s did not produce any output %s", p.binaryPath, postRendered.String())
+	}
+
 	return postRendered, nil
 }
 

--- a/pkg/postrender/exec_test.go
+++ b/pkg/postrender/exec_test.go
@@ -121,6 +121,21 @@ func TestExecRun(t *testing.T) {
 	is.Contains(output.String(), "BARTEST")
 }
 
+func TestExecRunWithNoOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// the actual Run test uses a basic sed example, so skip this test on windows
+		t.Skip("skipping on windows")
+	}
+	is := assert.New(t)
+	testpath := setupTestingScript(t)
+
+	renderer, err := NewExec(testpath)
+	require.NoError(t, err)
+
+	_, err = renderer.Run(bytes.NewBufferString(""))
+	is.Error(err)
+}
+
 func TestNewExecWithOneArgsRun(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// the actual Run test uses a basic sed example, so skip this test on windows


### PR DESCRIPTION
**What this PR does / why we need it**:

When the templating post-renderer produces no output, something went wrong so we error out.

- Closes https://github.com/helm/helm/issues/13473

**If applicable**:
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility (releases with 0 resources will fail now)
