### PR TITLE
refactor: use strings.builder

### DIFF
--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,15 +113,15 @@ spec:
 }
 
 func convertHooksToCommaSeparated(hookDefinitions []release.HookOutputLogPolicy) string {
-	var commaSeparated string
+	var commaSeparated strings.Builder
 	for i, policy := range hookDefinitions {
 		if i+1 == len(hookDefinitions) {
-			commaSeparated += policy.String()
+			commaSeparated.WriteString(policy.String())
 		} else {
-			commaSeparated += policy.String() + ","
+			commaSeparated.WriteString(policy.String() + ",")
 		}
 	}
-	return commaSeparated
+	return commaSeparated.String()
 }
 
 func TestInstallRelease_HookOutputLogsOnFailure(t *testing.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1024,15 +1024,15 @@ func TestRenderRecursionLimit(t *testing.T) {
 	times := 4000
 	phrase := "All work and no play makes Jack a dull boy"
 	printFunc := `{{define "overlook"}}{{printf "` + phrase + `\n"}}{{end}}`
-	var repeatedIncl string
+	var repeatedIncl strings.Builder
 	for i := 0; i < times; i++ {
-		repeatedIncl += `{{include "overlook" . }}`
+		repeatedIncl.WriteString(`{{include "overlook" . }}`)
 	}
 
 	d := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "overlook"},
 		Templates: []*common.File{
-			{Name: "templates/quote", Data: []byte(repeatedIncl)},
+			{Name: "templates/quote", Data: []byte(repeatedIncl.String())},
 			{Name: "templates/_function", Data: []byte(printFunc)},
 		},
 	}

--- a/pkg/strvals/literal_parser_test.go
+++ b/pkg/strvals/literal_parser_test.go
@@ -17,6 +17,7 @@ package strvals
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -416,14 +417,14 @@ func TestParseLiteralInto(t *testing.T) {
 }
 
 func TestParseLiteralNestedLevels(t *testing.T) {
-	var keyMultipleNestedLevels string
+	var keyMultipleNestedLevels strings.Builder
 
 	for i := 1; i <= MaxNestedNameLevel+2; i++ {
 		tmpStr := fmt.Sprintf("name%d", i)
 		if i <= MaxNestedNameLevel+1 {
 			tmpStr = tmpStr + "."
 		}
-		keyMultipleNestedLevels += tmpStr
+		keyMultipleNestedLevels.WriteString(tmpStr)
 	}
 
 	tests := []struct {
@@ -439,7 +440,7 @@ func TestParseLiteralNestedLevels(t *testing.T) {
 			"",
 		},
 		{
-			str:    keyMultipleNestedLevels + "=value",
+			str:    keyMultipleNestedLevels.String() + "=value",
 			err:    true,
 			errStr: fmt.Sprintf("value name nested level is greater than maximum supported nested level of %d", MaxNestedNameLevel),
 		},

--- a/pkg/strvals/parser_test.go
+++ b/pkg/strvals/parser_test.go
@@ -17,6 +17,7 @@ package strvals
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -757,13 +758,13 @@ func TestToYAML(t *testing.T) {
 }
 
 func TestParseSetNestedLevels(t *testing.T) {
-	var keyMultipleNestedLevels string
+	var keyMultipleNestedLevels strings.Builder
 	for i := 1; i <= MaxNestedNameLevel+2; i++ {
 		tmpStr := fmt.Sprintf("name%d", i)
 		if i <= MaxNestedNameLevel+1 {
 			tmpStr = tmpStr + "."
 		}
-		keyMultipleNestedLevels += tmpStr
+		keyMultipleNestedLevels.WriteString(tmpStr)
 	}
 	tests := []struct {
 		str    string
@@ -778,7 +779,7 @@ func TestParseSetNestedLevels(t *testing.T) {
 			"",
 		},
 		{
-			str: keyMultipleNestedLevels + "=value",
+			str: keyMultipleNestedLevels.String() + "=value",
 			err: true,
 			errStr: fmt.Sprintf("value name nested level is greater than maximum supported nested level of %d",
 				MaxNestedNameLevel),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The modernize has added an analyzer for using strings.Builder for string construction. strings.Builder has fewer memory allocations and better performance.

More info: https://github.com/golang/go/issues/75190

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
