### PR TITLE
fix: resolve dependencies with same name from different repositories

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -17,7 +17,7 @@ package resolver
 
 import (
 	"bytes"
-	"crypto"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -54,13 +54,13 @@ func New(chartpath, cachepath string, registryClient *registry.Client) *Resolver
 	}
 }
 
-// dependencyKey creates a unique key for a dependency that includes name, repository, and index
+// DependencyKey creates a unique key for a dependency that includes name, repository, and index
 // to handle cases where multiple dependencies have the same name but different repositories
-func dependencyKey(name, repository string, index int) string {
+func DependencyKey(name, repository string, index int) string {
 	// Use a combination of name, repository hash, and index to ensure uniqueness
 	repoHash := ""
 	if repository != "" {
-		hasher := crypto.SHA256.New()
+		hasher := sha256.New()
 		hasher.Write([]byte(repository))
 		repoHash = hex.EncodeToString(hasher.Sum(nil))[:8] // Use first 8 chars for brevity
 	}
@@ -123,9 +123,9 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 		}
 
 		// Try to get repository name using composite key first, then fall back to simple name
-		key := dependencyKey(d.Name, d.Repository, i)
+		key := DependencyKey(d.Name, d.Repository, i)
 		repoName := repoNames[key]
-		
+
 		// Fall back to simple name lookup for backward compatibility
 		if repoName == "" {
 			repoName = repoNames[d.Name]

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -308,3 +308,59 @@ func TestGetLocalPath(t *testing.T) {
 		})
 	}
 }
+
+func TestDependencyKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		depName    string
+		repository string
+		index      int
+		expect     string
+	}{
+		{
+			name:       "basic case",
+			depName:    "oedipus-rex",
+			repository: "http://example.com/test",
+			index:      0,
+			expect:     "oedipus-rex-0e52b63f-0",
+		},
+		{
+			name:       "different repo same name",
+			depName:    "oedipus-rex",
+			repository: "http://example.com",
+			index:      0,
+			expect:     "oedipus-rex-f0e6a6a9-0",
+		},
+		{
+			name:       "same repo different index",
+			depName:    "oedipus-rex",
+			repository: "http://example.com",
+			index:      1,
+			expect:     "oedipus-rex-f0e6a6a9-1",
+		},
+		{
+			name:       "local file path",
+			depName:    "local-dep",
+			repository: "file://./testdata/signtest",
+			index:      0,
+			expect:     "local-dep-93f23b0e-0",
+		},
+		{
+			name:       "empty repository",
+			depName:    "local-subchart",
+			repository: "",
+			index:      0,
+			expect:     "local-subchart--0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DependencyKey(tt.depName, tt.repository, tt.index)
+			if result != tt.expect {
+				t.Errorf("dependencyKey(%q, %q, %d) = %q, want %q",
+					tt.depName, tt.repository, tt.index, result, tt.expect)
+			}
+		})
+	}
+}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -617,11 +617,9 @@ func (m *Manager) resolveRepoNames(deps []*chart.Dependency) (map[string]string,
 		}
 		if !found {
 			repository := dd.Repository
-			// Add if URL
+			// Check if it's a valid URL
 			_, err := url.ParseRequestURI(repository)
 			if err == nil {
-				depKey := resolver.DependencyKey(dd.Name, repository, i)
-				reposMap[depKey] = repository
 				continue
 			}
 			missing = append(missing, repository)

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -166,9 +166,7 @@ func TestGetRepoNames(t *testing.T) {
 			req: []*chart.Dependency{
 				{Name: "oedipus-rex", Repository: "http://example.com/test"},
 			},
-			expect: map[string]string{
-				expectedKey("oedipus-rex", "http://example.com/test", 0): "http://example.com/test",
-			},
+			expect: map[string]string{},
 		},
 		{
 			name: "no repo definition failure -- stable repo",
@@ -225,12 +223,11 @@ func TestGetRepoNames(t *testing.T) {
 		{
 			name: "multiple dependencies with same name but different repos",
 			req: []*chart.Dependency{
-				{Name: "common-chart", Repository: "http://example.com"},
-				{Name: "common-chart", Repository: "http://other.com"},
+				{Name: "common-chart", Repository: "http://example.com"}, // Known repo
+				{Name: "common-chart", Repository: "http://other.com"},   // Unknown repo
 			},
 			expect: map[string]string{
 				expectedKey("common-chart", "http://example.com", 0): "testing",
-				expectedKey("common-chart", "http://other.com", 1):   "http://other.com",
 			},
 		},
 	}

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"helm.sh/helm/v4/internal/resolver"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
@@ -151,7 +152,7 @@ func TestGetRepoNames(t *testing.T) {
 
 	// Helper function to generate expected key
 	expectedKey := func(name, repo string, index int) string {
-		return dependencyKey(name, repo, index)
+		return resolver.DependencyKey(name, repo, index)
 	}
 
 	tests := []struct {
@@ -251,62 +252,6 @@ func TestGetRepoNames(t *testing.T) {
 			// Compare maps
 			if !reflect.DeepEqual(l, tt.expect) {
 				t.Errorf("%s: expected map %v, got %v", tt.name, tt.expect, l)
-			}
-		})
-	}
-}
-
-func TestDependencyKey(t *testing.T) {
-	tests := []struct {
-		name       string
-		depName    string
-		repository string
-		index      int
-		expect     string
-	}{
-		{
-			name:       "basic case",
-			depName:    "oedipus-rex",
-			repository: "http://example.com/test",
-			index:      0,
-			expect:     "oedipus-rex-0e52b63f-0",
-		},
-		{
-			name:       "different repo same name",
-			depName:    "oedipus-rex",
-			repository: "http://example.com",
-			index:      0,
-			expect:     "oedipus-rex-f0e6a6a9-0",
-		},
-		{
-			name:       "same repo different index",
-			depName:    "oedipus-rex",
-			repository: "http://example.com",
-			index:      1,
-			expect:     "oedipus-rex-f0e6a6a9-1",
-		},
-		{
-			name:       "local file path",
-			depName:    "local-dep",
-			repository: "file://./testdata/signtest",
-			index:      0,
-			expect:     "local-dep-93f23b0e-0",
-		},
-		{
-			name:       "empty repository",
-			depName:    "local-subchart",
-			repository: "",
-			index:      0,
-			expect:     "local-subchart--0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := dependencyKey(tt.depName, tt.repository, tt.index)
-			if result != tt.expect {
-				t.Errorf("dependencyKey(%q, %q, %d) = %q, want %q",
-					tt.depName, tt.repository, tt.index, result, tt.expect)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix dependency resolution for charts with same name from different repositories. This PR resolves the issue where Helm fails to handle multiple dependencies with the same chart name from different repositories, even when using aliases.

When a Helm chart declares multiple dependencies with the same name but from different repositories, dependency resolution fails. For example:

```yaml
dependencies:
- name: common-chart
  alias: common-chart
  repository: '@repo1'
  version: 1.0.0
- name: common-chart
  alias: common-chart-alt
  repository: '@repo2'  
  version: 2.0.0
```

In this case, Helm incorrectly tries to resolve both dependencies using only one of the repositories, leading to errors like:

```
Error: can't get a valid version for 1 subchart(s): "common-chart" (repository "https://repo2-url", version "1.0.0"). Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml
```

**Special notes for your reviewer**:
More information in the issue.
This PR is an update to a [previous ](https://github.com/helm/helm/pull/30947)PR that was made from dev-v3
Fixes: #30875

**If applicable**:
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility


