### PR TITLE
fix: hide notes in helm test command

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -45,7 +45,6 @@ type ReleaseTesting struct {
 	// Used for fetching logs from test pods
 	Namespace string
 	Filters   map[string][]string
-	HideNotes bool
 }
 
 // NewReleaseTesting creates a new ReleaseTesting object with the given configuration.

--- a/pkg/cmd/release_testing.go
+++ b/pkg/cmd/release_testing.go
@@ -77,7 +77,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 				release:      rel,
 				debug:        settings.Debug,
 				showMetadata: false,
-				hideNotes:    client.HideNotes,
+				hideNotes:    true,
 				noColor:      settings.ShouldDisableColor(),
 			}); err != nil {
 				return err
@@ -99,7 +99,6 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.BoolVar(&outputLogs, "logs", false, "dump the logs from test pods (this runs after all tests are complete, but before any cleanup)")
 	f.StringSliceVar(&filter, "filter", []string{}, "specify tests by attribute (currently \"name\") using attribute=value syntax or '!attribute=value' to exclude a test (can specify multiple or separate values with commas: name=test1,name=test2)")
-	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in test output. Does not affect presence in chart metadata")
 
 	return cmd
 }

--- a/pkg/cmd/release_testing_test.go
+++ b/pkg/cmd/release_testing_test.go
@@ -17,7 +17,16 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
+	"io"
+	"strings"
 	"testing"
+
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/common"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
 func TestReleaseTestingCompletion(t *testing.T) {
@@ -27,4 +36,45 @@ func TestReleaseTestingCompletion(t *testing.T) {
 func TestReleaseTestingFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "test", false)
 	checkFileCompletion(t, "test myrelease", false)
+}
+
+func TestReleaseTestNotesHandling(t *testing.T) {
+	// Test that ensures notes behavior is correct for test command
+	// This is a simpler test that focuses on the core functionality
+
+	rel := &release.Release{
+		Name:      "test-release",
+		Namespace: "default",
+		Info: &release.Info{
+			Status: release.StatusDeployed,
+			Notes:  "Some important notes that should be hidden by default",
+		},
+		Chart: &chart.Chart{Metadata: &chart.Metadata{Name: "test", Version: "1.0.0"}},
+	}
+
+	// Set up storage
+	store := storageFixture()
+	store.Create(rel)
+
+	// Set up action configuration properly
+	actionConfig := &action.Configuration{
+		Releases:     store,
+		KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}},
+		Capabilities: common.DefaultCapabilities,
+	}
+
+	// Test the newReleaseTestCmd function directly
+	var buf1 bytes.Buffer
+
+	// Test 1: Default behavior (should hide notes)
+	cmd1 := newReleaseTestCmd(actionConfig, &buf1)
+	cmd1.SetArgs([]string{"test-release"})
+	err1 := cmd1.Execute()
+	if err1 != nil {
+		t.Fatalf("Unexpected error for default test: %v", err1)
+	}
+	output1 := buf1.String()
+	if strings.Contains(output1, "NOTES:") {
+		t.Errorf("Expected notes to be hidden by default, but found NOTES section in output: %s", output1)
+	}
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Hide the notes in the helm test command and remove the `--hide-notes` option.

Closes: https://github.com/helm/helm/issues/12361

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
