### PR TITLE
fix:add proxy support when mTLS configured

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -339,6 +339,7 @@ func newRegistryClientWithTLS(
 		registry.ClientOptHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConf,
+				Proxy:           http.ProxyFromEnvironment,
 			},
 		}),
 		registry.ClientOptBasicAuth(username, password),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm registry client should respect `HTTPS_PROXY/NO_PROXY`. 
It was originally fixed by https://github.com/helm/helm/pull/13117 in 3.16.4

This commit https://github.com/helm/helm/commit/dc158f6208782b888fc5be6d23d8991042cf9f9c in 3.17 creates a regression on respecting proxy. 



relevant issue https://github.com/helm/helm/issues/13116
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
