### PR TITLE
chore(OWNERS): Add TerryHowe as Triage Maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ maintainers:
   - technosophos
 triage:
   - banjoh
+  - TerryHowe
   - yxxhero
   - zonggen
   - z4ce


### PR DESCRIPTION
Adding @TerryHowe to OWNERS file as Triage Maintainer, as agreed by
supermajority vote by core maintainers.

- Nomination email (public Helm mailing list):
  https://lists.cncf.io/g/cncf-helm/topic/nominating_terry_howe_as_a/112379173
- Voting email (provate Helm core mailing list):
  https://lists.cncf.io/g/cncf-helm-core-maintainers/topic/voting_for_terry_howe_as/112379286

Welcome, @TerryHowe! Glad to have you on board ☺️
