### PR TITLE
feature: add registry authorizer retry

### DIFF
--- a/pkg/registry/authorizer.go
+++ b/pkg/registry/authorizer.go
@@ -97,7 +97,8 @@ func (a *Authorizer) Do(originalReq *http.Request) (*http.Response, error) {
 				a.setAttemptBearerAuthentication(false)
 				return resp, nil
 			}
-			if !strings.Contains(err.Error(), "response status code 40") {
+			if !strings.Contains(err.Error(), "response status code 401") &&
+				!strings.Contains(err.Error(), "response status code 403") {
 				return nil, err
 			}
 		}

--- a/pkg/registry/authorizer.go
+++ b/pkg/registry/authorizer.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"helm.sh/helm/v4/internal/version"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+)
+
+type Authorizer struct {
+	auth.Client
+	AttemptBearerAuthentication bool
+}
+
+func NewAuthorizer(httpClient *http.Client, credentialsStore credentials.Store, username, password string) *Authorizer {
+	authorizer := Authorizer{
+		Client: auth.Client{
+			Client: httpClient,
+		},
+	}
+	authorizer.SetUserAgent(version.GetUserAgent())
+
+	if username != "" && password != "" {
+		authorizer.Credential = func(_ context.Context, _ string) (auth.Credential, error) {
+			return auth.Credential{Username: username, Password: password}, nil
+		}
+	} else {
+		authorizer.Credential = credentials.Credential(credentialsStore)
+	}
+
+	authorizer.AttemptBearerAuthentication = true
+	return &authorizer
+}
+
+func (a *Authorizer) EnableCache() {
+	a.Cache = auth.NewCache()
+}
+
+// Do This method wraps auth.Client.Do in attempt to retry authentication
+func (a *Authorizer) Do(originalReq *http.Request) (*http.Response, error) {
+	if a.AttemptBearerAuthentication {
+		needsAuthentication := originalReq.Header.Get("Authorization") == ""
+		if needsAuthentication {
+			a.ForceAttemptOAuth2 = true
+			if originalReq.Host == "ghcr.io" {
+				a.ForceAttemptOAuth2 = false
+				a.AttemptBearerAuthentication = false
+			}
+			resp, err := a.Client.Do(originalReq)
+			if err == nil {
+				a.AttemptBearerAuthentication = false
+				return resp, nil
+			}
+			if !strings.Contains(err.Error(), "response status code 40") {
+				return nil, err
+			}
+		}
+	}
+	return a.Client.Do(originalReq)
+}

--- a/pkg/registry/authorizer.go
+++ b/pkg/registry/authorizer.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/credentials"
 )
 
