### PR TITLE
Fix `helm pull` untar dir check with repo urls

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -114,6 +114,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		defer os.RemoveAll(dest)
 	}
 
+	downloadSourceRef := chartRef
 	if p.RepoURL != "" {
 		chartURL, err := repo.FindChartInRepoURL(
 			p.RepoURL,
@@ -128,10 +129,10 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		if err != nil {
 			return out.String(), err
 		}
-		chartRef = chartURL
+		downloadSourceRef = chartURL
 	}
 
-	saved, v, err := c.DownloadTo(chartRef, p.Version, dest)
+	saved, v, err := c.DownloadTo(downloadSourceRef, p.Version, dest)
 	if err != nil {
 		return out.String(), err
 	}

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -148,6 +148,18 @@ func TestPullCmd(t *testing.T) {
 			wantError:  true,
 		},
 		{
+			name:       "Chart fetch using repo URL with untardir",
+			args:       "signtest --version=0.1.0 --untar --untardir repo-url-test --repo " + srv.URL(),
+			expectFile: "./signtest",
+			expectDir:  true,
+		},
+		{
+			name:       "Chart fetch using repo URL with untardir and previous pull",
+			args:       "signtest --version=0.1.0 --untar --untardir repo-url-test --repo " + srv.URL(),
+			failExpect: "failed to untar",
+			wantError:  true,
+		},
+		{
 			name:       "Fetch OCI Chart",
 			args:       fmt.Sprintf("oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0", ociSrv.RegistryURL),
 			expectFile: "./oci-dependent-chart-0.1.0.tgz",


### PR DESCRIPTION
**What this PR does / why we need it**:

`helm pull` with the `--untar` option does a check if the output directory already exists.  The existing check worked for `helm pull downloaded-repo/chart-name`, but often does not work when using `--repo-url`, depending on the urls used by the charts.

This also means that it was possible to silently overwrite an existing downloaded chart when using `--repo-url`.  As far as I can tell this behaviour has existed since the original commit: https://github.com/helm/helm/commit/985827d09a0456551e116805a7c41c32800c85c0

Before:

```
# prepare
$ helm version
version.BuildInfo{Version:"v3.18.4", GitCommit:"d80839cf37d860c8aa9a0503fe463278f26cd5e2", GitTreeState:"", GoVersion:"go1.24.5"}
$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
"prometheus-community" has been added to your repositories
$ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "prometheus-community" chart repository
Update Complete. ⎈Happy Helming!⎈

# bug demo
$ ls -l
total 0
$ helm pull prometheus-community/prometheus --version 27.23.0 --untar
$ ls -l
total 0
drwxr-xr-x 4 luna luna 200 Jul 10 15:27 prometheus

# should not work because prometheus directory exists already
$ helm pull prometheus --repo https://prometheus-community.github.io/helm-charts --version 27.23.0 --untar

# but works anyways and creates funny .tgz directory (based on the chart url)
$ ls -l
total 0
drwxr-xr-x 4 luna luna 200 Jul 10 15:27 prometheus
drwxr-xr-x 2 luna luna  40 Jul 10 15:28 prometheus-27.23.0.tgz
```

After:

```
# prepare as above

$ ls -l
total 0
$ /tmp/helm-fixed pull prometheus-community/prometheus --version 27.23.0 --untar
$ ls -l
total 0
drwxr-xr-x 4 luna luna 200 Jul 10 15:39 prometheus

# download now fails as expected because chart already exists
$ /tmp/helm-fixed pull prometheus --repo https://prometheus-community.github.io/helm-charts --version 27.23.0 --untar
Error: failed to untar: a file or directory with the name prometheus already exists
$ ls -l
total 0
drwxr-xr-x 4 luna luna 200 Jul 10 15:39 prometheus

# but works when chart has not been downloaded yet
$ rm -rf prometheus
$ /tmp/helm-fixed pull prometheus --repo https://prometheus-community.github.io/helm-charts --version 27.23.0 --untar
$ ls -l
total 0
drwxr-xr-x 4 luna luna 200 Jul 10 15:39 prometheus
```

**Special notes for your reviewer**:

**If applicable**:

- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
