### PR TITLE
fix: remove duplicate error message

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -41,7 +41,6 @@ func main() {
 	}
 
 	if err := cmd.Execute(); err != nil {
-		slog.Debug("error", slog.Any("error", err))
 		switch e := err.(type) {
 		case helmcmd.PluginError:
 			os.Exit(e.Code)


### PR DESCRIPTION
closes #30857

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

There are 2 ways the error message from any subcommand is printed:

1. through the debug log line that this PR removes
2. through the spf13/cobra package before the error type is returned to the caller.

Since the spf13/cobra package already prints out the error, there is no use in redundantly printing out the error again within the debug log line.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
