### PR TITLE
chore: remove helm version `--client` option

### DIFF
--- a/pkg/cmd/testdata/output/version-client-shorthand.txt
+++ b/pkg/cmd/testdata/output/version-client-shorthand.txt
@@ -1,1 +1,0 @@
-version.BuildInfo{Version:"v4.0", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/pkg/cmd/testdata/output/version-client.txt
+++ b/pkg/cmd/testdata/output/version-client.txt
@@ -1,1 +1,0 @@
-version.BuildInfo{Version:"v4.0", GitCommit:"", GitTreeState:"", GoVersion:""}

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -62,7 +62,7 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "version",
-		Short:             "print the client version information",
+		Short:             "print the helm version information",
 		Long:              versionDesc,
 		Args:              require.NoArgs,
 		ValidArgsFunction: noMoreArgsCompFunc,
@@ -73,8 +73,6 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&o.short, "short", false, "print the version number")
 	f.StringVar(&o.template, "template", "", "template for version string format")
-	f.BoolP("client", "c", true, "display client version information")
-	f.MarkHidden("client")
 
 	return cmd
 }

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -32,14 +32,6 @@ func TestVersion(t *testing.T) {
 		name:   "template",
 		cmd:    "version --template='Version: {{.Version}}'",
 		golden: "output/version-template.txt",
-	}, {
-		name:   "client",
-		cmd:    "version --client",
-		golden: "output/version-client.txt",
-	}, {
-		name:   "client shorthand",
-		cmd:    "version -c",
-		golden: "output/version-client-shorthand.txt",
 	}}
 	runTestCmd(t, tests)
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

Remove the `--client` option from `helm version`. It does nothing, must have been there for v2 compatibility. Good time to remove it.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
