### PR TITLE
Allow signing multiple charts with a single passphrase from stdin.

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -39,6 +39,7 @@ type Package struct {
 	Key              string
 	Keyring          string
 	PassphraseFile   string
+	cachedPassphrase []byte
 	Version          string
 	AppVersion       string
 	Destination      string
@@ -54,6 +55,10 @@ type Package struct {
 	CaFile                string
 	InsecureSkipTLSverify bool
 }
+
+const (
+	passPhraseFileStdin = "-"
+)
 
 // NewPackage creates a new Package object with the given configuration.
 func NewPackage() *Package {
@@ -128,7 +133,7 @@ func (p *Package) Clearsign(filename string) error {
 
 	passphraseFetcher := promptUser
 	if p.PassphraseFile != "" {
-		passphraseFetcher, err = passphraseFileFetcher(p.PassphraseFile, os.Stdin)
+		passphraseFetcher, err = p.passphraseFileFetcher(p.PassphraseFile, os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -156,25 +161,42 @@ func promptUser(name string) ([]byte, error) {
 	return pw, err
 }
 
-func passphraseFileFetcher(passphraseFile string, stdin *os.File) (provenance.PassphraseFetcher, error) {
-	file, err := openPassphraseFile(passphraseFile, stdin)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
+func (p *Package) passphraseFileFetcher(passphraseFile string, stdin *os.File) (provenance.PassphraseFetcher, error) {
+	// When reading from stdin we cache the passphrase here. If we are
+	// packaging multiple charts, we reuse the cached passphrase. This
+	// allows giving the passphrase once on stdin without failing with
+	// complaints about stdin already being closed.
+	//
+	// An alternative to this would be to omit file.Close() for stdin
+	// below and require the user to provide the same passphrase once
+	// per chart on stdin, but that does not seem very user-friendly.
 
-	reader := bufio.NewReader(file)
-	passphrase, _, err := reader.ReadLine()
-	if err != nil {
-		return nil, err
+	if p.cachedPassphrase == nil {
+		file, err := openPassphraseFile(passphraseFile, stdin)
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+
+		reader := bufio.NewReader(file)
+		passphrase, _, err := reader.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		p.cachedPassphrase = passphrase
+
+		return func(_ string) ([]byte, error) {
+			return passphrase, nil
+		}, nil
 	}
+
 	return func(_ string) ([]byte, error) {
-		return passphrase, nil
+		return p.cachedPassphrase, nil
 	}, nil
 }
 
 func openPassphraseFile(passphraseFile string, stdin *os.File) (*os.File, error) {
-	if passphraseFile == "-" {
+	if passphraseFile == passPhraseFileStdin {
 		stat, err := stdin.Stat()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

When packaging and signing multiple charts, cache the read passphrase from stdin to avoid the second and later charts failing with an error about stdin already being closed.

closes #30717 

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility