### PR TITLE
Updates coalesce.go to use log/slog and update tests to pass

### DIFF
--- a/internal/logging/test/capture_handler.go
+++ b/internal/logging/test/capture_handler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package test
 
 import (
 	"context"

--- a/pkg/chart/v2/util/coalesce.go
+++ b/pkg/chart/v2/util/coalesce.go
@@ -87,8 +87,6 @@ func copyValues(vals map[string]interface{}) (Values, error) {
 	return valsCopy, nil
 }
 
-type printFn func(format string, v ...interface{})
-
 // coalesce coalesces the dest values and the chart values, giving priority to the dest values.
 //
 // This is a helper function for CoalesceValues and MergeValues.

--- a/pkg/chart/v2/util/coalesce.go
+++ b/pkg/chart/v2/util/coalesce.go
@@ -214,7 +214,7 @@ func coalesceValues(c *chart.Chart, v map[string]interface{}, prefix string, mer
 			// c.Values has a map[string]interface{} structure. If the copy of
 			// it cannot be treated as map[string]interface{} there is something
 			// strangely wrong. Log it and use c.Values
-			slog.Warn(fmt.Sprintf("warning: unable to convert values copy to values type"))
+			slog.Warn("warning: unable to convert values copy to values type")
 			vc = c.Values
 		}
 	}
@@ -293,12 +293,13 @@ func coalesceTablesFullKey(dst, src map[string]interface{}, prefix string, merge
 			dst[key] = val
 		} else if istable(val) {
 			if istable(dv) {
+				slog.Warn("testing")
 				coalesceTablesFullKey(dv.(map[string]interface{}), val.(map[string]interface{}), fullkey, merge)
 			} else {
-				slog.Warn(fmt.Sprintf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val))
+				slog.Warn(fmt.Sprintf("cannot overwrite table with non table for %s (%v)", fullkey, val))
 			}
 		} else if istable(dv) && val != nil {
-			slog.Warn(fmt.Sprintf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val))
+			slog.Warn(fmt.Sprintf("destination for %s is a table. Ignoring non-table value (%v)", fullkey, val))
 		}
 	}
 	return dst

--- a/pkg/chart/v2/util/coalesce_test.go
+++ b/pkg/chart/v2/util/coalesce_test.go
@@ -722,7 +722,6 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	// All warnings should have context as to where the warning is being emitted
 	capturedLogOutput.Filter(capture_handler.RecordLevelMatches(slog.LevelWarn)).
 		AssertThat(t).
-		HasAttr("chart").
 		HasAttr("error").
 		HasAttr("key")
 
@@ -739,7 +738,6 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
-		HasAttrValueString("chart", "level3").
 		HasAttrValueString("error", "cannot merge table and non-table values")
 
 	capturedLogOutput.Filter(capture_handler.RecordMessageMatches("skipping key")).
@@ -747,7 +745,6 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
-		HasAttrValueString("chart", "level3").
 		HasAttrValueString("error", "cannot merge table and non-table values")
 
 	// Reset and set the default logger back to its original state
