### PR TITLE
Oras v1 credentials file shim

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -107,7 +107,7 @@ func handleEmptyConfgFile(credentialsFile string, client *Client) {
 	if err == nil {
 		var configData map[string]json.RawMessage
 		// handle only if credentials file is empty
-		if err := json.NewDecoder(f).Decode(&configData); err != nil && !errors.Is(err, io.EOF) {
+		if err := json.NewDecoder(f).Decode(&configData); err != nil && errors.Is(err, io.EOF) {
 			// Attempt to write empty JSON map to config file
 			client.credentialsFile = ""
 			encoder := json.NewEncoder(f)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -109,10 +109,11 @@ func handleEmptyConfgFile(credentialsFile string, client *Client) string {
 		// handle only if credentials file is empty
 		if err := json.NewDecoder(f).Decode(&configData); err != nil && !errors.Is(err, io.EOF) {
 			// Attempt to write empty JSON map to config file
-			// Note that <3.18.0
 			client.credentialsFile = ""
 			encoder := json.NewEncoder(f)
 			err = encoder.Encode(configData)
+			// Note that <3.18.0 Helm would fail if the config file was not
+			// writable, so we can continue to error if that is the case
 			if err != nil {
 				client.err = err
 			}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -94,7 +94,7 @@ type (
 // ORAS v1 was tolerant of an empty config file
 // ORAS v2 is not
 // to workaround this regression, ensure configfile is valid JSON
-func handleEmptyConfgFile(credentialsFile string, client *Client) string {
+func handleEmptyConfgFile(credentialsFile string, client *Client) {
 	f, err := os.Open(credentialsFile)
 	defer func(f *os.File) {
 		err := f.Close()
@@ -119,7 +119,6 @@ func handleEmptyConfgFile(credentialsFile string, client *Client) string {
 			}
 		}
 	}
-	return client.credentialsFile
 }
 
 // NewClient returns a new registry client with config
@@ -137,7 +136,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		client.credentialsFile = helmpath.ConfigPath(CredentialsFileBasename)
 	}
 
-	client.credentialsFile = handleEmptyConfgFile(client.credentialsFile, client)
+	handleEmptyConfgFile(client.credentialsFile, client)
 
 	if client.httpClient == nil {
 		transport := newTransport()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix for regression in v3.18.0
ORAS v1 was tolerant of an empty config file
ORAS v2 is not
to workaround this regression, ensure configfile is valid JSON

**Special notes for your reviewer**:

heavily inspired by https://github.com/helm/helm/pull/30910. Changed some handling logic based on investigation with other helm maintainers. Also isolated to a separate func to easily mark deprecated and for clearer diffs with `main`.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
