### PR TITLE
fix: force bearer oauth for if registry requests bearer auth

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -134,6 +134,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 			authorizer.Cache = auth.NewCache()
 		}
 
+		authorizer.ForceAttemptOAuth2 = true
 		client.authorizer = &authorizer
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* This change does not effect basic auth.
* If a registry requests bearer auth, this change makes the request bearer auth instead of basic auth
* This change makes v4 auth work the way it did for 3.17 and earlier.

Force bearer auth for v4
Closes: https://github.com/helm/helm/issues/30987
Closes: https://github.com/helm/helm/issues/30970

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
