### PR TITLE
Prevent push cmd failure in 3.18 by handling version tag resolution in ORAS memory store

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -686,8 +686,8 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 
 	ociAnnotations := generateOCIAnnotations(meta, operation.creationTime)
 
-	manifestDescriptor, err := c.tagManifest(ctx, memoryStore, ref, configDescriptor,
-		layers, ociAnnotations)
+	manifestDescriptor, err := c.tagManifest(ctx, memoryStore, configDescriptor,
+		layers, ociAnnotations, parsedRef)
 	if err != nil {
 		return nil, err
 	}
@@ -891,8 +891,8 @@ func (c *Client) ValidateReference(ref, version string, u *url.URL) (*url.URL, e
 
 // tagManifest prepares and tags a manifest in memory storage
 func (c *Client) tagManifest(ctx context.Context, memoryStore *memory.Store,
-	ref string, configDescriptor ocispec.Descriptor, layers []ocispec.Descriptor,
-	ociAnnotations map[string]string) (ocispec.Descriptor, error) {
+	configDescriptor ocispec.Descriptor, layers []ocispec.Descriptor,
+	ociAnnotations map[string]string, parsedRef reference) (ocispec.Descriptor, error) {
 
 	manifest := ocispec.Manifest{
 		Versioned:   specs.Versioned{SchemaVersion: 2},
@@ -902,11 +902,6 @@ func (c *Client) tagManifest(ctx context.Context, memoryStore *memory.Store,
 	}
 
 	manifestData, err := json.Marshal(manifest)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
-
-	parsedRef, err := newReference(ref)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -685,19 +685,9 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	})
 
 	ociAnnotations := generateOCIAnnotations(meta, operation.creationTime)
-	manifest := ocispec.Manifest{
-		Versioned:   specs.Versioned{SchemaVersion: 2},
-		Config:      configDescriptor,
-		Layers:      layers,
-		Annotations: ociAnnotations,
-	}
 
-	manifestData, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	manifestDescriptor, err := oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, ref)
+	manifestDescriptor, err := c.tagManifest(ctx, memoryStore, ref, configDescriptor,
+		layers, ociAnnotations)
 	if err != nil {
 		return nil, err
 	}
