### PR TITLE
feat(lint): allow files starting with _ to be skipped

### DIFF
--- a/internal/chart/v3/lint/rules/template.go
+++ b/internal/chart/v3/lint/rules/template.go
@@ -220,6 +220,13 @@ func validateTemplatesDir(templatesPath string) error {
 }
 
 func validateAllowedExtension(fileName string) error {
+	baseName := filepath.Base(fileName)
+
+	if strings.HasPrefix(baseName, "_") {
+		fmt.Println("skipping _ files")
+		return nil
+	}
+
 	ext := filepath.Ext(fileName)
 	validExtensions := []string{".yaml", ".yml", ".tpl", ".txt"}
 

--- a/internal/chart/v3/lint/rules/template.go
+++ b/internal/chart/v3/lint/rules/template.go
@@ -123,6 +123,11 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 		fileName := template.Name
 		fpath = fileName
 
+		// skip the linting rules if the file starts with _ and is not a yml/yaml file
+		if isHelperFile(fileName) {
+			continue
+		}
+
 		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 
 		// We only apply the following lint rules to yaml files
@@ -219,14 +224,19 @@ func validateTemplatesDir(templatesPath string) error {
 	return nil
 }
 
-func validateAllowedExtension(fileName string) error {
+// checks if the file starts with '_'.
+func isHelperFile(fileName string) bool {
 	baseName := filepath.Base(fileName)
+	ext := filepath.Ext(fileName)
 
-	if strings.HasPrefix(baseName, "_") {
-		fmt.Println("skipping _ files")
-		return nil
+	if strings.HasPrefix(baseName, "_") && ext != ".yaml" && ext != ".yml" {
+		return true
 	}
 
+	return false
+}
+
+func validateAllowedExtension(fileName string) error {
 	ext := filepath.Ext(fileName)
 	validExtensions := []string{".yaml", ".yml", ".tpl", ".txt"}
 

--- a/internal/chart/v3/lint/rules/template.go
+++ b/internal/chart/v3/lint/rules/template.go
@@ -123,12 +123,9 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 		fileName := template.Name
 		fpath = fileName
 
-		// skip the linting rules if the file starts with _ and is not a yml/yaml file
-		if isHelperFile(fileName) {
-			continue
+		if !isHelperFile(fileName) {
+			linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 		}
-
-		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 
 		// We only apply the following lint rules to yaml files
 		if filepath.Ext(fileName) != ".yaml" || filepath.Ext(fileName) == ".yml" {

--- a/internal/chart/v3/lint/rules/template_test.go
+++ b/internal/chart/v3/lint/rules/template_test.go
@@ -32,14 +32,14 @@ import (
 const templateTestBasedir = "./testdata/albatross"
 
 func TestValidateAllowedExtension(t *testing.T) {
-	var failTest = []string{"/foo", "/test.toml"}
+	var failTest = []string{"/foo", "/test.toml", "regular.json"}
 	for _, test := range failTest {
 		err := validateAllowedExtension(test)
 		if err == nil || !strings.Contains(err.Error(), "Valid extensions are .yaml, .yml, .tpl, or .txt") {
 			t.Errorf("validateAllowedExtension('%s') to return \"Valid extensions are .yaml, .yml, .tpl, or .txt\", got no error", test)
 		}
 	}
-	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt"}
+	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt", "_envoy.json"}
 	for _, test := range successTest {
 		err := validateAllowedExtension(test)
 		if err != nil {

--- a/internal/chart/v3/lint/rules/template_test.go
+++ b/internal/chart/v3/lint/rules/template_test.go
@@ -32,14 +32,14 @@ import (
 const templateTestBasedir = "./testdata/albatross"
 
 func TestValidateAllowedExtension(t *testing.T) {
-	var failTest = []string{"/foo", "/test.toml", "regular.json"}
+	var failTest = []string{"/foo", "/test.toml"}
 	for _, test := range failTest {
 		err := validateAllowedExtension(test)
 		if err == nil || !strings.Contains(err.Error(), "Valid extensions are .yaml, .yml, .tpl, or .txt") {
 			t.Errorf("validateAllowedExtension('%s') to return \"Valid extensions are .yaml, .yml, .tpl, or .txt\", got no error", test)
 		}
 	}
-	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt", "_envoy.json"}
+	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt"}
 	for _, test := range successTest {
 		err := validateAllowedExtension(test)
 		if err != nil {
@@ -401,6 +401,7 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 		t.Fatalf("Expected 0 lint errors, got %d", l)
 	}
 }
+
 func TestValidateListAnnotations(t *testing.T) {
 	md := &k8sYamlStruct{
 		APIVersion: "v1",
@@ -437,5 +438,37 @@ items:
 
 	if err := validateListAnnotations(md, manifest); err != nil {
 		t.Fatalf("List objects keep annotations should pass. got: %s", err)
+	}
+}
+
+func TestIsHelperFile(t *testing.T) {
+	tests := []struct {
+		fileName string
+		expected bool
+	}{
+		// Should return true (helper files, non-yaml/yml)
+		{"_helpers.go", true},
+		{"_helpers.json", true},
+		{"subdir/_helpers.json", true},
+		{"subdir/_partial.tpl", true},
+		{"_config.txt", true},
+
+		// Should return false (yaml/yml files, even with _)
+		{"_helpers.yaml", false},
+		{"_config.yml", false},
+		{"subdir/_partial.yaml", false},
+
+		// Should return false (regular files without _)
+		{"helpers.go", false},
+		{"config.json", false},
+		{"deployment.yaml", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fileName, func(t *testing.T) {
+			result := isHelperFile(tt.fileName)
+			if result != tt.expected {
+				t.Errorf("isHelperFile(%q) = %v, expected %v", tt.fileName, result, tt.expected)
+			}
+		})
 	}
 }

--- a/pkg/chart/v2/lint/rules/template.go
+++ b/pkg/chart/v2/lint/rules/template.go
@@ -123,12 +123,9 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 		fileName := template.Name
 		fpath = fileName
 
-		// skip the linting rules if the file starts with _ and is not a yaml/yml file
-		if isHelperFile(fileName) {
-			continue
+		if !isHelperFile(fileName) {
+			linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 		}
-
-		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 
 		// We only apply the following lint rules to yaml files
 		if filepath.Ext(fileName) != ".yaml" || filepath.Ext(fileName) == ".yml" {

--- a/pkg/chart/v2/lint/rules/template.go
+++ b/pkg/chart/v2/lint/rules/template.go
@@ -123,6 +123,11 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 		fileName := template.Name
 		fpath = fileName
 
+		// skip the linting rules if the file starts with _ and is not a yaml/yml file
+		if isHelperFile(fileName) {
+			continue
+		}
+
 		linter.RunLinterRule(support.ErrorSev, fpath, validateAllowedExtension(fileName))
 
 		// We only apply the following lint rules to yaml files
@@ -219,13 +224,19 @@ func validateTemplatesDir(templatesPath string) error {
 	return nil
 }
 
-func validateAllowedExtension(fileName string) error {
+// checks if the file starts with '_'.
+func isHelperFile(fileName string) bool {
 	baseName := filepath.Base(fileName)
+	ext := filepath.Ext(fileName)
 
-	if strings.HasPrefix(baseName, "_") {
-		return nil
+	if strings.HasPrefix(baseName, "_") && ext != ".yaml" && ext != ".yml" {
+		return true
 	}
 
+	return false
+}
+
+func validateAllowedExtension(fileName string) error {
 	ext := filepath.Ext(fileName)
 	validExtensions := []string{".yaml", ".yml", ".tpl", ".txt"}
 

--- a/pkg/chart/v2/lint/rules/template.go
+++ b/pkg/chart/v2/lint/rules/template.go
@@ -220,6 +220,12 @@ func validateTemplatesDir(templatesPath string) error {
 }
 
 func validateAllowedExtension(fileName string) error {
+	baseName := filepath.Base(fileName)
+
+	if strings.HasPrefix(baseName, "_") {
+		return nil
+	}
+
 	ext := filepath.Ext(fileName)
 	validExtensions := []string{".yaml", ".yml", ".tpl", ".txt"}
 

--- a/pkg/chart/v2/lint/rules/template_test.go
+++ b/pkg/chart/v2/lint/rules/template_test.go
@@ -32,14 +32,14 @@ import (
 const templateTestBasedir = "./testdata/albatross"
 
 func TestValidateAllowedExtension(t *testing.T) {
-	var failTest = []string{"/foo", "/test.toml"}
+	var failTest = []string{"/foo", "/test.toml", "regular.json"}
 	for _, test := range failTest {
 		err := validateAllowedExtension(test)
 		if err == nil || !strings.Contains(err.Error(), "Valid extensions are .yaml, .yml, .tpl, or .txt") {
 			t.Errorf("validateAllowedExtension('%s') to return \"Valid extensions are .yaml, .yml, .tpl, or .txt\", got no error", test)
 		}
 	}
-	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt"}
+	var successTest = []string{"/foo.yaml", "foo.yaml", "foo.tpl", "/foo/bar/baz.yaml", "NOTES.txt", "_regular.json"}
 	for _, test := range successTest {
 		err := validateAllowedExtension(test)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, `helm lint` fails for files in the templates directory that have extensions other than `.yaml`, `.yml`, `.tpl`, or `.txt`.  

This PR adds support for files starting with `_`, allowing them to be skipped during linting.  
This makes it possible to include additional file types (e.g., `.json`, `.lua`) in the templates directory while still passing lint checks.  
Using `_` also makes it clear that these files are intended to be ignored by Helm.

**Which issue this PR fixes**:
closes #31305

**Special notes for your reviewer**:
N/A

**If applicable**:
- [ ] this PR contains user facing changes (apply the `docs needed` label if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
