### PR TITLE
test: add functional tests for "Fix 3.18.0 regression: registry login with scheme"

### DIFF
--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -58,21 +58,21 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testTags(&suite.TestSuite)
 }

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -28,6 +28,7 @@ import (
 
 type HTTPRegistryClientTestSuite struct {
 	TestSuite
+	protocol string
 }
 
 func (suite *HTTPRegistryClientTestSuite) SetupSuite() {
@@ -56,14 +57,23 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
+	if suite.protocol != "" {
+		return
+	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
+	if suite.protocol != "" {
+		return
+	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
+	if suite.protocol != "" {
+		return
+	}
 	testTags(&suite.TestSuite)
 }
 
@@ -78,4 +88,11 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 
 func TestHTTPRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRegistryClientTestSuite))
+	for _, protocol := range []string{"oci://", "http://", "https://"} {
+		var protocolSpecificTestSuite = new(HTTPRegistryClientTestSuite)
+		protocolSpecificTestSuite.protocol = protocol
+		protocolSpecificTestSuite.DockerRegistryHost = protocol + "helm-test-registry"
+		suite.Run(t, protocolSpecificTestSuite)
+	}
+
 }

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -57,21 +57,21 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testTags(&suite.TestSuite)
@@ -88,6 +88,9 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 
 func TestHTTPRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRegistryClientTestSuite))
+	var suiteWithRepo = new(HTTPRegistryClientTestSuite)
+	suiteWithRepo.Repo = "/testrepo/"
+	suite.Run(t, suiteWithRepo)
 	for _, protocol := range []string{"oci://", "http://", "https://"} {
 		var protocolSpecificTestSuite = new(HTTPRegistryClientTestSuite)
 		protocolSpecificTestSuite.protocol = protocol

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -127,7 +127,12 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) *registry.Registry {
 	// Change the registry host to another host which is not localhost.
 	// This is required because Docker enforces HTTP if the registry
 	// host is localhost/127.0.0.1.
-	suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+	if suite.DockerRegistryHost == "" {
+		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+	} else {
+		// may programmatically set this for custom protocol handling
+		suite.DockerRegistryHost = fmt.Sprintf("%s:%d", suite.DockerRegistryHost, port)
+	}
 	suite.srv, err = mockdns.NewServer(map[string]mockdns.Zone{
 		"helm-test-registry.": {
 			A: []string{"127.0.0.1"},

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -65,6 +65,7 @@ type TestSuite struct {
 	CompromisedRegistryHost string
 	WorkspaceDir            string
 	RegistryClient          *Client
+	Repo                    string
 
 	// A mock DNS server needed for TLS connection testing.
 	srv *mockdns.Server
@@ -128,10 +129,10 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) *registry.Registry {
 	// This is required because Docker enforces HTTP if the registry
 	// host is localhost/127.0.0.1.
 	if suite.DockerRegistryHost == "" {
-		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d%s", port, suite.Repo)
 	} else {
 		// may programmatically set this for custom protocol handling
-		suite.DockerRegistryHost = fmt.Sprintf("%s:%d", suite.DockerRegistryHost, port)
+		suite.DockerRegistryHost = fmt.Sprintf("%s:%d%s", suite.DockerRegistryHost, port, suite.Repo)
 	}
 	suite.srv, err = mockdns.NewServer(map[string]mockdns.Zone{
 		"helm-test-registry.": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR introduces extra tests for filtering out the registry protocol during the helm registry login commands.
This should augment the recently merged https://github.com/helm/helm/pull/30887 change which fixes this issue https://github.com/helm/helm/issues/30873.

I'm targeting v3 with this change since that's where the regression was introduced. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