@@ -897,4 +887,30 @@ func (c *Client) ValidateReference(ref, version string, u *url.URL) (*url.URL, e
 	u.Path = fmt.Sprintf("%s:%s", registryReference.Repository, tag)
 
 	return u, err
+}
+
+// tagManifest prepares and tags a manifest in memory storage
+func (c *Client) tagManifest(ctx context.Context, memoryStore *memory.Store,
+	ref string, configDescriptor ocispec.Descriptor, layers []ocispec.Descriptor,
+	ociAnnotations map[string]string) (ocispec.Descriptor, error) {
+
+	manifest := ocispec.Manifest{
+		Versioned:   specs.Versioned{SchemaVersion: 2},
+		Config:      configDescriptor,
+		Layers:      layers,
+		Annotations: ociAnnotations,
+	}
+
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	parsedRef, err := newReference(ref)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest,
+		manifestData, parsedRef.String())
 }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -39,7 +39,10 @@ func TestTagManifestTransformsReferences(t *testing.T) {
 	configDesc := ocispec.Descriptor{MediaType: ConfigMediaType, Digest: "sha256:config", Size: 100}
 	layers := []ocispec.Descriptor{{MediaType: ChartLayerMediaType, Digest: "sha256:layer", Size: 200}}
 
-	desc, err := client.tagManifest(ctx, memStore, refWithPlus, configDesc, layers, nil)
+	parsedRef, err := newReference(refWithPlus)
+	require.NoError(t, err)
+
+	desc, err := client.tagManifest(ctx, memStore, configDesc, layers, nil, parsedRef)
 	require.NoError(t, err)
 
 	transformedDesc, err := memStore.Resolve(ctx, expectedRef)

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// Inspired by oras test
+// https://github.com/oras-project/oras-go/blob/05a2b09cbf2eab1df691411884dc4df741ec56ab/content_test.go#L1802
+func TestTagManifestTransformsReferences(t *testing.T) {
+	memStore := memory.New()
+	client := &Client{out: io.Discard}
+	ctx := context.Background()
+
+	refWithPlus := "test-registry.io/charts/test:1.0.0+metadata"
+	expectedRef := "test-registry.io/charts/test:1.0.0_metadata" // + becomes _
+
+	configDesc := ocispec.Descriptor{MediaType: ConfigMediaType, Digest: "sha256:config", Size: 100}
+	layers := []ocispec.Descriptor{{MediaType: ChartLayerMediaType, Digest: "sha256:layer", Size: 200}}
+
+	desc, err := client.tagManifest(ctx, memStore, refWithPlus, configDesc, layers, nil)
+	require.NoError(t, err)
+
+	transformedDesc, err := memStore.Resolve(ctx, expectedRef)
+	require.NoError(t, err, "Should find the reference with _ instead of +")
+	require.Equal(t, desc.Digest, transformedDesc.Digest)
+
+	_, err = memStore.Resolve(ctx, refWithPlus)
+	require.Error(t, err, "Should NOT find the reference with the original +")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix: https://github.com/helm/helm/issues/30881

Initial work for `dev-v3` in https://github.com/helm/helm/pull/30889#issuecomment-2898909440 but as requested by @gjenkins8, we should backport after on v3. :)

The issue is:
- The `newReference()` function transforms version tags by replacing + with _ for OCI compatibility (as we can see in the output message)
- But the code was using the original ref (with +) for `TagBytes()`
- Then it tries to find the tagged reference using `parsedRef.String()` (with _)
- This mismatch causes the `Resolve` method to fail with "not found"
- By using `parsedRef.String()` consistently in both places, the references will match and the lookup will succeed.

I extracted the `TagBytes` function to improve testability. `Push()` includes several external calls that are hard to mock, so isolating this logic makes testing more manageable.

The patch could be summarized as:
```diff
- oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, ref)
+ oras.TagBytes(ctx, memoryStore, ocispec.MediaTypeImageManifest, manifestData, parsedRef.String())
```

The initial regression is something that was missed in https://github.com/helm/helm/commit/5a7046b9bfaf1d7e97c555e33fa8744bba758004#diff-acbc1e889c3e91003a88f18e21c3073b64937801b20f663fcf2601540b9e3cdaR709

Before :
```sh
» ../../helm/bin/helm push ./test-0.0.0-snapshot+dirty.tgz oci://ghcr.io/benoittgt/helm-charts/test --debug
Error: failed to perform "Resolve" on source: ghcr.io/benoittgt/helm-charts/test/test:0.0.0-snapshot_dirty: not found
helm.go:92: 2025-05-21 16:41:49.581662 +0200 CEST m=+0.041508960 [debug] failed to perform "Resolve" on source: ghcr.io/benoittgt/helm-charts/test/test:0.0.0-snapshot_dirty: not found
```

After :

```sh
» ../../helm/bin/helm push ./test-0.0.0-snapshot+dirty.tgz oci://ghcr.io/benoittgt/helm-charts/test --debug
Pushed: ghcr.io/benoittgt/helm-charts/test/test:0.0.0-snapshot_dirty
Digest: sha256:680f23c71cb6727ae8845daf01f019dc11bdac4b652289c9a970b270c56ba79d
ghcr.io/benoittgt/helm-charts/test/test:0.0.0-snapshot_dirty contains an underscore.

OCI artifact references (e.g. tags) do not support the plus sign (+). To support
storing semantic versions, Helm adopts the convention of changing plus (+) to
an underscore (_) in chart version tags when pushing to a registry and back to
a plus (+) when pulling from a registry.
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility (it will be backported)
