### PR TITLE
[backport] fix: set repo authorizer in registry.Client.Resolve()

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -885,6 +885,7 @@ func (c *Client) Resolve(ref string) (desc ocispec.Descriptor, err error) {
 		return desc, err
 	}
 	remoteRepository.PlainHTTP = c.plainHTTP
+	remoteRepository.Client = c.authorizer
 
 	parsedReference, err := newReference(ref)
 	if err != nil {


### PR DESCRIPTION
This is a backport of https://github.com/helm/helm/pull/31156, and it is legitimate as explained here: https://github.com/helm/helm/pull/31156#issuecomment-3212894875

Closes: https://github.com/helm/helm/issues/31158