### PR TITLE
Allow using a different value for the app.kubernetes.io/managed-by label

### DIFF
--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -32,10 +32,13 @@ var accessor = meta.NewAccessor()
 
 const (
 	appManagedByLabel              = "app.kubernetes.io/managed-by"
-	appManagedByHelm               = "Helm"
 	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
+
+// AppManagedByLabel is the value Helm should use in the app.kubernetes.io/managed-by label to
+// identify resources it manages. Defaults to "Helm", but can be overridden via this variable.
+var AppManagedByValue = "Helm"
 
 // requireAdoption returns the subset of resources that already exist in the cluster.
 func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
@@ -102,7 +105,7 @@ func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) er
 	}
 
 	var errs []error
-	if err := requireValue(lbls, appManagedByLabel, appManagedByHelm); err != nil {
+	if err := requireValue(lbls, appManagedByLabel, AppManagedByValue); err != nil {
 		errs = append(errs, fmt.Errorf("label validation error: %s", err))
 	}
 	if err := requireValue(annos, helmReleaseNameAnnotation, releaseName); err != nil {
@@ -150,7 +153,7 @@ func setMetadataVisitor(releaseName, releaseNamespace string, force bool) resour
 		}
 
 		if err := mergeLabels(info.Object, map[string]string{
-			appManagedByLabel: appManagedByHelm,
+			appManagedByLabel: AppManagedByValue,
 		}); err != nil {
 			return fmt.Errorf(
 				"%s labels could not be updated: %s",

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -139,7 +139,7 @@ func TestExistingResourceConflict(t *testing.T) {
 		releaseName      = "rel-name"
 		releaseNamespace = "rel-namespace"
 		labels           = map[string]string{
-			appManagedByLabel: appManagedByHelm,
+			appManagedByLabel: AppManagedByValue,
 		}
 		annotations = map[string]string{
 			helmReleaseNameAnnotation:      releaseName,
@@ -172,7 +172,7 @@ func TestCheckOwnership(t *testing.T) {
 
 	// Set managed by label and verify annotation error message
 	_ = accessor.SetLabels(deployFoo.Object, map[string]string{
-		appManagedByLabel: appManagedByHelm,
+		appManagedByLabel: AppManagedByValue,
 	})
 	err = checkOwnership(deployFoo.Object, "rel-a", "ns-a")
 	assert.EqualError(t, err, `invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "rel-a"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "ns-a"`)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows custom operators using the Helm SDK to override the default `app.kubernetes.io/managed-by: Helm` label value. If an operator uses Helm to deploy resources, the resources are not managed by Helm but by the operator, so it would be great if this fact could be represented in the `managed-by` label. Without this feature, the operator would have to introduce another `managed-by` label, which could be confusing.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