+// Authorizer wraps auth.Client to retry authentication with bearer-to-basic fallback on 401/403.
 type Authorizer struct {
 	auth.Client
 	lock                        sync.RWMutex
@@ -44,6 +45,15 @@ func isGHCR(host string) bool {
 	return strings.EqualFold(h, "ghcr.io")
 }
 
+// reqHost returns the effective host for an outbound request, preferring URL.Hostname() over req.Host.
+func reqHost(req *http.Request) string {
+	if h := req.URL.Hostname(); h != "" {
+		return h
+	}
+	return req.Host
+}
+
+// NewAuthorizer creates an Authorizer backed by the given HTTP client and credentials store.
 func NewAuthorizer(httpClient *http.Client, credentialsStore credentials.Store, username, password string) *Authorizer {
 	authorizer := Authorizer{
 		Client: auth.Client{
@@ -64,6 +74,7 @@ func NewAuthorizer(httpClient *http.Client, credentialsStore credentials.Store, 
 	return &authorizer
 }
 
+// EnableCache enables per-host token caching on the underlying auth client.
 func (a *Authorizer) EnableCache() {
 	a.Cache = auth.NewCache()
 }
@@ -92,31 +103,43 @@ func (a *Authorizer) setForceAttemptOAuth2(value bool) {
 	a.ForceAttemptOAuth2 = value
 }
 
-// Do wraps auth.Client.Do to retry with fallback authentication on 401/403 errors.
+// Do wraps auth.Client.Do to retry with OAuth2 bearer forced on 401/403 errors.
+// The first attempt uses standard auth; only on 401/403 failure do we retry with
+// ForceAttemptOAuth2=true to fix registries (e.g. Quay) whose token endpoints
+// require OAuth2-style requests.
 func (a *Authorizer) Do(originalReq *http.Request) (*http.Response, error) {
-	if a.getAttemptBearerAuthentication() {
-		needsAuthentication := originalReq.Header.Get("Authorization") == ""
-		if needsAuthentication {
-			if isGHCR(originalReq.Host) {
-				a.setForceAttemptOAuth2(false)
-				a.setAttemptBearerAuthentication(false)
-			} else {
-				prev := a.getForceAttemptOAuth2()
-				a.setForceAttemptOAuth2(true)
-				defer a.setForceAttemptOAuth2(prev)
-			}
-			resp, err := a.Client.Do(originalReq)
-			if err == nil {
-				a.setAttemptBearerAuthentication(false)
-				return resp, nil
-			}
-			if !strings.Contains(err.Error(), "response status code 401") &&
-				!strings.Contains(err.Error(), "response status code 403") {
-				return nil, err
-			}
-			// Switch to basic auth fallback before retrying
-			a.setForceAttemptOAuth2(false)
-		}
+	needsAuthentication := originalReq.Header.Get("Authorization") == ""
+
+	if needsAuthentication && a.getAttemptBearerAuthentication() && isGHCR(reqHost(originalReq)) {
+		a.setForceAttemptOAuth2(false)
+		a.setAttemptBearerAuthentication(false)
 	}
-	return a.Client.Do(originalReq)
+
+	resp, err := a.Client.Do(originalReq)
+	if err == nil {
+		if needsAuthentication {
+			a.setAttemptBearerAuthentication(false)
+		}
+		return resp, nil
+	}
+
+	if !needsAuthentication || !a.getAttemptBearerAuthentication() {
+		return nil, err
+	}
+
+	if !strings.Contains(err.Error(), "response status code 401") &&
+		!strings.Contains(err.Error(), "response status code 403") {
+		return nil, err
+	}
+
+	// Standard auth failed with 401/403; retry forcing OAuth2 bearer flow.
+	prev := a.getForceAttemptOAuth2()
+	a.setForceAttemptOAuth2(true)
+	defer a.setForceAttemptOAuth2(prev)
+
+	resp, err = a.Client.Do(originalReq)
+	if err == nil {
+		a.setAttemptBearerAuthentication(false)
+	}
+	return resp, err
 }

--- a/pkg/registry/authorizer.go
+++ b/pkg/registry/authorizer.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -32,6 +33,15 @@ type Authorizer struct {
 	auth.Client
 	lock                        sync.RWMutex
 	attemptBearerAuthentication bool
+}
+
+// isGHCR reports whether host refers to ghcr.io, normalizing port and case.
+func isGHCR(host string) bool {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	return strings.EqualFold(h, "ghcr.io")
 }
 
 func NewAuthorizer(httpClient *http.Client, credentialsStore credentials.Store, username, password string) *Authorizer {
@@ -82,15 +92,18 @@ func (a *Authorizer) setForceAttemptOAuth2(value bool) {
 	a.ForceAttemptOAuth2 = value
 }
 
-// Do This method wraps auth.Client.Do in attempt to retry authentication
+// Do wraps auth.Client.Do to retry with fallback authentication on 401/403 errors.
 func (a *Authorizer) Do(originalReq *http.Request) (*http.Response, error) {
 	if a.getAttemptBearerAuthentication() {
 		needsAuthentication := originalReq.Header.Get("Authorization") == ""
 		if needsAuthentication {
-			a.setForceAttemptOAuth2(true)
-			if originalReq.Host == "ghcr.io" {
+			if isGHCR(originalReq.Host) {
 				a.setForceAttemptOAuth2(false)
 				a.setAttemptBearerAuthentication(false)
+			} else {
+				prev := a.getForceAttemptOAuth2()
+				a.setForceAttemptOAuth2(true)
+				defer a.setForceAttemptOAuth2(prev)
 			}
 			resp, err := a.Client.Do(originalReq)
 			if err == nil {
@@ -101,6 +114,8 @@ func (a *Authorizer) Do(originalReq *http.Request) (*http.Response, error) {
 				!strings.Contains(err.Error(), "response status code 403") {
 				return nil, err
 			}
+			// Switch to basic auth fallback before retrying
+			a.setForceAttemptOAuth2(false)
 		}
 	}
 	return a.Client.Do(originalReq)

--- a/pkg/registry/authorizer_test.go
+++ b/pkg/registry/authorizer_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newHTTPClient(rt roundTripFunc) *http.Client {
+	return &http.Client{Transport: rt}
+}
+
+func resp(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body))}
+}
+
+// fakeStore is a fake credentials store used to assert it is used when username/password are not set.
+type fakeStore struct{ called bool }
+
+func (f *fakeStore) Get(_ context.Context, _ string) (auth.Credential, error) {
+	f.called = true
+	return auth.Credential{}, nil
+}
+func (f *fakeStore) Put(_ context.Context, _ string, _ auth.Credential) error { return nil }
+func (f *fakeStore) Delete(_ context.Context, _ string) error                 { return nil }
+
+func TestNewAuthorizer_UsernamePassword(t *testing.T) {
+	hc := newHTTPClient(func(r *http.Request) (*http.Response, error) {
+		// ensure user-agent header is set by authorizer
+		ua := r.Header.Get("User-Agent")
+		if ua == "" {
+			t.Fatalf("expected User-Agent to be set")
+		}
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "user", "pass")
+	if !a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should start true")
+	}
+	// Verify credential function returns our basic auth creds
+	cred, err := a.Credential(t.Context(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cred.Username != "user" || cred.Password != "pass" {
+		t.Fatalf("credential not set correctly: %+v", cred)
+	}
+	// simple do to trigger user-agent path and flip AttemptBearerAuthentication to false
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	_, err = a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected Do error: %v", err)
+	}
+	if a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should be false after Do")
+	}
+}
+
+func TestNewAuthorizer_CredentialStoreUsed(t *testing.T) {
+	fs := &fakeStore{}
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) { return resp(200, "ok"), nil })
+	a := NewAuthorizer(hc, fs, "", "")
+	// invoke Credential to ensure it delegates to store
+	_, _ = a.Credential(t.Context(), "registry.example")
+	if !fs.called {
+		t.Fatalf("expected credential store to be called")
+	}
+}
+
+func TestEnableCache_SetsCache(t *testing.T) {
+	a := NewAuthorizer(newHTTPClient(func(_ *http.Request) (*http.Response, error) { return resp(200, "ok"), nil }), nil, "", "")
+	if a.Cache != nil {
+		t.Fatalf("cache should be nil before EnableCache")
+	}
+	a.EnableCache()
+	if a.Cache == nil {
+		t.Fatalf("cache should be set after EnableCache")
+	}
+}
+
+func TestDo_SuccessFirstTry_DisablesAttempt(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example/v2/", nil)
+	req.Host = "registry.example" // not ghcr.io
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	if a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should be false after success")
+	}
+}
+
+func TestDo_AuthErrorThenRetry(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("unexpected response status code 401")
+		}
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error after retry: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls on auth error, got %d", calls)
+	}
+	// After a retry that succeeds on second attempt, AttemptBearerAuthentication remains true
+	// because the flag is only set to false after a successful first attempt
+	if !a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should remain true after retry path")
+	}
+}
+
+func TestDo_NonAuthErrorReturned(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return nil, errors.New("network down")
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+	_, err := a.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected only 1 call on non-auth error, got %d", calls)
+	}
+	// In this branch the code returns before flipping AttemptBearerAuthentication at end of block
+	if !a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should remain true when returning early on non-auth error")
+	}
+}
+
+func TestDo_GHCRSkipsFirstAttempt(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://ghcr.io/v2/", nil)
+	req.Host = "ghcr.io"
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected single call for ghcr.io, got %d", calls)
+	}
+	if a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should be false after ghcr path")
+	}
+}
+
+func TestDo_WithAuthorizationHeader_SkipsPreflight(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one direct call when Authorization present, got %d", calls)
+	}
+	if !a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should remain true when Authorization header is present")
+	}
+}
+
+func TestDo_ForceAttemptOAuth2_SetForNonGHCR(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+
+	// First call should set ForceAttemptOAuth2 to true for non-ghcr.io hosts
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.ForceAttemptOAuth2 {
+		t.Fatalf("ForceAttemptOAuth2 should be true for non-ghcr.io hosts")
+	}
+}
+
+func TestDo_ForceAttemptOAuth2_NotSetForGHCR(t *testing.T) {
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://ghcr.io/v2/", nil)
+	req.Host = "ghcr.io"
+
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.ForceAttemptOAuth2 {
+		t.Fatalf("ForceAttemptOAuth2 should be false for ghcr.io")
+	}
+}
+
+func TestDo_MultipleAuthErrors_RetriesCorrectly(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		switch calls {
+		case 1:
+			return nil, errors.New("unexpected response status code 401: Unauthorized")
+		case 2:
+			return resp(200, "ok"), nil
+		default:
+			t.Fatalf("unexpected number of calls: %d", calls)
+			return nil, errors.New("unexpected")
+		}
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+
+	resp, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 status, got %d", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Fatalf("expected exactly 2 calls for retry, got %d", calls)
+	}
+}
+
+func TestDo_403Error_RetriesCorrectly(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("unexpected response status code 403: Forbidden")
+		}
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls for 403 error retry, got %d", calls)
+	}
+}
+
+func TestDo_AttemptBearerAuthentication_False_SkipsLogic(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	a.AttemptBearerAuthentication = false // Explicitly set to false
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	_, err := a.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected single call when AttemptBearerAuthentication is false, got %d", calls)
+	}
+	if a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should remain false")
+	}
+}
+
+func TestDo_SequentialRequests_MaintainsState(t *testing.T) {
+	callCount := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		callCount++
+		return resp(200, "ok"), nil
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+
+	// First request without auth header
+	req1, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req1.Host = "example.com"
+	_, err := a.Do(req1)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	if a.AttemptBearerAuthentication {
+		t.Fatalf("AttemptBearerAuthentication should be false after first request")
+	}
+
+	// Second request should go straight through
+	req2, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/charts", nil)
+	req2.Host = "example.com"
+	_, err = a.Do(req2)
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+
+	// Should only have made 2 calls total (no retry on second)
+	if callCount != 2 {
+		t.Fatalf("expected 2 total calls, got %d", callCount)
+	}
+}
+
+func TestDo_ErrorMessageParsing_404NotRetried(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		// 404 error should contain "40" but not trigger retry since it's not 401/403
+		return nil, errors.New("unexpected response status code 404: Not Found")
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+
+	_, err := a.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected 404 error, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls for 404 (matches '40' pattern), got %d", calls)
+	}
+}
+
+func TestDo_ErrorMessageParsing_NonStatusCodeError(t *testing.T) {
+	calls := 0
+	hc := newHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		calls++
+		// Error containing "40" but not a status code error
+		return nil, errors.New("failed after 40 attempts")
+	})
+	a := NewAuthorizer(hc, nil, "", "")
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v2/", nil)
+	req.Host = "example.com"
+
+	_, err := a.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "40 attempts") {
+		t.Fatalf("expected error with '40 attempts', got %v", err)
+	}
+	// Should not retry since it doesn't match the pattern despite containing "40"
+	if calls != 1 {
+		t.Fatalf("expected 1 call (no retry for non-status code errors), got %d", calls)
+	}
+}
+
+func TestNewAuthorizer_NilHttpClient(t *testing.T) {
+	// Test that NewAuthorizer works with nil HTTP client
+	a := NewAuthorizer(nil, nil, "user", "pass")
+	if a == nil {
+		t.Fatalf("NewAuthorizer should not return nil")
+	}
+	if a.Client.Client != nil {
+		t.Fatalf("expected nil HTTP client to remain nil")
+	}
+	// Verify credential function still works
+	cred, err := a.Credential(t.Context(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.Username != "user" || cred.Password != "pass" {
+		t.Fatalf("credentials not set correctly: %+v", cred)
+	}
+}

--- a/pkg/registry/authorizer_test.go
+++ b/pkg/registry/authorizer_test.go
@@ -361,3 +361,33 @@ func TestAuthorizer_Do_NoRetryOn404(t *testing.T) {
 	assert.Equal(t, 1, callCount, "Authorizer.Do must not retry on non-401/403 errors")
 	assert.False(t, authorizer.getForceAttemptOAuth2(), "ForceAttemptOAuth2 must be false after Do()")
 }
+
+func TestAuthorizer_Do_GHCRSkipsBearerProbe(t *testing.T) {
+	var mu sync.Mutex
+	callCount := 0
+
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	authorizer := NewAuthorizer(&http.Client{Transport: transport}, &mockCredentialsStore{}, "", "")
+
+	// URL.Host is "ghcr.io" — simulates how ORAS constructs requests (host in URL, not req.Host)
+	req, err := http.NewRequest(http.MethodGet, "http://ghcr.io/v2/", nil)
+	require.NoError(t, err)
+
+	resp, err := authorizer.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 1, callCount, "ghcr.io must not trigger a bearer probe + retry")
+	assert.False(t, authorizer.getForceAttemptOAuth2())
+	assert.False(t, authorizer.getAttemptBearerAuthentication())
+}

--- a/pkg/registry/authorizer_test.go
+++ b/pkg/registry/authorizer_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 
@@ -136,7 +135,7 @@ func TestAuthorizer_Do(t *testing.T) {
 			host:                  "registry.example.com",
 			authHeader:            "",
 			serverStatus:          200,
-			expectForceOAuth2:     true,
+			expectForceOAuth2:     false,
 			expectBearerAuthAfter: false,
 		},
 		{
@@ -267,7 +266,10 @@ func TestAuthorizer_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numRequests; j++ {
 				req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-				require.NoError(t, err)
+				if err != nil {
+					t.Errorf("failed to create request: %v", err)
+					return
+				}
 				req.Host = "registry.example.com"
 
 				resp, err := authorizer.Do(req)
@@ -298,48 +300,64 @@ func TestAuthorizer_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestAuthorizer_Do_StatusCodeErrorChecking(t *testing.T) {
-	tests := []struct {
-		name        string
-		errorMsg    string
-		shouldRetry bool
-		description string
-	}{
-		{
-			name:        "retry on 401 error",
-			errorMsg:    "response status code 401",
-			shouldRetry: true,
-			description: "401 errors should trigger retry logic",
-		},
-		{
-			name:        "retry on 403 error",
-			errorMsg:    "response status code 403",
-			shouldRetry: true,
-			description: "403 errors should trigger retry logic",
-		},
-		{
-			name:        "no retry on 404 error",
-			errorMsg:    "response status code 404",
-			shouldRetry: false,
-			description: "404 errors should not trigger retry logic",
-		},
-		{
-			name:        "no retry on 500 error",
-			errorMsg:    "response status code 500",
-			shouldRetry: false,
-			description: "500 errors should not trigger retry logic",
-		},
-	}
+// roundTripFunc is an http.RoundTripper backed by a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := errors.New(tt.errorMsg)
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
-			should401Retry := strings.Contains(err.Error(), "response status code 401")
-			should403Retry := strings.Contains(err.Error(), "response status code 403")
-			actualShouldRetry := should401Retry || should403Retry
+func TestAuthorizer_Do_RetriesOn401(t *testing.T) {
+	var mu sync.Mutex
+	callCount := 0
 
-			assert.Equal(t, tt.shouldRetry, actualShouldRetry, tt.description)
-		})
-	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		n := callCount
+		callCount++
+		mu.Unlock()
+		if n == 0 {
+			// Simulate ORAS auth failure with 401
+			return nil, errors.New("response status code 401")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	authorizer := NewAuthorizer(&http.Client{Transport: transport}, &mockCredentialsStore{}, "", "")
+
+	req, err := http.NewRequest(http.MethodGet, "http://registry.example.com/v2/", nil)
+	require.NoError(t, err)
+	req.Host = "registry.example.com"
+
+	resp, err := authorizer.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 2, callCount, "Authorizer.Do should retry once after 401 error")
+	assert.False(t, authorizer.getForceAttemptOAuth2(), "ForceAttemptOAuth2 must be false after Do()")
+}
+
+func TestAuthorizer_Do_NoRetryOn404(t *testing.T) {
+	var mu sync.Mutex
+	callCount := 0
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		return nil, errors.New("response status code 404")
+	})
+
+	authorizer := NewAuthorizer(&http.Client{Transport: transport}, &mockCredentialsStore{}, "", "")
+
+	req, err := http.NewRequest(http.MethodGet, "http://registry.example.com/v2/", nil)
+	require.NoError(t, err)
+	req.Host = "registry.example.com"
+
+	_, err = authorizer.Do(req)
+	assert.Error(t, err, "404 error should propagate without retry")
+	assert.Equal(t, 1, callCount, "Authorizer.Do must not retry on non-401/403 errors")
+	assert.False(t, authorizer.getForceAttemptOAuth2(), "ForceAttemptOAuth2 must be false after Do()")
 }

