### PR TITLE
fix: port registry login stripping to v4

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -238,8 +238,39 @@ type (
 	}
 )
 
+// Deprecated: will be removed in Helm 4
+// Added for backwards compatibility for Helm < 3.18.0 after moving to ORAS v2
+// ref: https://github.com/helm/helm/issues/30873
+// TODO: document that Helm 4 `registry login` does accept full URLs
+func (c *Client) stripURL(host string) string {
+	// strip scheme from host in URL
+	for _, s := range []string{"oci://", "http://", "https://"} {
+		if strings.HasPrefix(host, s) {
+			plain := strings.TrimPrefix(host, s)
+			if c.debug {
+				fmt.Fprintf(c.out, "[WARNING] Invalid registry passed: registries should NOT be prefixed with a URL scheme. Use %q instead\n", plain)
+			}
+			host = plain
+			break
+		}
+	}
+	// strip repo from registry in URL
+	if idx := strings.Index(host, "/"); idx != -1 {
+		host = host[:idx]
+		if c.debug {
+			fmt.Fprintf(c.out, "[WARNING] Invalid registry passed: registries should NOT include a repository. Use %q instead\n", host)
+		}
+		return host
+	}
+
+	return host
+}
+
 // Login logs into a registry
 func (c *Client) Login(host string, options ...LoginOption) error {
+	// This is the lowest available point to strip incorrect URL parts
+	host = c.stripURL(host)
+
 	for _, option := range options {
 		option(&loginOperation{host, c})
 	}

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -58,21 +58,21 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
 	if suite.protocol != "" || suite.Repo != "" {
-		return
+		suite.T().Skip("Skipping we don't strip protocol or repo prior to execution")
 	}
 	testTags(&suite.TestSuite)
 }

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -28,6 +28,7 @@ import (
 
 type HTTPRegistryClientTestSuite struct {
 	TestSuite
+	protocol string
 }
 
 func (suite *HTTPRegistryClientTestSuite) SetupSuite() {
@@ -56,14 +57,23 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
+	if suite.protocol != "" {
+		return
+	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
+	if suite.protocol != "" {
+		return
+	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
+	if suite.protocol != "" {
+		return
+	}
 	testTags(&suite.TestSuite)
 }
 
@@ -78,4 +88,11 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 
 func TestHTTPRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRegistryClientTestSuite))
+	for _, protocol := range []string{"oci://", "http://", "https://"} {
+		var protocolSpecificTestSuite = new(HTTPRegistryClientTestSuite)
+		protocolSpecificTestSuite.protocol = protocol
+		protocolSpecificTestSuite.DockerRegistryHost = protocol + "helm-test-registry"
+		suite.Run(t, protocolSpecificTestSuite)
+	}
+
 }

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -57,21 +57,21 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testPush(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testPull(&suite.TestSuite)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
-	if suite.protocol != "" {
+	if suite.protocol != "" || suite.Repo != "" {
 		return
 	}
 	testTags(&suite.TestSuite)
@@ -88,6 +88,9 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 
 func TestHTTPRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRegistryClientTestSuite))
+	var suiteWithRepo = new(HTTPRegistryClientTestSuite)
+	suiteWithRepo.Repo = "/testrepo/"
+	suite.Run(t, suiteWithRepo)
 	for _, protocol := range []string{"oci://", "http://", "https://"} {
 		var protocolSpecificTestSuite = new(HTTPRegistryClientTestSuite)
 		protocolSpecificTestSuite.protocol = protocol

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -18,9 +18,10 @@ package registry
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -52,3 +52,23 @@ func TestTagManifestTransformsReferences(t *testing.T) {
 	_, err = memStore.Resolve(ctx, refWithPlus)
 	require.Error(t, err, "Should NOT find the reference with the original +")
 }
+
+func TestStripURL(t *testing.T) {
+	client := &Client{
+		out: io.Discard,
+	}
+	// no change with supported host formats
+	assert.Equal(t, "username@localhost:8000", client.stripURL("username@localhost:8000"))
+	assert.Equal(t, "localhost:8000", client.stripURL("localhost:8000"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("docker.pkg.dev"))
+
+	// test strip scheme from host in URL
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("oci://docker.pkg.dev"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("http://docker.pkg.dev"))
+	assert.Equal(t, "docker.pkg.dev", client.stripURL("https://docker.pkg.dev"))
+
+	// test strip repo from Registry in URL
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000/asdf/asdf"))
+	assert.Equal(t, "127.0.0.1:15000", client.stripURL("127.0.0.1:15000"))
+}

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -132,7 +132,12 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) *registry.Registry {
 	// Change the registry host to another host which is not localhost.
 	// This is required because Docker enforces HTTP if the registry
 	// host is localhost/127.0.0.1.
-	suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+	if suite.DockerRegistryHost == "" {
+		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+	} else {
+		// may programmatically set this for custom protocol handling
+		suite.DockerRegistryHost = fmt.Sprintf("%s:%d", suite.DockerRegistryHost, port)
+	}
 	suite.srv, err = mockdns.NewServer(map[string]mockdns.Zone{
 		"helm-test-registry.": {
 			A: []string{"127.0.0.1"},

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -65,6 +65,7 @@ type TestSuite struct {
 	CompromisedRegistryHost string
 	WorkspaceDir            string
 	RegistryClient          *Client
+	Repo                    string
 
 	// A mock DNS server needed for TLS connection testing.
 	srv *mockdns.Server
@@ -133,10 +134,10 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) *registry.Registry {
 	// This is required because Docker enforces HTTP if the registry
 	// host is localhost/127.0.0.1.
 	if suite.DockerRegistryHost == "" {
-		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d", port)
+		suite.DockerRegistryHost = fmt.Sprintf("helm-test-registry:%d%s", port, suite.Repo)
 	} else {
 		// may programmatically set this for custom protocol handling
-		suite.DockerRegistryHost = fmt.Sprintf("%s:%d", suite.DockerRegistryHost, port)
+		suite.DockerRegistryHost = fmt.Sprintf("%s:%d%s", suite.DockerRegistryHost, port, suite.Repo)
 	}
 	suite.srv, err = mockdns.NewServer(map[string]mockdns.Zone{
 		"helm-test-registry.": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

I made a v3 PR that introduced some integration tests that tested the functionality of stripping the url protocol prior to a `helm login` command. https://github.com/helm/helm/pull/30916 .  When I was figuring out whether the tests makes sense for v4, I noticed that the tests failed, and realized that the patch https://github.com/helm/helm/pull/30887 was not applied to v4 yet.

I'm still working out whether that is by-design or not, but for now I'm going to open up this PR pre-emptively until I have an answer.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
