### PR TITLE
fix: k8s version parsing to match original

### DIFF
--- a/pkg/chartutil/capabilities.go
+++ b/pkg/chartutil/capabilities.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Masterminds/semver/v3"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8sversion "k8s.io/apimachinery/pkg/util/version"
 
 	helmversion "helm.sh/helm/v3/internal/version"
 )
@@ -84,14 +84,16 @@ func (kv *KubeVersion) GitVersion() string { return kv.Version }
 
 // ParseKubeVersion parses kubernetes version from string
 func ParseKubeVersion(version string) (*KubeVersion, error) {
-	sv, err := semver.NewVersion(version)
+	// Based on the original k8s version parser.
+	// https://github.com/kubernetes/kubernetes/blob/b266ac2c3e42c2c4843f81e20213d2b2f43e450a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go#L137
+	sv, err := k8sversion.ParseGeneric(version)
 	if err != nil {
 		return nil, err
 	}
 	return &KubeVersion{
 		Version: "v" + sv.String(),
-		Major:   strconv.FormatUint(sv.Major(), 10),
-		Minor:   strconv.FormatUint(sv.Minor(), 10),
+		Major:   strconv.FormatUint(uint64(sv.Major()), 10),
+		Minor:   strconv.FormatUint(uint64(sv.Minor()), 10),
 	}, nil
 }
 

--- a/pkg/chartutil/capabilities_test.go
+++ b/pkg/chartutil/capabilities_test.go
@@ -82,3 +82,19 @@ func TestParseKubeVersion(t *testing.T) {
 		t.Errorf("Expected parsed KubeVersion.Minor to be 16, got %q", kv.Minor)
 	}
 }
+
+func TestParseKubeVersionSuffix(t *testing.T) {
+	kv, err := ParseKubeVersion("v1.28+")
+	if err != nil {
+		t.Errorf("Expected v1.28+ to parse successfully")
+	}
+	if kv.Version != "v1.28" {
+		t.Errorf("Expected parsed KubeVersion.Version to be v1.28, got %q", kv.String())
+	}
+	if kv.Major != "1" {
+		t.Errorf("Expected parsed KubeVersion.Major to be 1, got %q", kv.Major)
+	}
+	if kv.Minor != "28" {
+		t.Errorf("Expected parsed KubeVersion.Minor to be 28, got %q", kv.Minor)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of https://github.com/helm/helm/pull/31078
Addresses the https://github.com/helm/helm/issues/31063
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
