### PR TITLE
Add debug logging for helm pull command

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -88,6 +88,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		RegistryClient:   p.cfg.RegistryClient,
 		RepositoryConfig: p.Settings.RepositoryConfig,
 		RepositoryCache:  p.Settings.RepositoryCache,
+		Debug:            p.Settings.Debug,
 	}
 
 	if registry.IsOCI(chartRef) {

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -88,7 +88,6 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		RegistryClient:   p.cfg.RegistryClient,
 		RepositoryConfig: p.Settings.RepositoryConfig,
 		RepositoryCache:  p.Settings.RepositoryCache,
-		Debug:            p.Settings.Debug,
 	}
 
 	if registry.IsOCI(chartRef) {

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/url"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +71,7 @@ type ChartDownloader struct {
 	Getters getter.Providers
 	// Options provide parameters to be passed along to the Getter being initialized.
 	Options          []getter.Option
-        Debug bool	//Added to capture the --debug flag
+	Debug            bool //Added to capture the --debug flag
 	RegistryClient   *registry.Client
 	RepositoryConfig string
 	RepositoryCache  string
@@ -79,33 +79,38 @@ type ChartDownloader struct {
 
 type debugTransport struct {
 	*http.Transport
-	out       io.Writer
+	out   io.Writer
+	debug bool
 }
 
 func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-
-	fmt.Fprintf(t.out, "DEBUG: HTTP request to %s\n", req.URL.String())
-	// Log the request
-	reqDump, err := httputil.DumpRequestOut(req, false)
-	if err == nil {
-		fmt.Fprintf(t.out, "%s\n", reqDump)
+	if t.debug {
+		fmt.Fprintf(t.out, "DEBUG: HTTP request to %s\n", req.URL.String())
+		// Log the request
+		reqDump, err := httputil.DumpRequestOut(req, false)
+		if err == nil {
+			fmt.Fprintf(t.out, "%s\n", reqDump)
+		}
 	}
 	// Perform the request
 	resp, err := t.Transport.RoundTrip(req)
 	if err != nil {
-		fmt.Fprintf(t.out, "HTTP request failed: %v\n", err)
+		if t.debug {
+			fmt.Fprintf(t.out, "HTTP request failed: %v\n", err)
+		}
 		return nil, err
 	}
 	// Log the response
-	respDump, err := httputil.DumpResponse(resp, false)
-	if err == nil {
-		fmt.Fprintf(t.out, "HTTP Response: \n%s\n", respDump)
+	if t.debug {
+		respDump, err := httputil.DumpResponse(resp, false)
+		if err == nil {
+			fmt.Fprintf(t.out, "HTTP Response: \n%s\n", respDump)
+		}
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			location := resp.Header["Location"]
+			fmt.Fprintf(t.out, "DEBUG: Redirect to: %v\n", location)
+		}
 	}
-	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-            	location, _ := resp.Header["Location"]
-          	fmt.Fprintf(t.out, "DEBUG: Redirect to: %v\n", location)
-        }
-
 	return resp, err
 }
 
@@ -123,17 +128,24 @@ func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *provenance.Verification, error) {
 	u, err := c.ResolveChartVersion(ref, version)
 	if err != nil {
-		fmt.Fprintf(c.Out, "DEBUG: Failed to resolve chart version: %v\n", err)
+		if c.Debug {
+			fmt.Fprintf(c.Out, "DEBUG: Failed to resolve chart version: %v\n", err)
+		}
 		return "", nil, err
 	}
-	fmt.Fprintf(c.Out, "DEBUG: Resolved chart URL: %s\n", u.String())
+	if c.Debug {
+		fmt.Fprintf(c.Out, "DEBUG: Resolved chart URL: %s\n", u.String())
+	}
 	g, err := c.Getters.ByScheme(u.Scheme)
 	if err != nil {
-		fmt.Fprintf(c.Out, "DEBUG: Failed to get getter for scheme %s: %v\n", u.Scheme, err)
+		if c.Debug {
+			fmt.Fprintf(c.Out, "DEBUG: Failed to get getter for scheme %s: %v\n", u.Scheme, err)
+		}
 		return "", nil, err
 	}
-	fmt.Fprintf(c.Out, "DEBUG: Using getter for scheme: %s\n", u.Scheme)
-
+	if c.Debug {
+		fmt.Fprintf(c.Out, "DEBUG: Using getter for scheme: %s\n", u.Scheme)
+	}
 	c.Options = append(c.Options, getter.WithAcceptHeader("application/gzip,application/octet-stream"))
 
 	// If debug is enabled, wrap the getter's HTTP client with a debug transport
@@ -141,19 +153,24 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 		dt := &debugTransport{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
 			out:       c.Out,
+			debug:     c.Debug,
 		}
-		dt.Transport.DisableKeepAlives = true
+		dt.DisableKeepAlives = true
 		c.Options = append(c.Options, getter.WithClient(&http.Client{
-            		Transport: dt,
-            		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-                		fmt.Fprintf(c.Out, "DEBUG: Following redirect to %s\n", req.URL.String())
-                		return nil
-            		},
-        	}))
+			Transport: dt,
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				if c.Debug {
+					fmt.Fprintf(c.Out, "DEBUG: Following redirect to %s\n", req.URL.String())
+				}
+				return nil
+			},
+		}))
 	}
 	data, err := g.Get(u.String(), c.Options...)
 	if err != nil {
-		fmt.Fprintf(c.Out, "DEBUG: Failed to fetch chart: %v\n", err)
+		if c.Debug {
+			fmt.Fprintf(c.Out, "DEBUG: Failed to fetch chart: %v\n", err)
+		}
 		return "", nil, err
 	}
 
