### PR TITLE
fix: Helm v4 release distribution & `get-helm-3` script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,11 @@ jobs:
           # Push the latest semver tag, excluding prerelease tags
           LATEST_VERSION="$(git tag | sort -r --version-sort | grep '^v[0-9]' | grep -v '-' | head -n1)"
           echo "LATEST_VERSION=${LATEST_VERSION}"
-          echo "${LATEST_VERSION}" > _dist_versions/helm-latest-version
-          echo "${LATEST_VERSION}" > _dist_versions/helm3-latest-version
+          if [[ "${LATEST_VERSION}" != v4.* ]]; then
+            echo "Error: Latest version ${LATEST_VERSION} is not a v4 release"
+            exit 1
+          fi
+          echo "${LATEST_VERSION}" > _dist_versions/helm4-latest-version
 
       - name: Upload Binaries
         uses: bacongobbler/azure-blob-storage-upload@50f7d898b7697e864130ea04c303ca38b5751c50 # pin@3.0.0

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -114,7 +114,7 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://get.helm.sh/helm-latest-version"
+    local latest_release_url="https://get.helm.sh/helm3-latest-version"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
       latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes the impending situation where when Helm 4 is released, users of `get-helm-3` will actually get Helm v4 installed!

This PR:
1. Adds a check to ensure the major version matches the destination: ie. `v4` -> `helm4-latest-version`
2. Removes the write to `helm-latest-version` (see below)
3. Updates `get-helm-3` to use `helm3-latest-version`

As currently the latest version of Helm is written to `helm-latest-version` and `helm3-latest-version`. And awkwardly, the `get-helm-3` script reads `helm-latest-version` to determine the latest version to install.



**Special notes for your reviewer**:
I removed the write to `helm-latest-version` out of an abundance of caution. We should IMHO return this once we are confident consumers of `get-helm-3` have updated.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
