### PR TITLE
fix: legacy docker support broken for login

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -262,6 +262,7 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 	}
 
 	key := credentials.ServerAddressFromRegistry(host)
+	key = credentials.ServerAddressFromHostname(key)
 	if err := c.credentialsStore.Put(ctx, key, cred); err != nil {
 		return err
 	}


### PR DESCRIPTION


**What this PR does / why we need it**:
When logging in with `registry-1.docker.io` it does not map it to `https://index.docker.io/v1/`

Fixes: https://github.com/helm/helm/issues/30929

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
