### PR TITLE
fix: 'TestRunLinterRule' stateful test

### DIFF
--- a/pkg/lint/support/message_test.go
+++ b/pkg/lint/support/message_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 )
 
-var linter = Linter{}
 var errLint = errors.New("lint failed")
 
 func TestRunLinterRule(t *testing.T) {
@@ -45,6 +44,7 @@ func TestRunLinterRule(t *testing.T) {
 		{-1, errLint, 4, false, ErrorSev},
 	}
 
+	linter := Linter{}
 	for _, test := range tests {
 		isValid := linter.RunLinterRule(test.Severity, "chart", test.LintError)
 		if len(linter.Messages) != test.ExpectedMessages {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Before this PR, the global variable will collect errors from multiple test runs (if tests are e.g. run with `-count=n` (n>1)

```
$ go clean -testcache; go test  -run "^TestRunLinterRule$" -shuffle=on -count=2 helm.sh/helm/v4/pkg/lint/support 
-test.shuffle 1751516001964952000
--- FAIL: TestRunLinterRule (0.00s)
    message_test.go:51: RunLinterRule(1, "chart", lint failed), linter.Messages should now have 1 message, we got 5
    message_test.go:55: RunLinterRule(1, "chart", lint failed), linter.HighestSeverity should be 1, we got 3
    message_test.go:51: RunLinterRule(2, "chart", lint failed), linter.Messages should now have 2 message, we got 6
    message_test.go:55: RunLinterRule(2, "chart", lint failed), linter.HighestSeverity should be 2, we got 3
    message_test.go:51: RunLinterRule(3, "chart", lint failed), linter.Messages should now have 3 message, we got 7
    message_test.go:51: RunLinterRule(3, "chart", <nil>), linter.Messages should now have 3 message, we got 7
    message_test.go:51: RunLinterRule(1, "chart", lint failed), linter.Messages should now have 4 message, we got 8
    message_test.go:51: RunLinterRule(4, "chart", lint failed), linter.Messages should now have 4 message, we got 8
    message_test.go:51: RunLinterRule(22, "chart", lint failed), linter.Messages should now have 4 message, we got 8
    message_test.go:51: RunLinterRule(-1, "chart", lint failed), linter.Messages should now have 4 message, we got 8
FAIL
FAIL    helm.sh/helm/v4/pkg/lint/support        0.181s
FAIL
```

After:
```
$ go clean -testcache; go test  -run "^TestRunLinterRule$" -shuffle=on -count=2 helm.sh/helm/v4/pkg/lint/support
ok      helm.sh/helm/v4/pkg/lint/support        0.170s
```

**Special notes for your reviewer**:
Split this logic from: https://github.com/helm/helm/pull/31013/files#diff-6256c0d0a86ec981f703d50be88ae8533e069ee928e58dc0de204aca57941e20


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
