### PR TITLE
Fix flaky TestFindChartURL due to non-deterministic map iteration

### DIFF
--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -115,7 +115,7 @@ func TestFindChartURL(t *testing.T) {
 		t.Errorf("Unexpected passcredentialsall %t", passcredentialsall)
 	}
 
-	name = "baz"
+	name = "foo"
 	version = "1.2.3"
 	repoURL = "http://example.com/helm"
 
@@ -124,7 +124,7 @@ func TestFindChartURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if churl != "http://example.com/path/to/baz-1.2.3.tgz" {
+	if churl != "http://example.com/helm/charts/foo-1.2.3.tgz" {
 		t.Errorf("Unexpected URL %q", churl)
 	}
 	if username != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is another try of https://github.com/helm/helm/pull/30927

This was a pain to found. 😓 

TL;DR
`findChartURL()` iterates over a map without deterministic ordering, causing the first-match-wins behavior to be non-deterministic when multiple repositories match the same URL pattern.

---

The test was failing intermittently because of map iteration random ([see `range repos` in `findChartUrl`](https://github.com/helm/helm/blob/d4e58c54ba79434d7836ea6d8a1f457156958727/pkg/downloader/manager.go#L729)).
When looking up the `baz` chart with repository URL `http://example.com/helm`, two repositories match due to trailing slash equivalence:

- [`testing-relative`](https://github.com/helm/helm/blob/main/pkg/downloader/testdata/repository/testing-relative-index.yaml) (URL: http://example.com/helm) - contains baz chart GOOD
- [`testing-relative-trailing-slash`](https://github.com/helm/helm/blob/main/pkg/downloader/testdata/repository/testing-relative-trailing-slash-index.yaml) (URL: http://example.com/helm/) - does not contain baz chart.. NOT GOOD

The `urlutil.Equal()` function treats these URLs as equivalent, but depending on which repository the random map iterator encounters first, the test would either pass or fail with "entry not found".

So I changed the third test case from `baz` to `foo` chart, since `foo` exists in both matching repositories. This should eliminates the race condition I hope.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