@@ -803,7 +800,6 @@ func TestCoalesceValuesTopLevelGlobalsWarningsSrc(t *testing.T) {
 	// All warnings should have context as to where the warning is being emitted
 	capturedLogOutput.Filter(capture_handler.RecordLevelMatches(slog.LevelWarn)).
 		AssertThat(t).
-		HasAttr("chart").
 		HasAttr("error").
 		HasAttr("key")
 
@@ -811,7 +807,6 @@ func TestCoalesceValuesTopLevelGlobalsWarningsSrc(t *testing.T) {
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
-		HasAttrValueString("chart", "level1").
 		HasAttrValueString("key", "global")
 
 	// Reset and set the default logger back to its original state

--- a/pkg/chart/v2/util/coalesce_test.go
+++ b/pkg/chart/v2/util/coalesce_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	capture_handler "helm.sh/helm/v4/internal/logging/test"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 )
 
@@ -704,7 +705,7 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 
 	// Get all logs emitted from slog
 	defaultLogger := slog.Default()
-	handler := NewLogCaptureHandler(nil)
+	handler := capture_handler.NewLogCaptureHandler(nil)
 	slog.SetDefault(slog.New(handler))
 
 	_, err := coalesce(c, vals, "", false)
@@ -719,30 +720,30 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	t.Logf("logs: %s", capturedLogOutput.String())
 
 	// All warnings should have context as to where the warning is being emitted
-	capturedLogOutput.Filter(RecordLevelMatches(slog.LevelWarn)).
+	capturedLogOutput.Filter(capture_handler.RecordLevelMatches(slog.LevelWarn)).
 		AssertThat(t).
 		HasAttr("chart").
 		HasAttr("error").
 		HasAttr("key")
 
-	capturedLogOutput.Filter(RecordMessageMatches("skipping key")).
-		Filter(RecordHasAttrValue("key", "level1.level2.level3.boat")).
+	capturedLogOutput.Filter(capture_handler.RecordMessageMatches("skipping key")).
+		Filter(capture_handler.RecordHasAttrValue("key", "level1.level2.level3.boat")).
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
 		HasAttrValueString("chart", "level3").
 		HasAttrValueString("error", "cannot merge table and non-table values")
 
-	capturedLogOutput.Filter(RecordMessageMatches("skipping key")).
-		Filter(RecordHasAttrValue("key", "level1.level2.level3.spear.tip")).
+	capturedLogOutput.Filter(capture_handler.RecordMessageMatches("skipping key")).
+		Filter(capture_handler.RecordHasAttrValue("key", "level1.level2.level3.spear.tip")).
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
 		HasAttrValueString("chart", "level3").
 		HasAttrValueString("error", "cannot merge table and non-table values")
 
-	capturedLogOutput.Filter(RecordMessageMatches("skipping key")).
-		Filter(RecordHasAttrValue("key", "level1.level2.level3.spear.sail")).
+	capturedLogOutput.Filter(capture_handler.RecordMessageMatches("skipping key")).
+		Filter(capture_handler.RecordHasAttrValue("key", "level1.level2.level3.spear.sail")).
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).
@@ -785,7 +786,7 @@ func TestCoalesceValuesTopLevelGlobalsWarningsSrc(t *testing.T) {
 
 	// Get all logs emitted from slog
 	defaultLogger := slog.Default()
-	handler := NewLogCaptureHandler(nil)
+	handler := capture_handler.NewLogCaptureHandler(nil)
 	slog.SetDefault(slog.New(handler))
 
 	_, err := coalesce(c, vals, "", false)
@@ -800,13 +801,13 @@ func TestCoalesceValuesTopLevelGlobalsWarningsSrc(t *testing.T) {
 	t.Logf("logs: %s", capturedLogOutput.String())
 
 	// All warnings should have context as to where the warning is being emitted
-	capturedLogOutput.Filter(RecordLevelMatches(slog.LevelWarn)).
+	capturedLogOutput.Filter(capture_handler.RecordLevelMatches(slog.LevelWarn)).
 		AssertThat(t).
 		HasAttr("chart").
 		HasAttr("error").
 		HasAttr("key")
 
-	capturedLogOutput.Filter(RecordMessageMatches("skipping coalescing global values")).
+	capturedLogOutput.Filter(capture_handler.RecordMessageMatches("skipping coalescing global values")).
 		AssertThat(t).
 		MatchesExactly(1).
 		AtLevel(slog.LevelWarn).

--- a/pkg/chart/v2/util/utilities_test.go
+++ b/pkg/chart/v2/util/utilities_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// A simple handler to record the log messages emitted by slog.
+// Intended to be used only by tests
+type LogCaptureHandler struct {
+	mu      *sync.Mutex
+	records []slog.Record
+	opts    slog.HandlerOptions
+}
+
+type LogCaptureSlice []slog.Record
+
+func NewLogCaptureHandler(opts *slog.HandlerOptions) *LogCaptureHandler {
+	if opts == nil {
+		opts = &slog.HandlerOptions{}
+	}
+	return &LogCaptureHandler{
+		mu:   &sync.Mutex{},
+		opts: *opts,
+	}
+}
+
+func (h *LogCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	// Handle all levels
+	return true
+}
+
+func (h *LogCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+// This is intentionally not following "standard" usage of WithAttrs and WithGroup with regard
+// to handlers since we want to be able to capture all messages emitted from slog sources rather
+// than each sub-logger generating its own slice of records
+func (h *LogCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &LogCaptureHandler{
+		// Copy the mutex as we could be writing to the same records from multiple threads
+		mu: h.mu,
+		opts: slog.HandlerOptions{
+			Level:       h.opts.Level,
+			AddSource:   h.opts.AddSource,
+			ReplaceAttr: h.opts.ReplaceAttr,
+		},
+
+		// Copy the same records as we want to be able to collate _all_ the log messages
+		// emitted by slog sources
+		records: h.records,
+	}
+}
+
+// See comment on WithAttrs regarding reusing the mutex + records slice
+func (h *LogCaptureHandler) WithGroup(name string) slog.Handler {
+	return &LogCaptureHandler{
+		mu: h.mu,
+		opts: slog.HandlerOptions{
+			Level:       h.opts.Level,
+			AddSource:   h.opts.AddSource,
+			ReplaceAttr: h.opts.ReplaceAttr,
+		},
+
+		// Copy the same records as we want to be able to collate _all_ the log messages
+		// emitted by slog sources
+		records: h.records,
+	}
+}
+
+// Records returns a copy of the captured log records
+func (h *LogCaptureHandler) Records() *LogCaptureSlice {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	records := make([]slog.Record, len(h.records))
+	copy(records, h.records)
+
+	result := LogCaptureSlice(records)
+	return &result
+}
+
+// Converts the captured log records into a map of log message and log level
+func (l *LogCaptureSlice) AsMessageLevelMap() map[string]slog.Level {
+
+	result := make(map[string]slog.Level)
+	for _, record := range *l {
+		result[record.Message] = record.Level
+	}
+
+	return result
+}
+
+// Converts the captured log records into a slice of log messages
+func (l *LogCaptureSlice) AsMessageSlice() []string {
+
+	result := make([]string, 0)
+	for _, record := range *l {
+		result = append(result, record.Message)
+	}
+
+	return result
+}
+
+// Reset clears the captured log messages.
+func (h *LogCaptureHandler) Reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = make([]slog.Record, 0)
+}

--- a/pkg/chart/v2/util/utilities_test.go
+++ b/pkg/chart/v2/util/utilities_test.go
@@ -19,26 +19,59 @@ package util
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // A simple handler to record the log messages emitted by slog.
 // Intended to be used only by tests
 type LogCaptureHandler struct {
-	mu      *sync.Mutex
-	records []slog.Record
-	opts    slog.HandlerOptions
+	mu           *sync.Mutex
+	records      *[]slog.Record
+	opts         slog.HandlerOptions
+	handlerAttrs []slog.Attr
 }
 
-type LogCaptureSlice []slog.Record
+type LogCaptureRecord struct {
+	record slog.Record
+	attrs  []slog.Attr
+}
+
+// Clones the record and associated attributes
+func (l *LogCaptureRecord) Clone() LogCaptureRecord {
+	copyAttrs := make([]slog.Attr, len(l.attrs))
+	copy(copyAttrs, l.attrs)
+	return LogCaptureRecord{
+		record: l.record.Clone(),
+		attrs:  copyAttrs,
+	}
+}
+
+// A point in time capture of the logs emitted by slog
+type LogCaptureSlice struct {
+	records []LogCaptureRecord
+}
+
+// Build assertions based off the captured/filtered slice of records
+type LogCaptureSliceAssertionBuilder struct {
+	t *testing.T
+	l *LogCaptureSlice
+}
 
 func NewLogCaptureHandler(opts *slog.HandlerOptions) *LogCaptureHandler {
 	if opts == nil {
 		opts = &slog.HandlerOptions{}
 	}
+
+	records := make([]slog.Record, 0)
 	return &LogCaptureHandler{
-		mu:   &sync.Mutex{},
-		opts: *opts,
+		mu:           &sync.Mutex{},
+		records:      &records,
+		opts:         *opts,
+		handlerAttrs: make([]slog.Attr, 0),
 	}
 }
 
@@ -47,10 +80,14 @@ func (h *LogCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool {
 	return true
 }
 
+// Handle logs emitted by slog and capture
 func (h *LogCaptureHandler) Handle(_ context.Context, r slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.records = append(h.records, r)
+
+	r.AddAttrs(h.handlerAttrs...)
+	*h.records = append(*h.records, r)
+
 	return nil
 }
 
@@ -69,12 +106,14 @@ func (h *LogCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 		// Copy the same records as we want to be able to collate _all_ the log messages
 		// emitted by slog sources
-		records: h.records,
+		records:      h.records,
+		handlerAttrs: append(h.handlerAttrs, attrs...),
 	}
 }
 
 // See comment on WithAttrs regarding reusing the mutex + records slice
-func (h *LogCaptureHandler) WithGroup(name string) slog.Handler {
+// WithGroup is fairly unsupported in this right now as its not used in the codebase
+func (h *LogCaptureHandler) WithGroup(_ string) slog.Handler {
 	return &LogCaptureHandler{
 		mu: h.mu,
 		opts: slog.HandlerOptions{
@@ -89,43 +128,158 @@ func (h *LogCaptureHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-// Records returns a copy of the captured log records
-func (h *LogCaptureHandler) Records() *LogCaptureSlice {
+// Capture returns a point in time copy of the captured log records
+func (h *LogCaptureHandler) Capture() *LogCaptureSlice {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	records := make([]slog.Record, len(h.records))
-	copy(records, h.records)
+	result := LogCaptureSlice{
+		records: make([]LogCaptureRecord, 0),
+	}
+	for _, record := range *h.records {
+		l := LogCaptureRecord{}
+		l.record = record.Clone()
+		l.record.Attrs(func(a slog.Attr) bool {
+			if a.Key != "" {
+				l.attrs = append(l.attrs, a)
+			}
+			return true
+		})
 
-	result := LogCaptureSlice(records)
+		result.records = append(result.records, l)
+	}
 	return &result
 }
 
-// Converts the captured log records into a map of log message and log level
-func (l *LogCaptureSlice) AsMessageLevelMap() map[string]slog.Level {
-
-	result := make(map[string]slog.Level)
-	for _, record := range *l {
-		result[record.Message] = record.Level
+func (c *LogCaptureSlice) Filter(filterFn func(r *LogCaptureRecord) bool) *LogCaptureSlice {
+	result := LogCaptureSlice{
+		records: make([]LogCaptureRecord, 0),
 	}
 
-	return result
+	for _, record := range c.records {
+		if filterFn(&record) {
+			result.records = append(result.records, record.Clone())
+		}
+	}
+
+	return &result
 }
 
-// Converts the captured log records into a slice of log messages
-func (l *LogCaptureSlice) AsMessageSlice() []string {
-
-	result := make([]string, 0)
-	for _, record := range *l {
-		result = append(result, record.Message)
+func RecordMessageMatches(message string) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Message == message
 	}
+}
 
-	return result
+func RecordMessageContains(substring string) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return strings.Contains(r.record.Message, substring)
+	}
+}
+
+func RecordLevelMatches(level slog.Level) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Level == level
+	}
+}
+
+func RecordLevelAboveEqual(level slog.Level) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Level >= level
+	}
+}
+
+func RecordLevelAbove(level slog.Level) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Level > level
+	}
+}
+
+func RecordLevelBelowEqual(level slog.Level) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Level <= level
+	}
+}
+
+func RecordLevelBelow(level slog.Level) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		return r.record.Level < level
+	}
+}
+
+// Start an assertion builder for test validation
+func (c *LogCaptureSlice) AssertThat(t *testing.T) *LogCaptureSliceAssertionBuilder {
+	return &LogCaptureSliceAssertionBuilder{
+		t: t,
+		l: c,
+	}
 }
 
 // Reset clears the captured log messages.
 func (h *LogCaptureHandler) Reset() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.records = make([]slog.Record, 0)
