### PR TITLE
Remove legacy Command/Hooks from v1 Subprocess (#23)

### DIFF
--- a/internal/plugin/installer/local_installer_test.go
+++ b/internal/plugin/installer/local_installer_test.go
@@ -86,7 +86,7 @@ func TestLocalInstallerTarball(t *testing.T) {
 		Body string
 		Mode int64
 	}{
-		{"test-plugin/plugin.yaml", "name: test-plugin\nversion: 1.0.0\nusage: test\ndescription: test\ncommand: echo", 0644},
+		{"test-plugin/plugin.yaml", "name: test-plugin\napiVersion: v1\ntype: cli/v1\nruntime: subprocess\nversion: 1.0.0\nconfig:\n  shortHelp: test\n  longHelp: test\nruntimeConfig:\n  platformCommand:\n  - command: echo", 0644},
 		{"test-plugin/bin/test-plugin", "#!/bin/bash\necho test", 0755},
 	}
 

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -80,7 +80,7 @@ func TestLoadDir(t *testing.T) {
 				IgnoreFlags: true,
 			},
 			RuntimeConfig: &RuntimeConfigSubprocess{
-				PlatformCommands: []PlatformCommand{
+				PlatformCommand: []PlatformCommand{
 					{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "${HELM_PLUGIN_DIR}/hello.sh"}},
 					{OperatingSystem: "windows", Architecture: "", Command: "pwsh", Args: []string{"-c", "${HELM_PLUGIN_DIR}/hello.ps1"}},
 				},
@@ -90,6 +90,7 @@ func TestLoadDir(t *testing.T) {
 						{OperatingSystem: "windows", Architecture: "", Command: "pwsh", Args: []string{"-c", "echo \"installing...\""}},
 					},
 				},
+				expandHookArgs: apiVersion == "legacy",
 			},
 		}
 	}
