### PR TITLE
fix: chart icon presence test

### DIFF
--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -166,10 +166,30 @@ func TestValidateChartSources(t *testing.T) {
 }
 
 func TestValidateChartIconPresence(t *testing.T) {
-	err := validateChartIconPresence(badChart)
-	if err == nil {
-		t.Errorf("validateChartIconPresence to return a linter error, got no error")
-	}
+	t.Run("Icon absent", func(t *testing.T) {
+		testChart := &chart.Metadata{
+			Icon: "",
+		}
+
+		err := validateChartIconPresence(testChart)
+
+		if err == nil {
+			t.Errorf("validateChartIconPresence to return a linter error, got no error")
+		} else if !strings.Contains(err.Error(), "icon is recommended") {
+			t.Errorf("expected %q, got %q", "icon is recommended", err.Error())
+		}
+	})
+	t.Run("Icon present", func(t *testing.T) {
+		testChart := &chart.Metadata{
+			Icon: "http://example.org/icon.png",
+		}
+
+		err := validateChartIconPresence(testChart)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %q", err.Error())
+		}
+	})
 }
 
 func TestValidateChartIconURL(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `TestValidateChartIconPresence` test fails when run after `TestValidateChartIconURL` as they both are using a global variable `badChart.Icon`

```
: go test -v -test.shuffle 1 -run '^(TestValidateChartIconPresence|TestValidateChartIconURL)$' ./pkg/lint/rules/
-test.shuffle 1
=== RUN   TestValidateChartIconURL
--- PASS: TestValidateChartIconURL (0.00s)
=== RUN   TestValidateChartIconPresence
    chartfile_test.go:171: validateChartIconPresence to return a linter error, got no error
--- FAIL: TestValidateChartIconPresence (0.00s)
FAIL
FAIL    helm.sh/helm/v4/pkg/lint/rules  0.051s
FAIL

: go test -v -test.shuffle 2 -run '^(TestValidateChartIconPresence|TestValidateChartIconURL)$' ./pkg/lint/rules/
-test.shuffle 2
=== RUN   TestValidateChartIconPresence
--- PASS: TestValidateChartIconPresence (0.00s)
=== RUN   TestValidateChartIconURL
--- PASS: TestValidateChartIconURL (0.00s)
PASS
ok      helm.sh/helm/v4/pkg/lint/rules  0.050s
```

This commit:

1. Remove dependency on global variable
2. Explicitly set the state of the test object.

closes helm/helm#30782

Also see: helm/helm#30610

**Special notes for your reviewer**:


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
