### PR TITLE
Prevent failing `helm push` on ghcr.io using standard GET auth token flow

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -137,8 +137,6 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		if client.enableCache {
 			authorizer.Cache = auth.NewCache()
 		}
-
-		authorizer.ForceAttemptOAuth2 = true
 		client.authorizer = &authorizer
 	}
 
@@ -251,6 +249,8 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 			return fmt.Errorf("authenticating to %q: %w", host, err)
 		}
 	}
+	// Always restore to false after probing, to avoid forcing POST to token endpoints like GHCR.
+	c.authorizer.ForceAttemptOAuth2 = false
 
 	key := credentials.ServerAddressFromRegistry(host)
 	key = credentials.ServerAddressFromHostname(key)

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -18,6 +18,10 @@ package registry
 
 import (
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -50,4 +54,69 @@ func TestTagManifestTransformsReferences(t *testing.T) {
 
 	_, err = memStore.Resolve(ctx, refWithPlus)
 	require.Error(t, err, "Should NOT find the reference with the original +")
+}
+
+// Verifies that Login always restores ForceAttemptOAuth2 to false on success.
+func TestLogin_ResetsForceAttemptOAuth2_OnSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			// Accept either HEAD or GET
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	credFile := filepath.Join(t.TempDir(), "config.json")
+	c, err := NewClient(
+		ClientOptWriter(io.Discard),
+		ClientOptCredentialsFile(credFile),
+	)
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	if c.authorizer == nil || c.authorizer.ForceAttemptOAuth2 {
+		t.Fatalf("expected ForceAttemptOAuth2 default to be false")
+	}
+
+	// Call Login with plain HTTP against our test server
+	if err := c.Login(host, LoginOptPlainText(true), LoginOptBasicAuth("u", "p")); err != nil {
+		t.Fatalf("Login error: %v", err)
+	}
+
+	if c.authorizer.ForceAttemptOAuth2 {
+		t.Errorf("ForceAttemptOAuth2 should be false after successful Login")
+	}
+}
+
+// Verifies that Login restores ForceAttemptOAuth2 to false even when ping fails.
+func TestLogin_ResetsForceAttemptOAuth2_OnFailure(t *testing.T) {
+	t.Parallel()
+
+	// Start and immediately close, so connections will fail
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	host := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	credFile := filepath.Join(t.TempDir(), "config.json")
+	c, err := NewClient(
+		ClientOptWriter(io.Discard),
+		ClientOptCredentialsFile(credFile),
+	)
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	// Invoke Login, expect an error but ForceAttemptOAuth2 must end false
+	_ = c.Login(host, LoginOptPlainText(true), LoginOptBasicAuth("u", "p"))
+
+	if c.authorizer.ForceAttemptOAuth2 {
+		t.Errorf("ForceAttemptOAuth2 should be false after failed Login")
+	}
 }


### PR DESCRIPTION
While looking into https://github.com/helm/helm/issues/11735, I noticed I was unable to push using the current main build.  
There was no issue when using the latest release (v3.18.6).  

After digging a bit, I was able to succeed by applying the changes submitted here.  

**I think we need extra tests for different cloud providers**.  So far, I only tested with GitHub (GHCR) and Docker.  

---

Fix github GHCR auth by not forcing OAuth2 POST but also reset ForceAttemptOAuth2 after login.

- Remove ForceAttemptOAuth2 in NewClient and only enable during Login ping and always restore to false. **Forcing OAuth2 by default seems to triggers POST to the token endpoint.**
- Aligns with OCI Distribution auth (token via GET), avoiding GHCR 405 on POST /token.
- Some tests

Failures logs:

```sh
$ bin/helm push quicktest-0.1.0.tgz oci://ghcr.io/benoittgt/helm-charts --debug
level=DEBUG msg=HEAD id=0 url=https://ghcr.io/v2/benoittgt/helm-charts/quicktest/manifests/sha256:af359fd8fb968ec1097afbd6e8e1dac9ee130861082e54dc2340d0c019407873 header="   \"Accept\": \"application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.artifact.manifest.v1+json\"\n   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=Resp id=0 status="401 Unauthorized" header="   \"Www-Authenticate\": \"Bearer realm=\\\"https://ghcr.io/token\\\",service=\\\"ghcr.io\\\",scope=\\\"repository:benoittgt/helm-charts/quicktest:pull\\\"\"\n   \"Date\": \"Mon, 01 Sep 2025 13:56:35 GMT\"\n   \"Content-Length\": \"73\"\n   \"X-Github-Request-Id\": \"DC73:115F:2B40F2C:2BAB567:68B5A613\"\n   \"Content-Type\": \"application/json\"" body="   Response body is empty"
level=DEBUG msg=POST id=1 url=https://ghcr.io/token header="   \"Content-Type\": \"application/x-www-form-urlencoded\"\n   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=Resp id=1 status="405 Method Not Allowed" header="   \"Docker-Distribution-Api-Version\": \"registry/2.0\"\n   \"Strict-Transport-Security\": \"max-age=63072000; includeSubDomains; preload\"\n   \"Date\": \"Mon, 01 Sep 2025 13:56:35 GMT\"\n   \"Content-Length\": \"78\"\n   \"X-Github-Request-Id\": \"DC73:115F:2B40F75:2BAB5C2:68B5A613\"\n   \"Content-Type\": \"application/json\"" body="{\"errors\":[{\"code\":\"UNSUPPORTED\",\"message\":\"The operation is unsupported.\"}]}\n"
Error: failed to perform "Exists" on destination: HEAD "https://ghcr.io/v2/benoittgt/helm-charts/quicktest/manifests/sha256:af359fd8fb968ec1097afbd6e8e1dac9ee130861082e54dc2340d0c019407873": POST "https://ghcr.io/token": response status code 405: unsupported: The operation is unsupported.

# it was working with Docker
$ bin/helm push quicktest-0.1.0.tgz oci://registry-1.docker.io/benoittgt
Pushed: registry-1.docker.io/benoittgt/quicktest:0.1.0
Digest: sha256:af359fd8fb968ec1097afbd6e8e1dac9ee130861082e54dc2340d0c019407873
```

With this build:
```sh
$ bin/helm push quicktest-0.1.0.tgz oci://ghcr.io/benoittgt/helm-charts        
Pushed: ghcr.io/benoittgt/helm-charts/quicktest:0.1.0
Digest: sha256:af359fd8fb968ec1097afbd6e8e1dac9ee130861082e54dc2340d0c019407873

$ bin/helm push quicktest-0.1.0.tgz oci://registry-1.docker.io/benoittgt
Pushed: registry-1.docker.io/benoittgt/quicktest:0.1.0
Digest: sha256:af359fd8fb968ec1097afbd6e8e1dac9ee130861082e54dc2340d0c019407873
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

\ cc @TerryHowe 

Related:
- Close: https://github.com/helm/helm/issues/31223
- https://github.com/helm/helm/issues/30970