### PR TITLE
chore: improve OCI debug logging

### DIFF
--- a/pkg/registry/transport.go
+++ b/pkg/registry/transport.go
@@ -81,14 +81,14 @@ func NewTransport(debug bool) *retry.Transport {
 func (t *LoggingTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	id := atomic.AddUint64(&requestCount, 1) - 1
 
-	slog.Debug("Request", "id", id, "url", req.URL, "method", req.Method, "header", logHeader(req.Header))
+	slog.Debug(req.Method, "id", id, "url", req.URL, "header", logHeader(req.Header))
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {
-		slog.Debug("Response", "id", id, "error", err)
+		slog.Debug("Response"[:len(req.Method)], "id", id, "error", err)
 	} else if resp != nil {
-		slog.Debug("Response", "id", id, "status", resp.Status, "header", logHeader(resp.Header), "body", logResponseBody(resp))
+		slog.Debug("Response"[:len(req.Method)], "id", id, "status", resp.Status, "header", logHeader(resp.Header), "body", logResponseBody(resp))
 	} else {
-		slog.Debug("Response", "id", id, "response", "nil")
+		slog.Debug("Response"[:len(req.Method)], "id", id, "response", "nil")
 	}
 
 	return resp, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Shorten OCI debug logging so it is easier to read.  I spend a lot of time looking for what method was used.

Before:
```
level=DEBUG msg=Request id=0 url=https://registry-1.docker.io/v2/ method=GET header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=Response id=0 status="401 Unauthorized" header="   \"Www-Authenticate\": \"Bearer realm=\\\"https://auth.docker.io/token\\\",service=\\\"registry.docker.io\\\"\"\n   \"Date\": \"Tue, 15 Jul 2025 15:51:30 GMT\"\n   \"Content-Length\": \"87\"\n   \"Strict-Transport-Security\": \"max-age=31536000\"\n   \"Content-Type\": \"application/json\"\n   \"Docker-Distribution-Api-Version\": \"registry/2.0\"" body="{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"authentication required\",\"detail\":null}]}\n"
```

After:
```
level=DEBUG msg=GET id=0 url=https://registry-1.docker.io/v2/ header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=Res id=0 status="401 Unauthorized" header="   \"Content-Type\": \"application/json\"\n   \"Docker-Distribution-Api-Version\": \"registry/2.0\"\n   \"Www-Authenticate\": \"Bearer realm=\\\"https://auth.docker.io/token\\\",service=\\\"registry.docker.io\\\"\"\n   \"Date\": \"Tue, 15 Jul 2025 16:13:07 GMT\"\n   \"Content-Length\": \"87\"\n   \"Strict-Transport-Security\": \"max-age=31536000\"" body="{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"authentication required\",\"detail\":null}]}\n"
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
