### PR TITLE
fix(client): allow layer selection permissive 

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -459,7 +459,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 			PreCopy: func(_ context.Context, desc ocispec.Descriptor) error {
 				mediaType := desc.MediaType
 				if i := sort.SearchStrings(allowedMediaTypes, mediaType); i >= len(allowedMediaTypes) || allowedMediaTypes[i] != mediaType {
-					return nil
+					return oras.SkipNode
 				}
 
 				mu.Lock()

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -473,7 +473,6 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 		return nil, err
 	}
 
-	descriptors = append(descriptors, manifest)
 	descriptors = append(descriptors, layers...)
 
 	numDescriptors := len(descriptors)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -459,7 +459,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 			PreCopy: func(_ context.Context, desc ocispec.Descriptor) error {
 				mediaType := desc.MediaType
 				if i := sort.SearchStrings(allowedMediaTypes, mediaType); i >= len(allowedMediaTypes) || allowedMediaTypes[i] != mediaType {
-					return errors.Errorf("media type %q is not allowed, found in descriptor with digest: %q", mediaType, desc.Digest)
+					return nil
 				}
 
 				mu.Lock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

As noted in the issue below - the switch to ORAS V2 required implementation of the `PreCopy` function which checks that a descriptors `mediatype` is in the allowed list and otherwise returns an error. I believe the ORAS v1 logic was more permissive and rather did not include layers if they were not in the allowedMediaTypes list. 

In order to meet parity with `v3.17.3` with regards to OCI copy operations - I believe that this should instead be returning nil. 

additionally the manifest is already included in the layers and does not need to be appended to descriptors. 

closes #30890

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
