### PR TITLE
Inform about time spent waiting resources to be ready in slog format

### DIFF
--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -108,7 +108,7 @@ func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 
-	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(_ context.Context) (bool, error) {
 		for _, v := range deleted {
 			err := v.Get()
 			if err == nil || !apierrors.IsNotFound(err) {

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -19,6 +19,7 @@ package kube // import "helm.sh/helm/v4/pkg/kube"
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -101,12 +102,13 @@ func (w *waiter) isRetryableHTTPStatusCode(httpStatusCode int32) bool {
 
 // waitForDeletedResources polls to check if all the resources are deleted or a timeout is reached
 func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
-	w.log("beginning wait for %d resources to be deleted with timeout of %v", len(deleted), w.timeout)
+	slog.Info("beginning wait for resources to be deleted", "count", len(deleted), "timeout", w.timeout)
 
+	startTime := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 
-	return wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(_ context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		for _, v := range deleted {
 			err := v.Get()
 			if err == nil || !apierrors.IsNotFound(err) {
@@ -115,6 +117,15 @@ func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
 		}
 		return true, nil
 	})
+
+	elapsed := time.Since(startTime).Round(time.Second)
+	if err != nil {
+		slog.Debug("wait for resources failed", "elapsed", elapsed, "error", err)
+	} else {
+		slog.Debug("wait for resources succeeded", "elapsed", elapsed)
+	}
+
+	return err
 }
 
 // SelectorsForObject returns the pod label selector for a given object

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -102,7 +102,7 @@ func (w *waiter) isRetryableHTTPStatusCode(httpStatusCode int32) bool {
 
 // waitForDeletedResources polls to check if all the resources are deleted or a timeout is reached
 func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
-	slog.Info("beginning wait for resources to be deleted", "count", len(deleted), "timeout", w.timeout)
+	slog.Debug("beginning wait for resources to be deleted", "count", len(deleted), "timeout", w.timeout)
 
 	startTime := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -120,7 +120,7 @@ func (w *waiter) waitForDeletedResources(deleted ResourceList) error {
 
 	elapsed := time.Since(startTime).Round(time.Second)
 	if err != nil {
-		slog.Debug("wait for resources failed", "elapsed", elapsed, "error", err)
+		slog.Debug("wait for resources failed", "elapsed", elapsed, slog.Any("error", err))
 	} else {
 		slog.Debug("wait for resources succeeded", "elapsed", elapsed)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is the version of https://github.com/helm/helm/pull/30689 (merged) but for main/helm-v4. As started in https://github.com/helm/helm/pull/30603, @robertsirc is migrating log to slog. I migrated this function to use slog and added debug reporting. Now, it logs how long we wait for resources to be ready. This helps us better understand how much of the helm upgrade time is due to waiting for resources.

I could change the remaning part in the file but I am not sure what are expected in terms of log level

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
