### PR TITLE
Handle an empty registry config file.

### DIFF
--- a/cmd/helm/registry_login_test.go
+++ b/cmd/helm/registry_login_test.go
@@ -17,9 +17,73 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"helm.sh/helm/v3/pkg/repo/repotest"
 )
 
 func TestRegistryLoginFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "registry login", false)
+}
+
+func TestRegistryLogin(t *testing.T) {
+	srv, err := repotest.NewTempServerWithCleanup(t, "testdata/testcharts/*.tgz*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ociSrv.Run(t)
+
+	// Creating an empty json file to use as an empty registry configuration file. Used for
+	// testing the handling of this situation.
+	tmpDir := t.TempDir()
+	emptyFile, err := os.Create(filepath.Join(tmpDir, "empty.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyFile.Close()
+
+	tests := []struct {
+		name         string
+		cmd          string
+		wantError    bool
+		wantErrorMsg string
+	}{
+		{
+			name: "Normal login",
+			cmd:  fmt.Sprintf("registry login %s --username %s --password %s", ociSrv.RegistryURL, ociSrv.TestUsername, ociSrv.TestPassword),
+		},
+		{
+			name:      "Failed login",
+			cmd:       fmt.Sprintf("registry login %s --username foo --password bar", ociSrv.RegistryURL),
+			wantError: true,
+		},
+		{
+			name: "Normal login with empty registry file",
+			cmd:  fmt.Sprintf("registry login %s --username %s --password %s --registry-config %s", ociSrv.RegistryURL, ociSrv.TestUsername, ociSrv.TestPassword, emptyFile.Name()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := executeActionCommand(tt.cmd)
+			if err != nil {
+				if tt.wantError {
+					if tt.wantErrorMsg != "" && tt.wantErrorMsg == err.Error() {
+						t.Fatalf("Actual error %s, not equal to expected error %s", err, tt.wantErrorMsg)
+					}
+					return
+				}
+				t.Fatalf("%q reported error: %s", tt.name, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
In the move to oras v2, an existing but empty registry config file became an uncaught error. A missing file caused no error. This change catches the error and works around it so that Helm can continue to be fault tolerant to this issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: When Helm moved to oras v2, the handling of empty registry configuration files changed. It previously loaded default values and continued on. In oras v2, an error is produced.

This change restores the fault tolerant behavior so that the helm regression is fixed.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
