### PR TITLE
[v3 backport] fix: throw warning when chart version is not semverv2

### DIFF
--- a/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
+++ b/cmd/helm/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
@@ -9,6 +9,7 @@
 [ERROR] Chart.yaml: apiVersion is required. The value must be either "v1" or "v2"
 [ERROR] Chart.yaml: version is required
 [INFO] Chart.yaml: icon is recommended
+[WARNING] Chart.yaml: version '' is not a valid SemVerV2
 [ERROR] templates/: validation: chart.metadata.name is required
 [ERROR] : unable to load chart
 	validation: chart.metadata.name is required

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -39,12 +39,12 @@ const malformedTemplate = "rules/testdata/malformed-template"
 
 func TestBadChart(t *testing.T) {
 	m := All(badChartDir, values, namespace, strict).Messages
-	if len(m) != 8 {
+	if len(m) != 9 {
 		t.Errorf("Number of errors %v", len(m))
 		t.Errorf("All didn't fail with expected errors, got %#v", m)
 	}
-	// There should be one INFO, and 2 ERROR messages, check for them
-	var i, e, e2, e3, e4, e5, e6 bool
+	// There should be one INFO, one WARNING and 2 ERROR messages, check for them
+	var i, w, e, e2, e3, e4, e5, e6 bool
 	for _, msg := range m {
 		if msg.Severity == support.InfoSev {
 			if strings.Contains(msg.Err.Error(), "icon is recommended") {
@@ -75,8 +75,13 @@ func TestBadChart(t *testing.T) {
 				e6 = true
 			}
 		}
+		if msg.Severity == support.WarningSev {
+			if strings.Contains(msg.Err.Error(), "version '0.0.0.0' is not a valid SemVerV2") {
+				w = true
+			}
+		}
 	}
-	if !e || !e2 || !e3 || !e4 || !e5 || !i || !e6 {
+	if !e || !e2 || !e3 || !e4 || !e5 || !i || !e6 || !w {
 		t.Errorf("Didn't find all the expected errors, got %#v", m)
 	}
 }

--- a/pkg/lint/rules/chartfile.go
+++ b/pkg/lint/rules/chartfile.go
@@ -64,6 +64,7 @@ func Chartfile(linter *support.Linter) {
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartIconURL(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartType(chartFile))
 	linter.RunLinterRule(support.ErrorSev, chartFileName, validateChartDependencies(chartFile))
+	linter.RunLinterRule(support.WarningSev, chartFileName, validateChartVersionStrictSemVerV2(chartFile))
 }
 
 func validateChartVersionType(data map[string]interface{}) error {
@@ -144,6 +145,16 @@ func validateChartVersion(cf *chart.Metadata) error {
 
 	if !valid && len(msg) > 0 {
 		return errors.Errorf("version %v", msg[0])
+	}
+
+	return nil
+}
+
+func validateChartVersionStrictSemVerV2(cf *chart.Metadata) error {
+	_, err := semver.StrictNewVersion(cf.Version)
+
+	if err != nil {
+		return errors.Errorf("version '%s' is not a valid SemVerV2", cf.Version)
 	}
 
 	return nil

--- a/pkg/lint/rules/chartfile_test.go
+++ b/pkg/lint/rules/chartfile_test.go
@@ -109,6 +109,35 @@ func TestValidateChartVersion(t *testing.T) {
 	}
 }
 
+func TestValidateChartVersionStrictSemVerV2(t *testing.T) {
+	var failTest = []struct {
+		Version  string
+		ErrorMsg string
+	}{
+		{"", "version '' is not a valid SemVerV2"},
+		{"1", "version '1' is not a valid SemVerV2"},
+		{"1.1", "version '1.1' is not a valid SemVerV2"},
+	}
+
+	var successTest = []string{"1.1.1", "0.0.1+build", "0.0.1-beta"}
+
+	for _, test := range failTest {
+		badChart.Version = test.Version
+		err := validateChartVersionStrictSemVerV2(badChart)
+		if err == nil || !strings.Contains(err.Error(), test.ErrorMsg) {
+			t.Errorf("validateChartVersionStrictSemVerV2(%s) to return \"%s\", got no error", test.Version, test.ErrorMsg)
+		}
+	}
+
+	for _, version := range successTest {
+		badChart.Version = version
+		err := validateChartVersionStrictSemVerV2(badChart)
+		if err != nil {
+			t.Errorf("validateChartVersionStrictSemVerV2(%s) to return no error, got a linter error", version)
+		}
+	}
+}
+
 func TestValidateChartMaintainer(t *testing.T) {
 	var failTest = []struct {
 		Name     string
@@ -207,7 +236,7 @@ func TestChartfile(t *testing.T) {
 		linter := support.Linter{ChartDir: badChartDir}
 		Chartfile(&linter)
 		msgs := linter.Messages
-		expectedNumberOfErrorMessages := 6
+		expectedNumberOfErrorMessages := 7
 
 		if len(msgs) != expectedNumberOfErrorMessages {
 			t.Errorf("Expected %d errors, got %d", expectedNumberOfErrorMessages, len(msgs))
@@ -237,13 +266,16 @@ func TestChartfile(t *testing.T) {
 		if !strings.Contains(msgs[5].Err.Error(), "dependencies are not valid in the Chart file with apiVersion") {
 			t.Errorf("Unexpected message 5: %s", msgs[5].Err)
 		}
+		if !strings.Contains(msgs[6].Err.Error(), "version '0.0.0.0' is not a valid SemVerV2") {
+			t.Errorf("Unexpected message 6: %s", msgs[6].Err)
+		}
 	})
 
 	t.Run("Chart.yaml validity issues due to type mismatch", func(t *testing.T) {
 		linter := support.Linter{ChartDir: anotherBadChartDir}
 		Chartfile(&linter)
 		msgs := linter.Messages
-		expectedNumberOfErrorMessages := 3
+		expectedNumberOfErrorMessages := 4
 
 		if len(msgs) != expectedNumberOfErrorMessages {
 			t.Errorf("Expected %d errors, got %d", expectedNumberOfErrorMessages, len(msgs))
@@ -260,6 +292,9 @@ func TestChartfile(t *testing.T) {
 
 		if !strings.Contains(msgs[2].Err.Error(), "appVersion should be of type string") {
 			t.Errorf("Unexpected message 2: %s", msgs[2].Err)
+		}
+		if !strings.Contains(msgs[3].Err.Error(), "version '7.2445e+06' is not a valid SemVerV2") {
+			t.Errorf("Unexpected message 3: %s", msgs[3].Err)
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes https://github.com/helm/helm/issues/30513

**Special notes for your reviewer**:

- backport of https://github.com/helm/helm/pull/31064 - a bit different due to [moving lint directory ](https://github.com/helm/helm/pull/31225) and [this fix](https://github.com/helm/helm/pull/31019) that has not been backported yet - I am not sure if I should wait and if all of those will be backported.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so) https://github.com/helm/helm-www/pull/1744
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
