### PR TITLE
[v3 backport] fix: null merge

### DIFF
--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -283,6 +283,11 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]interface{}, pref
 	if dst == nil {
 		return src
 	}
+	for key, val := range dst {
+		if val == nil {
+			src[key] = nil
+		}
+	}
 	// Because dest has higher precedence than src, dest values override src
 	// values.
 	for key, val := range src {


### PR DESCRIPTION
(cherry-picked from commit c1175a410656c97050b5079b5afb475217663a99)

closes #31118

**What this PR does / why we need it**:
This PR cherry-picks a commit from the `main` branch which will solve the warnings described in #31118.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