@@ -175,16 +192,18 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 		if c.Debug {
 			dt := &debugTransport{
 				Transport: http.DefaultTransport.(*http.Transport).Clone(),
-				out: c.Out,
+				out:       c.Out,
 			}
-			dt.Transport.DisableKeepAlives = true
+			dt.DisableKeepAlives = true
 			c.Options = append(c.Options, getter.WithClient(&http.Client{
-            			Transport: dt,
-            			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-                			fmt.Fprintf(c.Out, "DEBUG: Following redirect to %s\n", req.URL.String())
-                			return nil
-            			},
-        		}))
+				Transport: dt,
+				CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+					if c.Debug {
+						fmt.Fprintf(c.Out, "DEBUG: Following redirect to %s\n", req.URL.String())
+					}
+					return nil
+				},
+			}))
 		}
 		body, err := g.Get(u.String() + ".prov")
 		if err != nil {

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -19,7 +19,9 @@ package getter
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"time"
 
@@ -191,6 +193,18 @@ const (
 )
 
 var defaultOptions = []Option{WithTimeout(time.Second * DefaultHTTPTimeout)}
+
+func init() {
+	level := slog.LevelInfo
+	if os.Getenv("HELM_DEBUG") == "true" {
+		level = slog.LevelDebug
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	}))
+	slog.SetDefault(logger)
+}
 
 func Getters(extraOpts ...Option) Providers {
 	return Providers{

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -47,7 +47,7 @@ type options struct {
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
-	client		      *http.Client
+	client                *http.Client
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -47,6 +47,7 @@ type options struct {
 	registryClient        *registry.Client
 	timeout               time.Duration
 	transport             *http.Transport
+	client		      *http.Client
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -35,7 +35,6 @@ type HTTPGetter struct {
 	once      sync.Once
 }
 
-
 // Get performs a Get from repo.Getter and returns the body.
 func (g *HTTPGetter) Get(href string, options ...Option) (*bytes.Buffer, error) {
 	for _, opt := range options {

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -35,6 +35,7 @@ type HTTPGetter struct {
 	once      sync.Once
 }
 
+
 // Get performs a Get from repo.Getter and returns the body.
 func (g *HTTPGetter) Get(href string, options ...Option) (*bytes.Buffer, error) {
 	for _, opt := range options {
@@ -80,9 +81,13 @@ func (g *HTTPGetter) get(href string) (*bytes.Buffer, error) {
 		}
 	}
 
-	client, err := g.httpClient()
-	if err != nil {
-		return nil, err
+	client := g.opts.client
+	if client == nil {
+		var err error
+		client, err = g.httpClient()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := client.Do(req)
@@ -154,4 +159,11 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 	}
 
 	return client, nil
+}
+
+// WithClient sets the HTTP client for the getter
+func WithClient(client *http.Client) Option {
+	return func(opts *options) {
+		opts.client = client
+	}
 }


### PR DESCRIPTION
Hi :)

This pull request closes #31098, where the --debug flag was being ignored when running helm pull. The changes ensure that HTTP-level debug logs (e.g., URLs called, redirects, proxy usage) are printed when the --debug flag is enabled.

### Changes Made

- **pkg/action/pull.go:** Added ```Debug``` to the ```HTTPGetter``` configuration to pass environment settings for debugging.
- **pkg/getter/httpgetter.go:** Integrated ```Debug``` to configure the HTTP client with a debug transport when enabled.
- **pkg/getter/getter.go:** Updated the ```options``` struct to include the Debug field.
- **pkg/downloader/chart_downloader.go:** Added support for debug transport to log HTTP requests and responses during chart downloads.

### Testing

**MP4 Video attached**

- I have tested this with the strimzi repository after adding the repo.
- Added the Strimzi repository: `helm repo add strimzi https://strimzi.io/charts`
- Ran `helm pull strimzi/strimzi-kafka-operator --version 0.46.1 --debug`
- Verified that HTTP-level debug logs are now printed:
  
  https://github.com/user-attachments/assets/ca1a9e95-37cc-4647-99d1-93e313b6f2d9
