### PR TITLE
Extend --skip-schema-validation for lint command

### DIFF
--- a/internal/chart/v3/lint/lint.go
+++ b/internal/chart/v3/lint/lint.go
@@ -57,7 +57,7 @@ func RunAll(baseDir string, values map[string]interface{}, namespace string, opt
 	}
 
 	rules.Chartfile(&result)
-	rules.ValuesWithOverrides(&result, values)
+	rules.ValuesWithOverrides(&result, values, lo.SkipSchemaValidation)
 	rules.TemplatesWithSkipSchemaValidation(&result, values, namespace, lo.KubeVersion, lo.SkipSchemaValidation)
 	rules.Dependencies(&result)
 	rules.Crds(&result)

--- a/internal/chart/v3/lint/rules/values.go
+++ b/internal/chart/v3/lint/rules/values.go
@@ -32,7 +32,7 @@ import (
 // they are only tested for well-formedness.
 //
 // If additional values are supplied, they are coalesced into the values in values.yaml.
-func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]interface{}) {
+func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]interface{}, skipSchemaValidation bool) {
 	file := "values.yaml"
 	vf := filepath.Join(linter.ChartDir, file)
 	fileExists := linter.RunLinterRule(support.InfoSev, file, validateValuesFileExistence(vf))
@@ -41,7 +41,7 @@ func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]inter
 		return
 	}
 
-	linter.RunLinterRule(support.ErrorSev, file, validateValuesFile(vf, valueOverrides))
+	linter.RunLinterRule(support.ErrorSev, file, validateValuesFile(vf, valueOverrides, skipSchemaValidation))
 }
 
 func validateValuesFileExistence(valuesPath string) error {
@@ -52,7 +52,7 @@ func validateValuesFileExistence(valuesPath string) error {
 	return nil
 }
 
-func validateValuesFile(valuesPath string, overrides map[string]interface{}) error {
+func validateValuesFile(valuesPath string, overrides map[string]interface{}, skipSchemaValidation bool) error {
 	values, err := common.ReadValuesFile(valuesPath)
 	if err != nil {
 		return fmt.Errorf("unable to parse YAML: %w", err)
@@ -75,5 +75,10 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	if err != nil {
 		return err
 	}
-	return util.ValidateAgainstSingleSchema(coalescedValues, schema)
+
+	if !skipSchemaValidation {
+		return util.ValidateAgainstSingleSchema(coalescedValues, schema)
+	}
+
+	return nil
 }

--- a/pkg/chart/v2/lint/lint.go
+++ b/pkg/chart/v2/lint/lint.go
@@ -57,7 +57,7 @@ func RunAll(baseDir string, values map[string]interface{}, namespace string, opt
 	}
 
 	rules.Chartfile(&result)
-	rules.ValuesWithOverrides(&result, values)
+	rules.ValuesWithOverrides(&result, values, lo.SkipSchemaValidation)
 	rules.TemplatesWithSkipSchemaValidation(&result, values, namespace, lo.KubeVersion, lo.SkipSchemaValidation)
 	rules.Dependencies(&result)
 	rules.Crds(&result)

--- a/pkg/chart/v2/lint/rules/values.go
+++ b/pkg/chart/v2/lint/rules/values.go
@@ -32,7 +32,7 @@ import (
 // they are only tested for well-formedness.
 //
 // If additional values are supplied, they are coalesced into the values in values.yaml.
-func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]interface{}) {
+func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]interface{}, skipSchemaValidation bool) {
 	file := "values.yaml"
 	vf := filepath.Join(linter.ChartDir, file)
 	fileExists := linter.RunLinterRule(support.InfoSev, file, validateValuesFileExistence(vf))
@@ -41,7 +41,7 @@ func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]inter
 		return
 	}
 
-	linter.RunLinterRule(support.ErrorSev, file, validateValuesFile(vf, valueOverrides))
+	linter.RunLinterRule(support.ErrorSev, file, validateValuesFile(vf, valueOverrides, skipSchemaValidation))
 }
 
 func validateValuesFileExistence(valuesPath string) error {
@@ -52,7 +52,7 @@ func validateValuesFileExistence(valuesPath string) error {
 	return nil
 }
 
-func validateValuesFile(valuesPath string, overrides map[string]interface{}) error {
+func validateValuesFile(valuesPath string, overrides map[string]interface{}, skipSchemaValidation bool) error {
 	values, err := common.ReadValuesFile(valuesPath)
 	if err != nil {
 		return fmt.Errorf("unable to parse YAML: %w", err)
@@ -75,5 +75,10 @@ func validateValuesFile(valuesPath string, overrides map[string]interface{}) err
 	if err != nil {
 		return err
 	}
-	return util.ValidateAgainstSingleSchema(coalescedValues, schema)
+
+	if !skipSchemaValidation {
+		return util.ValidateAgainstSingleSchema(coalescedValues, schema)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Closing stale [PR](https://github.com/helm/helm/pull/13414) that hasn’t had recent activity.

When --skip-schema-validation is enabled, the lint command will now skip JSON schema validation for `values.yaml` files, allowing charts with schema validation errors to pass linting when the flag is used.

This addresses the gap where `--skip-schema-validation` only applied to templates but not to values files, providing complete schema validation bypass when needed.

I've addressed @gjenkins8's feedback.

Fixes: #13413
Closes: https://github.com/helm/helm/pull/13414

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:

Tested with:
```sh
$ make build
$ ./bin/helm create lint-skip-schema
$ cd lint-skip-schema
$ rm -f templates/tests/test-connection.yaml # avoid noise
$ cat > values.schema.json <<'JSON'
{
  "$schema": "https://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": ["requiredField"],
  "properties": {
    "requiredField": { "type": "string" }
  }
}
JSON

$ helm template . --skip-schema-validation # work

$ helm lint . --skip-schema-validation # with last released version v3.18.6
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - at '': missing property 'requiredField'


Error: 1 chart(s) linted, 1 chart(s) failed

$ ../../bin/helm lint . --skip-schema-validation 
metadata: map[APIVersion:v2 Annotations:map[] AppVersion:1.16.0 Condition: Dependencies:[] Deprecated:false Description:A Helm chart for Kubernetes Home: Icon: Keywords:[] KubeVersion: Maintainers:[] Name:lint-skip-schema Sources:[] Tags: Type:application Version:0.1.0]
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
