### PR TITLE
refactor: replace pkg/engine regular expressions with parser

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -377,7 +377,7 @@ func parseTemplateExecErrorString(s string) (TraceableError, bool) {
 	// Matches https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=138
 	traceableError, done = parseTemplateSimpleErrorString(remainder)
 	if done {
-		return traceableError, done
+		return traceableError, true
 	}
 
 	return TraceableError{}, false

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -369,7 +369,7 @@ func parseTemplateExecErrorString(s string) (TraceableError, bool) {
 	// Matches https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=141
 	traceableError, done = parseTemplateExecutingAtErrorType(remainder)
 	if done {
-		return traceableError, done
+		return traceableError, true
 	}
 
 	// Simple form: "<templateName>: <errMsg>"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -362,7 +362,7 @@ func parseTemplateExecErrorString(s string) (TraceableError, bool) {
 	// Matches https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=191
 	traceableError, done := parseTemplateNoTemplateError(s, remainder)
 	if done {
-		return traceableError, done
+		return traceableError, true
 	}
 
 	// Executing form: "<templateName>: executing \"<funcName>\" at <<location>>: <errMsg>[ template:...]"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1445,8 +1445,8 @@ func TestTraceableError_SimpleForm(t *testing.T) {
 }
 func TestTraceableError_ExecutingForm(t *testing.T) {
 	testStrings := [][]string{
-		{"template: executing \"function_not_found/templates/secret.yaml\" at <include \"name\" .>: ", "function_not_found/templates/secret.yaml"},
-		{"template: executing \"name\" at <include \"common.names.get_name\" .>: ", "name"},
+		{"function_not_found/templates/secret.yaml:6:11: executing \"function_not_found/templates/secret.yaml\" at <include \"name\" .>: ", "function_not_found/templates/secret.yaml:6:11"},
+		{"divide_by_zero/templates/secret.yaml:6:11: executing \"divide_by_zero/templates/secret.yaml\" at <include \"division\" .>: ", "divide_by_zero/templates/secret.yaml:6:11"},
 	}
 	for _, errTuple := range testStrings {
 		errString := errTuple[0]
@@ -1466,7 +1466,7 @@ func TestTraceableError_NoTemplateForm(t *testing.T) {
 		"no template \"common.names.get_name\" associated with template \"gotpl\"",
 	}
 	for _, errString := range testStrings {
-		trace, done := parseTemplateNoTemplateError(errString, "")
+		trace, done := parseTemplateNoTemplateError(errString, errString)
 		if !done {
 			t.Errorf("Expected parse to pass but did not")
 		}


### PR DESCRIPTION

**What this PR does / why we need it**:
My junky MacBook does not have the memory or cpu to handle this regular expression parsing and the tests time out after 10m. With this change the entire pkg/engine tests run in less than 3 seconds.

Closes: https://github.com/helm/helm/issues/31192

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
