### PR TITLE
Refactor unreachableKubeClient for testing into failingKubeClient

### DIFF
--- a/pkg/action/get_metadata_test.go
+++ b/pkg/action/get_metadata_test.go
@@ -31,15 +31,6 @@ import (
 	helmtime "helm.sh/helm/v4/pkg/time"
 )
 
-// unreachableKubeClient is a test client that always returns an error for IsReachable
-type unreachableKubeClient struct {
-	kubefake.PrintingKubeClient
-}
-
-func (u *unreachableKubeClient) IsReachable() error {
-	return errors.New("connection refused")
-}
-
 func TestNewGetMetadata(t *testing.T) {
 	cfg := actionConfigFixture(t)
 	client := NewGetMetadata(cfg)
@@ -424,9 +415,9 @@ func TestGetMetadata_Run_DifferentStatuses(t *testing.T) {
 
 func TestGetMetadata_Run_UnreachableKubeClient(t *testing.T) {
 	cfg := actionConfigFixture(t)
-	cfg.KubeClient = &unreachableKubeClient{
-		PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
-	}
+	failingKubeClient := kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}, DummyResources: nil}
+	failingKubeClient.ConnectionError = errors.New("connection refused")
+	cfg.KubeClient = &failingKubeClient
 
 	client := NewGetMetadata(cfg)
 

--- a/pkg/action/get_values_test.go
+++ b/pkg/action/get_values_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -168,9 +169,9 @@ func TestGetValues_Run_EmptyValues(t *testing.T) {
 
 func TestGetValues_Run_UnreachableKubeClient(t *testing.T) {
 	cfg := actionConfigFixture(t)
-	cfg.KubeClient = &unreachableKubeClient{
-		PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
-	}
+	failingKubeClient := kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}, DummyResources: nil}
+	failingKubeClient.ConnectionError = errors.New("connection refused")
+	cfg.KubeClient = &failingKubeClient
 
 	client := NewGetValues(cfg)
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -997,3 +997,19 @@ func TestUrlEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestInstallRun_UnreachableKubeClient(t *testing.T) {
+	config := actionConfigFixture(t)
+	failingKubeClient := kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}, DummyResources: nil}
+	failingKubeClient.ConnectionError = errors.New("connection refused")
+	config.KubeClient = &failingKubeClient
+
+	instAction := NewInstall(config)
+	instAction.ClientOnly = false
+	ctx, done := context.WithCancel(t.Context())
+	res, err := instAction.RunWithContext(ctx, nil, nil)
+
+	done()
+	assert.Nil(t, res)
+	assert.ErrorContains(t, err, "connection refused")
+}

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -40,6 +40,7 @@ type FailingKubeClient struct {
 	UpdateError                error
 	BuildError                 error
 	BuildTableError            error
+	ConnectionError            error
 	BuildDummy                 bool
 	DummyResources             kube.ResourceList
 	BuildUnstructuredError     error
@@ -164,6 +165,13 @@ func (f *FailingKubeClient) GetWaiter(ws kube.WaitStrategy) (kube.Waiter, error)
 		watchUntilReadyError: f.WatchUntilReadyError,
 		waitDuration:         f.WaitDuration,
 	}, nil
+}
+
+func (f *FailingKubeClient) IsReachable() error {
+	if f.ConnectionError != nil {
+		return f.ConnectionError
+	}
+	return f.PrintingKubeClient.IsReachable()
 }
 
 func createDummyResourceList() kube.ResourceList {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors `unreachableKubeClient` from 'get_metadata_test' into the `failingKubeClient`, since other test classes need to cover that case as well, when calling `g.cfg.KubeClient.IsReachable()`.


**Special notes for your reviewer**:
This code go extracted from the PR #31239 

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
