### PR TITLE
Fix 3.18.0 regression: registry login with scheme

### DIFF
--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package registry
 
 import (
+	"io"
 	"testing"
 
 	"github.com/containerd/containerd/remotes"
@@ -30,4 +31,24 @@ func TestNewClientResolverNotSupported(t *testing.T) {
 	client, err := NewClient(ClientOptResolver(r))
 	require.Equal(t, err, errDeprecatedRemote)
 	assert.Nil(t, client)
+}
+
+func TestStripURL(t *testing.T) {
+	client := &Client{
+		out: io.Discard,
+	}
+	// no change with supported host formats
+	assert.Equal(t, "username@localhost:8000", client.stripURL("username@localhost:8000"))
+	assert.Equal(t, "localhost:8000", client.stripURL("localhost:8000"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("docker.pkg.dev"))
+
+	// test strip scheme from host in URL
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("oci://docker.pkg.dev"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("http://docker.pkg.dev"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("https://docker.pkg.dev"))
+
+	// test strip repo from Registry in URL
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000/asdf/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000"))
 }


### PR DESCRIPTION
fixes https://github.com/helm/helm/issues/30873

**What this PR does / why we need it**:

Helm 3.18.0 released an upgrade of ORAS from v1 to v2.

ORAS v2 correctly does not accept http/https scheme for registry login, while ORAS v1 previously did. Even if v1 should not have, we want to preserve backwards compatibility for Helm 3 users who pass the scheme.

This will be removed in Helm 4, where registry login will not accept http/https scheme.

**Special notes for your reviewer:**

edit: @sabre1041 tracked down that here is where the URL scheme gets stripped in older Helm versions: https://github.com/moby/moby/blob/v25.0.6/registry/config.go#L203-L205

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
