### PR TITLE
feat: add kube version option for `helm install`

### DIFF
--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -274,6 +274,11 @@ func TestInstall(t *testing.T) {
 			wantError: true,
 			golden:    "output/install-hide-secret.txt",
 		},
+		{
+			name:   "check kube version with dry-run",
+			cmd:    "install secrets testdata/testcharts/subchart --dry-run --kube-version 1.16.0",
+			golden: "output/install-dry-run-with-kube-version.txt",
+		},
 	}
 
 	runTestCmd(t, tests)

--- a/pkg/cmd/testdata/output/install-dry-run-with-kube-version.txt
+++ b/pkg/cmd/testdata/output/install-dry-run-with-kube-version.txt
@@ -1,0 +1,125 @@
+NAME: secrets
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: pending-install
+REVISION: 1
+DESCRIPTION: Dry run complete
+HOOKS:
+---
+# Source: subchart/templates/tests/test-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "secrets-testconfig"
+  annotations:
+    "helm.sh/hook": test
+data:
+  message: Hello World
+---
+# Source: subchart/templates/tests/test-nothing.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "secrets-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test
+      image: "alpine:latest"
+      envFrom:
+        - configMapRef:
+            name: "secrets-testconfig"
+      command:
+        - echo
+        - "$message"
+  restartPolicy: Never
+MANIFEST:
+---
+# Source: subchart/templates/subdir/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: subchart-sa
+---
+# Source: subchart/templates/subdir/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: subchart-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list","watch"]
+---
+# Source: subchart/templates/subdir/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: subchart-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: subchart-role
+subjects:
+- kind: ServiceAccount
+  name: subchart-sa
+  namespace: default
+---
+# Source: subchart/charts/subcharta/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subcharta
+  labels:
+    helm.sh/chart: "subcharta-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subcharta
+---
+# Source: subchart/charts/subchartb/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchartb
+  labels:
+    helm.sh/chart: "subchartb-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchartb
+---
+# Source: subchart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart
+  labels:
+    helm.sh/chart: "subchart-0.1.0"
+    app.kubernetes.io/instance: "secrets"
+    kube-version/major: "1"
+    kube-version/minor: "16"
+    kube-version/version: "v1.16.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart
+
+NOTES:
+Sample notes for subchart


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is to make `helm install --dry-run` consistent with `helm template`. `helm template` can set `kube-version`, `helm install` up until now could not. In order for this to work as intended, we also need to set `client.clientOnly`. This could not be set before due to backwards compatibility concerns but for v4 this should be fine.

Related to #12740.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
