### PR TITLE
Remove unused 'Settings' from plugin schema

### DIFF
--- a/internal/plugin/schema/cli.go
+++ b/internal/plugin/schema/cli.go
@@ -15,13 +15,10 @@ package schema
 
 import (
 	"bytes"
-
-	"helm.sh/helm/v4/pkg/cli"
 )
 
 type InputMessageCLIV1 struct {
-	ExtraArgs []string         `json:"extraArgs"`
-	Settings  *cli.EnvSettings `json:"settings"`
+	ExtraArgs []string `json:"extraArgs"`
 }
 
 type OutputMessageCLIV1 struct {

--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -113,7 +113,6 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 				input := &plugin.Input{
 					Message: schema.InputMessageCLIV1{
 						ExtraArgs: extraArgs,
-						Settings:  settings,
 					},
 					Env:    env,
 					Stdin:  os.Stdin,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Removes unused "Settings" from plugin messages. And in particular, dependency on the `cli` package causes a painful circular dependency if the "Settings" object is to maintain a reference to loaded plugins in the future.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
