### PR TITLE
[Doc] Help users avoid specifying URL scheme and path with `helm registry`

### DIFF
--- a/pkg/cmd/registry_login.go
+++ b/pkg/cmd/registry_login.go
@@ -33,6 +33,10 @@ import (
 
 const registryLoginDesc = `
 Authenticate to a remote registry.
+
+For example for Github Container Registry:
+
+    echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u $GITHUB_USER --password-stdin
 `
 
 type registryLoginOptions struct {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

We’ve noticed that some users [still include the URL scheme](https://github.com/helm/helm/issues/30873) and full path when logging into an OCI registry, for example:

```sh
helm registry login -u $OCI_REGISTRY_USER --password-stdin oci://ghcr.io/org/repo
```

This is no longer necessary and will not be supported in Helm v4.

To guide users toward the correct usage, we should show an example of the ideal command, as[ it was suggested by @scottrigby](https://github.com/helm/helm/issues/30873#issuecomment-2903202958).

Do we want to backport? I think it could be helpful for user to migrate to Helm v4 ?

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
