### PR TITLE
fix: oci push test chart_read_error broken when run in container as root

### DIFF
--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -355,6 +355,13 @@ func TestOCIPusher_Push_ChartOperations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Permission-related behavior can differ when running as root.
+			// The "chart read error" case relies on chmod 0000 causing a read failure,
+			// which root may bypass in some environments (e.g., Ubuntu containers).
+			if tt.name == "chart read error" && os.Geteuid() == 0 {
+				t.Skip("skipping permission test when running as root: chmod 0000 may not deny access for root")
+			}
+
 			chartRef := tt.chartRef
 			var cleanup func()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The ocipusher chart_read_test fails when I run the tests in a container as root.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