+
+	records := make([]slog.Record, 0)
+
+	h.records = &records
+}
+
+// Asserts that the log capture contains exactly the number of records specified
+func (b *LogCaptureSliceAssertionBuilder) MatchesExactly(count int) *LogCaptureSliceAssertionBuilder {
+	assert.Len(b.t, b.l.records, count, "number of records must match exactly %d record, but is %d", count, len(b.l.records))
+	return b
+}
+
+// Asserts that all log records at at a specific level
+func (b *LogCaptureSliceAssertionBuilder) AtLevel(level slog.Level) *LogCaptureSliceAssertionBuilder {
+	if len(b.l.records) == 0 {
+		assert.Fail(b.t, "expecting records to match level but there were no records to match")
+	}
+
+	for _, record := range b.l.records {
+		assert.True(b.t, record.record.Level == level, "record '%s' does not match the expected level. Was %d expected %d", record.record.Message, record.record.Level, level)
+	}
+
+	return b
+}
+
+func (b *LogCaptureSliceAssertionBuilder) HasAttr(key string) *LogCaptureSliceAssertionBuilder {
+	if len(b.l.records) == 0 {
+		assert.Fail(b.t, "expecting records to test for attributes but there were no records to match")
+	}
+
+	for _, record := range b.l.records {
+
+		hasAttr := false
+		for _, attr := range record.attrs {
+			if attr.Key == key {
+				hasAttr = true
+			}
+		}
+
+		assert.True(b.t, hasAttr, "record '%s' does not contain the attribute key '%s'", record.record.Message, key)
+	}
+
+	return b
+}
+
+func (b *LogCaptureSliceAssertionBuilder) HasAttrValueString(key string, value string) *LogCaptureSliceAssertionBuilder {
+	if len(b.l.records) == 0 {
+		assert.Fail(b.t, "expecting records to test for attributes but there were no records to match")
+	}
+
+	for _, record := range b.l.records {
+		hasAttr := false
+		for _, attr := range record.attrs {
+			if attr.Key == key {
+				hasAttr = true
+				assert.True(b.t, attr.Value.String() == value, "record '%s', attribute '%s' expected value '%s' but got '%s'", record.record.Message, key, value, attr.Value.String())
+			}
+		}
+
+		assert.True(b.t, hasAttr, "record '%s' does not contain the attribute key '%s'", record.record.Message, key)
+	}
+
+	return b
 }

