### PR TITLE
fix: raised error from downloadAll in case of dependency conflict

### DIFF
--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -298,6 +298,24 @@ version: 0.1.0`
 	if err == nil {
 		t.Fatal("Expected error for bad dependency name")
 	}
+
+	remoteDep := &chart.Dependency{
+		Name:       "sub",
+		Repository: "oci://remote",
+		Version:    "0.0.1",
+	}
+
+	// create a 'tmpcharts' directory to test #30710
+	if err := os.MkdirAll(filepath.Join(chartPath, "charts", "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	err = m.downloadAll([]*chart.Dependency{remoteDep})
+	if err == nil {
+		t.Fatal("Expected error as subchart already exist")
+	}
+	if err.Error() != "dependency conflict detected: A subchart named 'sub' already exists in charts/ directory" {
+		t.Fatal("Download should failed with conflict issue")
+	}
 }
 
 func TestUpdateBeforeBuild(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
fix #30710

**What this PR does / why we need it**:

Check if subchart already exist before downloading it, then in case of conflict raised an error.

**Special notes for your reviewer**:

I'm currently raising the error directly from downloadAll, wouldn't it be more appropriate to simply log a warning instead? In order to continue to iterate on deps to download ?

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
