### PR TITLE
fix(chartrepository): cache path customization in `FindChartInRepoURL` funcs 

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -796,7 +796,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 		dl.Verify = downloader.VerifyAlways
 	}
 	if c.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(c.RepoURL, c.Username, c.Password, name, version,
+		chartURL, err := repo.FindChartInAuthAndTLSAndPassAndCacheRepoURL(c.RepoURL, c.Username, c.Password, name, version,
 			c.CertFile, c.KeyFile, c.CaFile, c.InsecureSkipTLSverify, c.PassCredentialsAll, getter.All(settings), settings.RepositoryCache)
 		if err != nil {
 			return "", err

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -797,7 +797,7 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	}
 	if c.RepoURL != "" {
 		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(c.RepoURL, c.Username, c.Password, name, version,
-			c.CertFile, c.KeyFile, c.CaFile, c.InsecureSkipTLSverify, c.PassCredentialsAll, getter.All(settings))
+			c.CertFile, c.KeyFile, c.CaFile, c.InsecureSkipTLSverify, c.PassCredentialsAll, getter.All(settings), settings.RepositoryCache)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -122,7 +122,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings), p.Settings.RepositoryCache)
+		chartURL, err := repo.FindChartInAuthAndTLSAndPassAndCacheRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings), p.Settings.RepositoryCache)
 		if err != nil {
 			return out.String(), err
 		}

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -122,7 +122,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	}
 
 	if p.RepoURL != "" {
-		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings))
+		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings), p.Settings.RepositoryCache)
 		if err != nil {
 			return out.String(), err
 		}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -742,7 +742,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
-	url, err = repo.FindChartInRepoURL(repoURL, name, version, certFile, keyFile, caFile, m.Getters, m.RepositoryCache)
+	url, err = repo.FindChartInAuthAndTLSAndPassAndCacheRepoURL(repoURL, "", "", name, version, certFile, keyFile, caFile, false, false, m.Getters, m.RepositoryCache)
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -742,7 +742,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			return
 		}
 	}
-	url, err = repo.FindChartInRepoURL(repoURL, name, version, certFile, keyFile, caFile, m.Getters)
+	url, err = repo.FindChartInRepoURL(repoURL, name, version, certFile, keyFile, caFile, m.Getters, m.RepositoryCache)
 	if err == nil {
 		return url, username, password, false, false, "", "", "", err
 	}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -198,23 +198,23 @@ func (r *ChartRepository) generateIndex() error {
 
 // FindChartInRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories
-func FindChartInRepoURL(repoURL, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers, cachePath string) (string, error) {
-	return FindChartInAuthRepoURL(repoURL, "", "", chartName, chartVersion, certFile, keyFile, caFile, getters, cachePath)
+func FindChartInRepoURL(repoURL, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers) (string, error) {
+	return FindChartInAuthRepoURL(repoURL, "", "", chartName, chartVersion, certFile, keyFile, caFile, getters)
 }
 
 // FindChartInAuthRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories, like FindChartInRepoURL,
 // but it also receives credentials for the chart repository.
-func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers, cachePath string) (string, error) {
-	return FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, false, getters, cachePath)
+func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers) (string, error) {
+	return FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, false, getters)
 }
 
 // FindChartInAuthAndTLSRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories, like FindChartInRepoURL,
 // but it also receives credentials and TLS verify flag for the chart repository.
 // TODO Helm 4, FindChartInAuthAndTLSRepoURL should be integrated into FindChartInAuthRepoURL.
-func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify bool, getters getter.Providers, cachePath string) (string, error) {
-	return FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, insecureSkipTLSverify, false, getters, cachePath)
+func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify bool, getters getter.Providers) (string, error) {
+	return FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, insecureSkipTLSverify, false, getters)
 }
 
 // FindChartInAuthAndTLSAndPassRepoURL finds chart in chart repository pointed by repoURL
@@ -222,8 +222,15 @@ func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartV
 // but it also receives credentials, TLS verify flag, and if credentials should
 // be passed on to other domains.
 // TODO Helm 4, FindChartInAuthAndTLSAndPassRepoURL should be integrated into FindChartInAuthRepoURL.
-func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers, cachePath string) (string, error) {
+func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers) (string, error) {
+	return FindChartInAuthAndTLSAndPassAndCacheRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, insecureSkipTLSverify, passCredentialsAll, getters, "")
+}
 
+// FindChartInAuthAndTLSAndPassAndCacheRepoURL finds chart in chart repository pointed by repoURL
+// without adding repo to repositories, like FindChartInRepoURL,
+// but it also receives credentials, TLS verify flag, if credentials should
+// be passed on to other domains, and a custom cache path.
+func FindChartInAuthAndTLSAndPassAndCacheRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers, cachePath string) (string, error) {
 	// Download and write the index file to a temporary location
 	buf := make([]byte, 20)
 	rand.Read(buf)

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -48,6 +48,7 @@ type Entry struct {
 	CAFile                string `json:"caFile"`
 	InsecureSkipTLSverify bool   `json:"insecure_skip_tls_verify"`
 	PassCredentialsAll    bool   `json:"pass_credentials_all"`
+	CachePath             string `json:"cache_path"`
 }
 
 // ChartRepository represents a chart repository
@@ -71,11 +72,16 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 		return nil, errors.Errorf("could not find protocol handler for: %s", u.Scheme)
 	}
 
