### PR TITLE
fix: enable shuffle in Makefile for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ACCEPTANCE_RUN_TESTS=.
 PKG         := ./...
 TAGS        :=
 TESTS       := .
-TESTFLAGS   :=
+TESTFLAGS   := -shuffle=on -count=1
 LDFLAGS     := -w -s
 GOFLAGS     :=
 CGO_ENABLED ?= 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Works on my machine 🤷 

I'm going to do another PR for daily job as discussed in the dev meeting a while back.

Closes: https://github.com/helm/helm/pull/30953
Closes: https://github.com/helm/helm/pull/30952
Closes: https://github.com/helm/helm/pull/30951
Closes: https://github.com/helm/helm/pull/31068
Closes: https://github.com/helm/helm/pull/31013

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
