### PR TITLE
Use https://github.com/otiai10/copy/ for copying directories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/moby/term v0.5.2
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/otiai10/copy v1.14.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/rubenv/sql-migrate v1.8.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
+github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
+	cp "github.com/otiai10/copy"
 
-	"helm.sh/helm/v4/internal/third_party/dep/fs"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/helmpath"
@@ -148,7 +148,7 @@ func (i *HTTPInstaller) Install() error {
 	}
 
 	slog.Debug("copying", "source", src, "path", i.Path())
-	return fs.CopyDir(src, i.Path())
+	return cp.Copy(src, i.Path())
 }
 
 // Update updates a local repository

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/vcs"
+	cp "github.com/otiai10/copy"
 
-	"helm.sh/helm/v4/internal/third_party/dep/fs"
 	"helm.sh/helm/v4/pkg/helmpath"
 	"helm.sh/helm/v4/pkg/plugin/cache"
 )
@@ -92,7 +92,7 @@ func (i *VCSInstaller) Install() error {
 	}
 
 	slog.Debug("copying files", "source", i.Repo.LocalPath(), "destination", i.Path())
-	return fs.CopyDir(i.Repo.LocalPath(), i.Path())
+	return cp.Copy(i.Repo.LocalPath(), i.Path())
 }
 
 // Update updates a remote repository


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the first step for removing the partial copy of https://github.com/golang/dep in
https://github.com/helm/helm/blob/main/internal/third_party/dep/fs/fs.go, which is a deprecated and archived repo.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