+	cachePath := helmpath.CachePath("repository")
+	if cfg.CachePath != "" {
+		cachePath = cfg.CachePath
+	}
+
 	return &ChartRepository{
 		Config:    cfg,
 		IndexFile: NewIndexFile(),
 		Client:    client,
-		CachePath: helmpath.CachePath("repository"),
+		CachePath: cachePath,
 	}, nil
 }
 

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -48,7 +48,6 @@ type Entry struct {
 	CAFile                string `json:"caFile"`
 	InsecureSkipTLSverify bool   `json:"insecure_skip_tls_verify"`
 	PassCredentialsAll    bool   `json:"pass_credentials_all"`
-	CachePath             string `json:"cache_path"`
 }
 
 // ChartRepository represents a chart repository
@@ -72,16 +71,11 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 		return nil, errors.Errorf("could not find protocol handler for: %s", u.Scheme)
 	}
 
-	cachePath := helmpath.CachePath("repository")
-	if cfg.CachePath != "" {
-		cachePath = cfg.CachePath
-	}
-
 	return &ChartRepository{
 		Config:    cfg,
 		IndexFile: NewIndexFile(),
 		Client:    client,
-		CachePath: cachePath,
+		CachePath: helmpath.CachePath("repository"),
 	}, nil
 }
 
@@ -245,11 +239,13 @@ func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName,
 		CAFile:                caFile,
 		Name:                  name,
 		InsecureSkipTLSverify: insecureSkipTLSverify,
-		CachePath:             cachePath,
 	}
 	r, err := NewChartRepository(&c, getters)
 	if err != nil {
 		return "", err
+	}
+	if cachePath != "" {
+		r.CachePath = cachePath
 	}
 	idx, err := r.DownloadIndexFile()
 	if err != nil {

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -204,23 +204,23 @@ func (r *ChartRepository) generateIndex() error {
 
 // FindChartInRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories
-func FindChartInRepoURL(repoURL, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers) (string, error) {
-	return FindChartInAuthRepoURL(repoURL, "", "", chartName, chartVersion, certFile, keyFile, caFile, getters)
+func FindChartInRepoURL(repoURL, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers, cachePath string) (string, error) {
+	return FindChartInAuthRepoURL(repoURL, "", "", chartName, chartVersion, certFile, keyFile, caFile, getters, cachePath)
 }
 
 // FindChartInAuthRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories, like FindChartInRepoURL,
 // but it also receives credentials for the chart repository.
-func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers) (string, error) {
-	return FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, false, getters)
+func FindChartInAuthRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, getters getter.Providers, cachePath string) (string, error) {
+	return FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, false, getters, cachePath)
 }
 
 // FindChartInAuthAndTLSRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories, like FindChartInRepoURL,
 // but it also receives credentials and TLS verify flag for the chart repository.
 // TODO Helm 4, FindChartInAuthAndTLSRepoURL should be integrated into FindChartInAuthRepoURL.
-func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify bool, getters getter.Providers) (string, error) {
-	return FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, insecureSkipTLSverify, false, getters)
+func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify bool, getters getter.Providers, cachePath string) (string, error) {
+	return FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile, insecureSkipTLSverify, false, getters, cachePath)
 }
 
 // FindChartInAuthAndTLSAndPassRepoURL finds chart in chart repository pointed by repoURL
@@ -228,7 +228,7 @@ func FindChartInAuthAndTLSRepoURL(repoURL, username, password, chartName, chartV
 // but it also receives credentials, TLS verify flag, and if credentials should
 // be passed on to other domains.
 // TODO Helm 4, FindChartInAuthAndTLSAndPassRepoURL should be integrated into FindChartInAuthRepoURL.
-func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers) (string, error) {
+func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName, chartVersion, certFile, keyFile, caFile string, insecureSkipTLSverify, passCredentialsAll bool, getters getter.Providers, cachePath string) (string, error) {
 
 	// Download and write the index file to a temporary location
 	buf := make([]byte, 20)
@@ -245,6 +245,7 @@ func FindChartInAuthAndTLSAndPassRepoURL(repoURL, username, password, chartName,
 		CAFile:                caFile,
 		Name:                  name,
 		InsecureSkipTLSverify: insecureSkipTLSverify,
+		CachePath:             cachePath,
 	}
 	r, err := NewChartRepository(&c, getters)
 	if err != nil {

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -83,13 +83,14 @@ func TestNewChartRepositoryWithCachePath(t *testing.T) {
 
 	cacheDir := t.TempDir()
 	r, err := NewChartRepository(&Entry{
-		Name:      testRepository,
-		URL:       srv.URL,
-		CachePath: cacheDir,
+		Name: testRepository,
+		URL:  srv.URL,
 	}, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Errorf("Problem creating chart repository from %s: %v", testRepository, err)
 	}
+
+	r.CachePath = cacheDir
 
 	if err := r.Load(); err != nil {
 		t.Errorf("Problem loading chart repository from %s: %v", testRepository, err)

--- a/pkg/repo/chartrepo_test.go
+++ b/pkg/repo/chartrepo_test.go
@@ -333,7 +333,7 @@ func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}), "")
+	chartURL, err := FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "", "", "", "", true, false, getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -342,7 +342,7 @@ func TestFindChartInAuthAndTLSAndPassRepoURL(t *testing.T) {
 	}
 
 	// If the insecureSkipTLSVerify is false, it will return an error that contains "x509: certificate signed by unknown authority".
-	_, err = FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}), "")
+	_, err = FindChartInAuthAndTLSAndPassRepoURL(srv.URL, "", "", "nginx", "0.1.0", "", "", "", false, false, getter.All(&cli.EnvSettings{}))
 	// Go communicates with the platform and different platforms return different messages. Go itself tests darwin
 	// differently for its message. On newer versions of Darwin the message includes the "Acme Co" portion while older
 	// versions of Darwin do not. As there are people developing Helm using both old and new versions of Darwin we test
