### PR TITLE
Add timeout flag to repo add and update commands

### DIFF
--- a/pkg/cmd/repo_add.go
+++ b/pkg/cmd/repo_add.go
@@ -52,6 +52,7 @@ type repoAddOptions struct {
 	passCredentialsAll   bool
 	forceUpdate          bool
 	allowDeprecatedRepos bool
+	timeout              time.Duration
 
 	certFile              string
 	keyFile               string
@@ -96,6 +97,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&o.insecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the repository")
 	f.BoolVar(&o.allowDeprecatedRepos, "allow-deprecated-repos", false, "by default, this command will not allow adding official repos that have been permanently deleted. This disables that behavior")
 	f.BoolVar(&o.passCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+	f.DurationVar(&o.timeout, "timeout", getter.DefaultHTTPTimeout*time.Second, "time to wait for the index file download to complete")
 
 	return cmd
 }
@@ -199,7 +201,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 		return nil
 	}
 
-	r, err := repo.NewChartRepository(&c, getter.All(settings))
+	r, err := repo.NewChartRepository(&c, getter.All(settings, getter.WithTimeout(o.timeout)))
 	if err != nil {
 		return err
 	}

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -191,24 +191,32 @@ const (
 
 var defaultOptions = []Option{WithTimeout(time.Second * DefaultHTTPTimeout)}
 
-var httpProvider = Provider{
-	Schemes: []string{"http", "https"},
-	New: func(options ...Option) (Getter, error) {
-		options = append(options, defaultOptions...)
-		return NewHTTPGetter(options...)
-	},
-}
-
-var ociProvider = Provider{
-	Schemes: []string{registry.OCIScheme},
-	New:     NewOCIGetter,
+func Getters(extraOpts ...Option) Providers {
+	return Providers{
+		Provider{
+			Schemes: []string{"http", "https"},
+			New: func(options ...Option) (Getter, error) {
+				options = append(options, defaultOptions...)
+				options = append(options, extraOpts...)
+				return NewHTTPGetter(options...)
+			},
+		},
+		Provider{
+			Schemes: []string{registry.OCIScheme},
+			New: func(options ...Option) (Getter, error) {
+				options = append(options, defaultOptions...)
+				options = append(options, extraOpts...)
+				return NewOCIGetter(options...)
+			},
+		},
+	}
 }
 
 // All finds all of the registered getters as a list of Provider instances.
 // Currently, the built-in getters and the discovered plugins with downloader
 // notations are collected.
-func All(settings *cli.EnvSettings) Providers {
-	result := Providers{httpProvider, ociProvider}
+func All(settings *cli.EnvSettings, opts ...Option) Providers {
+	result := Getters(opts...)
 	pluginDownloaders, _ := collectPlugins(settings)
 	result = append(result, pluginDownloaders...)
 	return result

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v4/pkg/cli"
 )
@@ -49,6 +50,23 @@ func TestProviders(t *testing.T) {
 
 	if _, err := ps.ByScheme("five"); err == nil {
 		t.Error("Did not expect handler for five")
+	}
+}
+
+func TestProvidersWithTimeout(t *testing.T) {
+	want := time.Hour
+	getters := Getters(WithTimeout(want))
+	getter, err := getters.ByScheme("http")
+	if err != nil {
+		t.Error(err)
+	}
+	client, err := getter.(*HTTPGetter).httpClient()
+	if err != nil {
+		t.Error(err)
+	}
+	got := client.Timeout
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `--timeout` flags to `repo add` and `repo up` commands.
Fixes: #12952

**Special notes for your reviewer**:

This PR supersedes #13185. Adding an environment variable is not ideal IMO. Using CLI flag is more appropriate and consistent with what other commands do.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
