### PR TITLE
feat(engine): add checkHostByName to resolve hostnames with DNS error…

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -259,6 +259,9 @@ func (e Engine) initFunMap(t *template.Template) {
 		funcMap["getHostByName"] = func(_ string) string {
 			return ""
 		}
+		funcMap["checkHostByName"] = func(_ string) string {
+			return ""
+		}
 	}
 
 	// Set custom template funcs


### PR DESCRIPTION
### What this MR does

This introduces a function `checkHostByName` which resolves a hostname to its first IP address, and **fails rendering** if DNS resolution fails due to network issues or DNS errors like SERVFAIL or timeout.

---

### Why this is needed

We rely on conditional logic in templates, and Sprig's existing `getHostByName` does not handle DNS errors — it silently returns an empty string. This can lead to incorrect or invalid rendering when DNS is misconfigured or unreachable.

We created this patch internally to ensure rendering fails clearly when DNS infrastructure is broken.

However, we are not looking to maintain a long-term patch. We’d like to see Helm offer a safer alternative to `getHostByName`, like this function, or provide guidance on the correct Helm-native way to safely detect and handle DNS failures in templates.

This patch is intended to be upstreamable. If an alternative solution is preferred, we’re open to feedback and collaboration.


