### PR TITLE
docs: Note about http fallback for OCI registries

### DIFF
--- a/pkg/registry/fallback.go
+++ b/pkg/registry/fallback.go
@@ -22,6 +22,10 @@ import (
 	"sync/atomic"
 )
 
+// NOTE(terryhowe): This fallback feature is only provided in v3 for backward
+// compatibility. ORAS v1 had this feature and this code was added when helm
+// updated to ORAS v2. This will not be supported in helm v4.
+
 type fallbackTransport struct {
 	Base      http.RoundTripper
 	forceHTTP atomic.Bool


### PR DESCRIPTION
**What this PR does / why we need it**:

Document why helm v3 supports http fallback.
Closes: https://github.com/helm/helm/issues/30667

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
