### PR TITLE
fix: remove leftover debugging line that outputs invalid YAML for helm template command

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -473,7 +473,6 @@ func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Val
 		slog.Error("error accessing chart", "error", err)
 	}
 	chartMetaData := accessor.MetadataAsMap()
-	fmt.Printf("metadata: %v\n", chartMetaData)
 	chartMetaData["IsRoot"] = accessor.IsRoot()
 
 	next := map[string]interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

I think a debugging line was added to the `recAllTpls` function, it affects the `helm template` command output by generating an invalid yaml on stdout.

For example when running the following command:
```shell
helm template ingress-nginx ingress-nginx/ingress-nginx  --version 4.12.2
```
with the line:
```yaml
metadata: map[APIVersion:v2 Annotations:map[artifacthub.io/changes:- Update Ingress-Nginx version controller-v1.12.2
 artifacthub.io/prerelease:false] AppVersion:1.12.2 Condition: Dependencies:[] Deprecated:false Description:Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer Home:https://github.com/kubernetes/ingress-nginx Icon:https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png Keywords:[ingress nginx] KubeVersion:>=1.21.0-0 Maintainers:[map[Email: Name:cpanato URL:] map[Email: Name:Gacko URL:] map[Email: Name:strongjz URL:] map[Email: Name:tao12345666333 URL:]] Name:ingress-nginx Sources:[https://github.com/kubernetes/ingress-nginx] Tags: Type: Version:4.12.2]
---
# Source: ingress-nginx/templates/controller-serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    helm.sh/chart: ingress-nginx-4.12.2
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
```

without it:
```yaml
---
# Source: ingress-nginx/templates/controller-serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    helm.sh/chart: ingress-nginx-4.12.2
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
```

**Should this be the case? Or should it be removed? Or should it be a comment?**

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
