### PR TITLE
Use consistent slashes whether expanded on Windows or POSIX

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -281,7 +281,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 			if strings.TrimSpace(content) == "" {
 				continue
 			}
-			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, content)
+			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", filepath.ToSlash(name), content)
 		}
 		return hs, b, "", err
 	}
@@ -292,7 +292,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
 			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data[:]))
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", filepath.ToSlash(crd.Filename), string(crd.File.Data[:]))
 			} else {
 				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data[:]), fileWritten[crd.Filename])
 				if err != nil {
@@ -308,7 +308,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 			if hideSecret && m.Head.Kind == "Secret" && m.Head.Version == "v1" {
 				fmt.Fprintf(b, "---\n# Source: %s\n# HIDDEN: The Secret output has been suppressed\n", m.Name)
 			} else {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, m.Content)
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", filepath.ToSlash(m.Name), m.Content)
 			}
 		} else {
 			newDir := outputDir

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -657,7 +657,8 @@ func writeToFile(outputDir string, name string, data string, appendData bool) er
 
 	defer f.Close()
 
-	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", name, data)
+	// Use consistent (POSIX) filepaths in comments, even if expanded on Windows.
+	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", filepath.ToSlash(name), data)
 
 	if err != nil {
 		return err

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -26,7 +26,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -677,7 +676,7 @@ func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
 
 // check if the directory exists to create file. creates if doesn't exist
 func ensureDirectoryForFile(file string) error {
-	baseDir := path.Dir(file)
+	baseDir := filepath.Dir(file)
 	_, err := os.Stat(baseDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err

--- a/pkg/cmd/get_hooks.go
+++ b/pkg/cmd/get_hooks.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -53,7 +54,7 @@ func newGetHooksCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 			for _, hook := range res.Hooks {
-				fmt.Fprintf(out, "---\n# Source: %s\n%s\n", hook.Path, hook.Manifest)
+				fmt.Fprintf(out, "---\n# Source: %s\n%s\n", filepath.ToSlash(hook.Path), hook.Manifest)
 			}
 			return nil
 		},

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -214,7 +215,7 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 	if strings.EqualFold(s.release.Info.Description, "Dry run complete") || s.debug {
 		_, _ = fmt.Fprintln(out, "HOOKS:")
 		for _, h := range s.release.Hooks {
-			_, _ = fmt.Fprintf(out, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
+			_, _ = fmt.Fprintf(out, "---\n# Source: %s\n%s\n", filepath.ToSlash(h.Path), h.Manifest)
 		}
 		_, _ = fmt.Fprintf(out, "MANIFEST:\n%s\n", s.release.Manifest)
 	}

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -250,7 +249,7 @@ func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
 }
 
 func ensureDirectoryForFile(file string) error {
-	baseDir := path.Dir(file)
+	baseDir := filepath.Dir(file)
 	_, err := os.Stat(baseDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -115,7 +115,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							continue
 						}
 						if client.OutputDir == "" {
-							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)
+							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", filepath.ToSlash(m.Path), m.Manifest)
 						} else {
 							newDir := client.OutputDir
 							if client.UseReleaseName {
@@ -231,7 +231,7 @@ func writeToFile(outputDir string, name string, data string, appendData bool) er
 
 	defer f.Close()
 
-	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", name, data)
+	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", filepath.ToSlash(name), data)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
(This builds on #31227, but is separate because it actually changes output on Windows)

**What this PR does / why we need it**:

Currently, when expanding helm charts via `helm template` on Windows, Windows-style path separators are used.  This can generate unnecessary diffs like the following when checking in `helm template` results across different platforms (e.g. in the [rendered manifests pattern](https://akuity.io/blog/the-rendered-manifests-pattern)).

Example:

```
diff --git a/prod/argo/envoy-gateway-system/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml b/prod/argo/envoy-gateway-system/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
index d3c1ba2..f831846 100644
--- a/prod/argo/envoy-gateway-system/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/prod/argo/envoy-gateway-system/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: envoy-gateway-system/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+# Source: envoy-gateway-system\charts\gateway-helm\crds\generated\gateway.envoyproxy.io_securitypolicies.yaml
```

**Special notes for your reviewer**:

This could technically be breaking if people are relying on these elsewhere, but I'm not sure how to assess that.

If there's a standard way to add Windows-specific tests, I'd be happy to add some for this.  On the other hand, `go test ./...` has a lot of failures on Windows, so there may be more to clean up.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
