### PR TITLE
Use filepath.Path when handling directory names

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -26,7 +26,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -677,7 +676,7 @@ func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
 
 // check if the directory exists to create file. creates if doesn't exist
 func ensureDirectoryForFile(file string) error {
-	baseDir := path.Dir(file)
+	baseDir := filepath.Dir(file)
 	_, err := os.Stat(baseDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -250,7 +249,7 @@ func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
 }
 
 func ensureDirectoryForFile(file string) error {
-	baseDir := path.Dir(file)
+	baseDir := filepath.Dir(file)
 	_, err := os.Stat(baseDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

On Windows, attempting to use `helm template --include-crds` on `oci://docker.io/envoyproxy/gateway-helm:v1.5.0` fails with an error:

```
$ helm template envoy-gateway-system . -n envoy-gateway-system -f .\values.yaml --include-crds --output-dir ..\..\argo\

Error: open ..\..\argo\\envoy-gateway-system\charts\gateway-helm\crds\gatewayapi-crds.yaml: The system cannot find the path specified.
```

This seems to be because the `ensureDirectoryForFile` function uses `path.Join` rather than `filepath.Join`, which produces the wrong type of slashes on Windows.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
