### PR TITLE
fix(transport): leverage same tls config

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -122,6 +122,9 @@ func (g *HTTPGetter) httpClient() (*http.Client, error) {
 		g.transport = &http.Transport{
 			DisableCompression: true,
 			Proxy:              http.ProxyFromEnvironment,
+			// Being nil would cause the tls.Config default to be used
+			// "NewTLSConfig" modifies an empty TLS config, not the default one
+			TLSClientConfig: &tls.Config{},
 		}
 	})
 

--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -124,6 +125,9 @@ func (g *OCIGetter) newRegistryClient() (*registry.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			Proxy:                 http.ProxyFromEnvironment,
+			// Being nil would cause the tls.Config default to be used
+			// "NewTLSConfig" modifies an empty TLS config, not the default one
+			TLSClientConfig: &tls.Config{},
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
it fixes https://github.com/helm/helm/issues/31111, but the reason is not obvious. 

Closes: https://github.com/helm/helm/issues/31111
---

Before:
 - if `NewTLSConfig` was called: TLSClientConfig was created empty and then modified with the needed values
 - if `NewTLSConfig` was not called: TLSClientConfig was `nil`. 
 
Keep in mind that:
```
	// TLSClientConfig specifies the TLS configuration to use with
	// tls.Client.
	// If nil, the default configuration is used.
	// If non-nil, HTTP/2 support may not be enabled by default.
```
Therefore, we were using de facto a different `TLSClientConfig` depending whenever those inputs were passed and NewTLSConfig was called or not. In one case the default, in the other an empty one.

---

Now:
 - if `NewTLSConfig` is not called tlsConf = &tls.Config{}

This is the behaviour already implemented [elsewhere in the code!](https://github.com/helm/helm/blob/main/pkg/registry/client.go#L296-L296)
 
**Special notes for your reviewer**:
This change fixes my issue. I noticed a different behaviour whenever I was passing one of those flags.

```
HTTPS_PROXY=https://localhost:8080 go run ./... repo add test4 https://newrelic.github.io/helm-charts 
"test4" has been added to your repositories
```

---

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
