### PR TITLE
[backport] fix: get-helm-3 script use helm3-latest-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,12 @@ jobs:
           mkdir -p _dist_versions
 
           # Push the latest semver tag, excluding prerelease tags
-          LATEST_VERSION="$(git tag | sort -r --version-sort | grep '^v[0-9]' | grep -v '-' | head -n1)"
+          LATEST_VERSION="$(git tag | sort -r --version-sort | grep '^v3.' | grep -v '-' | head -n1)"
           echo "LATEST_VERSION=${LATEST_VERSION}"
+          if [[ "${LATEST_VERSION}" != v3.* ]]; then
+            echo "Error: Latest version ${LATEST_VERSION} is not a v3 release"
+            exit 1
+          fi
           echo "${LATEST_VERSION}" > _dist_versions/helm-latest-version
           echo "${LATEST_VERSION}" > _dist_versions/helm3-latest-version
 

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -114,7 +114,7 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://get.helm.sh/helm-latest-version"
+    local latest_release_url="https://get.helm.sh/helm3-latest-version"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
       latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Backport of https://github.com/helm/helm/pull/31318

**Special notes for your reviewer**:
I left the write to `helm-latest-version` for the moment. This will likely conflict with Helm v4 being the latest shortly. But likely discussion on how to handle this is needed first.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
