### PR TITLE
build: set kube version via `debug.BuildInfo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,20 +58,6 @@ LDFLAGS += -X helm.sh/helm/v4/internal/version.gitCommit=${GIT_COMMIT}
 LDFLAGS += -X helm.sh/helm/v4/internal/version.gitTreeState=${GIT_DIRTY}
 LDFLAGS += $(EXT_LDFLAGS)
 
-# Define constants based on the client-go version
-K8S_MODULES_VER=$(subst ., ,$(subst v,,$(shell go list -f '{{.Version}}' -m k8s.io/client-go)))
-K8S_MODULES_MAJOR_VER=$(shell echo $$(($(firstword $(K8S_MODULES_VER)) + 1)))
-K8S_MODULES_MINOR_VER=$(word 2,$(K8S_MODULES_VER))
-
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMinor=$(K8S_MODULES_MINOR_VER)
-
 .PHONY: all
 all: build
 

--- a/internal/chart/v3/lint/lint_test.go
+++ b/internal/chart/v3/lint/lint_test.go
@@ -175,16 +175,6 @@ func TestHelmCreateChart(t *testing.T) {
 //
 // Resources like hpa and ingress, which are disabled by default in values.yaml are enabled here using the equivalent
 // of the `--set` flag.
-//
-// Note: This test requires the following ldflags to be set per the current Kubernetes version to avoid false-positive
-// results.
-// 1. -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMajor=<k8s-major-version>
-// 2. -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMinor=<k8s-minor-version>
-// or directly use '$(LDFLAGS)' in Makefile.
-//
-// When run without ldflags, the test passes giving a false-positive result. This is because the variables
-// `k8sVersionMajor` and `k8sVersionMinor` by default are set to an older version of Kubernetes, with which, there
-// might not be the deprecation warning.
 func TestHelmCreateChart_CheckDeprecatedWarnings(t *testing.T) {
 	createdChart, err := chartutil.Create("checkdeprecatedwarnings", t.TempDir())
 	if err != nil {

--- a/internal/chart/v3/lint/rules/deprecations.go
+++ b/internal/chart/v3/lint/rules/deprecations.go
@@ -28,15 +28,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-var (
-	// This should be set in the Makefile based on the version of client-go being imported.
-	// These constants will be overwritten with LDFLAGS. The version components must be
-	// strings in order for LDFLAGS to set them.
-	k8sVersionMajor = "1"
-	k8sVersionMinor = "20"
-)
-
-// deprecatedAPIError indicates that an API is deprecated in Kubernetes
+// deprecatedAPIError indicates than an API is deprecated in Kubernetes
 type deprecatedAPIError struct {
 	Deprecated string
 	Message    string
@@ -56,12 +48,17 @@ func validateNoDeprecations(resource *k8sYamlStruct, kubeVersion *common.KubeVer
 		return nil
 	}
 
-	majorVersion := k8sVersionMajor
-	minorVersion := k8sVersionMinor
+	if kubeVersion == nil {
+		kubeVersion = &common.DefaultCapabilities.KubeVersion
+	}
 
-	if kubeVersion != nil {
-		majorVersion = kubeVersion.Major
-		minorVersion = kubeVersion.Minor
+	kubeVersionMajor, err := strconv.Atoi(kubeVersion.Major)
+	if err != nil {
+		return err
+	}
+	kubeVersionMinor, err := strconv.Atoi(kubeVersion.Minor)
+	if err != nil {
+		return err
 	}
 
 	runtimeObject, err := resourceToRuntimeObject(resource)
@@ -73,16 +70,7 @@ func validateNoDeprecations(resource *k8sYamlStruct, kubeVersion *common.KubeVer
 		return err
 	}
 
-	major, err := strconv.Atoi(majorVersion)
-	if err != nil {
-		return err
-	}
-	minor, err := strconv.Atoi(minorVersion)
-	if err != nil {
-		return err
-	}
-
-	if !deprecation.IsDeprecated(runtimeObject, major, minor) {
+	if !deprecation.IsDeprecated(runtimeObject, kubeVersionMajor, kubeVersionMinor) {
 		return nil
 	}
 	gvk := fmt.Sprintf("%s %s", resource.APIVersion, resource.Kind)

--- a/internal/version/clientgo.go
+++ b/internal/version/clientgo.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+	"slices"
+
+	_ "k8s.io/client-go/kubernetes" // Force k8s.io/client-go to be included in the build
+)
+
+func K8sIOClientGoModVersion() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", fmt.Errorf("failed to read build info")
+	}
+
+	idx := slices.IndexFunc(info.Deps, func(m *debug.Module) bool {
+		return m.Path == "k8s.io/client-go"
+	})
+
+	if idx == -1 {
+		return "", fmt.Errorf("k8s.io/client-go not found in build info")
+	}
+
+	m := info.Deps[idx]
+
+	return m.Version, nil
+}

--- a/internal/version/clientgo_test.go
+++ b/internal/version/clientgo_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8sClientGoModVersion(t *testing.T) {
+	// Unfortunately, test builds don't include debug info / module info
+	// So we expect "K8sIOClientGoModVersion" to return error
+	_, err := K8sIOClientGoModVersion()
+	require.ErrorContains(t, err, "k8s.io/client-go not found in build info")
+}

--- a/pkg/chart/common/capabilities_test.go
+++ b/pkg/chart/common/capabilities_test.go
@@ -41,7 +41,8 @@ func TestDefaultVersionSet(t *testing.T) {
 }
 
 func TestDefaultCapabilities(t *testing.T) {
-	kv := DefaultCapabilities.KubeVersion
+	caps := DefaultCapabilities
+	kv := caps.KubeVersion
 	if kv.String() != "v1.20.0" {
 		t.Errorf("Expected default KubeVersion.String() to be v1.20.0, got %q", kv.String())
 	}
@@ -57,11 +58,8 @@ func TestDefaultCapabilities(t *testing.T) {
 	if kv.Minor != "20" {
 		t.Errorf("Expected default KubeVersion.Minor to be 20, got %q", kv.Minor)
 	}
-}
 
-func TestDefaultCapabilitiesHelmVersion(t *testing.T) {
-	hv := DefaultCapabilities.HelmVersion
-
+	hv := caps.HelmVersion
 	if hv.Version != "v4.1" {
 		t.Errorf("Expected default HelmVersion to be v4.1, got %q", hv.Version)
 	}

--- a/pkg/chart/v2/lint/lint_test.go
+++ b/pkg/chart/v2/lint/lint_test.go
@@ -179,16 +179,6 @@ func TestHelmCreateChart(t *testing.T) {
 //
 // Resources like hpa and ingress, which are disabled by default in values.yaml are enabled here using the equivalent
 // of the `--set` flag.
-//
-// Note: This test requires the following ldflags to be set per the current Kubernetes version to avoid false-positive
-// results.
-// 1. -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMajor=<k8s-major-version>
-// 2. -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMinor=<k8s-minor-version>
-// or directly use '$(LDFLAGS)' in Makefile.
-//
-// When run without ldflags, the test passes giving a false-positive result. This is because the variables
-// `k8sVersionMajor` and `k8sVersionMinor` by default are set to an older version of Kubernetes, with which, there
-// might not be the deprecation warning.
 func TestHelmCreateChart_CheckDeprecatedWarnings(t *testing.T) {
 	createdChart, err := chartutil.Create("checkdeprecatedwarnings", t.TempDir())
 	if err != nil {

--- a/pkg/chart/v2/lint/rules/deprecations.go
+++ b/pkg/chart/v2/lint/rules/deprecations.go
@@ -28,15 +28,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-var (
-	// This should be set in the Makefile based on the version of client-go being imported.
-	// These constants will be overwritten with LDFLAGS. The version components must be
-	// strings in order for LDFLAGS to set them.
-	k8sVersionMajor = "1"
-	k8sVersionMinor = "20"
-)
-
-// deprecatedAPIError indicates that an API is deprecated in Kubernetes
+// deprecatedAPIError indicates than an API is deprecated in Kubernetes
 type deprecatedAPIError struct {
 	Deprecated string
 	Message    string
@@ -56,12 +48,8 @@ func validateNoDeprecations(resource *k8sYamlStruct, kubeVersion *common.KubeVer
 		return nil
 	}
 
-	majorVersion := k8sVersionMajor
-	minorVersion := k8sVersionMinor
-
-	if kubeVersion != nil {
-		majorVersion = kubeVersion.Major
-		minorVersion = kubeVersion.Minor
+	if kubeVersion == nil {
+		kubeVersion = &common.DefaultCapabilities.KubeVersion
 	}
 
 	runtimeObject, err := resourceToRuntimeObject(resource)
@@ -73,16 +61,16 @@ func validateNoDeprecations(resource *k8sYamlStruct, kubeVersion *common.KubeVer
 		return err
 	}
 
-	major, err := strconv.Atoi(majorVersion)
+	kubeVersionMajor, err := strconv.Atoi(kubeVersion.Major)
 	if err != nil {
 		return err
 	}
-	minor, err := strconv.Atoi(minorVersion)
+	kubeVersionMinor, err := strconv.Atoi(kubeVersion.Minor)
 	if err != nil {
 		return err
 	}
 
-	if !deprecation.IsDeprecated(runtimeObject, major, minor) {
+	if !deprecation.IsDeprecated(runtimeObject, kubeVersionMajor, kubeVersionMinor) {
 		return nil
 	}
 	gvk := fmt.Sprintf("%s %s", resource.APIVersion, resource.Kind)

--- a/pkg/cmd/lint_test.go
+++ b/pkg/cmd/lint_test.go
@@ -76,7 +76,7 @@ func TestLintCmdWithKubeVersionFlag(t *testing.T) {
 		golden:    "output/lint-chart-with-deprecated-api-strict.txt",
 		wantError: true,
 	}, {
-		// the test builds will use the default k8sVersionMinor const in deprecations.go and capabilities.go
+		// the test builds will use the kubeVersionMinorTesting const in capabilities.go
 		// which is "20"
 		name:      "lint chart with deprecated api version without kube version",
 		cmd:       fmt.Sprintf("lint %s", testChart),

--- a/pkg/cmd/testdata/output/version.txt
+++ b/pkg/cmd/testdata/output/version.txt
@@ -1,1 +1,1 @@
-version.BuildInfo{Version:"v4.1", GitCommit:"", GitTreeState:"", GoVersion:"", KubeClientVersion:"v."}
+version.BuildInfo{Version:"v4.1", GitCommit:"", GitTreeState:"", GoVersion:"", KubeClientVersion:"v1.20"}


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Read the Kubernetes client version (the `client-go` library version) directly from from Go's internal `runtime.DebugInfo`. Rather than setting the link time build variables.

The PR is an update of https://github.com/helm/helm/pull/13180 with some (needed) changes

Thanks to @branchvincent for the idea and initial implementation

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
