### PR TITLE
[v3 backport] fix: legacy docker support broken for login

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -301,8 +301,6 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 		return fmt.Errorf("authenticating to %q: %w", host, err)
 	}
 
-	key := credentials.ServerAddressFromRegistry(host)
-
 	// The credentialsStore loader does not handle empty files. So, there is a workaround.
 	// This can be removed when the credentials loader can handle empty files.
 	// When Helm catches an empty file error it causes the loader to trigger its fault
@@ -327,6 +325,8 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 		c.credentialsFileTemp = false
 	}
 
+	key := credentials.ServerAddressFromRegistry(host)
+	key = credentials.ServerAddressFromHostname(key)
 	if err := c.credentialsStore.Put(ctx, key, cred); err != nil {
 		return err
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
Map to the legacy server

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
