### PR TITLE
fix: downloader loadChartRepositories dynamic return

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -814,7 +814,7 @@ func versionEquals(v1, v2 string) bool {
 //
 // The key is the local name (which is only present in the repositories.yaml).
 func (m *Manager) loadChartRepositories() (map[string]*repo.ChartRepository, error) {
-	indices := map[string]*repo.ChartRepository{}
+	indices := make(map[string]*repo.ChartRepository)
 
 	// Load repositories.yaml file
 	rf, err := loadRepoConfig(m.RepositoryConfig)


### PR DESCRIPTION

**What this PR does / why we need it**:
This causes occasional test failures and it currently blocking https://github.com/helm/helm/pull/30917

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
