### PR TITLE
fix: Port pluginCommand & command warning

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -83,7 +83,7 @@ type Metadata struct {
 	PlatformCommand []PlatformCommand `json:"platformCommand"`
 
 	// Command is the plugin command, as a single string.
-	// Providing a command will result in an deprecation warning if PlatformCommand is also set.
+	// Providing Command and PlatformCommand will result in a warning being emitted (PlatformCommand takes precedence).
 	//
 	// The command will be passed through environment expansion, so env vars can
 	// be present in this command. Unless IgnoreFlags is set, this will
@@ -119,7 +119,7 @@ type Metadata struct {
 	PlatformHooks PlatformHooks `json:"platformHooks"`
 
 	// Hooks are commands that will run on plugin events, as a single string.
-	// Providing a command will result in an deprecation warning if PlatformHooks is also set.
+	// Providing Hook and PlatformHooks will result in a warning being emitted (PlatformHooks takes precedence).
 	//
 	// The command will be passed through environment expansion, so env vars can
 	// be present in this command.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -83,7 +83,7 @@ type Metadata struct {
 	PlatformCommand []PlatformCommand `json:"platformCommand"`
 
 	// Command is the plugin command, as a single string.
-	// Providing a command will result in an error if PlatformCommand is also set.
+	// Providing a command will result in an deprecation warning if PlatformCommand is also set.
 	//
 	// The command will be passed through environment expansion, so env vars can
 	// be present in this command. Unless IgnoreFlags is set, this will
@@ -92,7 +92,7 @@ type Metadata struct {
 	// Note that command is not executed in a shell. To do so, we suggest
 	// pointing the command to a shell script.
 	//
-	// DEPRECATED: Use PlatformCommand instead. Remove in Helm 4.
+	// DEPRECATED: Use PlatformCommand instead
 	Command string `json:"command"`
 
 	// IgnoreFlags ignores any flags passed in from Helm
@@ -119,14 +119,14 @@ type Metadata struct {
 	PlatformHooks PlatformHooks `json:"platformHooks"`
 
 	// Hooks are commands that will run on plugin events, as a single string.
-	// Providing a hooks will result in an error if PlatformHooks is also set.
+	// Providing a command will result in an deprecation warning if PlatformHooks is also set.
 	//
 	// The command will be passed through environment expansion, so env vars can
 	// be present in this command.
 	//
 	// Note that the command is executed in the sh shell.
 	//
-	// DEPRECATED: Use PlatformHooks instead. Remove in Helm 4.
+	// DEPRECATED: Use PlatformHooks instead
 	Hooks Hooks
 
 	// Downloaders field is used if the plugin supply downloader mechanism
@@ -265,11 +265,11 @@ func validatePluginData(plug *Plugin, filepath string) error {
 	plug.Metadata.Usage = sanitizeString(plug.Metadata.Usage)
 
 	if len(plug.Metadata.PlatformCommand) > 0 && len(plug.Metadata.Command) > 0 {
-		return fmt.Errorf("both platformCommand and command are set in %q", filepath)
+		fmt.Printf("WARNING: both 'platformCommand' and 'command' are set in %q (this will become an error in a future Helm version)\n", filepath)
 	}
 
 	if len(plug.Metadata.PlatformHooks) > 0 && len(plug.Metadata.Hooks) > 0 {
-		return fmt.Errorf("both platformHooks and hooks are set in %q", filepath)
+		fmt.Printf("WARNING: both 'platformHooks' and 'hooks' are set in %q (this will become an error in a future Helm version)\n", filepath)
 	}
 
 	// We could also validate SemVer, executable, and other fields should we so choose.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -17,6 +17,7 @@ package plugin // import "helm.sh/helm/v4/pkg/plugin"
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -265,11 +266,11 @@ func validatePluginData(plug *Plugin, filepath string) error {
 	plug.Metadata.Usage = sanitizeString(plug.Metadata.Usage)
 
 	if len(plug.Metadata.PlatformCommand) > 0 && len(plug.Metadata.Command) > 0 {
-		fmt.Printf("WARNING: both 'platformCommand' and 'command' are set in %q (this will become an error in a future Helm version)\n", filepath)
+		slog.Warn("both 'platformCommand' and 'command' are set (this will become an error in a future Helm version)", slog.String("filepath", filepath))
 	}
 
 	if len(plug.Metadata.PlatformHooks) > 0 && len(plug.Metadata.Hooks) > 0 {
-		fmt.Printf("WARNING: both 'platformHooks' and 'hooks' are set in %q (this will become an error in a future Helm version)\n", filepath)
+		slog.Warn("both 'platformHooks' and 'hooks' are set (this will become an error in a future Helm version)", slog.String("filepath", filepath))
 	}
 
 	// We could also validate SemVer, executable, and other fields should we so choose.

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -496,8 +496,8 @@ func TestValidatePluginData(t *testing.T) {
 		{false, mockMissingMeta},         // Test if the metadata section missing
 		{true, mockNoCommand},            // Test no command metadata works
 		{true, mockLegacyCommand},        // Test legacy command metadata works
-		{false, mockWithCommand},         // Test platformCommand and command both set fails
-		{false, mockWithHooks},           // Test platformHooks and hooks both set fails
+		{true, mockWithCommand},          // Test platformCommand and command both set works
+		{true, mockWithHooks},            // Test platformHooks and hooks both set works
 	} {
 		err := validatePluginData(item.plug, fmt.Sprintf("test-%d", i))
 		if item.pass && err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Port the fix from Helm 3 to `main` to not error if `platformCommand` and `command` (and `platformHook` and `hook`) are set:
https://github.com/helm/helm/pull/30886

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
