### PR TITLE
[v3 backport] Prevent push cmd failure in 3.18 by handling version tag resolution in ORAS memory store

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -693,7 +693,7 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 		return nil, err
 	}
 
-	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, ref)
+	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, parsedRef.String())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -681,19 +681,9 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	})
 
 	ociAnnotations := generateOCIAnnotations(meta, operation.creationTime)
-	manifest := ocispec.Manifest{
-		Versioned:   specs.Versioned{SchemaVersion: 2},
-		Config:      configDescriptor,
-		Layers:      layers,
-		Annotations: ociAnnotations,
-	}
 
-	manifestData, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, ref)
+	manifestDescriptor, err := c.tagManifest(ctx, memoryStore, ref, configDescriptor,
+		layers, ociAnnotations)
 	if err != nil {
 		return nil, err
 	}
@@ -893,4 +883,30 @@ func (c *Client) ValidateReference(ref, version string, u *url.URL) (*url.URL, e
 	u.Path = fmt.Sprintf("%s:%s", registryReference.Repository, tag)
 
 	return u, err
+}
+
+// tagManifest prepares and tags a manifest in memory storage
+func (c *Client) tagManifest(ctx context.Context, memoryStore *memory.Store,
+	ref string, configDescriptor ocispec.Descriptor, layers []ocispec.Descriptor,
+	ociAnnotations map[string]string) (ocispec.Descriptor, error) {
+
+	manifest := ocispec.Manifest{
+		Versioned:   specs.Versioned{SchemaVersion: 2},
+		Config:      configDescriptor,
+		Layers:      layers,
+		Annotations: ociAnnotations,
+	}
+
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	parsedRef, err := newReference(ref)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest,
+		manifestData, parsedRef.String())
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -693,7 +693,7 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 		return nil, err
 	}
 
-	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, parsedRef.String())
+	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -17,12 +17,40 @@ limitations under the License.
 package registry
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	"github.com/containerd/containerd/remotes"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
 )
+
+// Inspired by oras test
+// https://github.com/oras-project/oras-go/blob/05a2b09cbf2eab1df691411884dc4df741ec56ab/content_test.go#L1802
+func TestTagManifestTransformsReferences(t *testing.T) {
+	memStore := memory.New()
+	client := &Client{out: io.Discard}
+	ctx := context.Background()
+
+	refWithPlus := "test-registry.io/charts/test:1.0.0+metadata"
+	expectedRef := "test-registry.io/charts/test:1.0.0_metadata" // + becomes _
+
+	configDesc := ocispec.Descriptor{MediaType: ConfigMediaType, Digest: "sha256:config", Size: 100}
+	layers := []ocispec.Descriptor{{MediaType: ChartLayerMediaType, Digest: "sha256:layer", Size: 200}}
+
+	desc, err := client.tagManifest(ctx, memStore, refWithPlus, configDesc, layers, nil)
+	require.NoError(t, err)
+
+	transformedDesc, err := memStore.Resolve(ctx, expectedRef)
+	require.NoError(t, err, "Should find the reference with _ instead of +")
+	require.Equal(t, desc.Digest, transformedDesc.Digest)
+
+	_, err = memStore.Resolve(ctx, refWithPlus)
+	require.Error(t, err, "Should NOT find the reference with the original +")
+}
 
 func TestNewClientResolverNotSupported(t *testing.T) {
 	var r remotes.Resolver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix: https://github.com/helm/helm/issues/30881

Backport of https://github.com/helm/helm/pull/30894

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
