### PR TITLE
fix: copy dependencies on aliasing to avoid sharing chart references on multiply aliased dependencies [v3 backport]

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -116,15 +116,28 @@ func getAliasDependency(charts []*chart.Chart, dep *chart.Dependency) *chart.Cha
 		}
 
 		out := *c
-		md := *c.Metadata
-		out.Metadata = &md
+		out.Metadata = copyMetadata(c.Metadata)
 
 		if dep.Alias != "" {
-			md.Name = dep.Alias
+			out.Metadata.Name = dep.Alias
 		}
 		return &out
 	}
 	return nil
+}
+
+func copyMetadata(metadata *chart.Metadata) *chart.Metadata {
+	md := *metadata
+
+	if md.Dependencies != nil {
+		dependencies := make([]*chart.Dependency, len(md.Dependencies))
+		for i := range md.Dependencies {
+			dependency := *md.Dependencies[i]
+			dependencies[i] = &dependency
+		}
+		md.Dependencies = dependencies
+	}
+	return &md
 }
 
 // processDependencyEnabled removes disabled charts from dependencies

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -286,6 +286,38 @@ func TestProcessDependencyImportValues(t *testing.T) {
 	}
 }
 
+func TestProcessDependencyImportValuesFromSharedDependencyToAliases(t *testing.T) {
+	c := loadChart(t, "testdata/chart-with-import-from-aliased-dependencies")
+
+	if err := processDependencyEnabled(c, c.Values, ""); err != nil {
+		t.Fatalf("expected no errors but got %q", err)
+	}
+	if err := processDependencyImportValues(c, true); err != nil {
+		t.Fatalf("processing import values dependencies %v", err)
+	}
+	e := make(map[string]string)
+
+	e["foo-defaults.defaultValue"] = "42"
+	e["bar-defaults.defaultValue"] = "42"
+
+	e["foo.defaults.defaultValue"] = "42"
+	e["bar.defaults.defaultValue"] = "42"
+
+	e["foo.grandchild.defaults.defaultValue"] = "42"
+	e["bar.grandchild.defaults.defaultValue"] = "42"
+
+	cValues := Values(c.Values)
+	for kk, vv := range e {
+		pv, err := cValues.PathValue(kk)
+		if err != nil {
+			t.Fatalf("retrieving import values table %v %v", kk, err)
+		}
+		if pv != vv {
+			t.Errorf("failed to match imported value %v with expected %v", pv, vv)
+		}
+	}
+}
+
 func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 	c := loadChart(t, "testdata/three-level-dependent-chart/umbrella")
 

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/Chart.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+appVersion: 1.0.0
+name: chart-with-dependency-aliased-twice
+type: application
+version: 1.0.0
+
+dependencies:
+  - name: child
+    alias: foo
+    version: 1.0.0
+    import-values:
+      - parent: foo-defaults
+        child: defaults
+  - name: child
+    alias: bar
+    version: 1.0.0
+    import-values:
+      - parent: bar-defaults
+        child: defaults
+

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/Chart.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: 1.0.0
+name: child
+type: application
+version: 1.0.0
+
+dependencies:
+  - name: grandchild
+    version: 1.0.0
+    import-values:
+      - parent: defaults
+        child: defaults

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/charts/grandchild/Chart.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/charts/grandchild/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.0.0
+name: grandchild
+type: application
+version: 1.0.0
+

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/charts/grandchild/values.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/charts/grandchild/values.yaml
@@ -1,0 +1,2 @@
+defaults:
+  defaultValue: "42"

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/templates/dummy.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/charts/child/templates/dummy.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+data:
+  {{ .Values.defaults | toYaml }}
+

--- a/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/templates/dummy.yaml
+++ b/pkg/chartutil/testdata/chart-with-import-from-aliased-dependencies/templates/dummy.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+data:
+  {{ toYaml .Values.defaults | indent 2 }}
+


### PR DESCRIPTION
This is a back port of #9175 as requested per https://github.com/helm/helm/pull/9175#issuecomment-2825181992

Dependencies keep a reference on their parent chart, which breaks if a chart reference is shared among multiple aliases.
By copying the dependencies, parent information can be set correctly to render the templates as expected later on.

Note that this change will make ChartFullPath return a different path for sub-subcharts. It will contain the alias names instead of the path to the chart files which makes it consistent with paths to templates on the subchart level.

Closes #9150

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