--- a/pkg/chart/v2/util/utilities_test.go
+++ b/pkg/chart/v2/util/utilities_test.go
@@ -151,6 +151,18 @@ func (h *LogCaptureHandler) Capture() *LogCaptureSlice {
 	return &result
 }
 
+func (c *LogCaptureSlice) String() string {
+	result := ""
+	for i, record := range c.records {
+		if i != 0 {
+			result += "\n"
+		}
+		result += record.record.Message
+	}
+
+	return result
+}
+
 func (c *LogCaptureSlice) Filter(filterFn func(r *LogCaptureRecord) bool) *LogCaptureSlice {
 	result := LogCaptureSlice{
 		records: make([]LogCaptureRecord, 0),
@@ -204,6 +216,30 @@ func RecordLevelBelowEqual(level slog.Level) func(r *LogCaptureRecord) bool {
 func RecordLevelBelow(level slog.Level) func(r *LogCaptureRecord) bool {
 	return func(r *LogCaptureRecord) bool {
 		return r.record.Level < level
+	}
+}
+
+func RecordHasAttr(key string) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		for _, attr := range r.attrs {
+			if attr.Key == key {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+func RecordHasAttrValue(key string, value string) func(r *LogCaptureRecord) bool {
+	return func(r *LogCaptureRecord) bool {
+		for _, attr := range r.attrs {
+			if attr.Key == key && attr.Value.String() == value {
+				return true
+			}
+		}
+
+		return false
 	}
 }
 


### PR DESCRIPTION
This adds `log/slog` to the `coalesce.go` file and also defines a slog handler to capture log records as they are written by slog for validation in tests.

- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
