### PR TITLE
fix: Revert Helm v3 to OAuth2 workflow for OCI

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -156,6 +156,8 @@ func NewClient(options ...ClientOption) (*Client, error) {
 			authorizer.Cache = auth.NewCache()
 		}
 
+		authorizer.ForceAttemptOAuth2 = true
+
 		client.authorizer = &authorizer
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it

ORAS v1 used POST for auth as part of OAuth workflow
ORAS v2 changed to GET for this

While this does not affect most users, the change has caused a regression in at least one custom registry that relied on checking the POST auth request. 

This one-line PR reverts the OCI OAuth workflow behavior back how 3.17.3 worked.

## Special notes for your reviewer

We can use the ForceAttemptOAuth2 setting to revert to prior behavior

This was not well-documented in the docker implementation used by ORAS 1

This is well-documented in the ORAS 2 OCI auth implementation:
https://github.com/opencontainers/wg-auth/blob/main/docs/implementations/ORAS.md?plain=1

Unit tests: this PR does not add any additional unit tests because the auth workflow is tested extensively in ORAS 2 unit tests, and all of our tests in Helm apply equally to them. This PR however has been tested extensively for backwards compatibility, fixing one registry edge case while all other behavior remains the same. See:
- https://pkg.go.dev/oras.land/oras-go/v2/registry/remote/auth@v2.6.0#Client.ForceAttemptOAuth2
- https://github.com/oras-project/oras-go/blob/v2.6.0/registry/remote/auth/client_test.go

See 

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
