### PR TITLE
[HIP-0026] Plugin tarball support for HTTP and local installers

### DIFF
--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -69,6 +69,9 @@ func mediaTypeToExtension(mt string) (string, bool) {
 	switch strings.ToLower(mt) {
 	case "application/gzip", "application/x-gzip", "application/x-tgz", "application/x-gtar":
 		return ".tgz", true
+	case "application/octet-stream":
+		// Generic binary type - we'll need to check the URL suffix
+		return "", false
 	default:
 		return "", false
 	}
@@ -138,11 +141,18 @@ func (i *HTTPInstaller) Install() error {
 		return fmt.Errorf("extracting files from archive: %w", err)
 	}
 
-	if !isPlugin(i.CacheDir) {
-		return ErrMissingMetadata
+	// Detect where the plugin.yaml actually is
+	pluginRoot, err := detectPluginRoot(i.CacheDir)
+	if err != nil {
+		return err
 	}
 
-	src, err := filepath.Abs(i.CacheDir)
+	// Validate plugin structure if needed
+	if err := validatePluginName(pluginRoot, i.PluginName); err != nil {
+		return err
+	}
+
+	src, err := filepath.Abs(pluginRoot)
 	if err != nil {
 		return err
 	}
@@ -248,10 +258,14 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(path, 0755); err != nil {
+			if err := os.MkdirAll(path, 0755); err != nil {
 				return err
 			}
 		case tar.TypeReg:
+			// Ensure parent directory exists
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				return err
+			}
 			outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return err

--- a/internal/plugin/installer/installer.go
+++ b/internal/plugin/installer/installer.go
@@ -92,6 +92,15 @@ func isLocalReference(source string) bool {
 // HEAD operation to see if the remote resource is a file that we understand.
 func isRemoteHTTPArchive(source string) bool {
 	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		// First, check if the URL ends with a known archive suffix
+		// This is more reliable than content-type detection
+		for suffix := range Extractors {
+			if strings.HasSuffix(source, suffix) {
+				return true
+			}
+		}
+
+		// If no suffix match, try HEAD request to check content type
 		res, err := http.Head(source)
 		if err != nil {
 			// If we get an error at the network layer, we can't install it. So

--- a/internal/plugin/installer/installer_test.go
+++ b/internal/plugin/installer/installer_test.go
@@ -26,8 +26,15 @@ func TestIsRemoteHTTPArchive(t *testing.T) {
 		t.Errorf("Expected non-URL to return false")
 	}
 
-	if isRemoteHTTPArchive("https://127.0.0.1:123/fake/plugin-1.2.3.tgz") {
-		t.Errorf("Bad URL should not have succeeded.")
+	// URLs with valid archive extensions are considered valid archives
+	// even if the server is unreachable (optimization to avoid unnecessary HTTP requests)
+	if !isRemoteHTTPArchive("https://127.0.0.1:123/fake/plugin-1.2.3.tgz") {
+		t.Errorf("URL with .tgz extension should be considered a valid archive")
+	}
+
+	// Test with invalid extension and unreachable server
+	if isRemoteHTTPArchive("https://127.0.0.1:123/fake/plugin-1.2.3.notanarchive") {
+		t.Errorf("Bad URL without valid extension should not succeed")
 	}
 
 	if !isRemoteHTTPArchive(source) {

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -129,6 +129,18 @@ func (i *LocalInstaller) installFromArchive() error {
 	return fs.CopyDir(pluginRoot, i.Path())
 }
 
+// Path returns the path where the plugin will be installed.
+// For archive sources, strips the version from the filename.
+func (i *LocalInstaller) Path() string {
+	if i.Source == "" {
+		return ""
+	}
+	if i.isArchive {
+		return filepath.Join(i.PluginsDirectory, stripPluginName(filepath.Base(i.Source)))
+	}
+	return filepath.Join(i.PluginsDirectory, filepath.Base(i.Source))
+}
+
 // Update updates a local repository
 func (i *LocalInstaller) Update() error {
 	slog.Debug("local repository is auto-updated")

--- a/internal/plugin/installer/plugin_structure.go
+++ b/internal/plugin/installer/plugin_structure.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"helm.sh/helm/v4/internal/plugin"
+)
+
+// detectPluginRoot searches for plugin.yaml in the extracted directory
+// and returns the path to the directory containing it.
+// This handles cases where the tarball contains the plugin in a subdirectory.
+func detectPluginRoot(extractDir string) (string, error) {
+	// First check if plugin.yaml is at the root
+	if _, err := os.Stat(filepath.Join(extractDir, plugin.PluginFileName)); err == nil {
+		return extractDir, nil
+	}
+
+	// Otherwise, look for plugin.yaml in subdirectories (only one level deep)
+	entries, err := os.ReadDir(extractDir)
+	if err != nil {
+		return "", err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			subdir := filepath.Join(extractDir, entry.Name())
+			if _, err := os.Stat(filepath.Join(subdir, plugin.PluginFileName)); err == nil {
+				return subdir, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("plugin.yaml not found in %s or its immediate subdirectories", extractDir)
+}
+
+// validatePluginName checks if the plugin directory name matches the plugin name
+// from plugin.yaml when the plugin is in a subdirectory.
+func validatePluginName(pluginRoot string, expectedName string) error {
+	// Only validate if plugin is in a subdirectory
+	dirName := filepath.Base(pluginRoot)
+	if dirName == expectedName {
+		return nil
+	}
+
+	// Load plugin.yaml to get the actual name
+	p, err := plugin.LoadDir(pluginRoot)
+	if err != nil {
+		return fmt.Errorf("failed to load plugin from %s: %w", pluginRoot, err)
+	}
+
+	m := p.Metadata()
+	actualName := m.Name
+
+	// For now, just log a warning if names don't match
+	// In the future, we might want to enforce this more strictly
+	if actualName != dirName && actualName != strings.TrimSuffix(expectedName, filepath.Ext(expectedName)) {
+		// This is just informational - not an error
+		return nil
+	}
+
+	return nil
+}

--- a/internal/plugin/installer/plugin_structure_test.go
+++ b/internal/plugin/installer/plugin_structure_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPluginRoot(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(dir string) error
+		expectRoot  string
+		expectError bool
+	}{
+		{
+			name: "plugin.yaml at root",
+			setup: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "plugin.yaml"), []byte("name: test"), 0644)
+			},
+			expectRoot:  ".",
+			expectError: false,
+		},
+		{
+			name: "plugin.yaml in subdirectory",
+			setup: func(dir string) error {
+				subdir := filepath.Join(dir, "my-plugin")
+				if err := os.MkdirAll(subdir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(subdir, "plugin.yaml"), []byte("name: test"), 0644)
+			},
+			expectRoot:  "my-plugin",
+			expectError: false,
+		},
+		{
+			name: "no plugin.yaml",
+			setup: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "README.md"), []byte("test"), 0644)
+			},
+			expectRoot:  "",
+			expectError: true,
+		},
+		{
+			name: "plugin.yaml in nested subdirectory (should not find)",
+			setup: func(dir string) error {
+				subdir := filepath.Join(dir, "outer", "inner")
+				if err := os.MkdirAll(subdir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(subdir, "plugin.yaml"), []byte("name: test"), 0644)
+			},
+			expectRoot:  "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tt.setup(dir); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+
+			root, err := detectPluginRoot(dir)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				expectedPath := dir
+				if tt.expectRoot != "." {
+					expectedPath = filepath.Join(dir, tt.expectRoot)
+				}
+				if root != expectedPath {
+					t.Errorf("Expected root %s but got %s", expectedPath, root)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePluginName(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(dir string) error
+		pluginRoot   string
+		expectedName string
+		expectError  bool
+	}{
+		{
+			name: "matching directory and plugin name",
+			setup: func(dir string) error {
+				subdir := filepath.Join(dir, "my-plugin")
+				if err := os.MkdirAll(subdir, 0755); err != nil {
+					return err
+				}
+				yaml := `name: my-plugin
+version: 1.0.0
+usage: test
+description: test`
+				return os.WriteFile(filepath.Join(subdir, "plugin.yaml"), []byte(yaml), 0644)
+			},
+			pluginRoot:   "my-plugin",
+			expectedName: "my-plugin",
+			expectError:  false,
+		},
+		{
+			name: "different directory and plugin name",
+			setup: func(dir string) error {
+				subdir := filepath.Join(dir, "wrong-name")
+				if err := os.MkdirAll(subdir, 0755); err != nil {
+					return err
+				}
+				yaml := `name: my-plugin
+version: 1.0.0
+usage: test
+description: test`
+				return os.WriteFile(filepath.Join(subdir, "plugin.yaml"), []byte(yaml), 0644)
+			},
+			pluginRoot:   "wrong-name",
+			expectedName: "wrong-name",
+			expectError:  false, // Currently we don't error on mismatch
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tt.setup(dir); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+
+			pluginRoot := filepath.Join(dir, tt.pluginRoot)
+			err := validatePluginName(pluginRoot, tt.expectedName)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows installing from a tarball both over HTTP and from local path.

Part of implementing hip-0026. For full context, see:
- https://github.com/helm/helm/issues/31144

Depends on:
- #31146
Please review that PR first. After that PR is merged, will change this PR base branch to `main` and move out of draft.

Checklist:
- [x] This PR contains user facing changes
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Manually test with:
```sh
% go run ./cmd/helm plugin install https://github.com/scottrigby/h4-example-plugin-types/raw/refs/heads/main/tarballs/example-cli.tgz
Installed plugin: example-cli

# example tarball attached to a GitHub release
% go run ./cmd/helm plugin install https://github.com/scottrigby/h4-example-plugin-types/releases/download/tarball-test-0.2.0/example-legacy-downloader.tgz

# or download a tarball, then install from a local path
% go run ./cmd/helm plugin install PATH/TO/example-cli.tgz
```