### PR TITLE
fix: test teardown dns data race

### DIFF
--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
@@ -172,6 +173,9 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) *registry.Registry {
 }
 
 func teardown(suite *TestSuite) {
+	var lock sync.Mutex
+	lock.Lock()
+	defer lock.Unlock()
 	if suite.srv != nil {
 		mockdns.UnpatchNet(net.DefaultResolver)
 		suite.srv.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes data race in mock dns teardown
