### PR TITLE
Move logging setup to be configurable

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -34,7 +34,7 @@ func main() {
 	// manager as picked up by the automated name detection.
 	kube.ManagedFieldsManager = "helm"
 
-	cmd, err := helmcmd.NewRootCmd(os.Stdout, os.Args[1:])
+	cmd, err := helmcmd.NewRootCmd(os.Stdout, os.Args[1:], helmcmd.SetupLogging)
 	if err != nil {
 		slog.Warn("command failed", slog.Any("error", err))
 		os.Exit(1)

--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -94,7 +94,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		Capabilities: chartutil.DefaultCapabilities,
 	}
 
-	root, err := newRootCmdWithConfig(actionConfig, buf, args)
+	root, err := newRootCmdWithConfig(actionConfig, buf, args, SetupLogging)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: If another application uses NewRootCmd it will step any logger they have setup. This change allows NewRootCmd to be called and it tied to the logger they are using in their application as long as it works through the slog interface.

**Special notes for your reviewer**: Parsing flags was used further up to make sure debug is available to pass around.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
