### PR TITLE
fix: strip repository for login for backwards compatibility

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -229,8 +229,23 @@ type (
 	}
 )
 
+// Added for backwards compatibility for Helm < 3.18.0 after moving to ORAS v2
+// ref: https://github.com/helm/helm/issues/30873
+// TODO: document that Helm 4 `registry login` does accept repositories
+func stripRepository(host string) string {
+	if idx := strings.Index(host, "/"); idx != -1 {
+		host = host[:idx]
+		fmt.Printf("WARNING: Invalid registry passed: registries must NOT include a repository. Use %q instead\n", host)
+		return host
+	}
+	return host
+}
+
 // Login logs into a registry
 func (c *Client) Login(host string, options ...LoginOption) error {
+	// This is the lowest available point to strip the repository
+	host = stripRepository(host)
+
 	for _, option := range options {
 		option(&loginOperation{host, c})
 	}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -232,10 +232,10 @@ type (
 // Added for backwards compatibility for Helm < 3.18.0 after moving to ORAS v2
 // ref: https://github.com/helm/helm/issues/30873
 // TODO: document that Helm 4 `registry login` does accept repositories
-func stripRepository(host string) string {
+func (c *Client) stripRepository(host string) string {
 	if idx := strings.Index(host, "/"); idx != -1 {
 		host = host[:idx]
-		fmt.Printf("WARNING: Invalid registry passed: registries must NOT include a repository. Use %q instead\n", host)
+		fmt.Fprintf(c.out, "WARNING: Invalid registry passed: registries must NOT include a repository. Use %q instead\n", host)
 		return host
 	}
 	return host
@@ -244,7 +244,7 @@ func stripRepository(host string) string {
 // Login logs into a registry
 func (c *Client) Login(host string, options ...LoginOption) error {
 	// This is the lowest available point to strip the repository
-	host = stripRepository(host)
+	host = c.stripRepository(host)
 
 	for _, option := range options {
 		option(&loginOperation{host, c})

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package registry
 
 import (
+	"io"
 	"testing"
 
 	"github.com/containerd/containerd/remotes"
@@ -33,7 +34,11 @@ func TestNewClientResolverNotSupported(t *testing.T) {
 }
 
 func TestStripRepository(t *testing.T) {
-	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000/asdf"))
-	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000/asdf/asdf"))
-	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000"))
+	client := &Client{
+		out: io.Discard,
+	}
+
+	assert.Equal(t, "127.0.0.1:15000", client.stripRepository("127.0.0.1:15000/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripRepository("127.0.0.1:15000/asdf/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripRepository("127.0.0.1:15000"))
 }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -31,3 +31,9 @@ func TestNewClientResolverNotSupported(t *testing.T) {
 	require.Equal(t, err, errDeprecatedRemote)
 	assert.Nil(t, client)
 }
+
+func TestStripRepository(t *testing.T) {
+	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000/asdf/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", stripRepository("127.0.0.1:15000"))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to maintain backward compatibility for oras-go v2 for 3.18, we need to strip the repository off the url provided on the login command line. The protocol also needs to be stripped off which is handled in https://github.com/helm/helm/pull/30887

Partial https://github.com/helm/helm/issues/30873

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
