### PR TITLE
Add timeout flag to repo add and update flags

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -51,6 +51,7 @@ type repoAddOptions struct {
 	passCredentialsAll   bool
 	forceUpdate          bool
 	allowDeprecatedRepos bool
+	timeout              time.Duration
 
 	certFile              string
 	keyFile               string
@@ -99,6 +100,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&o.insecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the repository")
 	f.BoolVar(&o.allowDeprecatedRepos, "allow-deprecated-repos", false, "by default, this command will not allow adding official repos that have been permanently deleted. This disables that behavior")
 	f.BoolVar(&o.passCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+	f.DurationVar(&o.timeout, "timeout", getter.DefaultHTTPTimeout*time.Second, "time to wait for the index file download to complete")
 
 	return cmd
 }
@@ -203,7 +205,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 		return nil
 	}
 
-	r, err := repo.NewChartRepository(&c, getter.All(settings))
+	r, err := repo.NewChartRepository(&c, getter.All(settings, getter.WithTimeout(o.timeout)))
 	if err != nil {
 		return err
 	}

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -161,11 +161,6 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf("template '%s' -f %s/extra_values.yaml", chartPath, chartPath),
 			golden: "output/template-subchart-cm-set-file.txt",
 		},
-		{
-			name:   "check toToml function rendering",
-			cmd:    fmt.Sprintf("template '%s'", "testdata/testcharts/issue-totoml"),
-			golden: "output/issue-totoml.txt",
-		},
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/helm/testdata/output/issue-totoml.txt
+++ b/cmd/helm/testdata/output/issue-totoml.txt
@@ -1,8 +1,0 @@
----
-# Source: issue-totoml/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: issue-totoml
-data: |
-  key = 13

--- a/cmd/helm/testdata/testcharts/issue-totoml/Chart.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/Chart.yaml
@@ -1,3 +1,0 @@
-apiVersion: v2
-name: issue-totoml
-version: 0.1.0

--- a/cmd/helm/testdata/testcharts/issue-totoml/templates/configmap.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/templates/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: issue-totoml
-data: |
-  {{ .Values.global | toToml }}

--- a/cmd/helm/testdata/testcharts/issue-totoml/values.yaml
+++ b/cmd/helm/testdata/testcharts/issue-totoml/values.yaml
@@ -1,2 +1,0 @@
-global:
-  key: 13

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -18,7 +18,6 @@ package loader
 
 import (
 	"bytes"
-	"encoding/json"
 	"log"
 	"os"
 	"path/filepath"
@@ -105,10 +104,7 @@ func LoadFiles(files []*BufferedFile) (*chart.Chart, error) {
 			}
 		case f.Name == "values.yaml":
 			c.Values = make(map[string]interface{})
-			if err := yaml.Unmarshal(f.Data, &c.Values, func(d *json.Decoder) *json.Decoder {
-				d.UseNumber()
-				return d
-			}); err != nil {
+			if err := yaml.Unmarshal(f.Data, &c.Values); err != nil {
 				return c, errors.Wrap(err, "cannot load values.yaml")
 			}
 		case f.Name == "values.schema.json":

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package chartutil
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -238,20 +237,6 @@ func TestProcessDependencyImportValues(t *testing.T) {
 			if b := strconv.FormatBool(pv); b != vv {
 				t.Errorf("failed to match imported bool value %v with expected %v for key %q", b, vv, kk)
 			}
-		case json.Number:
-			if fv, err := pv.Float64(); err == nil {
-				if sfv := strconv.FormatFloat(fv, 'f', -1, 64); sfv != vv {
-					t.Errorf("failed to match imported float value %v with expected %v for key %q", sfv, vv, kk)
-				}
-			}
-			if iv, err := pv.Int64(); err == nil {
-				if siv := strconv.FormatInt(iv, 10); siv != vv {
-					t.Errorf("failed to match imported int value %v with expected %v for key %q", siv, vv, kk)
-				}
-			}
-			if pv.String() != vv {
-				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
-			}
 		default:
 			if pv != vv {
 				t.Errorf("failed to match imported string value %q with expected %q for key %q", pv, vv, kk)
@@ -323,10 +308,6 @@ func TestProcessDependencyImportValuesMultiLevelPrecedence(t *testing.T) {
 		case float64:
 			if s := strconv.FormatFloat(pv, 'f', -1, 64); s != vv {
 				t.Errorf("failed to match imported float value %v with expected %v", s, vv)
-			}
-		case json.Number:
-			if pv.String() != vv {
-				t.Errorf("failed to match imported string value %q with expected %q", pv, vv)
 			}
 		default:
 			if pv != vv {

--- a/pkg/chartutil/values.go
+++ b/pkg/chartutil/values.go
@@ -17,7 +17,6 @@ limitations under the License.
 package chartutil
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -106,10 +105,7 @@ func tableLookup(v Values, simple string) (Values, error) {
 
 // ReadValues will parse YAML byte data into a Values.
 func ReadValues(data []byte) (vals Values, err error) {
-	err = yaml.Unmarshal(data, &vals, func(d *json.Decoder) *json.Decoder {
-		d.UseNumber()
-		return d
-	})
+	err = yaml.Unmarshal(data, &vals)
 	if len(vals) == 0 {
 		vals = Values{}
 	}

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/pkg/cli"
 )
@@ -49,6 +50,23 @@ func TestProviders(t *testing.T) {
 
 	if _, err := ps.ByScheme("five"); err == nil {
 		t.Error("Did not expect handler for five")
+	}
+}
+
+func TestProvidersWithTimeout(t *testing.T) {
+	want := time.Hour
+	getters := Getters(WithTimeout(want))
+	getter, err := getters.ByScheme("http")
+	if err != nil {
+		t.Error(err)
+	}
+	client, err := getter.(*HTTPGetter).httpClient()
+	if err != nil {
+		t.Error(err)
+	}
+	got := client.Timeout
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `--timeout` flags to `repo add` and `repo up` commands.
Fixes: #12952

**Special notes for your reviewer**:

This PR supersedes #13185. Adding an environment variable is not ideal IMO. Using CLI flag is more appropriate and consistent with what other commands do.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