@@ -363,7 +363,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}), "")
+	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -371,7 +371,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 		t.Errorf("%s is not the valid URL", chartURL)
 	}
 
-	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{}), "")
+	chartURL, err = FindChartInRepoURL(srv.URL, "nginx", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{}))
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -380,7 +380,7 @@ func TestFindChartInRepoURL(t *testing.T) {
 	}
 }
 
-func TestFindChartInRepoURLWithCachePath(t *testing.T) {
+func TestFindChartInAuthAndTLSAndPassAndCacheRepoURL(t *testing.T) {
 	srv, err := startLocalServerForTests(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -388,7 +388,7 @@ func TestFindChartInRepoURLWithCachePath(t *testing.T) {
 	defer srv.Close()
 
 	cacheDir := t.TempDir()
-	chartURL, err := FindChartInRepoURL(srv.URL, "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}), cacheDir)
+	chartURL, err := FindChartInAuthAndTLSAndPassAndCacheRepoURL(srv.URL, "", "", "nginx", "", "", "", "", false, false, getter.All(&cli.EnvSettings{}), cacheDir)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -398,7 +398,7 @@ func TestFindChartInRepoURLWithCachePath(t *testing.T) {
 }
 
 func TestErrorFindChartInRepoURL(t *testing.T) {
-	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", getter.All(&cli.EnvSettings{}), ""); err == nil {
+	if _, err := FindChartInRepoURL("http://someserver/something", "nginx", "", "", "", "", getter.All(&cli.EnvSettings{})); err == nil {
 		t.Errorf("Expected error for bad chart URL, but did not get any errors")
 	} else if !strings.Contains(err.Error(), `looks like "http://someserver/something" is not a valid chart repository or cannot be reached`) {
 		t.Errorf("Expected error for bad chart URL, but got a different error (%v)", err)
@@ -410,19 +410,19 @@ func TestErrorFindChartInRepoURL(t *testing.T) {
 	}
 	defer srv.Close()
 
-	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "", "", "", "", getter.All(&cli.EnvSettings{}), ""); err == nil {
+	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "", "", "", "", getter.All(&cli.EnvSettings{})); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{}), ""); err == nil {
+	if _, err = FindChartInRepoURL(srv.URL, "nginx1", "0.1.0", "", "", "", getter.All(&cli.EnvSettings{})); err == nil {
 		t.Errorf("Expected error for chart not found, but did not get any errors")
 	} else if err.Error() != `chart "nginx1" version "0.1.0" not found in `+srv.URL+` repository` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)
 	}
 
-	if _, err = FindChartInRepoURL(srv.URL, "chartWithNoURL", "", "", "", "", getter.All(&cli.EnvSettings{}), ""); err == nil {
+	if _, err = FindChartInRepoURL(srv.URL, "chartWithNoURL", "", "", "", "", getter.All(&cli.EnvSettings{})); err == nil {
 		t.Errorf("Expected error for no chart URLs available, but did not get any errors")
 	} else if err.Error() != `chart "chartWithNoURL" has no downloadable URLs` {
 		t.Errorf("Expected error for chart not found, but got a different error (%v)", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the issue reported in #31028 for the v3 branch. It doesn't necessarily close it yet because the problem still needs fixing in the v4 branch. I am planning to open a similar PR to fix the v4 code after this.

This pull request adds a `cachePath` parameter to all the functions in the `FindChartInRepoURL` family.

Following the previous change, there were updates to three places where that functionw is being used:

- In the `action.ChartPathOptions.LocateChart()` method: to adopt the cache path set from its `settings` parameter.
- In the `action.Pull.Run()` method: to adopt the cache path from its settings field.
- in the `downloader.Manager`: to adopt the cache path set in the manager itself.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
