### PR TITLE
Remove deprecated code

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -62,21 +61,6 @@ var (
 	// errPending indicates that another instance of Helm is already applying an operation on a release.
 	errPending = errors.New("another operation (install/upgrade/rollback) is in progress")
 )
-
-// ValidName is a regular expression for resource names.
-//
-// DEPRECATED: This will be removed in Helm 4, and is no longer used here. See
-// pkg/lint/rules.validateMetadataNameFunc for the replacement.
-//
-// According to the Kubernetes help text, the regular expression it uses is:
-//
-//	[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
-//
-// This follows the above regular expression (but requires a full string match, not partial).
-//
-// The Kubernetes documentation is here, though it is not entirely correct:
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-var ValidName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // Configuration injects the dependencies that all actions share.
 type Configuration struct {

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -35,9 +35,6 @@ type lookupFunc = func(apiversion string, resource string, namespace string, nam
 // NewLookupFunction returns a function for looking up objects in the cluster.
 //
 // If the resource does not exist, no error is raised.
-//
-// This function is considered deprecated, and will be renamed in Helm 4. It will no
-// longer be a public function.
 func NewLookupFunction(config *rest.Config) lookupFunc {
 	return newLookupFunction(clientProviderFromConfig{config: config})
 }


### PR DESCRIPTION
This change removes deprecated code (marked for removal in Helm v4).

This also exposes the Helm template engine function map for SDK users. The removed public function constructor was used by SDK users who were trying to reconstruct some of Helms template functions so their custom code can render render templates. With the removal of this public function that no longer works. By exposing this publicly, those use cases can continue.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Removing deprecated code while keeping a solution for community user use cases.

**Special notes for your reviewer**: There are three ways to handle this situation.

1. Remove `NewLookupFunction` and no longer expose this for SDK users. Some of the SDK users are using it outside of Helm. Some of them are partially providing Helms functions. I did not find a public app on GitHub using all of Helms template functions. Removing it means they will need to vendor a copy of our code or write their own.
2. Do not deprecate the `NewLookupFunction` function and and instead make it `newLookupFunction`. This will help some community users who use it.
3. Expose all the Helm template functions for the community.

My initial reaction was to go with (1) to keep this code Helm focused. 

If we are going to expose our template functions, we could do so with those in mind who are working with Helm charts and need all our functions. This is to power SDK users who are doing Helm work. That's why I went with (3) in this PR.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
