### PR TITLE
pull: log resolved version and digest for repo/non-OCI pulls

### DIFF
--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -214,7 +214,7 @@ func trimAnySuffix(s string, suffixes ...string) string {
 }
 
 func splitChartNameVersion(s string) (name, version string) {
-	if i := strings.LastIndex(s, "-"); i > 0 {
+	if i := strings.LastIndex(s, "-"); i >= 0 {
 		return s[:i], s[i+1:]
 	}
 	return s, ""

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -152,7 +152,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	// For direct OCI pulls, the registry client already prints "Pulled:" and
 	// "Digest:" (manifest digest), so we do not print here to avoid duplicates.
 	if p.RepoURL != "" || !registry.IsOCI(downloadSourceRef) {
-		base := trimAnySuffix(downloadSourceRef, ".tar.gz", ".tgz")
+		base := strings.TrimSuffix(downloadSourceRef, ".tgz")
 		chart, ver := splitChartNameVersion(base)
 
 		tag := chart
@@ -204,15 +204,6 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		return out.String(), chartutil.ExpandFile(ud, saved)
 	}
 	return out.String(), nil
-}
-
-func trimAnySuffix(s string, suffixes ...string) string {
-	for _, suf := range suffixes {
-		if strings.HasSuffix(s, suf) {
-			return strings.TrimSuffix(s, suf)
-		}
-	}
-	return s
 }
 
 func splitChartNameVersion(s string) (name, version string) {

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -165,6 +165,8 @@ func (p *Pull) Run(chartRef string) (string, error) {
 
 		if sum, err := sha256File(saved); err == nil {
 			fmt.Fprintf(&out, "Digest: sha256:%x\n", sum)
+		} else {
+			fmt.Fprintf(&out, "Digest failed: %v\n", err)
 		}
 	}
 

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -146,7 +146,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	// a consistent summary here. We mirror the OCI output format:
 	//
 	//   Pulled: <chartUrl>:<version>
-	//   Digest: sha256:<digest>
+	//   Checksum: sha256:<digest>
 	//
 	// For HTTP/repo pulls, the digest is the SHA-256 of the downloaded .tgz archive.
 	// For direct OCI pulls, the registry client already prints "Pulled:" and
@@ -164,9 +164,9 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		fmt.Fprintf(&out, "Pulled: %s\n", tag)
 
 		if sum, err := sha256File(saved); err == nil {
-			fmt.Fprintf(&out, "Digest: sha256:%x\n", sum)
+			fmt.Fprintf(&out, "Checksum: sha256:%x\n", sum)
 		} else {
-			fmt.Fprintf(&out, "Digest failed: %v\n", err)
+			fmt.Fprintf(&out, "Checksum failed: %v\n", err)
 		}
 	}
 

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -151,18 +151,7 @@ func (p *Pull) Run(chartRef string) (string, error) {
 	// For direct OCI pulls, the registry client already prints "Pulled:" and
 	// "Digest:" (manifest digest), so we do not print here to avoid duplicates.
 	if p.RepoURL != "" || !registry.IsOCI(downloadSourceRef) {
-		base := strings.TrimSuffix(filepath.Base(saved), ".tgz")
-		chart := base
-		ver := ""
-		if i := strings.LastIndex(base, "-"); i > 0 {
-			chart = base[:i]
-			ver = base[i+1:]
-		}
-		if ver != "" {
-			fmt.Fprintf(&out, "Pulled: %s:%s\n", chart, ver)
-		} else {
-			fmt.Fprintf(&out, "Pulled: %s\n", chart)
-		}
+		fmt.Fprintf(&out, "Pulled: %s\n", downloadSourceRef)
 
 		if f, err := os.ReadFile(saved); err == nil {
 			sum := sha256.Sum256(f)

--- a/pkg/action/pull_test.go
+++ b/pkg/action/pull_test.go
@@ -79,7 +79,7 @@ entries:
 
 	expectedURL := srv.URL + "/testchart:1.2.3"
 	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
-	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
+	assert.Contains(t, out, "Checksum: "+wantDigest, "expected archive checksum in output")
 
 	// Ensure the chart file was saved.
 	_, statErr := os.Stat(filepath.Join(p.DestDir, "testchart-1.2.3.tgz"))
@@ -122,7 +122,7 @@ func TestPull_PrintsSummary_ForDirectHTTPURL(t *testing.T) {
 	// Output should reflect name-version.tgz from the URL.
 	expectedURL := srv.URL + "/directchart:9.9.9"
 	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
-	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
+	assert.Contains(t, out, "Checksum: "+wantDigest, "expected archive checksum in output")
 
 	// Ensure the chart file was saved.
 	_, statErr := os.Stat(filepath.Join(p.DestDir, "directchart-9.9.9.tar.gz"))

--- a/pkg/action/pull_test.go
+++ b/pkg/action/pull_test.go
@@ -61,13 +61,12 @@ entries:
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Isolate Helm env/cache to temp dirs for deterministic tests.
 	settings := cli.New()
 	settings.RepositoryCache = t.TempDir()
 	settings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
 	settings.ContentCache = t.TempDir()
 
-	cfg := &Configuration{} // minimal config; no K8s or registry for HTTP path
+	cfg := &Configuration{}
 
 	p := NewPull(WithConfig(cfg))
 	p.Settings = settings

--- a/pkg/action/pull_test.go
+++ b/pkg/action/pull_test.go
@@ -77,7 +77,7 @@ entries:
 	out, err := p.Run("testchart")
 	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
 
-	expectedURL := srv.URL + "/testchart-1.2.3.tgz"
+	expectedURL := srv.URL + "/testchart:1.2.3"
 	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
 	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
 
@@ -95,7 +95,7 @@ func TestPull_PrintsSummary_ForDirectHTTPURL(t *testing.T) {
 	wantDigest := fmt.Sprintf("sha256:%x", sum)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/directchart-9.9.9.tgz", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/directchart-9.9.9.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(chartBytes)
 	})
@@ -114,17 +114,17 @@ func TestPull_PrintsSummary_ForDirectHTTPURL(t *testing.T) {
 	p.DestDir = t.TempDir()
 
 	// Direct HTTP URL (absolute URL). Version is ignored for absolute URLs.
-	chartURL := srv.URL + "/directchart-9.9.9.tgz"
+	chartURL := srv.URL + "/directchart-9.9.9.tar.gz"
 
 	out, err := p.Run(chartURL)
 	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
 
 	// Output should reflect name-version.tgz from the URL.
-	expectedURL := srv.URL + "/directchart-9.9.9.tgz"
+	expectedURL := srv.URL + "/directchart:9.9.9"
 	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
 	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
 
 	// Ensure the chart file was saved.
-	_, statErr := os.Stat(filepath.Join(p.DestDir, "directchart-9.9.9.tgz"))
+	_, statErr := os.Stat(filepath.Join(p.DestDir, "directchart-9.9.9.tar.gz"))
 	require.NoError(t, statErr, "expected chart archive to be saved")
 }

--- a/pkg/action/pull_test.go
+++ b/pkg/action/pull_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package action
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"helm.sh/helm/v4/pkg/cli"
+)
+
+// helm pull testchart --repo=http://127.0.0.1:<port> --version 1.2.3
+func TestPull_PrintsSummary_ForHTTPRepo(t *testing.T) {
+	t.Parallel()
+
+	// Minimal chart payload; verification is off so a plain byte buffer is fine.
+	chartBytes := []byte("dummy-chart-content")
+	sum := sha256.Sum256(chartBytes)
+	wantDigest := fmt.Sprintf("sha256:%x", sum)
+
+	// Serve a valid index.yaml and the chart archive.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		// Valid index entry requires both name and version.
+		fmt.Fprintf(w, `apiVersion: v1
+entries:
+  testchart:
+    - name: testchart
+      version: 1.2.3
+      urls:
+        - testchart-1.2.3.tgz
+      created: "2020-01-01T00:00:00Z"
+`)
+	})
+	mux.HandleFunc("/testchart-1.2.3.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(chartBytes)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Isolate Helm env/cache to temp dirs for deterministic tests.
+	settings := cli.New()
+	settings.RepositoryCache = t.TempDir()
+	settings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+	settings.ContentCache = t.TempDir()
+
+	cfg := &Configuration{} // minimal config; no K8s or registry for HTTP path
+
+	p := NewPull(WithConfig(cfg))
+	p.Settings = settings
+	p.DestDir = t.TempDir()
+	p.RepoURL = srv.URL
+	p.Version = "1.2.3"
+
+	out, err := p.Run("testchart")
+	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
+
+	assert.Contains(t, out, "Pulled: testchart:1.2.3", "expected Pulled summary in output")
+	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
+
+	// Ensure the chart file was saved.
+	_, statErr := os.Stat(filepath.Join(p.DestDir, "testchart-1.2.3.tgz"))
+	require.NoError(t, statErr, "expected chart archive to be saved")
+}
+
+// helm pull http://127.0.0.1:<port>/directchart-9.9.9.tgz
+func TestPull_PrintsSummary_ForDirectHTTPURL(t *testing.T) {
+	t.Parallel()
+
+	chartBytes := []byte("another-dummy-chart")
+	sum := sha256.Sum256(chartBytes)
+	wantDigest := fmt.Sprintf("sha256:%x", sum)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/directchart-9.9.9.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(chartBytes)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	settings := cli.New()
+	settings.RepositoryCache = t.TempDir()
+	settings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+	settings.ContentCache = t.TempDir()
+
+	cfg := &Configuration{}
+
+	p := NewPull(WithConfig(cfg))
+	p.Settings = settings
+	p.DestDir = t.TempDir()
+
+	// Direct HTTP URL (absolute URL). Version is ignored for absolute URLs.
+	chartURL := srv.URL + "/directchart-9.9.9.tgz"
+
+	out, err := p.Run(chartURL)
+	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
+
+	// Output should reflect name-version.tgz from the URL.
+	assert.Contains(t, out, "Pulled: directchart:9.9.9", "expected Pulled summary in output")
+	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
+
+	// Ensure the chart file was saved.
+	_, statErr := os.Stat(filepath.Join(p.DestDir, "directchart-9.9.9.tgz"))
+	require.NoError(t, statErr, "expected chart archive to be saved")
+}

--- a/pkg/action/pull_test.go
+++ b/pkg/action/pull_test.go
@@ -77,7 +77,8 @@ entries:
 	out, err := p.Run("testchart")
 	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
 
-	assert.Contains(t, out, "Pulled: testchart:1.2.3", "expected Pulled summary in output")
+	expectedURL := srv.URL + "/testchart-1.2.3.tgz"
+	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
 	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
 
 	// Ensure the chart file was saved.
@@ -119,7 +120,8 @@ func TestPull_PrintsSummary_ForDirectHTTPURL(t *testing.T) {
 	require.NoError(t, err, "Pull.Run() should succeed. Output:\n%s", out)
 
 	// Output should reflect name-version.tgz from the URL.
-	assert.Contains(t, out, "Pulled: directchart:9.9.9", "expected Pulled summary in output")
+	expectedURL := srv.URL + "/directchart-9.9.9.tgz"
+	assert.Contains(t, out, "Pulled: "+expectedURL, "expected Pulled summary in output")
 	assert.Contains(t, out, "Digest: "+wantDigest, "expected archive digest in output")
 
 	// Ensure the chart file was saved.

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -45,7 +45,7 @@ func TestPullCmd(t *testing.T) {
 	}
 
 	helmTestKeyOut := "Pulled: test/signtest\n" +
-		"Digest: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55\n" +
+		"Checksum: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55\n" +
 		"Signed by: Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>\n" +
 		"Using Key With Fingerprint: 5E615389B53CA37F0EE60BD3843BBF981FC18762\n" +
 		"Chart Hash Verified: "

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -44,7 +44,9 @@ func TestPullCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	helmTestKeyOut := "Signed by: Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>\n" +
+	helmTestKeyOut := "Pulled: signtest:0.1.0\n" +
+		"Digest: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55\n" +
+		"Signed by: Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>\n" +
 		"Using Key With Fingerprint: 5E615389B53CA37F0EE60BD3843BBF981FC18762\n" +
 		"Chart Hash Verified: "
 

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -44,7 +44,7 @@ func TestPullCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	helmTestKeyOut := "Pulled: signtest:0.1.0\n" +
+	helmTestKeyOut := "Pulled: test/signtest\n" +
 		"Digest: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55\n" +
 		"Signed by: Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>\n" +
 		"Using Key With Fingerprint: 5E615389B53CA37F0EE60BD3843BBF981FC18762\n" +


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: https://github.com/helm/helm/issues/31205

When users run `helm pull` without a version, OCI pulls already print “Pulled:” and “Digest:”. HTTP/repo pulls do not. Some providers (e.g. Bitnami) resolve --repo pulls to `oci://` but skip the registry client summary, so nothing is printed.

- Now we print a summary for `--repo` and direct HTTP pulls after download.
- Keep direct oci:// behavior unchanged (avoid duplicate output).
- Mirror OCI format: 
    ```
    Pulled: <chart>:<version>
    Digest: sha256:<digest>
    ```

For HTTP/repo, the digest is the archive SHA-256 (.tgz). For OCI, the digest is the manifest digest (unchanged).

I tested with command like:

```sh
helm pull ingress-nginx --repo=https://kubernetes.github.io/ingress-nginx --version 4.10.1
helm pull oci://registry-1.docker.io/bitnamicharts/nginx --version '20.0.7'
helm/bin/helm pull redis --repo=https://charts.bitnami.com/bitnami --version='22.0.4'
```

Overall, I think the solution a little bit _hacky_ but interested with your feedbacks.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**Special notes for your reviewer**:

See inline pull request comments.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
