### PR TITLE
Improve test coverage of pkg/registry/util.go

### DIFF
--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -53,7 +53,8 @@ func ContainsTag(tags []string, tag string) bool {
 	return false
 }
 
-// GetTagMatchingVersionOrConstraint expects a sorted slice of semver tags (highest version first)
+// GetTagMatchingVersionOrConstraint gets the latest tag matching a given semver constraint.
+// Expects tags to be a sorted slice of semver tags (highest version first)
 func GetTagMatchingVersionOrConstraint(tags []string, versionString string) (string, error) {
 	var constraint *semver.Constraints
 	if versionString == "" {

--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -53,6 +53,7 @@ func ContainsTag(tags []string, tag string) bool {
 	return false
 }
 
+// GetTagMatchingVersionOrConstraint expects a sorted slice of semver tags (highest version first)
 func GetTagMatchingVersionOrConstraint(tags []string, versionString string) (string, error) {
 	var constraint *semver.Constraints
 	if versionString == "" {

--- a/pkg/registry/util_test.go
+++ b/pkg/registry/util_test.go
@@ -280,28 +280,28 @@ func TestIsOCI(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		url     string
+		uri     string
 		isValid bool
 	}{
 		{
-			name:    "Valid url",
-			url:     "oci://example.com/myregistry:1.2.3",
+			name:    "Valid URI",
+			uri:     "oci://example.com/myregistry:1.2.3",
 			isValid: true,
 		},
 		{
-			name:    "Invalid URL prefix (boundary test 1)",
-			url:     "noci://example.com/myregistry:1.2.3",
+			name:    "Invalid URI prefix (boundary test 1)",
+			uri:     "noci://example.com/myregistry:1.2.3",
 			isValid: false,
 		},
 		{
-			name:    "Invalid URL prefix (boundary test 2)",
-			url:     "ocin://example.com/myregistry:1.2.3",
+			name:    "Invalid URI prefix (boundary test 2)",
+			uri:     "ocin://example.com/myregistry:1.2.3",
 			isValid: false,
 		},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.isValid, IsOCI(tt.url), tt.name)
+		assert.Equal(t, tt.isValid, IsOCI(tt.uri), tt.name)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the test coverage of `pkg/registry/util.go`

**Special notes for your reviewer**:

Improves coverage of the package overall from 70.8% to 75.7%

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
