### PR TITLE
Fix tests deleting XDG_DATA_HOME

### DIFF
--- a/pkg/plugin/installer/local_installer_test.go
+++ b/pkg/plugin/installer/local_installer_test.go
@@ -20,12 +20,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"helm.sh/helm/v4/internal/test/ensure"
 	"helm.sh/helm/v4/pkg/helmpath"
 )
 
 var _ Installer = new(LocalInstaller)
 
 func TestLocalInstaller(t *testing.T) {
+	ensure.HelmHome(t)
 	// Make a temp dir
 	tdir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tdir, "plugin.yaml"), []byte{}, 0644); err != nil {


### PR DESCRIPTION
That includes ~/.local/share/keyrings which was the most immediatelly visible effect.

**What this PR does / why we need it**:

Running tests locally can end up deleting XDG_DATA_DIR as can be seen here:

```
root@dd45cb081089:/code# mkdir ~/.local/share/{helm,keyrings,foo} -p
root@dd45cb081089:/code# ls -lha ~/.local/share

total 0
drwxr-xr-x 1 root root 30 Jun  4 00:45 .
drwxr-xr-x 1 root root 10 Jun  4 00:44 ..
drwxr-xr-x 1 root root  0 Jun  4 00:45 foo
drwxr-xr-x 1 root root 14 Jun  4 00:44 helm
drwxr-xr-x 1 root root  0 Jun  4 00:45 keyrings


root@dd45cb081089:/code# go test -count=1 -run 'TestLocalInstaller' ./pkg/plugin/installer/

ok  	helm.sh/helm/v4/pkg/plugin/installer	0.011s

root@dd45cb081089:/code# ls -lha ~/.local/share

total 0
drwxr-xr-x 1 root root  8 Jun  4 00:46 .
drwxr-xr-x 1 root root 10 Jun  4 00:46 ..
drwxr-xr-x 1 root root 14 Jun  4 00:46 helm
```

The same results are observed regardless of XDG_DATA_HOME being defined or not.

And we can confirm the removal with a short log:

```
~/h/i/helm ((c0aa690c…))> git diff

diff --git a/pkg/plugin/installer/local_installer_test.go b/pkg/plugin/installer/local_installer_test.go
index b28920af4..a6f92fc99 100644
--- a/pkg/plugin/installer/local_installer_test.go
+++ b/pkg/plugin/installer/local_installer_test.go
@@ -45,6 +45,7 @@ func TestLocalInstaller(t *testing.T) {
        if i.Path() != helmpath.DataPath("plugins", "echo") {
                t.Fatalf("expected path '$XDG_CONFIG_HOME/helm/plugins/helm-env', got %q", i.Path())
        }
+       t.Log("data:", helmpath.DataPath(), "-- removing:", filepath.Dir(helmpath.DataPath()))
        defer os.RemoveAll(filepath.Dir(helmpath.DataPath())) // helmpath.DataPath is like /tmp/helm013130971/helm
 }

root@dd45cb081089:/code# go test -count=1 -v -run 'TestLocalInstaller' ./pkg/plugin/installer/
=== RUN   TestLocalInstaller
    local_installer_test.go:48: data: /root/.local/share/helm -- removing: /root/.local/share
--- PASS: TestLocalInstaller (0.00s)
=== RUN   TestLocalInstallerNotAFolder
--- PASS: TestLocalInstallerNotAFolder (0.00s)
PASS
ok  	helm.sh/helm/v4/pkg/plugin/installer	0.012s

```

This PR resolves it:

```
root@dd45cb081089:/code# mkdir ~/.local/share/{helm,keyrings,foo} -p
root@dd45cb081089:/code# ls -lha ~/.local/share
total 0
drwxr-xr-x 1 root root 30 Jun  4 00:56 .
drwxr-xr-x 1 root root 10 Jun  4 00:51 ..
drwxr-xr-x 1 root root  0 Jun  4 00:56 foo
drwxr-xr-x 1 root root 14 Jun  4 00:51 helm
drwxr-xr-x 1 root root  0 Jun  4 00:56 keyrings


root@dd45cb081089:/code# go test -count=1 -v -run 'TestLocalInstaller' ./pkg/plugin/installer/

=== RUN   TestLocalInstaller
    local_installer_test.go:50: data: /tmp/TestLocalInstaller4146781603/001/helm -- removing: /tmp/TestLocalInstaller4146781603/001
--- PASS: TestLocalInstaller (0.00s)
=== RUN   TestLocalInstallerNotAFolder
--- PASS: TestLocalInstallerNotAFolder (0.00s)
PASS
ok  	helm.sh/helm/v4/pkg/plugin/installer	0.013s


root@dd45cb081089:/code# ls -lha ~/.local/share
total 0
drwxr-xr-x 1 root root 30 Jun  4 00:56 .
drwxr-xr-x 1 root root 10 Jun  4 00:51 ..
drwxr-xr-x 1 root root  0 Jun  4 00:56 foo
drwxr-xr-x 1 root root 14 Jun  4 00:51 helm
drwxr-xr-x 1 root root  0 Jun  4 00:56 keyrings

```