### PR TITLE
fix: k8s version parsing to match original

### DIFF
--- a/pkg/chart/v2/util/capabilities.go
+++ b/pkg/chart/v2/util/capabilities.go
@@ -20,11 +20,11 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/Masterminds/semver/v3"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8sversion "k8s.io/apimachinery/pkg/util/version"
 
 	helmversion "helm.sh/helm/v4/internal/version"
 )
@@ -85,14 +85,16 @@ func (kv *KubeVersion) GitVersion() string { return kv.Version }
 
 // ParseKubeVersion parses kubernetes version from string
 func ParseKubeVersion(version string) (*KubeVersion, error) {
-	sv, err := semver.NewVersion(version)
+	// Based on the original k8s version parser.
+	// https://github.com/kubernetes/kubernetes/blob/b266ac2c3e42c2c4843f81e20213d2b2f43e450a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go#L137
+	sv, err := k8sversion.ParseGeneric(version)
 	if err != nil {
 		return nil, err
 	}
 	return &KubeVersion{
 		Version: "v" + sv.String(),
-		Major:   strconv.FormatUint(sv.Major(), 10),
-		Minor:   strconv.FormatUint(sv.Minor(), 10),
+		Major:   strconv.FormatUint(uint64(sv.Major()), 10),
+		Minor:   strconv.FormatUint(uint64(sv.Minor()), 10),
 	}, nil
 }
 

--- a/pkg/chart/v2/util/capabilities_test.go
+++ b/pkg/chart/v2/util/capabilities_test.go
@@ -82,3 +82,19 @@ func TestParseKubeVersion(t *testing.T) {
 		t.Errorf("Expected parsed KubeVersion.Minor to be 16, got %q", kv.Minor)
 	}
 }
+
+func TestParseKubeVersionSuffix(t *testing.T) {
+	kv, err := ParseKubeVersion("v1.28+")
+	if err != nil {
+		t.Errorf("Expected v1.28+ to parse successfully")
+	}
+	if kv.Version != "v1.28" {
+		t.Errorf("Expected parsed KubeVersion.Version to be v1.28, got %q", kv.String())
+	}
+	if kv.Major != "1" {
+		t.Errorf("Expected parsed KubeVersion.Major to be 1, got %q", kv.Major)
+	}
+	if kv.Minor != "28" {
+		t.Errorf("Expected parsed KubeVersion.Minor to be 28, got %q", kv.Minor)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The semver validation is not compatible with what k8s itself uses.
Here is an example of the version response from the kube api:
```bash
kubectl version --output json | jq '.serverVersion'
{
  "major": "1",
  "minor": "28+",
  "gitVersion": "v1.28.15-eks-4096722",
  "gitCommit": "79964c34fd537f50bf77579c5bd51cb4426ae5e7",
  "gitTreeState": "clean",
  "buildDate": "2025-04-19T08:21:43Z",
  "goVersion": "go1.23.6",
  "compiler": "gc",
  "platform": "linux/arm64"
}
```
The version is compiled as `1.28+`. This type of version format is used by AWS EKS and considered valid according to [the version validator in k8s](https://github.com/kubernetes/kubernetes/blob/b266ac2c3e42c2c4843f81e20213d2b2f43e450a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go#L45).

When the same version is parsed into `helm template` of `helm lint`, it is being validated with [ParseKubeVersion](https://github.com/helm/helm/blob/1a736339081890a89c45e30612825c5426895ff7/pkg/chart/v2/util/capabilities.go#L87) which uses the github.com/Masterminds/semver/v3 package.

The Masterminds/semver package does not support trailing `+` symbol and upon command run, it throws the `Invalid Semantic Version` error.
```
`helm template . --name-template <APP_NAME> --namespace <NAMESPACE> --kube-version 1.28+ --values <TEMP_DIR_1>/values.yaml --values <TEMP_DIR_2> <api versions removed> --include-crds`
failed exit status 1: Error: invalid kube version '1.28+': Invalid Semantic Version
```

Adresses the  https://github.com/helm/helm/issues/31063

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
