### PR TITLE
fix(v3 backport): Add timeout flag to repo add and update flags

### DIFF
--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -51,6 +51,7 @@ type repoAddOptions struct {
 	passCredentialsAll   bool
 	forceUpdate          bool
 	allowDeprecatedRepos bool
+	timeout              time.Duration
 
 	certFile              string
 	keyFile               string
@@ -99,6 +100,7 @@ func newRepoAddCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&o.insecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the repository")
 	f.BoolVar(&o.allowDeprecatedRepos, "allow-deprecated-repos", false, "by default, this command will not allow adding official repos that have been permanently deleted. This disables that behavior")
 	f.BoolVar(&o.passCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+	f.DurationVar(&o.timeout, "timeout", getter.DefaultHTTPTimeout*time.Second, "time to wait for the index file download to complete")
 
 	return cmd
 }
@@ -203,7 +205,7 @@ func (o *repoAddOptions) run(out io.Writer) error {
 		return nil
 	}
 
-	r, err := repo.NewChartRepository(&c, getter.All(settings))
+	r, err := repo.NewChartRepository(&c, getter.All(settings, getter.WithTimeout(o.timeout)))
 	if err != nil {
 		return err
 	}

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/pkg/cli"
 )
@@ -49,6 +50,23 @@ func TestProviders(t *testing.T) {
 
 	if _, err := ps.ByScheme("five"); err == nil {
 		t.Error("Did not expect handler for five")
+	}
+}
+
+func TestProvidersWithTimeout(t *testing.T) {
+	want := time.Hour
+	getters := Getters(WithTimeout(want))
+	getter, err := getters.ByScheme("http")
+	if err != nil {
+		t.Error(err)
+	}
+	client, err := getter.(*HTTPGetter).httpClient()
+	if err != nil {
+		t.Error(err)
+	}
+	got := client.Timeout
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of #30900 to v3.
(cherry picked from commit d448cf1943735d3e99e1485d85bf73418707a8cb)
