### PR TITLE
fix(helm-lint): do not validate metadata.name for List resources

### DIFF
--- a/pkg/lint/rules/testdata/configmaplist-chart/Chart.yaml
+++ b/pkg/lint/rules/testdata/configmaplist-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: configmaplist-chart
+description: Test chart with ConfigMapList
+type: application
+version: "0.1.0"
+appVersion: "1.0"

--- a/pkg/lint/rules/testdata/configmaplist-chart/templates/configmap.yaml
+++ b/pkg/lint/rules/testdata/configmaplist-chart/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-single-config
+  namespace: {{ .Release.Namespace }}
+data:
+  setting: "value"

--- a/pkg/lint/rules/testdata/configmaplist-chart/templates/configmaplist.yaml
+++ b/pkg/lint/rules/testdata/configmaplist-chart/templates/configmaplist.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMapList
+metadata:
+  # ConfigMapList objects don't require meaningful names
+  # This should not trigger lint warnings
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ .Release.Name }}-database-config
+      namespace: {{ .Release.Namespace }}
+    data:
+      host: {{ .Values.configs.database.host }}
+      port: "{{ .Values.configs.database.port }}"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ .Release.Name }}-cache-config
+      namespace: {{ .Release.Namespace }}
+    data:
+      redis-url: {{ .Values.configs.cache.redis }}

--- a/pkg/lint/rules/testdata/configmaplist-chart/values.yaml
+++ b/pkg/lint/rules/testdata/configmaplist-chart/values.yaml
@@ -1,0 +1,7 @@
+# Default values for configmaplist-chart
+configs:
+  database:
+    host: localhost
+    port: 5432
+  cache:
+    redis: redis://localhost:6379


### PR DESCRIPTION
Closes #13192

**What this PR does / why we need it**:

- Issue: helm lint was incorrectly validating `metadata.name` for `List`-type resources (like `ConfigMapList`, `SecretList`, etc.)
- Root Cause: The validation logic in `pkg/lint/rules/template.go` was calling `validateMetadataName()` for ALL resources without checking if they were `List` types
- Impact: `List` resources don't require meaningful names at the top level, only the items within the list need names

Enhance the list detection logic to be defensive by checking for both the "List" suffix and the presence of an `items` field.

**Special notes for your reviewer**: c.f. linked ticket

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
