### PR TITLE
removing old apis

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +102,7 @@ func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, err
 			ready, err := c.jobReady(job)
 			return ready, err
 		}
-	case *appsv1.Deployment, *appsv1beta1.Deployment, *appsv1beta2.Deployment, *extensionsv1beta1.Deployment:
+	case *appsv1.Deployment:
 		currentDeployment, err := c.client.AppsV1().Deployments(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -138,7 +135,7 @@ func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, err
 		if !c.serviceReady(svc) {
 			return false, nil
 		}
-	case *extensionsv1beta1.DaemonSet, *appsv1.DaemonSet, *appsv1beta2.DaemonSet:
+	case *appsv1.DaemonSet:
 		ds, err := c.client.AppsV1().DaemonSets(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -168,7 +165,7 @@ func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, err
 		if !c.crdReady(*crd) {
 			return false, nil
 		}
-	case *appsv1.StatefulSet, *appsv1beta1.StatefulSet, *appsv1beta2.StatefulSet:
+	case *appsv1.StatefulSet:
 		sts, err := c.client.AppsV1().StatefulSets(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -188,7 +185,7 @@ func (c *ReadyChecker) IsReady(ctx context.Context, v *resource.Info) (bool, err
 		if !ready || err != nil {
 			return false, err
 		}
-	case *extensionsv1beta1.ReplicaSet, *appsv1beta2.ReplicaSet, *appsv1.ReplicaSet:
+	case *appsv1.ReplicaSet:
 		rs, err := c.client.AppsV1().ReplicaSets(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -20,10 +20,8 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -523,7 +521,7 @@ func Test_ReadyChecker_IsReady_StatefulSet(t *testing.T) {
 			},
 			args: args{
 				ctx:      context.TODO(),
-				resource: &resource.Info{Object: &appsv1beta1.StatefulSet{}, Name: "foo", Namespace: defaultNamespace},
+				resource: &resource.Info{Object: &appsv1.StatefulSet{}, Name: "foo", Namespace: defaultNamespace},
 			},
 			ss:      newStatefulSet("foo", 1, 0, 0, 1, true),
 			want:    false,
@@ -539,7 +537,7 @@ func Test_ReadyChecker_IsReady_StatefulSet(t *testing.T) {
 			},
 			args: args{
 				ctx:      context.TODO(),
-				resource: &resource.Info{Object: &appsv1beta1.StatefulSet{}, Name: "foo", Namespace: defaultNamespace},
+				resource: &resource.Info{Object: &appsv1.StatefulSet{}, Name: "foo", Namespace: defaultNamespace},
 			},
 			ss:      newStatefulSet("bar", 1, 0, 1, 1, true),
 			want:    false,
@@ -689,7 +687,7 @@ func Test_ReadyChecker_IsReady_ReplicaSet(t *testing.T) {
 			},
 			args: args{
 				ctx:      context.TODO(),
-				resource: &resource.Info{Object: &extensionsv1beta1.ReplicaSet{}, Name: "foo", Namespace: defaultNamespace},
+				resource: &resource.Info{Object: &appsv1.ReplicaSet{}, Name: "foo", Namespace: defaultNamespace},
 			},
 			rs:      newReplicaSet("foo", 1, 1, true),
 			want:    false,
@@ -705,7 +703,7 @@ func Test_ReadyChecker_IsReady_ReplicaSet(t *testing.T) {
 			},
 			args: args{
 				ctx:      context.TODO(),
-				resource: &resource.Info{Object: &extensionsv1beta1.ReplicaSet{}, Name: "foo", Namespace: defaultNamespace},
+				resource: &resource.Info{Object: &appsv1.ReplicaSet{}, Name: "foo", Namespace: defaultNamespace},
 			},
 			rs:      newReplicaSet("bar", 1, 1, false),
 			want:    false,


### PR DESCRIPTION
Removing old APIs. These are outlined [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/). 

Closes #30584

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
