### PR TITLE
fix: Ignore absolute path when RepoUrl is provided

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -828,7 +828,7 @@ func urlEqual(u1, u2 *url.URL) bool {
 // This does not ensure that the chart is well-formed; only that the requested filename exists.
 //
 // Order of resolution:
-// - relative to current working directory
+// - relative to current working directory when --repo flag is not presented
 // - if path is absolute or begins with '.', error out here
 // - URL
 //
@@ -841,20 +841,22 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	name = strings.TrimSpace(name)
 	version := strings.TrimSpace(c.Version)
 
-	if _, err := os.Stat(name); err == nil {
-		abs, err := filepath.Abs(name)
-		if err != nil {
-			return abs, err
-		}
-		if c.Verify {
-			if _, err := downloader.VerifyChart(abs, abs+".prov", c.Keyring); err != nil {
-				return "", err
+	if c.RepoURL == "" {
+		if _, err := os.Stat(name); err == nil {
+			abs, err := filepath.Abs(name)
+			if err != nil {
+				return abs, err
 			}
+			if c.Verify {
+				if _, err := downloader.VerifyChart(abs, abs+".prov", c.Keyring); err != nil {
+					return "", err
+				}
+			}
+			return abs, nil
 		}
-		return abs, nil
-	}
-	if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
-		return name, fmt.Errorf("path %q not found", name)
+		if filepath.IsAbs(name) || strings.HasPrefix(name, ".") {
+			return name, fmt.Errorf("path %q not found", name)
+		}
 	}
 
 	dl := downloader.ChartDownloader{


### PR DESCRIPTION

**What this PR does / why we need it**:

Ignore absolute path when RepoUrl is provided

Closes: https://github.com/helm/helm/issues/7862

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
