### PR TITLE
fix: plugin installer test with no Internet

### DIFF
--- a/pkg/plugin/installer/vcs_installer_test.go
+++ b/pkg/plugin/installer/vcs_installer_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/vcs"
@@ -119,6 +120,8 @@ func TestVCSInstallerNonExistentVersion(t *testing.T) {
 
 	if err := Install(i); err == nil {
 		t.Fatalf("expected error for version does not exists, got none")
+	} else if strings.Contains(err.Error(), "Could not resolve host: github.com") {
+		t.Skip("Unable to run test without Internet access")
 	} else if err.Error() != fmt.Sprintf("requested version %q does not exist for plugin %q", version, source) {
 		t.Fatalf("expected error for version does not exists, got (%v)", err)
 	}
@@ -146,7 +149,11 @@ func TestVCSInstallerUpdate(t *testing.T) {
 
 	// Install plugin before update
 	if err := Install(i); err != nil {
-		t.Fatal(err)
+		if strings.Contains(err.Error(), "Could not resolve host: github.com") {
+			t.Skip("Unable to run test without Internet access")
+		} else {
+			t.Fatal(err)
+		}
 	}
 
 	// Test FindSource method for positive result


### PR DESCRIPTION

**What this PR does / why we need it**:
If you are off line, these are the onl tests that fail. This change skips them on failure.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
