### PR TITLE
fix: remove redundant error check

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -269,10 +269,6 @@ func (c *Client) Create(resources ResourceList, options ...ClientCreateOption) (
 		return nil, fmt.Errorf("invalid client create option(s): %w", err)
 	}
 
-	if createOptions.forceConflicts && !createOptions.serverSideApply {
-		return nil, fmt.Errorf("invalid operation: force conflicts can only be used with server-side apply")
-	}
-
 	makeCreateApplyFunc := func() func(target *resource.Info) error {
 		if createOptions.serverSideApply {
 			slog.Debug("using server-side apply for resource creation", slog.Bool("forceConflicts", createOptions.forceConflicts), slog.Bool("dryRun", createOptions.dryRun), slog.String("fieldValidationDirective", string(createOptions.fieldValidationDirective)))


### PR DESCRIPTION

**What this PR does / why we need it**:
This error check is redundant.

https://github.com/helm/helm/pull/31030/files#r2276348205

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
