### PR TITLE
fix: flaky registry data race on mockdns close

### DIFF
--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -32,10 +32,7 @@ type HTTPRegistryClientTestSuite struct {
 
 func (suite *HTTPRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	dockerRegistry := setup(&suite.TestSuite, false, false)
-
-	// Start Docker registry
-	go dockerRegistry.ListenAndServe()
+	setup(&suite.TestSuite, false, false)
 }
 
 func (suite *HTTPRegistryClientTestSuite) TearDownSuite() {

--- a/pkg/registry/client_insecure_tls_test.go
+++ b/pkg/registry/client_insecure_tls_test.go
@@ -29,10 +29,7 @@ type InsecureTLSRegistryClientTestSuite struct {
 
 func (suite *InsecureTLSRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	dockerRegistry := setup(&suite.TestSuite, true, true)
-
-	// Start Docker registry
-	go dockerRegistry.ListenAndServe()
+	setup(&suite.TestSuite, true, true)
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) TearDownSuite() {

--- a/pkg/registry/client_tls_test.go
+++ b/pkg/registry/client_tls_test.go
@@ -31,10 +31,7 @@ type TLSRegistryClientTestSuite struct {
 
 func (suite *TLSRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	dockerRegistry := setup(&suite.TestSuite, true, false)
-
-	// Start Docker registry
-	go dockerRegistry.ListenAndServe()
+	setup(&suite.TestSuite, true, false)
 }
 
 func (suite *TLSRegistryClientTestSuite) TearDownSuite() {

--- a/pkg/registry/main_test.go
+++ b/pkg/registry/main_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/foxcpp/go-mockdns"
+)
+
+func TestMain(m *testing.M) {
+	// A mock DNS server needed for TLS connection testing.
+	var srv *mockdns.Server
+	var err error
+
+	srv, err = mockdns.NewServer(map[string]mockdns.Zone{
+		"helm-test-registry.": {
+			A: []string{"127.0.0.1"},
+		},
+	}, false)
+	if err != nil {
+		panic(err)
+	}
+
+	saveDialFunction := net.DefaultResolver.Dial
+	srv.PatchNet(net.DefaultResolver)
+
+	// Run all tests in the package
+	code := m.Run()
+
+	net.DefaultResolver.Dial = saveDialFunction
+	_ = srv.Close()
+
+	os.Exit(code)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
This failure just shows up every once in a while where there is a DATA RACE on closing mockdns. I tried a couple things before, but I think this makes the most sense.  Passes for me after running multiple times.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