--- a/pkg/registry/authorizer_test.go
+++ b/pkg/registry/authorizer_test.go
@@ -261,10 +261,10 @@ func TestAuthorizer_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines * 2)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numRequests; j++ {
+			for range numRequests {
 				req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 				if err != nil {
 					t.Errorf("failed to create request: %v", err)
@@ -281,7 +281,7 @@ func TestAuthorizer_ConcurrentAccess(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numRequests; j++ {
+			for range numRequests {
 				authorizer.setAttemptBearerAuthentication(true)
 				val := authorizer.getAttemptBearerAuthentication()
 				if val != true {
@@ -309,7 +309,7 @@ func TestAuthorizer_Do_RetriesOn401(t *testing.T) {
 	var mu sync.Mutex
 	callCount := 0
 
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		mu.Lock()
 		n := callCount
 		callCount++
@@ -343,7 +343,7 @@ func TestAuthorizer_Do_NoRetryOn404(t *testing.T) {
 	var mu sync.Mutex
 	callCount := 0
 
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		mu.Lock()
 		callCount++
 		mu.Unlock()

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -42,7 +42,6 @@ import (
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
 
-	"helm.sh/helm/v4/internal/version"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/helmpath"
 )
@@ -71,7 +70,7 @@ type (
 		username           string
 		password           string
 		out                io.Writer
-		authorizer         *auth.Client
+		authorizer         *Authorizer
 		registryAuthorizer RemoteClient
 		credentialsStore   credentials.Store
 		httpClient         *http.Client
@@ -119,23 +118,11 @@ func NewClient(options ...ClientOption) (*Client, error) {
 	}
 
 	if client.authorizer == nil {
-		authorizer := auth.Client{
-			Client: client.httpClient,
-		}
-		authorizer.SetUserAgent(version.GetUserAgent())
-
-		if client.username != "" && client.password != "" {
-			authorizer.Credential = func(_ context.Context, _ string) (auth.Credential, error) {
-				return auth.Credential{Username: client.username, Password: client.password}, nil
-			}
-		} else {
-			authorizer.Credential = credentials.Credential(client.credentialsStore)
-		}
-
+		authorizer := NewAuthorizer(client.httpClient, client.credentialsStore, client.username, client.password)
 		if client.enableCache {
-			authorizer.Cache = auth.NewCache()
+			authorizer.EnableCache()
 		}
-		client.authorizer = &authorizer
+		client.authorizer = authorizer
 	}
 
 	return client, nil
@@ -175,17 +162,17 @@ func ClientOptWriter(out io.Writer) ClientOption {
 	}
 }
 
-// ClientOptAuthorizer returns a function that sets the authorizer setting on a client options set. This
+// ClientOptAuthorizer returns a function that sets the Authorizer setting on a client options set. This
 // can be used to override the default authorization mechanism.
 //
 // Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
 func ClientOptAuthorizer(authorizer auth.Client) ClientOption {
 	return func(client *Client) {
-		client.authorizer = &authorizer
+		client.authorizer = &Authorizer{Client: authorizer}
 	}
 }
 
-// ClientOptRegistryAuthorizer returns a function that sets the registry authorizer setting on a client options set. This
+// ClientOptRegistryAuthorizer returns a function that sets the registry Authorizer setting on a client options set. This
 // can be used to override the default authorization mechanism.
 //
 // Depending on the use-case you may need to set both ClientOptAuthorizer and ClientOptRegistryAuthorizer.
@@ -252,18 +239,12 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 	}
 	reg.PlainHTTP = c.plainHTTP
 	cred := auth.Credential{Username: c.username, Password: c.password}
-	c.authorizer.ForceAttemptOAuth2 = true
 	reg.Client = c.authorizer
 
 	ctx := context.Background()
 	if err := reg.Ping(ctx); err != nil {
-		c.authorizer.ForceAttemptOAuth2 = false
-		if err := reg.Ping(ctx); err != nil {
-			return fmt.Errorf("authenticating to %q: %w", host, err)
-		}
+		return fmt.Errorf("authenticating to %q: %w", host, err)
 	}
-	// Always restore to false after probing, to avoid forcing POST to token endpoints like GHCR.
-	c.authorizer.ForceAttemptOAuth2 = false
 
 	key := credentials.ServerAddressFromRegistry(host)
 	key = credentials.ServerAddressFromHostname(key)
@@ -292,10 +273,10 @@ func LoginOptPlainText(isPlainText bool) LoginOption {
 	}
 }
 
-func ensureTLSConfig(client *auth.Client, setConfig *tls.Config) (*tls.Config, error) {
+func ensureTLSConfig(client *Authorizer, setConfig *tls.Config) (*tls.Config, error) {
 	var transport *http.Transport
 
-	switch t := client.Client.Transport.(type) {
+	switch t := client.Client.Client.Transport.(type) {
 	case *http.Transport:
 		transport = t
 	case *retry.Transport:
@@ -313,7 +294,7 @@ func ensureTLSConfig(client *auth.Client, setConfig *tls.Config) (*tls.Config, e
 	if transport == nil {
 		// we don't know how to access the http.Transport, most likely the
 		// auth.Client.Client was provided by API user
-		return nil, fmt.Errorf("unable to access TLS client configuration, the provided HTTP Transport is not supported, given: %T", client.Client.Transport)
+		return nil, fmt.Errorf("unable to access TLS client configuration, the provided HTTP Transport is not supported, given: %T", client.Client.Client.Transport)
 	}
 
 	switch {

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -62,7 +62,6 @@ func TestLogin_ResetsForceAttemptOAuth2_OnSuccess(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v2/" {
-			// Accept either HEAD or GET
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -85,7 +84,6 @@ func TestLogin_ResetsForceAttemptOAuth2_OnSuccess(t *testing.T) {
 		t.Fatal("expected ForceAttemptOAuth2 default to be false")
 	}
 
-	// Call Login with plain HTTP against our test server
 	if err := c.Login(host, LoginOptPlainText(true), LoginOptBasicAuth("u", "p")); err != nil {
 		t.Fatalf("Login error: %v", err)
 	}

--- a/pkg/registry/generic.go
+++ b/pkg/registry/generic.go
@@ -29,7 +29,6 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 )
 
@@ -41,7 +40,7 @@ type GenericClient struct {
 	username           string
 	password           string
 	out                io.Writer
-	authorizer         *auth.Client
+	authorizer         *Authorizer
 	registryAuthorizer RemoteClient
 	credentialsStore   credentials.Store
 	httpClient         *http.Client


### PR DESCRIPTION
**What this PR does / why we need it**:

I have functionally tested and docker.io uses bearer auth and ghcr.io uses basic auth. This should fix the Quay issue and the private registry issue.

Closes: https://github.com/helm/helm/issues/31256
Closes: https://github.com/helm/helm/issues/31567

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
