### PR TITLE
feat(show): add helm show schema cli command

### DIFF
--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -40,6 +40,8 @@ const (
 	ShowChart ShowOutputFormat = "chart"
 	// ShowValues is the format which only shows the chart's values
 	ShowValues ShowOutputFormat = "values"
+	// ShowSchema is the format which only shows the chart's schema values
+	ShowSchema ShowOutputFormat = "schema"
 	// ShowReadme is the format which only shows the chart's README
 	ShowReadme ShowOutputFormat = "readme"
 	// ShowCRDs is the format which only shows the chart's CRDs
@@ -135,6 +137,12 @@ func (s *Show) Run(chartpath string) (string, error) {
 			for _, crd := range crds {
 				fmt.Fprintf(&out, "%s\n", string(crd.File.Data))
 			}
+		}
+	}
+
+	if s.OutputFormat == ShowSchema {
+		if len(s.chart.Schema) != 0 {
+			fmt.Fprintf(&out, "%s\n", s.chart.Schema)
 		}
 	}
 	return out.String(), nil

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -42,6 +42,11 @@ This command inspects a chart (directory, file, or URL) and displays the content
 of the values.yaml file
 `
 
+const showSchemaDesc = `
+This command inspects a chart (directory, file, or URL) and displays the contents
+of the values.schema.json file
+`
+
 const showChartDesc = `
 This command inspects a chart (directory, file, or URL) and displays the contents
 of the Chart.yaml file
@@ -118,6 +123,27 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		},
 	}
 
+	schemaSubCmd := &cobra.Command{
+		Use:               "schema [CHART]",
+		Short:             "show the chart's schema values",
+		Long:              showSchemaDesc,
+		Args:              require.ExactArgs(1),
+		ValidArgsFunction: validArgsFunc,
+		RunE: func(_ *cobra.Command, args []string) error {
+			client.OutputFormat = action.ShowSchema
+			err := addRegistryClient(client)
+			if err != nil {
+				return err
+			}
+			output, err := runShow(args, client)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(out, output)
+			return nil
+		},
+	}
+
 	chartSubCmd := &cobra.Command{
 		Use:               "chart [CHART]",
 		Short:             "show the chart's definition",
@@ -181,7 +207,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmds := []*cobra.Command{all, readmeSubCmd, valuesSubCmd, chartSubCmd, crdsSubCmd}
+	cmds := []*cobra.Command{all, readmeSubCmd, valuesSubCmd, schemaSubCmd, chartSubCmd, crdsSubCmd}
 	for _, subCmd := range cmds {
 		addShowFlags(subCmd, client)
 		showCommand.AddCommand(subCmd)

--- a/pkg/cmd/show_test.go
+++ b/pkg/cmd/show_test.go
@@ -150,6 +150,10 @@ func TestShowValuesFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "show values", true)
 }
 
+func TestShowSchemaFileCompletion(t *testing.T) {
+	checkFileCompletion(t, "show schema", true)
+}
+
 func TestShowCRDsFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "show crds", true)
 }


### PR DESCRIPTION
This PR adds a new subcommand to Helm: `helm show schema`. 
Resolves helm/helm#30726

The `helm show schema` command displays the contents of a chart's `values.schema.json` file, if present. It behaves similarly to `helm show values`: if the schema file is not present, the output is empty (no error).

This feature is useful for users and tooling to programmatically inspect or extract parts of the schema without manually navigating the chart.

- [x] This PR introduces a user-facing changes and should be labeled as `docs needed` and `feature`.
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Notes:
- The implementation follows the structure of other `helm show` subcommands (e.g., `values`, `readme`, `chart`).
- `ShowSchema` is a new output format handled in `pkg/action/show.go`.
- `cmd/helm/show.go` registers the new subcommand `schemaSubCmd`.
- Unlike other `helm show` subcommands (such as `show values`, `show readme`, etc.), `show schema` **is intentionally not included in `helm show all`**, in order to preserve backward compatibility and avoid unexpected changes in output for users relying on `show all`.


