### PR TITLE
Remove unused golangci-lint rules that produce warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,11 +42,6 @@ linters:
       - legacy
       - std-error-handling
 
-    rules:
-      - linters:
-          - revive
-        text: 'var-naming: avoid meaningless package names'
-
     warn-unused: true
 
   settings:


### PR DESCRIPTION
Avoid noisy output when running lint locally:

```sh
❯ golangci-lint run ./...
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Linters: "revive"]
```

It looks like we don’t need this exclusion rule anymore.