### PR TITLE
fix: Improve error reporting for `helm template --debug` with `--show-only`

### DIFF
--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -186,7 +186,12 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							missing = false
 						}
 						if missing {
-							return fmt.Errorf("could not find template %s in chart", f)
+							if err != nil && settings.Debug {
+								// assume the manifest itself is too malformed to be rendered
+								return err
+							} else {
+								return fmt.Errorf("could not find template %s in chart", f)
+							}
 						}
 					}
 					for _, m := range manifestsToRender {

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -113,7 +113,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 				return err
 			}
-			savedErr := err
+			installErr := err
 
 			// We ignore a potential error here because, when the --debug flag was specified,
 			// we always want to print the YAML, even if it is not valid. The error is still returned afterwards.
@@ -187,9 +187,9 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							missing = false
 						}
 						if missing {
-							if savedErr != nil && settings.Debug {
+							if installErr != nil && settings.Debug {
 								// assume the manifest itself is too malformed to be rendered
-								return savedErr
+								return installErr
 							}
 							return fmt.Errorf("could not find template %s in chart", f)
 						}
@@ -202,7 +202,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 			}
 
-			return savedErr
+			return installErr
 		},
 	}
 

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -113,6 +113,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 				return err
 			}
+			savedErr := err
 
 			// We ignore a potential error here because, when the --debug flag was specified,
 			// we always want to print the YAML, even if it is not valid. The error is still returned afterwards.
@@ -186,9 +187,9 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							missing = false
 						}
 						if missing {
-							if err != nil && settings.Debug {
+							if savedErr != nil && settings.Debug {
 								// assume the manifest itself is too malformed to be rendered
-								return err
+								return savedErr
 							} else {
 								return fmt.Errorf("could not find template %s in chart", f)
 							}
@@ -202,7 +203,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 			}
 
-			return err
+			return savedErr
 		},
 	}
 

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -190,9 +190,8 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							if savedErr != nil && settings.Debug {
 								// assume the manifest itself is too malformed to be rendered
 								return savedErr
-							} else {
-								return fmt.Errorf("could not find template %s in chart", f)
 							}
+							return fmt.Errorf("could not find template %s in chart", f)
 						}
 					}
 					for _, m := range manifestsToRender {

--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -134,6 +134,12 @@ func TestTemplateCmd(t *testing.T) {
 			golden:    "output/template-with-invalid-yaml-debug.txt",
 		},
 		{
+			name:      "chart with template with invalid template expression (--debug, --show-only)",
+			cmd:       fmt.Sprintf("template '%s' --debug --show-only %s", "testdata/testcharts/chart-with-template-with-invalid-template-expr", "templates/alpine-pod.yaml"),
+			wantError: true,
+			golden:    "output/template-with-invalid-template-expr-debug-show-only.txt",
+		},
+		{
 			name:   "template skip-tests",
 			cmd:    fmt.Sprintf(`template '%s' --skip-tests`, chartPath),
 			golden: "output/template-skip-tests.txt",

--- a/pkg/cmd/testdata/output/template-with-invalid-template-expr-debug-show-only.txt
+++ b/pkg/cmd/testdata/output/template-with-invalid-template-expr-debug-show-only.txt
@@ -1,0 +1,3 @@
+Error: chart-with-template-with-invalid-template-expr/templates/alpine-pod.yaml:7:38
+  executing "chart-with-template-with-invalid-template-expr/templates/alpine-pod.yaml" at <b64enc>:
+    invalid value; expected string

--- a/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: Deploy a basic Alpine Linux pod
+home: https://helm.sh/helm
+name: chart-with-template-with-invalid-template-expr
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+type: application

--- a/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/README.md
+++ b/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/README.md
@@ -1,0 +1,13 @@
+#Alpine: A simple Helm chart
+
+Run a single pod of Alpine Linux.
+
+This example was generated using the command `helm create alpine`.
+
+The `templates/` directory contains a very simple pod resource with a
+couple of parameters.
+
+The `values.yaml` file contains the default values for the
+`alpine-pod.yaml` template.
+
+You can install this example using `helm install ./alpine`.

--- a/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/templates/alpine-pod.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/templates/alpine-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{.Release.Name}}-{{.Values.Name}}"
+spec:
+  containers:
+  - name: {{ .Values.nonExistentKey | b64enc }}
+    image: "alpine:3.9"
+    command: ["/bin/sleep","9000"]

--- a/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/values.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-template-with-invalid-template-expr/values.yaml
@@ -1,0 +1,1 @@
+Name: my-alpine


### PR DESCRIPTION
closes #31183

**What this PR does / why we need it**:

This PR fixes a bug where `helm template --debug --show-only` would show a misleading "could not find template" error when the target template had a rendering error.
Currently, the `--debug` flag suppresses the initial template rendering error and then later reports the misleading error, which hides the true cause of the failure. This change ensures that the original rendering error is captured and prioritized, providing users with accurate and actionable feedback.

**Special notes for your reviewer**:
The core of the fix is in the error handling logic after the templates are rendered. I've introduced a change to preserve the error from the `runInstall()` function, even in debug mode. The final error report now checks for this rendering error first before checking if the file specified in `--show-only` exists in the manifest output.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility