### PR TITLE
feat: add globstar support to --show-only

### DIFF
--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -114,6 +114,12 @@ func TestTemplateCmd(t *testing.T) {
 			repeat: 10,
 		},
 		{
+			name:   "template with show-only globstar",
+			cmd:    fmt.Sprintf("template '%s' --show-only **/service.yaml ", chartPath),
+			golden: "output/template-show-only-globstar.txt",
+			repeat: 10,
+		},
+		{
 			name:   "sorted output of manifests (order of filenames, then order of objects within each YAML file)",
 			cmd:    fmt.Sprintf("template '%s'", "testdata/testcharts/object-order"),
 			golden: "output/object-order.txt",

--- a/pkg/cmd/testdata/output/template-show-only-globstar.txt
+++ b/pkg/cmd/testdata/output/template-show-only-globstar.txt
@@ -1,0 +1,55 @@
+---
+# Source: subchart/charts/subcharta/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subcharta
+  labels:
+    helm.sh/chart: "subcharta-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subcharta
+---
+# Source: subchart/charts/subchartb/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchartb
+  labels:
+    helm.sh/chart: "subchartb-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchartb
+---
+# Source: subchart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart
+  labels:
+    helm.sh/chart: "subchart-0.1.0"
+    app.kubernetes.io/instance: "release-name"
+    kube-version/major: "1"
+    kube-version/minor: "20"
+    kube-version/version: "v1.20.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend matching capabilities of `--show-only` flag by using [glob](https://github.com/gobwas/glob) instead of stdlib path matching. This library was already used by the `.Files` object during helm template and provides support for `**` among other things.
This makes the --show-only flag easier to use for charts with a deeply nested structure, e.g. `helm template foo foo-chart -s '**deployment.yaml`

The change should be backwards-compatible, because previous patterns will still behave the same.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
