### PR TITLE
fix(install): ensure --dry-run in client mode (=client, =true or empty) doesn't call kube API - fixes #30514

### DIFF
--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -254,7 +254,7 @@ func TestInstallReleaseWithValues(t *testing.T) {
 func TestInstallReleaseClientOnly(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)
-	instAction.ClientOnly = true
+	instAction.DryRunOption = "client"
 	instAction.Run(buildChart(), nil) // disregard output
 
 	is.Equal(instAction.cfg.Capabilities, chartutil.DefaultCapabilities)

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -89,10 +89,13 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if client.DryRunOption == "" {
 				client.DryRunOption = "true"
 			}
+			if validate {
+				client.DryRunOption = "server"
+			}
+
 			client.DryRun = true
 			client.ReleaseName = "release-name"
 			client.Replace = true // Skip the name check
-			client.ClientOnly = !validate
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			client.IncludeCRDs = includeCrds
 			rel, err := runInstall(args, client, valueOpts, out)


### PR DESCRIPTION
**What this PR does / why we need it**:

Running `helm install --dry-run=client` (or any equivalent for `[=client]`) was trying to call kube API (see associated issue).

After further investigation, multiple solutions were possible:
- Just mapping `client.ClientOnly` in case `DryRunOption` was `client` (or true ?) in `cmd/helm/install.go`.
- Using both `client.ClientOnly` and `interactWithRemote` in conditions to call / not call kube API (in `pkg/action/install.go`).
- Juste remove `client.ClientOnly` to fully use `interactWithRemote` (in `pkg/action/install.go`).

I chose the latter because it simplifies how client mode / server mode works. It's also more consistent with `upgrade` action which doesn't have a `ClientMode` property.

However it does break the interface since `action` is an exported package for all ... Shall I change for one of the other options ?

Closes #30514 