@@ -150,8 +151,8 @@ func TestLoadDirGetter(t *testing.T) {
 		RuntimeConfig: &RuntimeConfigSubprocess{
 			ProtocolCommands: []SubprocessProtocolCommand{
 				{
-					Protocols: []string{"myprotocol", "myprotocols"},
-					Command:   "echo getter",
+					Protocols:       []string{"myprotocol", "myprotocols"},
+					PlatformCommand: []PlatformCommand{{Command: "echo getter"}},
 				},
 			},
 		},
@@ -174,7 +175,7 @@ func TestPostRenderer(t *testing.T) {
 		Runtime:    "subprocess",
 		Config:     &ConfigPostrenderer{},
 		RuntimeConfig: &RuntimeConfigSubprocess{
-			PlatformCommands: []PlatformCommand{
+			PlatformCommand: []PlatformCommand{
 				{
 					Command: "${HELM_PLUGIN_DIR}/sed-test.sh",
 				},

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -45,8 +45,8 @@ type MetadataLegacy struct {
 	// Description is a long description shown in places like `helm help`
 	Description string `yaml:"description"`
 
-	// PlatformCommands is the plugin command, with a platform selector and support for args.
-	PlatformCommands []PlatformCommand `yaml:"platformCommand"`
+	// PlatformCommand is the plugin command, with a platform selector and support for args.
+	PlatformCommand []PlatformCommand `yaml:"platformCommand"`
 
 	// Command is the plugin command, as a single string.
 	// DEPRECATED: Use PlatformCommand instead. Removed in subprocess/v1 plugins.
@@ -73,7 +73,7 @@ func (m *MetadataLegacy) Validate() error {
 	}
 	m.Usage = sanitizeString(m.Usage)
 
-	if len(m.PlatformCommands) > 0 && len(m.Command) > 0 {
+	if len(m.PlatformCommand) > 0 && len(m.Command) > 0 {
 		return fmt.Errorf("both platformCommand and command are set")
 	}
 

--- a/internal/plugin/metadata_test.go
+++ b/internal/plugin/metadata_test.go
@@ -25,43 +25,24 @@ func TestValidatePluginData(t *testing.T) {
 	// A mock plugin with no commands
 	mockNoCommand := mockSubprocessCLIPlugin(t, "foo")
 	mockNoCommand.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{},
-		PlatformHooks:    map[string][]PlatformCommand{},
+		PlatformCommand: []PlatformCommand{},
+		PlatformHooks:   map[string][]PlatformCommand{},
 	}
 
 	// A mock plugin with legacy commands
 	mockLegacyCommand := mockSubprocessCLIPlugin(t, "foo")
 	mockLegacyCommand.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{},
-		Command:          "echo \"mock plugin\"",
-		PlatformHooks:    map[string][]PlatformCommand{},
-		Hooks: map[string]string{
-			Install: "echo installing...",
-		},
-	}
-
-	// A mock plugin with a command also set
-	mockWithCommand := mockSubprocessCLIPlugin(t, "foo")
-	mockWithCommand.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{
-			{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"mock plugin\""}},
-		},
-		Command: "echo \"mock plugin\"",
-	}
-
-	// A mock plugin with a hooks also set
-	mockWithHooks := mockSubprocessCLIPlugin(t, "foo")
-	mockWithHooks.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{
-			{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"mock plugin\""}},
+		PlatformCommand: []PlatformCommand{
+			{
+				Command: "echo \"mock plugin\"",
+			},
 		},
 		PlatformHooks: map[string][]PlatformCommand{
 			Install: {
-				{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"installing...\""}},
+				PlatformCommand{
+					Command: "echo installing...",
+				},
 			},
-		},
-		Hooks: map[string]string{
-			Install: "echo installing...",
 		},
 	}
 
@@ -78,8 +59,6 @@ func TestValidatePluginData(t *testing.T) {
 		{false, mockSubprocessCLIPlugin(t, "foo\nbar"), "invalid name"},  // Test newline
 		{true, mockNoCommand, ""},     // Test no command metadata works
 		{true, mockLegacyCommand, ""}, // Test legacy command metadata works
-		{false, mockWithCommand, "runtime config validation failed: both platformCommand and command are set"}, // Test platformCommand and command both set fails
-		{false, mockWithHooks, "runtime config validation failed: both platformHooks and hooks are set"},       // Test platformHooks and hooks both set fails
 	} {
 		err := item.plug.Metadata().Validate()
 		if item.pass && err != nil {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -23,7 +23,7 @@ func mockSubprocessCLIPlugin(t *testing.T, pluginName string) *SubprocessPluginR
 	t.Helper()
 
 	rc := RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{
+		PlatformCommand: []PlatformCommand{
 			{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"mock plugin\""}},
 			{OperatingSystem: "windows", Architecture: "", Command: "pwsh", Args: []string{"-c", "echo \"mock plugin\""}},
 		},

--- a/internal/plugin/subprocess_commands_test.go
+++ b/internal/plugin/subprocess_commands_test.go
@@ -27,14 +27,14 @@ func TestPrepareCommand(t *testing.T) {
 	cmdMain := "sh"
 	cmdArgs := []string{"-c", "echo \"test\""}
 
-	platformCommands := []PlatformCommand{
+	platformCommand := []PlatformCommand{
 		{OperatingSystem: "no-os", Architecture: "no-arch", Command: "pwsh", Args: []string{"-c", "echo \"error\""}},
 		{OperatingSystem: runtime.GOOS, Architecture: "no-arch", Command: "pwsh", Args: []string{"-c", "echo \"error\""}},
 		{OperatingSystem: runtime.GOOS, Architecture: "", Command: "pwsh", Args: []string{"-c", "echo \"error\""}},
 		{OperatingSystem: runtime.GOOS, Architecture: runtime.GOARCH, Command: cmdMain, Args: cmdArgs},
 	}
 
-	cmd, args, err := PrepareCommands(platformCommands, true, []string{})
+	cmd, args, err := PrepareCommands(platformCommand, true, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestPrepareCommandExtraArgs(t *testing.T) {
 
 	cmdMain := "sh"
 	cmdArgs := []string{"-c", "echo \"test\""}
-	platformCommands := []PlatformCommand{
+	platformCommand := []PlatformCommand{
 		{OperatingSystem: "no-os", Architecture: "no-arch", Command: "pwsh", Args: []string{"-c", "echo \"error\""}},
 		{OperatingSystem: runtime.GOOS, Architecture: runtime.GOARCH, Command: cmdMain, Args: cmdArgs},
 		{OperatingSystem: runtime.GOOS, Architecture: "no-arch", Command: "pwsh", Args: []string{"-c", "echo \"error\""}},
@@ -91,7 +91,7 @@ func TestPrepareCommandExtraArgs(t *testing.T) {
 			if tc.ignoreFlags {
 				testExtraArgs = []string{}
 			}
-			cmd, args, err := PrepareCommands(platformCommands, true, testExtraArgs)
+			cmd, args, err := PrepareCommands(platformCommand, true, testExtraArgs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/plugin/testdata/plugdir/bad/duplicate-entries-v1/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/bad/duplicate-entries-v1/plugin.yaml
@@ -9,8 +9,11 @@ config:
     description
   ignoreFlags: true
 runtimeConfig:
-  command: "echo hello"
-  hooks:
-    install: "echo installing..."
-  hooks:
-    install: "echo installing something different"
+  platformCommand:
+  - command: "echo hello"
+  platformHooks:
+    install:
+    - command: "echo installing..."
+  platformHooks:
+    install:
+    - command: "echo installing something different"

--- a/internal/plugin/testdata/plugdir/good/getter/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/good/getter/plugin.yaml
@@ -10,7 +10,8 @@ config:
     - "myprotocols"
 runtimeConfig:
   protocolCommands:
-    - command: "echo getter"
+    - platformCommand:
+      - command: "echo getter"
       protocols:
         - "myprotocol"
         - "myprotocols"

--- a/pkg/cmd/plugin_package_test.go
+++ b/pkg/cmd/plugin_package_test.go
@@ -34,7 +34,7 @@ config:
   shortHelp: A test plugin
   longHelp: A test plugin for testing purposes
 runtimeConfig:
-  platformCommands:
+  platformCommand:
     - os: linux
       command: echo
       args: ["test"]`

--- a/pkg/cmd/plugin_test.go
+++ b/pkg/cmd/plugin_test.go
@@ -122,7 +122,7 @@ func TestLoadCLIPlugins(t *testing.T) {
 
 	require.Len(t, plugins, len(tests), "Expected %d plugins, got %d", len(tests), len(plugins))
 
-	for i := 0; i < len(plugins); i++ {
+	for i := range plugins {
 		out.Reset()
 		tt := tests[i]
 		pp := plugins[i]

--- a/pkg/cmd/testdata/helm home with space/helm/plugins/fullenv/plugin.yaml
+++ b/pkg/cmd/testdata/helm home with space/helm/plugins/fullenv/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: fullenv
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "show env vars"
   longHelp: "show all env vars"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/fullenv.sh"
+  platformCommand:
+  - command: "$HELM_PLUGIN_DIR/fullenv.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
@@ -7,4 +7,5 @@ config:
   longHelp: "This echos args"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/args.sh"
+  platformCommand:
+  - command: "$HELM_PLUGIN_DIR/args.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/echo/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/echo/plugin.yaml
@@ -7,4 +7,5 @@ config:
   longHelp: "This echos stuff"
   ignoreFlags: false
 runtimeConfig:
-  command: "echo hello"
+  platformCommand:
+  - command: "echo hello"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/env/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/env/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: env
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "env stuff"
   longHelp: "show the env"
   ignoreFlags: false
 runtimeConfig:
-  command: "echo $HELM_PLUGIN_NAME"
+  platformCommand:
+  - command: "echo $HELM_PLUGIN_NAME"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: exitwith
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "exitwith code"
   longHelp: "This exits with the specified exit code"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/exitwith.sh"
+  platformCommand:
+  - command: "$HELM_PLUGIN_DIR/exitwith.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/fullenv/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/fullenv/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: fullenv
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "show env vars"
   longHelp: "show all env vars"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/fullenv.sh"
+  platformCommand:
+  - command: "$HELM_PLUGIN_DIR/fullenv.sh"

--- a/pkg/cmd/testdata/testplugin/plugin.yaml
+++ b/pkg/cmd/testdata/testplugin/plugin.yaml
@@ -1,8 +1,7 @@
 ---
 apiVersion: v1
-name: "postrenderer-v1"
-version: "1.2.3"
-type: postrenderer/v1
+name: testplugin
+type: cli/v1
 runtime: subprocess
 config:
   shortHelp: "echo test"
@@ -10,4 +9,4 @@ config:
   ignoreFlags: false
 runtimeConfig:
   platformCommand:
-  - command: "${HELM_PLUGIN_DIR}/sed-test.sh"
+  - command: "echo test"

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -112,7 +112,7 @@ func (t *testPlugin) Metadata() plugin.Metadata {
 		Runtime:    "subprocess",
 		Config:     &plugin.ConfigCLI{},
 		RuntimeConfig: &plugin.RuntimeConfigSubprocess{
-			PlatformCommands: []plugin.PlatformCommand{
+			PlatformCommand: []plugin.PlatformCommand{
 				{
 					Command: "echo fake-plugin",
 				},

--- a/pkg/postrenderer/testdata/plugins/postrenderer-v1/plugin.yaml
+++ b/pkg/postrenderer/testdata/plugins/postrenderer-v1/plugin.yaml
@@ -5,4 +5,4 @@ apiVersion: v1
 runtime: subprocess
 runtimeConfig:
   platformCommand:
-    - command: "${HELM_PLUGIN_DIR}/sed-test.sh"
+  - command: "${HELM_PLUGIN_DIR}/sed-test.sh"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
v1 plugins should support legacy/deprecated "command" and "hooks" fields (only `platformCommand` / `platformHooks` fields) instead 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
