### PR TITLE
chore: enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - revive
     - staticcheck
     - unused
+    - usestdlibvars
 
   exclusions:
     # Helm, and the Go source code itself, sometimes uses these names outside their built-in

--- a/internal/monocular/search.go
+++ b/internal/monocular/search.go
@@ -129,7 +129,7 @@ func (c *Client) Search(term string) ([]SearchResult, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch %s : %s", p.String(), res.Status)
 	}
 

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -182,7 +182,7 @@ func initCompromisedRegistryTestServer() string {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "manifests") {
 			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			fmt.Fprintf(w, `{ "schemaVersion": 2, "config": {
     "mediaType": "%s",
@@ -199,16 +199,16 @@ func initCompromisedRegistryTestServer() string {
 }`, ConfigMediaType, ChartLayerMediaType)
 		} else if r.URL.Path == "/v2/testrepo/supposedlysafechart/blobs/sha256:a705ee2789ab50a5ba20930f246dbd5cc01ff9712825bb98f57ee8414377f133" {
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("{\"name\":\"mychart\",\"version\":\"0.1.0\",\"description\":\"A Helm chart for Kubernetes\\n" +
 				"an 'application' or a 'library' chart.\",\"apiVersion\":\"v2\",\"appVersion\":\"1.16.0\",\"type\":" +
 				"\"application\"}"))
 		} else if r.URL.Path == "/v2/testrepo/supposedlysafechart/blobs/sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb" {
 			w.Header().Set("Content-Type", ChartLayerMediaType)
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("b"))
 		} else {
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}))
 

--- a/pkg/repo/repotest/server_test.go
+++ b/pkg/repo/repotest/server_test.go
@@ -92,7 +92,7 @@ func TestServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.StatusCode != 404 {
+	if res.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected 404, got %d", res.StatusCode)
 	}
 }
@@ -140,7 +140,7 @@ func TestNewTempServer(t *testing.T) {
 
 				res.Body.Close()
 
-				if res.StatusCode != 200 {
+				if res.StatusCode != http.StatusOK {
 					t.Errorf("Expected 200, got %d", res.StatusCode)
 				}
 
@@ -153,7 +153,7 @@ func TestNewTempServer(t *testing.T) {
 				}
 				res.Body.Close()
 
-				if res.StatusCode != 200 {
+				if res.StatusCode != http.StatusOK {
 					t.Errorf("Expected 200, got %d", res.StatusCode)
 				}
 			}
@@ -198,7 +198,7 @@ func TestNewTempServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if res.StatusCode != 404 {
+			if res.StatusCode != http.StatusNotFound {
 				t.Fatalf("Expected 404, got %d", res.StatusCode)
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables and fixes [usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) issues

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
