### PR TITLE
Adapt test-coverage command to be able to run for a certain package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,12 @@ test-unit:
 	go test $(GOFLAGS) -run ^TestHelmCreateChart_CheckDeprecatedWarnings$$ ./internal/chart/v3/lint/ $(TESTFLAGS) -ldflags '$(LDFLAGS)'
 
 
+# To run the coverage for a specific package use: make test-coverage PKG=./pkg/action
 .PHONY: test-coverage
 test-coverage:
 	@echo
-	@echo "==> Running unit tests with coverage <=="
-	@ ./scripts/coverage.sh
+	@echo "==> Running unit tests with coverage: $(PKG) <=="
+	@ ./scripts/coverage.sh $(PKG)
 
 .PHONY: test-style
 test-style:
@@ -147,10 +148,6 @@ test-acceptance: build build-cross
 .PHONY: test-acceptance-completion
 test-acceptance-completion: ACCEPTANCE_RUN_TESTS = shells.robot
 test-acceptance-completion: test-acceptance
-
-.PHONY: coverage
-coverage:
-	@scripts/coverage.sh
 
 .PHONY: format
 format: $(GOIMPORTS)

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -19,9 +19,10 @@ set -euo pipefail
 covermode=${COVERMODE:-atomic}
 coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
 profile="${coverdir}/cover.out"
+target="${1:-./...}" # by default the whole repository is tested
 
 generate_cover_data() {
-  for d in $(go list ./...) ; do
+  for d in $(go list "$target"); do
     (
       local output="${coverdir}/${d//\//-}.cover"
       go test -coverprofile="${output}" -covermode="$covermode" "$d"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts the test-coverage function in the Makefile and adapt coverage.sh to accept a directory as argument.
So that the test coverage can be run for a single package locally, rather than for the whole repository.

When no argument is given to coverage.sh, it is defaulting to test the whole repository.

**Special notes for your reviewer**:
Test locally: `make tet-coverage PKG=./pkg/action`

Originally part of the PR  #31239 

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
