### PR TITLE
fix: assign KUBECONFIG environment variable value to env.Kubeconfig

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -95,6 +95,7 @@ func New() *EnvSettings {
 	env := &EnvSettings{
 		namespace:                 os.Getenv("HELM_NAMESPACE"),
 		MaxHistory:                envIntOr("HELM_MAX_HISTORY", defaultMaxHistory),
+		KubeConfig:                os.Getenv("KUBECONFIG"),
 		KubeContext:               os.Getenv("HELM_KUBECONTEXT"),
 		KubeToken:                 os.Getenv("HELM_KUBETOKEN"),
 		KubeAsUser:                os.Getenv("HELM_KUBEASUSER"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
when I imported this pacakge, I found it can't get the kubeconfig from the KUBECONFIG env  automatically，so I read the source code. The field supposed to be assigned

**What this PR does / why we need it**:
To get the kubeconfig from KUBECONFIG environment variable automatically
**Special notes for your reviewer**:
Refer to this issue: #31103 


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
