### PR TITLE
feat: Merge lists when passing multiple values files, allowing to sig…

### DIFF
--- a/pkg/chart/v2/loader/load.go
+++ b/pkg/chart/v2/loader/load.go
@@ -303,23 +303,23 @@ func MergeMapLists(a, b []any) []any {
 			continue
 		}
 
-		var mergeKey string
-		var mergeValue interface{}
+		var uniqueKey string
+		var dedupValue interface{}
 		for k, v := range mapEntry {
 			if strings.HasPrefix(k, mergePrefix) {
-				mergeKey = k
-				mergeValue = v
+				uniqueKey = k
+				dedupValue = v
 				bj, ok := b[j].(map[string]any)
 				if !ok {
 					continue
 				}
-				bj[strings.TrimPrefix(mergeKey, mergePrefix)] = v
-				delete(bj, mergeKey)
+				bj[strings.TrimPrefix(uniqueKey, mergePrefix)] = v
+				delete(bj, uniqueKey)
 				break
 			}
 		}
-		if len(mergeKey) > 0 {
-			strippedMergeKey := strings.TrimPrefix(mergeKey, mergePrefix)
+		if len(uniqueKey) > 0 {
+			strippedMergeKey := strings.TrimPrefix(uniqueKey, mergePrefix)
 
 			for i, sourceMapEntry := range out {
 				sourceMapEntry, ok := sourceMapEntry.(map[string]any)
@@ -327,7 +327,7 @@ func MergeMapLists(a, b []any) []any {
 					continue
 				}
 				for k, v := range sourceMapEntry {
-					if (k == strippedMergeKey || k == mergeKey) && v == mergeValue {
+					if (k == strippedMergeKey || k == uniqueKey) && v == dedupValue {
 						mergedMapEntry := MergeMaps(sourceMapEntry, mapEntry)
 						out[i] = mergedMapEntry
 						break


### PR DESCRIPTION
…nal a unique key for merging lists of maps

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR allows merging lists inside values files, which is a very useful feature when using overlays to simplify/merge deployment files, e.g. merging kubernetes environment variables from several values files.

It has the following behaviour:
- Behaviour is unchanged for any lists whose key name does not start with *

- Lists of plain values are concatenated when the key name is prefixed by *
- Lists of maps are concatenated when the key name is prefixed by *, allowing to specify a unique key (by prefixing the key name with *) for merging specific entries instead of adding. 
- The * prefix will be stripped from key names of list properties in the final rendering 

Addresses: 
[#3486](https://github.com/helm/helm/issues/3486)
https://github.com/fluxcd/helm-controller/issues/300

**Special notes for your reviewer**:

This enables users to opt-in to list merging with some degree of control over which lists are merged, and how they are merged.

Applicability example:

values1.yaml
```
env:
  - name: MYVAR1
    value: value1
  - name: MYVAR2
    value: value2
```
values2.yaml
```
*env:
  - *name: MYVAR1
    value: override_this_value
  - name: MYVAR3
    value: add_this
```
result:
```
env:
  - name: MYVAR1
    value: override_this_value
  - name: MYVAR2
    value: value2
  - name: MYVAR3
    value: add_this
```

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
