### PR TITLE
Error when failed repo update.

### DIFF
--- a/pkg/cmd/repo_update_test.go
+++ b/pkg/cmd/repo_update_test.go
@@ -34,7 +34,7 @@ func TestUpdateCmd(t *testing.T) {
 	var out bytes.Buffer
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer, _ bool) error {
+	updater := func(repos []*repo.ChartRepository, out io.Writer) error {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
@@ -59,7 +59,7 @@ func TestUpdateCmdMultiple(t *testing.T) {
 	var out bytes.Buffer
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer, _ bool) error {
+	updater := func(repos []*repo.ChartRepository, out io.Writer) error {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
@@ -85,7 +85,7 @@ func TestUpdateCmdInvalid(t *testing.T) {
 	var out bytes.Buffer
 	// Instead of using the HTTP updater, we provide our own for this test.
 	// The TestUpdateCharts test verifies the HTTP behavior independently.
-	updater := func(repos []*repo.ChartRepository, out io.Writer, _ bool) error {
+	updater := func(repos []*repo.ChartRepository, out io.Writer) error {
 		for _, re := range repos {
 			fmt.Fprintln(out, re.Config.Name)
 		}
@@ -145,7 +145,7 @@ func TestUpdateCharts(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	updateCharts([]*repo.ChartRepository{r}, b, false)
+	updateCharts([]*repo.ChartRepository{r}, b)
 
 	got := b.String()
 	if strings.Contains(got, "Unable to get an update") {
@@ -159,39 +159,6 @@ func TestUpdateCharts(t *testing.T) {
 func TestRepoUpdateFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "repo update", false)
 	checkFileCompletion(t, "repo update repo1", false)
-}
-
-func TestUpdateChartsFail(t *testing.T) {
-	defer resetEnv()()
-	ensure.HelmHome(t)
-
-	ts := repotest.NewTempServer(
-		t,
-		repotest.WithChartSourceGlob("testdata/testserver/*.*"),
-	)
-	defer ts.Stop()
-
-	var invalidURL = ts.URL() + "55"
-	r, err := repo.NewChartRepository(&repo.Entry{
-		Name: "charts",
-		URL:  invalidURL,
-	}, getter.All(settings))
-	if err != nil {
-		t.Error(err)
-	}
-
-	b := bytes.NewBuffer(nil)
-	if err := updateCharts([]*repo.ChartRepository{r}, b, false); err != nil {
-		t.Error("Repo update should not return error if update of repository fails")
-	}
-
-	got := b.String()
-	if !strings.Contains(got, "Unable to get an update") {
-		t.Errorf("Repo should have failed update but instead got: %q", got)
-	}
-	if !strings.Contains(got, "Update Complete.") {
-		t.Error("Update was not successful")
-	}
 }
 
 func TestUpdateChartsFailWithError(t *testing.T) {
@@ -214,7 +181,7 @@ func TestUpdateChartsFailWithError(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	err = updateCharts([]*repo.ChartRepository{r}, b, true)
+	err = updateCharts([]*repo.ChartRepository{r}, b)
 	if err == nil {
 		t.Error("Repo update should return error because update of repository fails and 'fail-on-repo-update-fail' flag set")
 		return


### PR DESCRIPTION
In Helm v3 we did not change exit codes for existing commands to maintain compat. A flag was introduced so a failure would result in a non-0 exit code. A note was left to make this the default in Helm v4. That's what this change does.

Closes #10016

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
