### PR TITLE
Remove implicit support for helm lint current directory

### DIFF
--- a/pkg/cmd/lint.go
+++ b/pkg/cmd/lint.go
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/v2/lint/support"
 	"helm.sh/helm/v4/pkg/cli/values"
+	"helm.sh/helm/v4/pkg/cmd/require"
 	"helm.sh/helm/v4/pkg/getter"
 )
 
@@ -51,11 +52,9 @@ func newLintCmd(out io.Writer) *cobra.Command {
 		Use:   "lint PATH",
 		Short: "examine a chart for possible issues",
 		Long:  longLintHelp,
+		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			paths := []string{"."}
-			if len(args) > 0 {
-				paths = args
-			}
+			paths := args
 
 			if kubeVersion != "" {
 				parsedKubeVersion, err := common.ParseKubeVersion(kubeVersion)

--- a/pkg/cmd/lint_test.go
+++ b/pkg/cmd/lint_test.go
@@ -91,6 +91,15 @@ func TestLintCmdWithKubeVersionFlag(t *testing.T) {
 	runTestCmd(t, tests)
 }
 
+func TestLintCmdRequiresArgs(t *testing.T) {
+	tests := []cmdTestCase{{
+		name:      "lint without arguments should fail",
+		cmd:       "lint",
+		wantError: true,
+	}}
+	runTestCmd(t, tests)
+}
+
 func TestLintFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "lint", true)
 	checkFileCompletion(t, "lint mypath", true) // Multiple paths can be given


### PR DESCRIPTION
This change removes the implicit path support for the helm lint command to align it with other Helm commands like install, upgrade, and package.

Closes: https://github.com/helm/helm/issues/8051
