### PR TITLE
fix: prevent panic when ChartDownloader.getOciURI

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -164,6 +164,10 @@ func (c *ChartDownloader) ResolveChartVersion(ref, version string) (*url.URL, er
 	}
 
 	if registry.IsOCI(u.String()) {
+		if c.RegistryClient == nil {
+			return nil, fmt.Errorf("unable to lookup ref %s at version '%s', missing registry client", ref, version)
+		}
+
 		return c.RegistryClient.ValidateReference(ref, version, u)
 	}
 

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -23,6 +23,7 @@ import (
 	"helm.sh/helm/v4/internal/test/ensure"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/getter"
+	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/repo"
 	"helm.sh/helm/v4/pkg/repo/repotest"
 )
@@ -60,10 +61,17 @@ func TestResolveChartRef(t *testing.T) {
 		{name: "oci ref with sha256 and version mismatch", ref: "oci://example.com/install/by/sha:0.1.1@sha256:d234555386402a5867ef0169fefe5486858b6d8d209eaf32fd26d29b16807fd6", version: "0.1.2", fail: true},
 	}
 
+	// Create a mock registry client for OCI references
+	registryClient, err := registry.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	c := ChartDownloader{
 		Out:              os.Stderr,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
+		RegistryClient:   registryClient,
 		Getters: getter.All(&cli.EnvSettings{
 			RepositoryConfig: repoConfig,
 			RepositoryCache:  repoCache,


### PR DESCRIPTION
needs to lookup tags because no version is provided but no RegistryClient is provided

Reopening #13105 given that #13436 was closed

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
