### PR TITLE
Report as debug log, the time spent waiting for resources

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -49,6 +49,7 @@ type waiter struct {
 func (w *waiter) waitForResources(created ResourceList) error {
 	w.log("beginning wait for %d resources with timeout of %v", len(created), w.timeout)
 
+	startTime := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 
@@ -57,7 +58,7 @@ func (w *waiter) waitForResources(created ResourceList) error {
 		numberOfErrors[i] = 0
 	}
 
-	return wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		waitRetries := 30
 		for i, v := range created {
 			ready, err := w.c.IsReady(ctx, v)
@@ -78,6 +79,15 @@ func (w *waiter) waitForResources(created ResourceList) error {
 		}
 		return true, nil
 	})
+
+	elapsed := time.Since(startTime).Round(time.Second)
+	if err != nil {
+		w.log("wait for resources failed after %v: %v", elapsed, err)
+	} else {
+		w.log("wait for ressources succeeded within %v", elapsed)
+	}
+
+	return err
 }
 
 func (w *waiter) isRetryableError(err error, resource *resource.Info) bool {

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -84,7 +84,7 @@ func (w *waiter) waitForResources(created ResourceList) error {
 	if err != nil {
 		w.log("wait for resources failed after %v: %v", elapsed, err)
 	} else {
-		w.log("wait for ressources succeeded within %v", elapsed)
+		w.log("wait for resources succeeded within %v", elapsed)
 	}
 
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When trying to improve the speed of a helm upgrade. I think it could be great to see how much time the helm upgrade spent waiting for ressources when you use `--wait`. So I thought about adding a small log point with the elapsed time in seconds.

Output example
```
creating 2 resource(s)
preparing upgrade for podinfo
performing update for podinfo
creating upgraded release for podinfo
checking 2 resources for changes
Looks like there are no changes for Service \"podinfo\"
Patch Deployment \"podinfo\" in namespace default
waiting for release podinfo resources (created: 0 updated: 2  deleted: 0)
beginning wait for 2 resources with timeout of 15m0s
Deployment is not ready: default/podinfo. 0 out of 9 expected pods are ready
Deployment is not ready: default/podinfo. 0 out of 9 expected pods are ready
wait for ressources succeeded within 4s
```

If approved, I can backport it to main/v4.

Similar work: https://github.com/helm/helm/pull/30685

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
