### PR TITLE
Reverting fix "renders int as float"

### DIFF
--- a/pkg/chart/v2/loader/load.go
+++ b/pkg/chart/v2/loader/load.go
@@ -19,7 +19,6 @@ package loader
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -224,10 +223,7 @@ func LoadValues(data io.Reader) (map[string]interface{}, error) {
 			}
 			return nil, fmt.Errorf("error reading yaml document: %w", err)
 		}
-		if err := yaml.Unmarshal(raw, &currentMap, func(d *json.Decoder) *json.Decoder {
-			d.UseNumber()
-			return d
-		}); err != nil {
+		if err := yaml.Unmarshal(raw, &currentMap); err != nil {
 			return nil, fmt.Errorf("cannot unmarshal yaml document: %w", err)
 		}
 		values = MergeMaps(values, currentMap)

--- a/pkg/chart/v2/util/dependencies_test.go
+++ b/pkg/chart/v2/util/dependencies_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package util
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -238,20 +237,6 @@ func TestProcessDependencyImportValues(t *testing.T) {
 			if b := strconv.FormatBool(pv); b != vv {
 				t.Errorf("failed to match imported bool value %v with expected %v for key %q", b, vv, kk)
 			}
-		case json.Number:
-			if fv, err := pv.Float64(); err == nil {
-				if sfv := strconv.FormatFloat(fv, 'f', -1, 64); sfv != vv {
-					t.Errorf("failed to match imported float value %v with expected %v for key %q", sfv, vv, kk)
-				}
-			}
-			if iv, err := pv.Int64(); err == nil {
-				if siv := strconv.FormatInt(iv, 10); siv != vv {
-					t.Errorf("failed to match imported int value %v with expected %v for key %q", siv, vv, kk)
-				}
-			}
-			if pv.String() != vv {
-				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
-			}
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
@@ -355,10 +340,6 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 		case float64:
 			if s := strconv.FormatFloat(pv, 'f', -1, 64); s != vv {
 				t.Errorf("failed to match imported float value %v with expected %v", s, vv)
-			}
-		case json.Number:
-			if pv.String() != vv {
-				t.Errorf("failed to match imported string value %q with expected %q", pv, vv)
 			}
 		default:
 			if pv != vv {

--- a/pkg/chart/v2/util/values.go
+++ b/pkg/chart/v2/util/values.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -106,10 +105,7 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
-		d.UseNumber()
-		return d
-	})
+	err = yaml.Unmarshal(data, &vals)
 	if len(vals) == 0 {
 		vals = Values{}
 	}

--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -22,18 +22,6 @@ import (
 	"testing"
 )
 
-func TestTemplateCmdWithToml(t *testing.T) {
-
-	tests := []cmdTestCase{
-		{
-			name:   "check toToml function rendering",
-			cmd:    fmt.Sprintf("template '%s'", "testdata/testcharts/issue-totoml"),
-			golden: "output/issue-totoml.txt",
-		},
-	}
-	runTestCmd(t, tests)
-}
-
 var chartPath = "testdata/testcharts/subchart"
 
 func TestTemplateCmd(t *testing.T) {

--- a/pkg/cmd/testdata/output/issue-totoml.txt
+++ b/pkg/cmd/testdata/output/issue-totoml.txt
@@ -1,8 +1,0 @@
----
-# Source: issue-totoml/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: issue-totoml
-data: |
-  key = 13

--- a/pkg/cmd/testdata/testcharts/issue-totoml/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/issue-totoml/Chart.yaml
@@ -1,3 +1,0 @@
-apiVersion: v2
-name: issue-totoml
-version: 0.1.0

--- a/pkg/cmd/testdata/testcharts/issue-totoml/templates/configmap.yaml
+++ b/pkg/cmd/testdata/testcharts/issue-totoml/templates/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: issue-totoml
-data: |
-  {{ .Values.global | toToml }}

--- a/pkg/cmd/testdata/testcharts/issue-totoml/values.yaml
+++ b/pkg/cmd/testdata/testcharts/issue-totoml/values.yaml
@@ -1,2 +1,0 @@
-global:
-  key: 13


### PR DESCRIPTION
This reverts #13533

This change has caused issues with numerous charts around things unrelated to toml. This is because of functions like typeIs/typeOf being used and acted upon.

The change caused a significant regression.

Note: This kind of change can be put into v3 charts, that are in active development, without causing a regression.

Closes #30880

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: There is regression caused by #13533 and its backport.

**Special notes for your reviewer**: This change can later be folded into the next generation of charts safely.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
