### PR TITLE
cleanup: Remove Helm v2 template lint rules

### DIFF
--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -37,11 +36,6 @@ import (
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/engine"
 	"helm.sh/helm/v4/pkg/lint/support"
-)
-
-var (
-	crdHookSearch     = regexp.MustCompile(`"?helm\.sh/hook"?:\s+crd-install`)
-	releaseTimeSearch = regexp.MustCompile(`\.Release\.Time`)
 )
 
 // Templates lints the templates in the Linter.
@@ -119,14 +113,10 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 	- Metadata.Namespace is not set
 	*/
 	for _, template := range chart.Templates {
-		fileName, data := template.Name, template.Data
+		fileName := template.Name
 		fpath = fileName
 
 		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
-		// These are v3 specific checks to make sure and warn people if their
-		// chart is not compatible with v3
-		linter.RunLinterRule(support.WarningSev, fpath, validateNoCRDHooks(data))
-		linter.RunLinterRule(support.ErrorSev, fpath, validateNoReleaseTime(data))
 
 		// We only apply the following lint rules to yaml files
 		if filepath.Ext(fileName) != ".yaml" || filepath.Ext(fileName) == ".yml" {
@@ -289,20 +279,6 @@ func validateMetadataNameFunc(obj *K8sYamlStruct) validation.ValidateNameFunc {
 	default:
 		return validation.NameIsDNSSubdomain
 	}
-}
-
-func validateNoCRDHooks(manifest []byte) error {
-	if crdHookSearch.Match(manifest) {
-		return errors.New("manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart")
-	}
-	return nil
-}
-
-func validateNoReleaseTime(manifest []byte) error {
-	if releaseTimeSearch.Match(manifest) {
-		return errors.New(".Release.Time has been removed in v3, please replace with the `now` function in your templates")
-	}
-	return nil
 }
 
 // validateMatchSelector ensures that template specs have a selector declared.

--- a/pkg/lint/rules/template_test.go
+++ b/pkg/lint/rules/template_test.go
@@ -85,26 +85,6 @@ func TestTemplateIntegrationHappyPath(t *testing.T) {
 	}
 }
 
-func TestV3Fail(t *testing.T) {
-	linter := support.Linter{ChartDir: "./testdata/v3-fail"}
-	Templates(&linter, values, namespace, strict)
-	res := linter.Messages
-
-	if len(res) != 3 {
-		t.Fatalf("Expected 3 errors, got %d, %v", len(res), res)
-	}
-
-	if !strings.Contains(res[0].Err.Error(), ".Release.Time has been removed in v3") {
-		t.Errorf("Unexpected error: %s", res[0].Err)
-	}
-	if !strings.Contains(res[1].Err.Error(), "manifest is a crd-install hook") {
-		t.Errorf("Unexpected error: %s", res[1].Err)
-	}
-	if !strings.Contains(res[2].Err.Error(), "manifest is a crd-install hook") {
-		t.Errorf("Unexpected error: %s", res[2].Err)
-	}
-}
-
 func TestMultiTemplateFail(t *testing.T) {
 	linter := support.Linter{ChartDir: "./testdata/multi-template-fail"}
 	Templates(&linter, values, namespace, strict)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Remove a couple of lint rules which are specific to Helm v2 -> v3 (Helm v4 should no longer need to validate charts are compatible with v3)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
