### PR TITLE
updates mutate and validate web hook configs

### DIFF
--- a/pkg/release/util/kind_sorter.go
+++ b/pkg/release/util/kind_sorter.go
@@ -64,18 +64,18 @@ var InstallOrder KindSortOrder = []string{
 	"CronJob",
 	"IngressClass",
 	"Ingress",
-	"APIService",
 	"MutatingWebhookConfiguration",
 	"ValidatingWebhookConfiguration",
+	"APIService",
 }
 
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
 //
 // Those occurring earlier in the list get uninstalled before those occurring later in the list.
 var UninstallOrder KindSortOrder = []string{
+	"APIService",
 	"ValidatingWebhookConfiguration",
 	"MutatingWebhookConfiguration",
-	"APIService",
 	"Ingress",
 	"IngressClass",
 	"Service",

--- a/pkg/release/util/kind_sorter.go
+++ b/pkg/release/util/kind_sorter.go
@@ -64,18 +64,19 @@ var InstallOrder KindSortOrder = []string{
 	"CronJob",
 	"IngressClass",
 	"Ingress",
+	"APIService",
 	"MutatingWebhookConfiguration",
 	"ValidatingWebhookConfiguration",
-	"APIService",
 }
 
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
 //
 // Those occurring earlier in the list get uninstalled before those occurring later in the list.
 var UninstallOrder KindSortOrder = []string{
-	"APIService",
+	// For uninstall, we remove validation before mutation to ensure webhooks don't block removal
 	"ValidatingWebhookConfiguration",
 	"MutatingWebhookConfiguration",
+	"APIService",
 	"Ingress",
 	"IngressClass",
 	"Service",

--- a/pkg/release/util/kind_sorter.go
+++ b/pkg/release/util/kind_sorter.go
@@ -65,12 +65,16 @@ var InstallOrder KindSortOrder = []string{
 	"IngressClass",
 	"Ingress",
 	"APIService",
+	"MutatingWebhookConfiguration",
+	"ValidatingWebhookConfiguration",
 }
 
 // UninstallOrder is the order in which manifests should be uninstalled (by Kind).
 //
 // Those occurring earlier in the list get uninstalled before those occurring later in the list.
 var UninstallOrder KindSortOrder = []string{
+	"ValidatingWebhookConfiguration",
+	"MutatingWebhookConfiguration",
 	"APIService",
 	"Ingress",
 	"IngressClass",

--- a/pkg/release/util/kind_sorter_test.go
+++ b/pkg/release/util/kind_sorter_test.go
@@ -173,6 +173,14 @@ func TestKindSorter(t *testing.T) {
 			Name: "F",
 			Head: &SimpleHead{Kind: "PriorityClass"},
 		},
+		{
+			Name: "M",
+			Head: &SimpleHead{Kind: "MutatingWebhookConfiguration"},
+		},
+		{
+			Name: "V",
+			Head: &SimpleHead{Kind: "ValidatingWebhookConfiguration"},
+		},
 	}
 
 	for _, test := range []struct {
@@ -180,8 +188,8 @@ func TestKindSorter(t *testing.T) {
 		order       KindSortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvw!"},
-		{"uninstall", UninstallOrder, "wvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
+		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvwMV!"},
+		{"uninstall", UninstallOrder, "VMwvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {

--- a/pkg/release/util/kind_sorter_test.go
+++ b/pkg/release/util/kind_sorter_test.go
@@ -188,8 +188,8 @@ func TestKindSorter(t *testing.T) {
 		order       KindSortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvwMV!"},
-		{"uninstall", UninstallOrder, "VMwvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
+		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvMVw!"},
+		{"uninstall", UninstallOrder, "wVMvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {

--- a/pkg/release/util/kind_sorter_test.go
+++ b/pkg/release/util/kind_sorter_test.go
@@ -188,8 +188,8 @@ func TestKindSorter(t *testing.T) {
 		order       KindSortOrder
 		expected    string
 	}{
-		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvMVw!"},
-		{"uninstall", UninstallOrder, "wVMvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
+		{"install", InstallOrder, "FaAbcC3deEf1gh2iIjJkKlLmnopqrxstuUvwMV!"},
+		{"uninstall", UninstallOrder, "VMwvUmutsxrqponLlKkJjIi2hg1fEed3CcbAaF!"},
 	} {
 		var buf bytes.Buffer
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` to the Helm installation and uninstallation order. These resources are placed at the end of the installation order (after APIService) and at the beginning of the uninstallation order, which matches the expected behavior that webhook configurations should be installed after workloads like deployments and pods.

This addresses issue #30617 which requested clarification on the installation order of these Kubernetes resources. While the original issue requested documentation updates, these webhooks weren't explicitly included in the code. 

Scott note:
fixes #5642

By adding them we get the following:
- webhooks are installed after workloads, preventing potential interference
- provide predictable installation/uninstallation behavior
- enable accurate documentation of an intentional ordering rather than implicit behavior

**Special notes**:

This change only affects the ordering of resources during installation and uninstallation. The existing tests have been updated to account for these additions, and all tests pass.

**If applicable**:

[x] this PR contains user facing changes (the docs needed label should be applied if so)
[x] this PR contains unit tests
[ ] this PR has been tested for backwards compatibility ( not sure )

Note: After this PR is merged, a follow-up PR to the helm-www repository will be needed to update the installation guide documentation to reflect these changes.
