### PR TITLE
fix: accept semver range in ValidateReference

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -835,10 +835,6 @@ func (c *Client) ValidateReference(ref, version string, u *url.URL) (string, *ur
 	if version == "" {
 		// Use OCI URI tag as default
 		version = registryReference.Tag
-	} else {
-		if registryReference.Tag != "" && registryReference.Tag != version {
-			return "", nil, fmt.Errorf("chart reference and version mismatch: %s is not %s", version, registryReference.Tag)
-		}
 	}
 
 	if registryReference.Digest != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes #31304

This PR removes incorrect version validation that was blocking usage of semantic version ranges.

**Special notes for your reviewer**:

When a user provide a semantic version range for the  `--version` option, the validation is already performed at `GetTagMatchingVersionOrConstraint`. Therefore, addititonal validtion logic was not only unncessary but also prevented the semantic version range feature.

Support for semantic version range when a url includes a `digest` is still doesn't avaliable in this PR. this will be improve in future PRs. 

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
