### PR TITLE
refactor: utilize `pluginTypesIndex` for config unmarshalling 

### DIFF
--- a/internal/plugin/config_test.go
+++ b/internal/plugin/config_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"helm.sh/helm/v4/internal/plugin/schema"
+)
+
+func TestUnmarshaConfig(t *testing.T) {
+	// Test unmarshalling a CLI plugin config
+	{
+		config, err := unmarshaConfig("cli/v1", map[string]any{
+			"usage":       "usage string",
+			"shortHelp":   "short help string",
+			"longHelp":    "long help string",
+			"ignoreFlags": true,
+		})
+		require.NoError(t, err)
+
+		require.IsType(t, &schema.ConfigCLIV1{}, config)
+		assert.Equal(t, schema.ConfigCLIV1{
+			Usage:       "usage string",
+			ShortHelp:   "short help string",
+			LongHelp:    "long help string",
+			IgnoreFlags: true,
+		}, *(config.(*schema.ConfigCLIV1)))
+	}
+
+	// Test unmarshalling invalid config data
+	{
+		config, err := unmarshaConfig("cli/v1", map[string]any{
+			"invalid field": "foo",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field not found")
+		assert.Nil(t, config)
+	}
+}

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"helm.sh/helm/v4/internal/plugin/schema"
 )
 
 func TestPeekAPIVersion(t *testing.T) {
@@ -73,7 +75,7 @@ func TestLoadDir(t *testing.T) {
 			Version:    "0.1.0",
 			Type:       "cli/v1",
 			Runtime:    "subprocess",
-			Config: &ConfigCLI{
+			Config: &schema.ConfigCLIV1{
 				Usage:       usage,
 				ShortHelp:   "echo hello message",
 				LongHelp:    "description",
@@ -145,7 +147,7 @@ func TestLoadDirGetter(t *testing.T) {
 		Type:       "getter/v1",
 		APIVersion: "v1",
 		Runtime:    "subprocess",
-		Config: &ConfigGetter{
+		Config: &schema.ConfigGetterV1{
 			Protocols: []string{"myprotocol", "myprotocols"},
 		},
 		RuntimeConfig: &RuntimeConfigSubprocess{
@@ -173,7 +175,7 @@ func TestPostRenderer(t *testing.T) {
 		Type:       "postrenderer/v1",
 		APIVersion: "v1",
 		Runtime:    "subprocess",
-		Config:     &ConfigPostrenderer{},
+		Config:     &schema.ConfigPostRendererV1{},
 		RuntimeConfig: &RuntimeConfigSubprocess{
 			PlatformCommand: []PlatformCommand{
 				{

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -17,6 +17,8 @@ package plugin
 
 import (
 	"testing"
+
+	"helm.sh/helm/v4/internal/plugin/schema"
 )
 
 func mockSubprocessCLIPlugin(t *testing.T, pluginName string) *SubprocessPluginRuntime {
@@ -46,7 +48,7 @@ func mockSubprocessCLIPlugin(t *testing.T, pluginName string) *SubprocessPluginR
 			Type:       "cli/v1",
 			APIVersion: "v1",
 			Runtime:    "subprocess",
-			Config: &ConfigCLI{
+			Config: &schema.ConfigCLIV1{
 				Usage:       "Mock plugin",
 				ShortHelp:   "Mock plugin",
 				LongHelp:    "Mock plugin for testing",

--- a/internal/plugin/plugin_type_registry.go
+++ b/internal/plugin/plugin_type_registry.go
@@ -81,13 +81,19 @@ var pluginTypes = []pluginTypeMeta{
 		pluginType: "cli/v1",
 		inputType:  reflect.TypeOf(schema.InputMessageCLIV1{}),
 		outputType: reflect.TypeOf(schema.OutputMessageCLIV1{}),
-		configType: reflect.TypeOf(ConfigCLI{}),
+		configType: reflect.TypeOf(schema.ConfigCLIV1{}),
 	},
 	{
 		pluginType: "getter/v1",
 		inputType:  reflect.TypeOf(schema.InputMessageGetterV1{}),
 		outputType: reflect.TypeOf(schema.OutputMessageGetterV1{}),
-		configType: reflect.TypeOf(ConfigGetter{}),
+		configType: reflect.TypeOf(schema.ConfigGetterV1{}),
+	},
+	{
+		pluginType: "postrenderer/v1",
+		inputType:  reflect.TypeOf(schema.InputMessagePostRendererV1{}),
+		outputType: reflect.TypeOf(schema.OutputMessagePostRendererV1{}),
+		configType: reflect.TypeOf(schema.ConfigPostRendererV1{}),
 	},
 }
 

--- a/internal/plugin/plugin_type_registry_test.go
+++ b/internal/plugin/plugin_type_registry_test.go
@@ -34,5 +34,5 @@ func TestMakeOutputMessage(t *testing.T) {
 func TestMakeConfig(t *testing.T) {
 	ptm := pluginTypesIndex["getter/v1"]
 	config := reflect.New(ptm.configType).Interface().(Config)
-	assert.IsType(t, &ConfigGetter{}, config)
+	assert.IsType(t, &schema.ConfigGetterV1{}, config)
 }

--- a/internal/plugin/runtime_subprocess_test.go
+++ b/internal/plugin/runtime_subprocess_test.go
@@ -45,7 +45,7 @@ func mockSubprocessCLIPluginErrorExit(t *testing.T, pluginName string, exitCode 
 		Type:       "cli/v1",
 		APIVersion: "v1",
 		Runtime:    "subprocess",
-		Config: &ConfigCLI{
+		Config: &schema.ConfigCLIV1{
 			Usage:       "Mock plugin",
 			ShortHelp:   "Mock plugin",
 			LongHelp:    "Mock plugin for testing",

--- a/internal/plugin/schema/cli.go
+++ b/internal/plugin/schema/cli.go
@@ -27,3 +27,22 @@ type InputMessageCLIV1 struct {
 type OutputMessageCLIV1 struct {
 	Data *bytes.Buffer `json:"data"`
 }
+
+// ConfigCLIV1 represents the configuration for CLI plugins
+type ConfigCLIV1 struct {
+	// Usage is the single-line usage text shown in help
+	// For recommended syntax, see [spf13/cobra.command.Command] Use field comment:
+	// https://pkg.go.dev/github.com/spf13/cobra#Command
+	Usage string `yaml:"usage"`
+	// ShortHelp is the short description shown in the 'helm help' output
+	ShortHelp string `yaml:"shortHelp"`
+	// LongHelp is the long message shown in the 'helm help <this-command>' output
+	LongHelp string `yaml:"longHelp"`
+	// IgnoreFlags ignores any flags passed in from Helm
+	IgnoreFlags bool `yaml:"ignoreFlags"`
+}
+
+func (c *ConfigCLIV1) Validate() error {
+	// Config validation for CLI plugins
+	return nil
+}

--- a/internal/plugin/schema/doc.go
+++ b/internal/plugin/schema/doc.go
@@ -1,0 +1,18 @@
+/*
+ Copyright The Helm Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+
+ */
+
+package schema

--- a/internal/plugin/schema/getter.go
+++ b/internal/plugin/schema/getter.go
@@ -14,10 +14,11 @@
 package schema
 
 import (
+	"fmt"
 	"time"
 )
 
-// TODO: can we generate these plugin input/outputs?
+// TODO: can we generate these plugin input/output messages?
 
 type GetterOptionsV1 struct {
 	URL                   string
@@ -44,4 +45,22 @@ type InputMessageGetterV1 struct {
 
 type OutputMessageGetterV1 struct {
 	Data []byte `json:"data"`
+}
+
+// ConfigGetterV1 represents the configuration for download plugins
+type ConfigGetterV1 struct {
+	// Protocols are the list of URL schemes supported by this downloader
+	Protocols []string `yaml:"protocols"`
+}
+
+func (c *ConfigGetterV1) Validate() error {
+	if len(c.Protocols) == 0 {
+		return fmt.Errorf("getter has no protocols")
+	}
+	for i, protocol := range c.Protocols {
+		if protocol == "" {
+			return fmt.Errorf("getter has empty protocol at index %d", i)
+		}
+	}
+	return nil
 }

--- a/internal/plugin/schema/postrenderer.go
+++ b/internal/plugin/schema/postrenderer.go
@@ -30,3 +30,9 @@ type InputMessagePostRendererV1 struct {
 type OutputMessagePostRendererV1 struct {
 	Manifests *bytes.Buffer `json:"manifests"`
 }
+
+type ConfigPostRendererV1 struct{}
+
+func (c *ConfigPostRendererV1) Validate() error {
+	return nil
+}

--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -71,7 +71,7 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 	for _, plug := range found {
 		var use, short, long string
 		var ignoreFlags bool
-		if cliConfig, ok := plug.Metadata().Config.(*plugin.ConfigCLI); ok {
+		if cliConfig, ok := plug.Metadata().Config.(*schema.ConfigCLIV1); ok {
 			use = cliConfig.Usage
 			short = cliConfig.ShortHelp
 			long = cliConfig.LongHelp
@@ -340,7 +340,7 @@ func pluginDynamicComp(plug plugin.Plugin, cmd *cobra.Command, args []string, to
 	}
 
 	var ignoreFlags bool
-	if cliConfig, ok := subprocessPlug.Metadata().Config.(*plugin.ConfigCLI); ok {
+	if cliConfig, ok := subprocessPlug.Metadata().Config.(*schema.ConfigCLIV1); ok {
 		ignoreFlags = cliConfig.IgnoreFlags
 	}
 

--- a/pkg/cmd/plugin_list.go
+++ b/pkg/cmd/plugin_list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v4/internal/plugin"
+	"helm.sh/helm/v4/internal/plugin/schema"
 )
 
 func newPluginListCmd(out io.Writer) *cobra.Command {
@@ -106,7 +107,7 @@ func compListPlugins(_ string, ignoredPluginNames []string) []string {
 		for _, p := range filteredPlugins {
 			m := p.Metadata()
 			var shortHelp string
-			if config, ok := m.Config.(*plugin.ConfigCLI); ok {
+			if config, ok := m.Config.(*schema.ConfigCLIV1); ok {
 				shortHelp = config.ShortHelp
 			}
 			pNames = append(pNames, fmt.Sprintf("%s\t%s", p.Metadata().Name, shortHelp))

--- a/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer-v1/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer-v1/plugin.yaml
@@ -4,10 +4,6 @@ name: "postrenderer-v1"
 version: "1.2.3"
 type: postrenderer/v1
 runtime: subprocess
-config:
-  shortHelp: "echo test"
-  longHelp: "This echos test"
-  ignoreFlags: false
 runtimeConfig:
   platformCommand:
   - command: "${HELM_PLUGIN_DIR}/sed-test.sh"

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -49,7 +49,7 @@ func collectGetterPlugins(settings *cli.EnvSettings) (Providers, error) {
 	}
 	results := make([]Provider, 0, len(plgs))
 	for _, plg := range plgs {
-		if c, ok := plg.Metadata().Config.(*plugin.ConfigGetter); ok {
+		if c, ok := plg.Metadata().Config.(*schema.ConfigGetterV1); ok {
 			results = append(results, Provider{
 				Schemes: c.Protocols,
 				New:     pluginConstructorBuilder(plg),

--- a/pkg/getter/plugingetter_test.go
+++ b/pkg/getter/plugingetter_test.go
@@ -110,7 +110,7 @@ func (t *testPlugin) Metadata() plugin.Metadata {
 		Type:       "cli/v1",
 		APIVersion: "v1",
 		Runtime:    "subprocess",
-		Config:     &plugin.ConfigCLI{},
+		Config:     &schema.ConfigCLIV1{},
 		RuntimeConfig: &plugin.RuntimeConfigSubprocess{
 			PlatformCommand: []plugin.PlatformCommand{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Clean up plugin config some:
1. Move config types to the `schema` package
2. Utilize `pluginTypesIndex` for unmarshaling config based on the plugin type (removes `convertMetadataConfig` and associated switch statement)

**Special notes for your reviewer**:
Depends on: https://github.com/helm/helm/pull/31219

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
