### PR TITLE
Fix referencing another schema file relative to CWD

### DIFF
--- a/pkg/chart/common/util/jsonschema.go
+++ b/pkg/chart/common/util/jsonschema.go
@@ -131,12 +131,12 @@ func ValidateAgainstSingleSchema(values common.Values, schemaJSON []byte) (reter
 
 	compiler := jsonschema.NewCompiler()
 	compiler.UseLoader(loader)
-	err = compiler.AddResource("file:///values.schema.json", schema)
+	err = compiler.AddResource("./values.schema.json", schema)
 	if err != nil {
 		return err
 	}
 
-	validator, err := compiler.Compile("file:///values.schema.json")
+	validator, err := compiler.Compile("./values.schema.json")
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (e JSONSchemaValidationError) Error() string {
 
 	// This string prefixes all of our error details. Further up the stack of helm error message
 	// building more detail is provided to users. This is removed.
-	errStr = strings.TrimPrefix(errStr, "jsonschema validation failed with 'file:///values.schema.json#'\n")
+	errStr = strings.TrimPrefix(errStr, "jsonschema validation failed with './values.schema.json#'\n")
 
 	// The extra new line is needed for when there are sub-charts.
 	return errStr + "\n"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This commit puts back the behaviour found in v3.18.4 where executing a helm subcommand that validates against a values.schema.json file it follows references to additional schema files and closes #31260.

**Special notes for your reviewer**:

Although I have some Go experience Helm is the biggest codebase I've contributed to and it could be that I am barking up the wrong tree.  My changes fix my issue as described in #31260, but I don't know how to test or discover if there are wider implications.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
