### PR TITLE
Add detailed debug logging for resource readiness states

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -240,6 +240,7 @@ func (c *ReadyChecker) jobReady(job *batchv1.Job) (bool, error) {
 		slog.Debug("Job is not completed", "namespace", job.GetNamespace(), "name", job.GetName())
 		return false, nil
 	}
+	slog.Debug("Job is completed", "namespace", job.GetNamespace(), "name", job.GetName())
 	return true, nil
 }
 
@@ -268,7 +269,7 @@ func (c *ReadyChecker) serviceReady(s *corev1.Service) bool {
 			return false
 		}
 	}
-
+	slog.Debug("Service is ready", "namespace", s.GetNamespace(), "name", s.GetName(), "clusterIP", s.Spec.ClusterIP, "externalIPs", s.Spec.ExternalIPs)
 	return true
 }
 
@@ -277,6 +278,7 @@ func (c *ReadyChecker) volumeReady(v *corev1.PersistentVolumeClaim) bool {
 		slog.Debug("PersistentVolumeClaim is not bound", "namespace", v.GetNamespace(), "name", v.GetName())
 		return false
 	}
+	slog.Debug("PersistentVolumeClaim is bound", "namespace", v.GetNamespace(), "name", v.GetName(), "phase", v.Status.Phase)
 	return true
 }
 
@@ -296,6 +298,7 @@ func (c *ReadyChecker) deploymentReady(rs *appsv1.ReplicaSet, dep *appsv1.Deploy
 		slog.Debug("Deployment does not have enough pods ready", "namespace", dep.GetNamespace(), "name", dep.GetName(), "readyPods", rs.Status.ReadyReplicas, "totalPods", expectedReady)
 		return false
 	}
+	slog.Debug("Deployment is ready", "namespace", dep.GetNamespace(), "name", dep.GetName(), "readyPods", rs.Status.ReadyReplicas, "totalPods", expectedReady)
 	return true
 }
 
@@ -329,6 +332,7 @@ func (c *ReadyChecker) daemonSetReady(ds *appsv1.DaemonSet) bool {
 		slog.Debug("DaemonSet does not have enough Pods ready", "namespace", ds.GetNamespace(), "name", ds.GetName(), "readyPods", ds.Status.NumberReady, "totalPods", expectedReady)
 		return false
 	}
+	slog.Debug("DaemonSet is ready", "namespace", ds.GetNamespace(), "name", ds.GetName(), "readyPods", ds.Status.NumberReady, "totalPods", expectedReady)
 	return true
 }
 
@@ -425,7 +429,6 @@ func (c *ReadyChecker) statefulSetReady(sts *appsv1.StatefulSet) bool {
 		slog.Debug("StatefulSet is not ready, currentRevision does not match updateRevision", "namespace", sts.GetNamespace(), "name", sts.GetName(), "currentRevision", sts.Status.CurrentRevision, "updateRevision", sts.Status.UpdateRevision)
 		return false
 	}
-
 	slog.Debug("StatefulSet is ready", "namespace", sts.GetNamespace(), "name", sts.GetName(), "readyPods", sts.Status.ReadyReplicas, "totalPods", replicas)
 	return true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

We are consuming debug logs on our project based on the helm SDK. We would like to add even more logs when resources like deployments and jobs are ready. At the moment there is a difference between statefullsets and deployments for example.

```
Deployment is not ready: l-app-staging/g-station-staging-lfapp-web. 1 out of 2 expected pods are ready
Deployment is not ready: l-app-staging/g-station-staging-lfapp-web. 1 out of 2 expected pods are ready
StatefulSet is ready: l-app-staging/g-station-staging-rediscache-master. 1 out of 1 expected pods are ready
StatefulSet is ready: l-app-staging/g-station-staging-redis-master. 1 out of 1 expected pods are ready
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
