### PR TITLE
Warn when we fallback to a different version on `helm pull`

### DIFF
--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -215,6 +215,7 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 		}
 
 		if constraint.Check(test) {
+			slog.Warn("unable to find exact version; falling back to closest available version", "chart", name, "requested", version, "selected", ver.Version)
 			return ver, nil
 		}
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

Closes: https://github.com/helm/helm/issues/31253

**Special notes for your reviewer**:

1. Do we want to have this only on v3 and on v4 we raise `ErrNoChartVersion` when we do no have exact match?
2. Do we want to backport this?

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
