### PR TITLE
Update tests in create_test.go and package_test.go to work in a temp directory

### DIFF
--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -30,10 +30,9 @@ import (
 )
 
 func TestCreateCmd(t *testing.T) {
+	t.Chdir(t.TempDir())
 	ensure.HelmHome(t)
 	cname := "testchart"
-	dir := t.TempDir()
-	defer t.Chdir(dir)
 
 	// Run a create
 	if _, _, err := executeActionCommand("create " + cname); err != nil {
@@ -64,9 +63,7 @@ func TestCreateStarterCmd(t *testing.T) {
 	ensure.HelmHome(t)
 	cname := "testchart"
 	defer resetEnv()()
-	os.MkdirAll(helmpath.CachePath(), 0o755)
-	defer t.Chdir(helmpath.CachePath())
-
+	t.Chdir(t.TempDir())
 	// Create a starter.
 	starterchart := helmpath.DataPath("starters")
 	os.MkdirAll(starterchart, 0o755)
@@ -125,6 +122,7 @@ func TestCreateStarterCmd(t *testing.T) {
 }
 
 func TestCreateStarterAbsoluteCmd(t *testing.T) {
+	t.Chdir(t.TempDir())
 	defer resetEnv()()
 	ensure.HelmHome(t)
 	cname := "testchart"

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -60,10 +60,10 @@ func TestCreateCmd(t *testing.T) {
 }
 
 func TestCreateStarterCmd(t *testing.T) {
+	t.Chdir(t.TempDir())
 	ensure.HelmHome(t)
 	cname := "testchart"
 	defer resetEnv()()
-	t.Chdir(t.TempDir())
 	// Create a starter.
 	starterchart := helmpath.DataPath("starters")
 	os.MkdirAll(starterchart, 0o755)
@@ -139,9 +139,6 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 	if err := os.WriteFile(tplpath, []byte("test"), 0o644); err != nil {
 		t.Fatalf("Could not write template: %s", err)
 	}
-
-	os.MkdirAll(helmpath.CachePath(), 0o755)
-	defer t.Chdir(helmpath.CachePath())
 
 	starterChartPath := filepath.Join(starterchart, "starterchart")
 

--- a/pkg/cmd/package_test.go
+++ b/pkg/cmd/package_test.go
@@ -110,8 +110,7 @@ func TestPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cachePath := t.TempDir()
-			defer t.Chdir(cachePath)
+			t.Chdir(t.TempDir())
 
 			if err := os.MkdirAll("toot", 0o777); err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/package_test.go
+++ b/pkg/cmd/package_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"helm.sh/helm/v4/internal/test/ensure"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 )
@@ -111,6 +112,7 @@ func TestPackage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Chdir(t.TempDir())
+			ensure.HelmHome(t)
 
 			if err := os.MkdirAll("toot", 0o777); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates tests in create_test.go and package_test.go to actually run in a test-provided temp directory so the Git directory doesn't accumulate generated files that aren't in `.gitignore`.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Fixes #31020