### PR TITLE
fix: correctly check for chart directory conflict

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -150,23 +150,6 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		if !filepath.IsAbs(ud) {
 			ud = filepath.Join(p.DestDir, ud)
 		}
-		// Let udCheck to check conflict file/dir without replacing ud when untarDir is the current directory(.).
-		udCheck := ud
-		if udCheck == "." {
-			_, udCheck = filepath.Split(chartRef)
-		} else {
-			_, chartName := filepath.Split(chartRef)
-			udCheck = filepath.Join(udCheck, chartName)
-		}
-
-		if _, err := os.Stat(udCheck); err != nil {
-			if err := os.MkdirAll(udCheck, 0755); err != nil {
-				return out.String(), fmt.Errorf("failed to untar (mkdir): %w", err)
-			}
-		} else {
-			return out.String(), fmt.Errorf("failed to untar: a file or directory with the name %s already exists", udCheck)
-		}
-
 		return out.String(), chartutil.ExpandFile(ud, saved)
 	}
 	return out.String(), nil

--- a/pkg/chart/v2/util/expand.go
+++ b/pkg/chart/v2/util/expand.go
@@ -61,6 +61,15 @@ func Expand(dir string, r io.Reader) error {
 		return err
 	}
 
+	// Check if chartdir conflict with an already existing directory
+	if _, err := os.Stat(chartdir); err != nil {
+		if err := os.MkdirAll(chartdir, 0755); err != nil {
+			return fmt.Errorf("failed to untar (mkdir): %w", err)
+		}
+	} else {
+		return fmt.Errorf("failed to untar: a file or directory with the name %s already exists", chartdir)
+	}
+
 	// Copy all files verbatim. We don't parse these files because parsing can remove
 	// comments.
 	for _, file := range files {


### PR DESCRIPTION
Hello,

This PR fix an inconsistency when checking for a directory conflict while expanding a chart. Before we would check for a directory name composed of the chart name and the chart version. This would create a superfluous directory while also not really checking for a conflict because the chart will be expanded in a directory whose name would only be the chart name.

Example:

```
# bin/helm fetch external-dns --untar --version 8.7.12 --repo https://charts.bitnami.com/bitnami
# ls | grep external-dns
external-dns
external-dns:8.7.12

# bin/helm fetch external-dns --untar --version 8.7.11 --repo https://charts.bitnami.com/bitnami
# ls | grep external-dns
external-dns
external-dns:8.7.11
external-dns:8.7.12
```

We end up with a mix of the `8.7.11` and `8.7.12` charts.

Since we compute the final `chartDir` path from the `chartName` found in the `Chart.yaml` file in the `Expand` function, I think the directory conflict check is more reliable if implemented there.

Best Regards.