### PR TITLE
Added Env for max decompressed chart size and chart file size limits

### DIFF
--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -99,8 +99,9 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		if fi.Size() > MaxDecompressedFileSize {
-			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), MaxDecompressedFileSize)
+		maxChartFileSize := getMaxDecompressedFileSize()
+		if fi.Size() > maxChartFileSize {
+			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), maxChartFileSize)
 		}
 
 		data, err := os.ReadFile(name)

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -92,7 +92,6 @@ type EnvSettings struct {
 }
 
 func New() *EnvSettings {
-
 	env := &EnvSettings{
 		namespace:                 os.Getenv("HELM_NAMESPACE"),
 		MaxHistory:                envIntOr("HELM_MAX_HISTORY", defaultMaxHistory),

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -89,15 +89,9 @@ type EnvSettings struct {
 	BurstLimit int
 	// QPS is queries per second which may be used to avoid throttling.
 	QPS float32
-	// Max DecompressedChartSize is the maximum size of a chart archive that will be decompressed.
-	MaxDecompressedChartSize int
-	// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
-	MaxDecompressedFileSize int
 }
 
 func New() *EnvSettings {
-	var defaultMaxDecompressedFileSize int = 5 * 1024 * 1024    // Default 5 MiB
-	var defaultMaxDecompressedChartSize int = 100 * 1024 * 1024 // Default 100 MiB
 
 	env := &EnvSettings{
 		namespace:                 os.Getenv("HELM_NAMESPACE"),
@@ -116,8 +110,6 @@ func New() *EnvSettings {
 		RepositoryCache:           envOr("HELM_REPOSITORY_CACHE", helmpath.CachePath("repository")),
 		BurstLimit:                envIntOr("HELM_BURST_LIMIT", defaultBurstLimit),
 		QPS:                       envFloat32Or("HELM_QPS", defaultQPS),
-		MaxDecompressedChartSize:  envIntOr("HELM_MAX_DECOMPRESSED_CHART_SIZE", defaultMaxDecompressedChartSize),
-		MaxDecompressedFileSize:   envIntOr("HELM_MAX_DECOMPRESSED_FILE_SIZE", defaultMaxDecompressedFileSize),
 	}
 	env.Debug, _ = strconv.ParseBool(os.Getenv("HELM_DEBUG"))
 

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -89,9 +89,16 @@ type EnvSettings struct {
 	BurstLimit int
 	// QPS is queries per second which may be used to avoid throttling.
 	QPS float32
+	// Max DecompressedChartSize is the maximum size of a chart archive that will be decompressed.
+	MaxDecompressedChartSize int
+	// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
+	MaxDecompressedFileSize int
 }
 
 func New() *EnvSettings {
+	var defaultMaxDecompressedFileSize int = 5 * 1024 * 1024    // Default 5 MiB
+	var defaultMaxDecompressedChartSize int = 100 * 1024 * 1024 // Default 100 MiB
+
 	env := &EnvSettings{
 		namespace:                 os.Getenv("HELM_NAMESPACE"),
 		MaxHistory:                envIntOr("HELM_MAX_HISTORY", defaultMaxHistory),
@@ -109,6 +116,8 @@ func New() *EnvSettings {
 		RepositoryCache:           envOr("HELM_REPOSITORY_CACHE", helmpath.CachePath("repository")),
 		BurstLimit:                envIntOr("HELM_BURST_LIMIT", defaultBurstLimit),
 		QPS:                       envFloat32Or("HELM_QPS", defaultQPS),
+		MaxDecompressedChartSize:  envIntOr("HELM_MAX_DECOMPRESSED_CHART_SIZE", defaultMaxDecompressedChartSize),
+		MaxDecompressedFileSize:   envIntOr("HELM_MAX_DECOMPRESSED_FILE_SIZE", defaultMaxDecompressedFileSize),
 	}
 	env.Debug, _ = strconv.ParseBool(os.Getenv("HELM_DEBUG"))
 


### PR DESCRIPTION
closes #30738

### Summary
Allows the user to set the max decompressed chart and file size limits introduced in v3.17.3 via environment variables, This can be used to resolve existing charts exceeding the size limits raised in #30738 

### New Environment Variables 
`HELM_MAX_DECOMPRESSED_CHART_SIZE` - Default: 100 MiB
`HELM_MAX_DECOMPRESSED_FILE_SIZE` - Default: 5 MiB