### PR TITLE
Reproducible chart archive builds

### DIFF
--- a/internal/chart/v3/chart.go
+++ b/internal/chart/v3/chart.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 )
@@ -47,9 +48,13 @@ type Chart struct {
 	Values map[string]interface{} `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values
 	Schema []byte `json:"schema"`
+	// SchemaModTime the schema was last modified
+	SchemaModTime time.Time `json:"schemamodtime,omitempty"`
 	// Files are miscellaneous files in a chart archive,
 	// e.g. README, LICENSE, etc.
 	Files []*common.File `json:"files"`
+	// ModTime the chart metadata was last modified
+	ModTime time.Time `json:"modtime,omitzero"`
 
 	parent       *Chart
 	dependencies []*Chart

--- a/internal/chart/v3/chart_test.go
+++ b/internal/chart/v3/chart_test.go
@@ -18,6 +18,7 @@ package v3
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -25,27 +26,33 @@ import (
 )
 
 func TestCRDs(t *testing.T) {
+	modTime := time.Now()
 	chrt := Chart{
 		Files: []*common.File{
 			{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "bar.yaml",
-				Data: []byte("hello"),
+				Name:    "bar.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crdsfoo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crdsfoo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/README.md",
-				Data: []byte("# hello"),
+				Name:    "crds/README.md",
+				ModTime: modTime,
+				Data:    []byte("# hello"),
 			},
 		},
 	}
@@ -61,8 +68,9 @@ func TestSaveChartNoRawData(t *testing.T) {
 	chrt := Chart{
 		Raw: []*common.File{
 			{
-				Name: "fhqwhgads.yaml",
-				Data: []byte("Everybody to the Limit"),
+				Name:    "fhqwhgads.yaml",
+				ModTime: time.Now(),
+				Data:    []byte("Everybody to the Limit"),
 			},
 		},
 	}
@@ -163,27 +171,33 @@ func TestChartFullPath(t *testing.T) {
 }
 
 func TestCRDObjects(t *testing.T) {
+	modTime := time.Now()
 	chrt := Chart{
 		Files: []*common.File{
 			{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "bar.yaml",
-				Data: []byte("hello"),
+				Name:    "bar.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crdsfoo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crdsfoo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/README.md",
-				Data: []byte("# hello"),
+				Name:    "crds/README.md",
+				ModTime: modTime,
+				Data:    []byte("# hello"),
 			},
 		},
 	}
@@ -193,16 +207,18 @@ func TestCRDObjects(t *testing.T) {
 			Name:     "crds/foo.yaml",
 			Filename: "crds/foo.yaml",
 			File: &common.File{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 		},
 		{
 			Name:     "crds/foo/bar/baz.yaml",
 			Filename: "crds/foo/bar/baz.yaml",
 			File: &common.File{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 		},
 	}

--- a/internal/chart/v3/lint/rules/template_test.go
+++ b/internal/chart/v3/lint/rules/template_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	chart "helm.sh/helm/v4/internal/chart/v3"
 	"helm.sh/helm/v4/internal/chart/v3/lint/support"
@@ -183,6 +184,7 @@ func TestValidateMetadataName(t *testing.T) {
 }
 
 func TestDeprecatedAPIFails(t *testing.T) {
+	modTime := time.Now()
 	mychart := chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion: "v2",
@@ -192,12 +194,14 @@ func TestDeprecatedAPIFails(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/baddeployment.yaml",
-				Data: []byte("apiVersion: apps/v1beta1\nkind: Deployment\nmetadata:\n  name: baddep\nspec: {selector: {matchLabels: {foo: bar}}}"),
+				Name:    "templates/baddeployment.yaml",
+				ModTime: modTime,
+				Data:    []byte("apiVersion: apps/v1beta1\nkind: Deployment\nmetadata:\n  name: baddep\nspec: {selector: {matchLabels: {foo: bar}}}"),
 			},
 			{
-				Name: "templates/goodsecret.yaml",
-				Data: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: goodsecret"),
+				Name:    "templates/goodsecret.yaml",
+				ModTime: modTime,
+				Data:    []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: goodsecret"),
 			},
 		},
 	}
@@ -252,8 +256,9 @@ func TestStrictTemplateParsingMapError(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/configmap.yaml",
-				Data: []byte(manifest),
+				Name:    "templates/configmap.yaml",
+				ModTime: time.Now(),
+				Data:    []byte(manifest),
 			},
 		},
 	}
@@ -381,8 +386,9 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/empty-with-comments.yaml",
-				Data: []byte("#@formatter:off\n"),
+				Name:    "templates/empty-with-comments.yaml",
+				ModTime: time.Now(),
+				Data:    []byte("#@formatter:off\n"),
 			},
 		},
 	}

--- a/internal/chart/v3/loader/directory.go
+++ b/internal/chart/v3/loader/directory.go
@@ -111,7 +111,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 		data = bytes.TrimPrefix(data, utf8bom)
 
-		files = append(files, &archive.BufferedFile{Name: n, Data: data})
+		files = append(files, &archive.BufferedFile{Name: n, ModTime: fi.ModTime(), Data: data})
 		return nil
 	}
 	if err = sympath.Walk(topdir, walk); err != nil {

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -184,9 +184,11 @@ func TestLoadFile(t *testing.T) {
 }
 
 func TestLoadFiles(t *testing.T) {
+	modTime := time.Now()
 	goodFiles := []*archive.BufferedFile{
 		{
-			Name: "Chart.yaml",
+			Name:    "Chart.yaml",
+			ModTime: modTime,
 			Data: []byte(`apiVersion: v3
 name: frobnitz
 description: This is a frobnitz.
@@ -207,20 +209,24 @@ icon: https://example.com/64x64.png
 `),
 		},
 		{
-			Name: "values.yaml",
-			Data: []byte("var: some values"),
+			Name:    "values.yaml",
+			ModTime: modTime,
+			Data:    []byte("var: some values"),
 		},
 		{
-			Name: "values.schema.json",
-			Data: []byte("type: Values"),
+			Name:    "values.schema.json",
+			ModTime: modTime,
+			Data:    []byte("type: Values"),
 		},
 		{
-			Name: "templates/deployment.yaml",
-			Data: []byte("some deployment"),
+			Name:    "templates/deployment.yaml",
+			ModTime: modTime,
+			Data:    []byte("some deployment"),
 		},
 		{
-			Name: "templates/service.yaml",
-			Data: []byte("some service"),
+			Name:    "templates/service.yaml",
+			ModTime: modTime,
+			Data:    []byte("some service"),
 		},
 	}
 
@@ -260,26 +266,32 @@ icon: https://example.com/64x64.png
 // Test the order of file loading. The Chart.yaml file needs to come first for
 // later comparison checks. See https://github.com/helm/helm/pull/8948
 func TestLoadFilesOrder(t *testing.T) {
+	modTime := time.Now()
 	goodFiles := []*archive.BufferedFile{
 		{
-			Name: "requirements.yaml",
-			Data: []byte("dependencies:"),
+			Name:    "requirements.yaml",
+			ModTime: modTime,
+			Data:    []byte("dependencies:"),
 		},
 		{
-			Name: "values.yaml",
-			Data: []byte("var: some values"),
+			Name:    "values.yaml",
+			ModTime: modTime,
+			Data:    []byte("var: some values"),
 		},
 
 		{
-			Name: "templates/deployment.yaml",
-			Data: []byte("some deployment"),
+			Name:    "templates/deployment.yaml",
+			ModTime: modTime,
+			Data:    []byte("some deployment"),
 		},
 		{
-			Name: "templates/service.yaml",
-			Data: []byte("some service"),
+			Name:    "templates/service.yaml",
+			ModTime: modTime,
+			Data:    []byte("some service"),
 		},
 		{
-			Name: "Chart.yaml",
+			Name:    "Chart.yaml",
+			ModTime: modTime,
 			Data: []byte(`apiVersion: v3
 name: frobnitz
 description: This is a frobnitz.

--- a/internal/chart/v3/util/create.go
+++ b/internal/chart/v3/util/create.go
@@ -661,7 +661,7 @@ func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
 
 	for _, template := range schart.Templates {
 		newData := transform(string(template.Data), schart.Name())
-		updatedTemplates = append(updatedTemplates, &common.File{Name: template.Name, Data: newData})
+		updatedTemplates = append(updatedTemplates, &common.File{Name: template.Name, ModTime: template.ModTime, Data: newData})
 	}
 
 	schart.Templates = updatedTemplates

--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -166,7 +166,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime); err != nil {
 		return err
 	}
 
@@ -176,7 +176,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if err != nil {
 			return err
 		}
-		if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata); err != nil {
+		if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated); err != nil {
 			return err
 		}
 	}
@@ -184,7 +184,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save values.yaml
 	for _, f := range c.Raw {
 		if f.Name == ValuesfileName {
-			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data); err != nil {
+			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime); err != nil {
 				return err
 			}
 		}
@@ -195,7 +195,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if !json.Valid(c.Schema) {
 			return errors.New("invalid JSON in " + SchemafileName)
 		}
-		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema); err != nil {
+		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime); err != nil {
 			return err
 		}
 	}
@@ -203,7 +203,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
 			return err
 		}
 	}
@@ -211,7 +211,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save files
 	for _, f := range c.Files {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
 			return err
 		}
 	}
@@ -226,13 +226,13 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 }
 
 // writeToTar writes a single file to a tar archive.
-func writeToTar(out *tar.Writer, name string, body []byte) error {
+func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) error {
 	// TODO: Do we need to create dummy parent directory names if none exist?
 	h := &tar.Header{
 		Name:    filepath.ToSlash(name),
 		Mode:    0644,
 		Size:    int64(len(body)),
-		ModTime: time.Now(),
+		ModTime: modTime,
 	}
 	if err := out.WriteHeader(h); err != nil {
 		return err

--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -234,6 +234,9 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
+	if h.ModTime.IsZero() {
+		h.ModTime = time.Now()
+	}
 	if err := out.WriteHeader(h); err != nil {
 		return err
 	}

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -285,7 +285,8 @@ func TestRepeatableSave(t *testing.T) {
 				},
 				ModTime: modTime,
 				Lock: &chart.Lock{
-					Digest: "testdigest",
+					Digest:    "testdigest",
+					Generated: modTime,
 				},
 				Files: []*common.File{
 					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
@@ -293,7 +294,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "bcb52ba7b7c2801be84cdc96d395f00749896a4679a7c9deacdfe934d0c49c1b",
+			want: "5bfea18cc3c8cbc265744bc32bffa9489a4dbe87d6b51b90f4255e4839d35e03",
 		},
 		{
 			name: "Package 2 files",
@@ -305,7 +306,8 @@ func TestRepeatableSave(t *testing.T) {
 				},
 				ModTime: modTime,
 				Lock: &chart.Lock{
-					Digest: "testdigest",
+					Digest:    "testdigest",
+					Generated: modTime,
 				},
 				Files: []*common.File{
 					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
@@ -314,7 +316,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "566bb87d0a044828e1e3acc4e9849b2c378eb9156a8662ceb618ea41b279bb10",
+			want: "a240365c21e0a2f4a57873132a9b686566a612d08bcb3f20c9446bfff005ccce",
 		},
 	}
 	for _, test := range tests {

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -20,6 +20,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -49,7 +51,7 @@ func TestSave(t *testing.T) {
 					Digest: "testdigest",
 				},
 				Files: []*common.File{
-					{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+					{Name: "scheherazade/shahryar.txt", ModTime: time.Now(), Data: []byte("1,001 Nights")},
 				},
 				Schema: []byte("{\n  \"title\": \"Values\"\n}"),
 			}
@@ -115,7 +117,7 @@ func TestSave(t *testing.T) {
 			Digest: "testdigest",
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: time.Now(), Data: []byte("1,001 Nights")},
 		},
 	}
 	_, err := Save(c, tmp)
@@ -141,7 +143,6 @@ func TestSavePreservesTimestamps(t *testing.T) {
 	// check will fail because `initialCreateTime` will be identical to the
 	// written timestamp for the files.
 	initialCreateTime := time.Now().Add(-1 * time.Second)
-
 	tmp := t.TempDir()
 
 	c := &chart.Chart{
@@ -150,14 +151,16 @@ func TestSavePreservesTimestamps(t *testing.T) {
 			Name:       "ahab",
 			Version:    "1.2.3",
 		},
+		ModTime: initialCreateTime,
 		Values: map[string]interface{}{
 			"imageName": "testimage",
 			"imageId":   42,
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: initialCreateTime, Data: []byte("1,001 Nights")},
 		},
-		Schema: []byte("{\n  \"title\": \"Values\"\n}"),
+		Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+		SchemaModTime: initialCreateTime,
 	}
 
 	where, err := Save(c, tmp)
@@ -170,8 +173,9 @@ func TestSavePreservesTimestamps(t *testing.T) {
 		t.Fatalf("Failed to parse tar: %v", err)
 	}
 
+	roundedTime := initialCreateTime.Round(time.Second)
 	for _, header := range allHeaders {
-		if header.ModTime.Before(initialCreateTime) {
+		if !header.ModTime.Equal(roundedTime) {
 			t.Fatalf("File timestamp not preserved: %v", header.ModTime)
 		}
 	}
@@ -213,6 +217,7 @@ func retrieveAllHeadersFromTar(path string) ([]*tar.Header, error) {
 
 func TestSaveDir(t *testing.T) {
 	tmp := t.TempDir()
+	modTime := time.Now()
 
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{
@@ -221,10 +226,10 @@ func TestSaveDir(t *testing.T) {
 			Version:    "1.2.3",
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
 		},
 		Templates: []*common.File{
-			{Name: path.Join(TemplatesDir, "nested", "dir", "thing.yaml"), Data: []byte("abc: {{ .Values.abc }}")},
+			{Name: path.Join(TemplatesDir, "nested", "dir", "thing.yaml"), ModTime: modTime, Data: []byte("abc: {{ .Values.abc }}")},
 		},
 	}
 
@@ -259,4 +264,91 @@ func TestSaveDir(t *testing.T) {
 	if err := SaveDir(c, pth); err.Error() != "\"../ahab\" is not a valid chart name" {
 		t.Fatalf("Did not get expected error for chart named %q", c.Name())
 	}
+}
+
+func TestRepeatableSave(t *testing.T) {
+	tmp := t.TempDir()
+	defer os.RemoveAll(tmp)
+	modTime := time.Date(2021, 9, 1, 20, 34, 58, 651387237, time.UTC)
+	tests := []struct {
+		name  string
+		chart *chart.Chart
+		want  string
+	}{
+		{
+			name: "Package 1 file",
+			chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					APIVersion: chart.APIVersionV3,
+					Name:       "ahab",
+					Version:    "1.2.3",
+				},
+				ModTime: modTime,
+				Lock: &chart.Lock{
+					Digest: "testdigest",
+				},
+				Files: []*common.File{
+					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+				},
+				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+				SchemaModTime: modTime,
+			},
+			want: "bcb52ba7b7c2801be84cdc96d395f00749896a4679a7c9deacdfe934d0c49c1b",
+		},
+		{
+			name: "Package 2 files",
+			chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					APIVersion: chart.APIVersionV3,
+					Name:       "ahab",
+					Version:    "1.2.3",
+				},
+				ModTime: modTime,
+				Lock: &chart.Lock{
+					Digest: "testdigest",
+				},
+				Files: []*common.File{
+					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+					{Name: "scheherazade/dunyazad.txt", ModTime: modTime, Data: []byte("1,001 Nights again")},
+				},
+				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+				SchemaModTime: modTime,
+			},
+			want: "566bb87d0a044828e1e3acc4e9849b2c378eb9156a8662ceb618ea41b279bb10",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create package
+			dest := path.Join(tmp, "newdir")
+			where, err := Save(test.chart, dest)
+			if err != nil {
+				t.Fatalf("Failed to save: %s", err)
+			}
+			// get shasum for package
+			result, err := sha256Sum(where)
+			if err != nil {
+				t.Fatalf("Failed to check shasum: %s", err)
+			}
+			// assert that the package SHA is what we wanted.
+			if result != test.want {
+				t.Errorf("FormatName() result = %v, want %v", result, test.want)
+			}
+		})
+	}
+}
+
+func sha256Sum(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -123,9 +123,10 @@ type chartOptions struct {
 type chartOption func(*chartOptions)
 
 func buildChart(opts ...chartOption) *chart.Chart {
+	modTime := time.Now()
 	defaultTemplates := []*common.File{
-		{Name: "templates/hello", Data: []byte("hello: world")},
-		{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+		{Name: "templates/hello", ModTime: modTime, Data: []byte("hello: world")},
+		{Name: "templates/hooks", ModTime: modTime, Data: []byte(manifestWithHook)},
 	}
 	return buildChartWithTemplates(defaultTemplates, opts...)
 }
@@ -181,8 +182,9 @@ func withValues(values map[string]interface{}) chartOption {
 func withNotes(notes string) chartOption {
 	return func(opts *chartOptions) {
 		opts.Templates = append(opts.Templates, &common.File{
-			Name: "templates/NOTES.txt",
-			Data: []byte(notes),
+			Name:    "templates/NOTES.txt",
+			ModTime: time.Now(),
+			Data:    []byte(notes),
 		})
 	}
 }
@@ -201,12 +203,13 @@ func withMetadataDependency(dependency chart.Dependency) chartOption {
 
 func withSampleTemplates() chartOption {
 	return func(opts *chartOptions) {
+		modTime := time.Now()
 		sampleTemplates := []*common.File{
 			// This adds basic templates and partials.
-			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
-			{Name: "templates/empty", Data: []byte("")},
-			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
-			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+			{Name: "templates/goodbye", ModTime: modTime, Data: []byte("goodbye: world")},
+			{Name: "templates/empty", ModTime: modTime, Data: []byte("")},
+			{Name: "templates/with-partials", ModTime: modTime, Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", ModTime: modTime, Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}
@@ -214,20 +217,21 @@ func withSampleTemplates() chartOption {
 
 func withSampleSecret() chartOption {
 	return func(opts *chartOptions) {
-		sampleSecret := &common.File{Name: "templates/secret.yaml", Data: []byte("apiVersion: v1\nkind: Secret\n")}
+		sampleSecret := &common.File{Name: "templates/secret.yaml", ModTime: time.Now(), Data: []byte("apiVersion: v1\nkind: Secret\n")}
 		opts.Templates = append(opts.Templates, sampleSecret)
 	}
 }
 
 func withSampleIncludingIncorrectTemplates() chartOption {
 	return func(opts *chartOptions) {
+		modTime := time.Now()
 		sampleTemplates := []*common.File{
 			// This adds basic templates and partials.
-			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
-			{Name: "templates/empty", Data: []byte("")},
-			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
-			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
-			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+			{Name: "templates/goodbye", ModTime: modTime, Data: []byte("goodbye: world")},
+			{Name: "templates/empty", ModTime: modTime, Data: []byte("")},
+			{Name: "templates/incorrect", ModTime: modTime, Data: []byte("{{ .Values.bad.doh }}")},
+			{Name: "templates/with-partials", ModTime: modTime, Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", ModTime: modTime, Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}
@@ -236,7 +240,7 @@ func withSampleIncludingIncorrectTemplates() chartOption {
 func withMultipleManifestTemplate() chartOption {
 	return func(opts *chartOptions) {
 		sampleTemplates := []*common.File{
-			{Name: "templates/rbac", Data: []byte(rbacManifests)},
+			{Name: "templates/rbac", ModTime: time.Now(), Data: []byte(rbacManifests)},
 		}
 		opts.Templates = append(opts.Templates, sampleTemplates...)
 	}
@@ -853,7 +857,7 @@ func TestRenderResources_PostRenderer_MergeError(t *testing.T) {
 			Version:    "0.1.0",
 		},
 		Templates: []*common.File{
-			{Name: "templates/invalid", Data: []byte("invalid: yaml: content:")},
+			{Name: "templates/invalid", ModTime: time.Now(), Data: []byte("invalid: yaml: content:")},
 		},
 	}
 	values := map[string]interface{}{}

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -180,9 +180,10 @@ func runInstallForHooksWithSuccess(t *testing.T, manifest, expectedNamespace str
 	outBuffer := &bytes.Buffer{}
 	instAction.cfg.KubeClient = &kubefake.PrintingKubeClient{Out: io.Discard, LogOutput: outBuffer}
 
+	modTime := time.Now()
 	templates := []*common.File{
-		{Name: "templates/hello", Data: []byte("hello: world")},
-		{Name: "templates/hooks", Data: []byte(manifest)},
+		{Name: "templates/hello", ModTime: modTime, Data: []byte("hello: world")},
+		{Name: "templates/hooks", ModTime: modTime, Data: []byte(manifest)},
 	}
 	vals := map[string]interface{}{}
 
@@ -209,9 +210,10 @@ func runInstallForHooksWithFailure(t *testing.T, manifest, expectedNamespace str
 	outBuffer := &bytes.Buffer{}
 	failingClient.PrintingKubeClient = kubefake.PrintingKubeClient{Out: io.Discard, LogOutput: outBuffer}
 
+	modTime := time.Now()
 	templates := []*common.File{
-		{Name: "templates/hello", Data: []byte("hello: world")},
-		{Name: "templates/hooks", Data: []byte(manifest)},
+		{Name: "templates/hello", ModTime: modTime, Data: []byte("hello: world")},
+		{Name: "templates/hooks", ModTime: modTime, Data: []byte(manifest)},
 	}
 	vals := map[string]interface{}{}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -465,8 +465,9 @@ func TestInstallRelease_DryRun_Lookup(t *testing.T) {
 
 	mockChart := buildChart(withSampleTemplates())
 	mockChart.Templates = append(mockChart.Templates, &common.File{
-		Name: "templates/lookup",
-		Data: []byte(`goodbye: {{ lookup "v1" "Namespace" "" "___" }}`),
+		Name:    "templates/lookup",
+		ModTime: time.Now(),
+		Data:    []byte(`goodbye: {{ lookup "v1" "Namespace" "" "___" }}`),
 	})
 
 	resi, err := instAction.Run(mockChart, vals)

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -18,6 +18,7 @@ package action
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -26,17 +27,18 @@ import (
 func TestShow(t *testing.T) {
 	config := actionConfigFixture(t)
 	client := NewShow(ShowAll, config)
+	modTime := time.Now()
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*common.File{
-			{Name: "README.md", Data: []byte("README\n")},
-			{Name: "crds/ignoreme.txt", Data: []byte("error")},
-			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
-			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
-			{Name: "crds/baz.yaml", Data: []byte("baz\n")},
+			{Name: "README.md", ModTime: modTime, Data: []byte("README\n")},
+			{Name: "crds/ignoreme.txt", ModTime: modTime, Data: []byte("error")},
+			{Name: "crds/foo.yaml", ModTime: modTime, Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", ModTime: modTime, Data: []byte("---\nbar\n")},
+			{Name: "crds/baz.yaml", ModTime: modTime, Data: []byte("baz\n")},
 		},
 		Raw: []*common.File{
-			{Name: "values.yaml", Data: []byte("VALUES\n")},
+			{Name: "values.yaml", ModTime: modTime, Data: []byte("VALUES\n")},
 		},
 		Values: map[string]interface{}{},
 	}
@@ -104,13 +106,14 @@ func TestShowValuesByJsonPathFormat(t *testing.T) {
 func TestShowCRDs(t *testing.T) {
 	config := actionConfigFixture(t)
 	client := NewShow(ShowCRDs, config)
+	modTime := time.Now()
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*common.File{
-			{Name: "crds/ignoreme.txt", Data: []byte("error")},
-			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
-			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
-			{Name: "crds/baz.yaml", Data: []byte("baz\n")},
+			{Name: "crds/ignoreme.txt", ModTime: modTime, Data: []byte("error")},
+			{Name: "crds/foo.yaml", ModTime: modTime, Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", ModTime: modTime, Data: []byte("---\nbar\n")},
+			{Name: "crds/baz.yaml", ModTime: modTime, Data: []byte("baz\n")},
 		},
 	}
 
@@ -137,12 +140,13 @@ baz
 func TestShowNoReadme(t *testing.T) {
 	config := actionConfigFixture(t)
 	client := NewShow(ShowAll, config)
+	modTime := time.Now()
 	client.chart = &chart.Chart{
 		Metadata: &chart.Metadata{Name: "alpine"},
 		Files: []*common.File{
-			{Name: "crds/ignoreme.txt", Data: []byte("error")},
-			{Name: "crds/foo.yaml", Data: []byte("---\nfoo\n")},
-			{Name: "crds/bar.json", Data: []byte("---\nbar\n")},
+			{Name: "crds/ignoreme.txt", ModTime: modTime, Data: []byte("error")},
+			{Name: "crds/foo.yaml", ModTime: modTime, Data: []byte("---\nfoo\n")},
+			{Name: "crds/bar.json", ModTime: modTime, Data: []byte("---\nbar\n")},
 		},
 	}
 

--- a/pkg/chart/common/file.go
+++ b/pkg/chart/common/file.go
@@ -15,6 +15,8 @@ limitations under the License.
 
 package common
 
+import "time"
+
 // File represents a file as a name/value pair.
 //
 // By convention, name is a relative path within the scope of the chart's
@@ -24,4 +26,6 @@ type File struct {
 	Name string `json:"name"`
 	// Data is the template as byte data.
 	Data []byte `json:"data"`
+	// ModTime is the file's mod-time
+	ModTime time.Time `json:"modtime,omitzero"`
 }

--- a/pkg/chart/common/util/values_test.go
+++ b/pkg/chart/common/util/values_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"testing"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -46,7 +47,7 @@ func TestToRenderValues(t *testing.T) {
 		Templates: []*common.File{},
 		Values:    chartValues,
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: time.Now(), Data: []byte("1,001 Nights")},
 		},
 	}
 	c.AddDependency(&chart.Chart{

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // MaxDecompressedChartSize is the maximum size of a chart archive that will be
@@ -46,8 +47,9 @@ var utf8bom = []byte{0xEF, 0xBB, 0xBF}
 
 // BufferedFile represents an archive file buffered for later processing.
 type BufferedFile struct {
-	Name string
-	Data []byte
+	Name    string
+	ModTime time.Time
+	Data    []byte
 }
 
 // LoadArchiveFiles reads in files out of an archive into memory. This function
@@ -148,7 +150,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 
 		data := bytes.TrimPrefix(b.Bytes(), utf8bom)
 
-		files = append(files, &BufferedFile{Name: n, Data: data})
+		files = append(files, &BufferedFile{Name: n, ModTime: hd.ModTime, Data: data})
 		b.Reset()
 	}
 

--- a/pkg/chart/v2/chart.go
+++ b/pkg/chart/v2/chart.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 )
@@ -50,9 +51,13 @@ type Chart struct {
 	Values map[string]interface{} `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values
 	Schema []byte `json:"schema"`
+	// SchemaModTime the schema was last modified
+	SchemaModTime time.Time `json:"schemamodtime,omitempty"`
 	// Files are miscellaneous files in a chart archive,
 	// e.g. README, LICENSE, etc.
 	Files []*common.File `json:"files"`
+	// ModTime the chart metadata was last modified
+	ModTime time.Time `json:"modtime,omitzero"`
 
 	parent       *Chart
 	dependencies []*Chart

--- a/pkg/chart/v2/chart_test.go
+++ b/pkg/chart/v2/chart_test.go
@@ -18,6 +18,7 @@ package v2
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -25,27 +26,33 @@ import (
 )
 
 func TestCRDs(t *testing.T) {
+	modTime := time.Now()
 	chrt := Chart{
 		Files: []*common.File{
 			{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "bar.yaml",
-				Data: []byte("hello"),
+				Name:    "bar.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crdsfoo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crdsfoo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/README.md",
-				Data: []byte("# hello"),
+				Name:    "crds/README.md",
+				ModTime: modTime,
+				Data:    []byte("# hello"),
 			},
 		},
 	}
@@ -61,8 +68,9 @@ func TestSaveChartNoRawData(t *testing.T) {
 	chrt := Chart{
 		Raw: []*common.File{
 			{
-				Name: "fhqwhgads.yaml",
-				Data: []byte("Everybody to the Limit"),
+				Name:    "fhqwhgads.yaml",
+				ModTime: time.Now(),
+				Data:    []byte("Everybody to the Limit"),
 			},
 		},
 	}
@@ -163,27 +171,33 @@ func TestChartFullPath(t *testing.T) {
 }
 
 func TestCRDObjects(t *testing.T) {
+	modTime := time.Now()
 	chrt := Chart{
 		Files: []*common.File{
 			{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "bar.yaml",
-				Data: []byte("hello"),
+				Name:    "bar.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crdsfoo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crdsfoo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 			{
-				Name: "crds/README.md",
-				Data: []byte("# hello"),
+				Name:    "crds/README.md",
+				ModTime: modTime,
+				Data:    []byte("# hello"),
 			},
 		},
 	}
@@ -193,16 +207,18 @@ func TestCRDObjects(t *testing.T) {
 			Name:     "crds/foo.yaml",
 			Filename: "crds/foo.yaml",
 			File: &common.File{
-				Name: "crds/foo.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 		},
 		{
 			Name:     "crds/foo/bar/baz.yaml",
 			Filename: "crds/foo/bar/baz.yaml",
 			File: &common.File{
-				Name: "crds/foo/bar/baz.yaml",
-				Data: []byte("hello"),
+				Name:    "crds/foo/bar/baz.yaml",
+				ModTime: modTime,
+				Data:    []byte("hello"),
 			},
 		},
 	}

--- a/pkg/chart/v2/lint/rules/template_test.go
+++ b/pkg/chart/v2/lint/rules/template_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -194,6 +195,7 @@ func TestValidateMetadataName(t *testing.T) {
 }
 
 func TestDeprecatedAPIFails(t *testing.T) {
+	modTime := time.Now()
 	mychart := chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion: "v2",
@@ -203,12 +205,14 @@ func TestDeprecatedAPIFails(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/baddeployment.yaml",
-				Data: []byte("apiVersion: apps/v1beta1\nkind: Deployment\nmetadata:\n  name: baddep\nspec: {selector: {matchLabels: {foo: bar}}}"),
+				Name:    "templates/baddeployment.yaml",
+				ModTime: modTime,
+				Data:    []byte("apiVersion: apps/v1beta1\nkind: Deployment\nmetadata:\n  name: baddep\nspec: {selector: {matchLabels: {foo: bar}}}"),
 			},
 			{
-				Name: "templates/goodsecret.yaml",
-				Data: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: goodsecret"),
+				Name:    "templates/goodsecret.yaml",
+				ModTime: modTime,
+				Data:    []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: goodsecret"),
 			},
 		},
 	}
@@ -267,8 +271,9 @@ func TestStrictTemplateParsingMapError(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/configmap.yaml",
-				Data: []byte(manifest),
+				Name:    "templates/configmap.yaml",
+				ModTime: time.Now(),
+				Data:    []byte(manifest),
 			},
 		},
 	}
@@ -400,8 +405,9 @@ func TestEmptyWithCommentsManifests(t *testing.T) {
 		},
 		Templates: []*common.File{
 			{
-				Name: "templates/empty-with-comments.yaml",
-				Data: []byte("#@formatter:off\n"),
+				Name:    "templates/empty-with-comments.yaml",
+				ModTime: time.Now(),
+				Data:    []byte("#@formatter:off\n"),
 			},
 		},
 	}

--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -111,7 +111,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 		data = bytes.TrimPrefix(data, utf8bom)
 
-		files = append(files, &archive.BufferedFile{Name: n, Data: data})
+		files = append(files, &archive.BufferedFile{Name: n, ModTime: fi.ModTime(), Data: data})
 		return nil
 	}
 	if err = sympath.Walk(topdir, walk); err != nil {

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -219,8 +219,9 @@ func TestLoadFiles_BadCases(t *testing.T) {
 			name: "These files contain only requirements.lock",
 			bufferedFiles: []*archive.BufferedFile{
 				{
-					Name: "requirements.lock",
-					Data: []byte(""),
+					Name:    "requirements.lock",
+					ModTime: time.Now(),
+					Data:    []byte(""),
 				},
 			},
 			expectError: "validation: chart.metadata.apiVersion is required"},
@@ -236,9 +237,11 @@ func TestLoadFiles_BadCases(t *testing.T) {
 }
 
 func TestLoadFiles(t *testing.T) {
+	modTime := time.Now()
 	goodFiles := []*archive.BufferedFile{
 		{
-			Name: "Chart.yaml",
+			Name:    "Chart.yaml",
+			ModTime: modTime,
 			Data: []byte(`apiVersion: v1
 name: frobnitz
 description: This is a frobnitz.
@@ -259,20 +262,24 @@ icon: https://example.com/64x64.png
 `),
 		},
 		{
-			Name: "values.yaml",
-			Data: []byte("var: some values"),
+			Name:    "values.yaml",
+			ModTime: modTime,
+			Data:    []byte("var: some values"),
 		},
 		{
-			Name: "values.schema.json",
-			Data: []byte("type: Values"),
+			Name:    "values.schema.json",
+			ModTime: modTime,
+			Data:    []byte("type: Values"),
 		},
 		{
-			Name: "templates/deployment.yaml",
-			Data: []byte("some deployment"),
+			Name:    "templates/deployment.yaml",
+			ModTime: modTime,
+			Data:    []byte("some deployment"),
 		},
 		{
-			Name: "templates/service.yaml",
-			Data: []byte("some service"),
+			Name:    "templates/service.yaml",
+			ModTime: modTime,
+			Data:    []byte("some service"),
 		},
 	}
 
@@ -312,26 +319,32 @@ icon: https://example.com/64x64.png
 // Test the order of file loading. The Chart.yaml file needs to come first for
 // later comparison checks. See https://github.com/helm/helm/pull/8948
 func TestLoadFilesOrder(t *testing.T) {
+	modTime := time.Now()
 	goodFiles := []*archive.BufferedFile{
 		{
-			Name: "requirements.yaml",
-			Data: []byte("dependencies:"),
+			Name:    "requirements.yaml",
+			ModTime: modTime,
+			Data:    []byte("dependencies:"),
 		},
 		{
-			Name: "values.yaml",
-			Data: []byte("var: some values"),
+			Name:    "values.yaml",
+			ModTime: modTime,
+			Data:    []byte("var: some values"),
 		},
 
 		{
-			Name: "templates/deployment.yaml",
-			Data: []byte("some deployment"),
+			Name:    "templates/deployment.yaml",
+			ModTime: modTime,
+			Data:    []byte("some deployment"),
 		},
 		{
-			Name: "templates/service.yaml",
-			Data: []byte("some service"),
+			Name:    "templates/service.yaml",
+			ModTime: modTime,
+			Data:    []byte("some service"),
 		},
 		{
-			Name: "Chart.yaml",
+			Name:    "Chart.yaml",
+			ModTime: modTime,
 			Data: []byte(`apiVersion: v1
 name: frobnitz
 description: This is a frobnitz.

--- a/pkg/chart/v2/util/create.go
+++ b/pkg/chart/v2/util/create.go
@@ -660,7 +660,7 @@ func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
 
 	for _, template := range schart.Templates {
 		newData := transform(string(template.Data), schart.Name())
-		updatedTemplates = append(updatedTemplates, &common.File{Name: template.Name, Data: newData})
+		updatedTemplates = append(updatedTemplates, &common.File{Name: template.Name, ModTime: template.ModTime, Data: newData})
 	}
 
 	schart.Templates = updatedTemplates

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -175,7 +175,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime); err != nil {
 		return err
 	}
 
@@ -187,7 +187,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 			if err != nil {
 				return err
 			}
-			if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata); err != nil {
+			if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated); err != nil {
 				return err
 			}
 		}
@@ -196,7 +196,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save values.yaml
 	for _, f := range c.Raw {
 		if f.Name == ValuesfileName {
-			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data); err != nil {
+			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime); err != nil {
 				return err
 			}
 		}
@@ -207,7 +207,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if !json.Valid(c.Schema) {
 			return errors.New("invalid JSON in " + SchemafileName)
 		}
-		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema); err != nil {
+		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime); err != nil {
 			return err
 		}
 	}
@@ -215,7 +215,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
 			return err
 		}
 	}
@@ -223,7 +223,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save files
 	for _, f := range c.Files {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
 			return err
 		}
 	}
@@ -238,13 +238,13 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 }
 
 // writeToTar writes a single file to a tar archive.
-func writeToTar(out *tar.Writer, name string, body []byte) error {
+func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) error {
 	// TODO: Do we need to create dummy parent directory names if none exist?
 	h := &tar.Header{
 		Name:    filepath.ToSlash(name),
 		Mode:    0644,
 		Size:    int64(len(body)),
-		ModTime: time.Now(),
+		ModTime: modTime,
 	}
 	if err := out.WriteHeader(h); err != nil {
 		return err

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -246,6 +246,9 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
+	if h.ModTime.IsZero() {
+		h.ModTime = time.Now()
+	}
 	if err := out.WriteHeader(h); err != nil {
 		return err
 	}

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -20,6 +20,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -49,7 +51,7 @@ func TestSave(t *testing.T) {
 					Digest: "testdigest",
 				},
 				Files: []*common.File{
-					{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+					{Name: "scheherazade/shahryar.txt", ModTime: time.Now(), Data: []byte("1,001 Nights")},
 				},
 				Schema: []byte("{\n  \"title\": \"Values\"\n}"),
 			}
@@ -118,7 +120,7 @@ func TestSave(t *testing.T) {
 			Digest: "testdigest",
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: time.Now(), Data: []byte("1,001 Nights")},
 		},
 	}
 	_, err := Save(c, tmp)
@@ -153,14 +155,16 @@ func TestSavePreservesTimestamps(t *testing.T) {
 			Name:       "ahab",
 			Version:    "1.2.3",
 		},
+		ModTime: initialCreateTime,
 		Values: map[string]interface{}{
 			"imageName": "testimage",
 			"imageId":   42,
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: initialCreateTime, Data: []byte("1,001 Nights")},
 		},
-		Schema: []byte("{\n  \"title\": \"Values\"\n}"),
+		Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+		SchemaModTime: initialCreateTime,
 	}
 
 	where, err := Save(c, tmp)
@@ -173,8 +177,9 @@ func TestSavePreservesTimestamps(t *testing.T) {
 		t.Fatalf("Failed to parse tar: %v", err)
 	}
 
+	roundedTime := initialCreateTime.Round(time.Second)
 	for _, header := range allHeaders {
-		if header.ModTime.Before(initialCreateTime) {
+		if !header.ModTime.Equal(roundedTime) {
 			t.Fatalf("File timestamp not preserved: %v", header.ModTime)
 		}
 	}
@@ -217,6 +222,7 @@ func retrieveAllHeadersFromTar(path string) ([]*tar.Header, error) {
 func TestSaveDir(t *testing.T) {
 	tmp := t.TempDir()
 
+	modTime := time.Now()
 	c := &chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion: chart.APIVersionV1,
@@ -224,10 +230,10 @@ func TestSaveDir(t *testing.T) {
 			Version:    "1.2.3",
 		},
 		Files: []*common.File{
-			{Name: "scheherazade/shahryar.txt", Data: []byte("1,001 Nights")},
+			{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
 		},
 		Templates: []*common.File{
-			{Name: path.Join(TemplatesDir, "nested", "dir", "thing.yaml"), Data: []byte("abc: {{ .Values.abc }}")},
+			{Name: path.Join(TemplatesDir, "nested", "dir", "thing.yaml"), ModTime: modTime, Data: []byte("abc: {{ .Values.abc }}")},
 		},
 	}
 
@@ -262,4 +268,91 @@ func TestSaveDir(t *testing.T) {
 	if err := SaveDir(c, pth); err.Error() != "\"../ahab\" is not a valid chart name" {
 		t.Fatalf("Did not get expected error for chart named %q", c.Name())
 	}
+}
+
+func TestRepeatableSave(t *testing.T) {
+	tmp := t.TempDir()
+	defer os.RemoveAll(tmp)
+	modTime := time.Date(2021, 9, 1, 20, 34, 58, 651387237, time.UTC)
+	tests := []struct {
+		name  string
+		chart *chart.Chart
+		want  string
+	}{
+		{
+			name: "Package 1 file",
+			chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					APIVersion: chart.APIVersionV1,
+					Name:       "ahab",
+					Version:    "1.2.3",
+				},
+				ModTime: modTime,
+				Lock: &chart.Lock{
+					Digest: "testdigest",
+				},
+				Files: []*common.File{
+					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+				},
+				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+				SchemaModTime: modTime,
+			},
+			want: "5e14a06037e5d4cb277c7b21770639d4e1a337be9ae391460e50653bac5a80ed",
+		},
+		{
+			name: "Package 2 files",
+			chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					APIVersion: chart.APIVersionV1,
+					Name:       "ahab",
+					Version:    "1.2.3",
+				},
+				ModTime: modTime,
+				Lock: &chart.Lock{
+					Digest: "testdigest",
+				},
+				Files: []*common.File{
+					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+					{Name: "scheherazade/dunyazad.txt", ModTime: modTime, Data: []byte("1,001 Nights again")},
+				},
+				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
+				SchemaModTime: modTime,
+			},
+			want: "6967787da46fbfcc563cad31240e564e14f2602e6f66302129a59a9669622a36",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create package
+			dest := path.Join(tmp, "newdir")
+			where, err := Save(test.chart, dest)
+			if err != nil {
+				t.Fatalf("Failed to save: %s", err)
+			}
+			// get shasum for package
+			result, err := sha256Sum(where)
+			if err != nil {
+				t.Fatalf("Failed to check shasum: %s", err)
+			}
+			// assert that the package SHA is what we wanted.
+			if result != test.want {
+				t.Errorf("FormatName() result = %v, want %v", result, test.want)
+			}
+		})
+	}
+}
+
+func sha256Sum(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -283,13 +283,14 @@ func TestRepeatableSave(t *testing.T) {
 			name: "Package 1 file",
 			chart: &chart.Chart{
 				Metadata: &chart.Metadata{
-					APIVersion: chart.APIVersionV1,
+					APIVersion: chart.APIVersionV2,
 					Name:       "ahab",
 					Version:    "1.2.3",
 				},
 				ModTime: modTime,
 				Lock: &chart.Lock{
-					Digest: "testdigest",
+					Digest:    "testdigest",
+					Generated: modTime,
 				},
 				Files: []*common.File{
 					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
@@ -297,19 +298,20 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "5e14a06037e5d4cb277c7b21770639d4e1a337be9ae391460e50653bac5a80ed",
+			want: "fea2662522317b65c2788ff9e5fc446a9264830038dac618d4449493d99b3257",
 		},
 		{
 			name: "Package 2 files",
 			chart: &chart.Chart{
 				Metadata: &chart.Metadata{
-					APIVersion: chart.APIVersionV1,
+					APIVersion: chart.APIVersionV2,
 					Name:       "ahab",
 					Version:    "1.2.3",
 				},
 				ModTime: modTime,
 				Lock: &chart.Lock{
-					Digest: "testdigest",
+					Digest:    "testdigest",
+					Generated: modTime,
 				},
 				Files: []*common.File{
 					{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
@@ -318,7 +320,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "6967787da46fbfcc563cad31240e564e14f2602e6f66302129a59a9669622a36",
+			want: "7ae92b2f274bb51ea3f1969e4187d78cc52b5f6f663b44b8fb3b40bcb8ee46f3",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/cmd/upgrade_test.go
+++ b/pkg/cmd/upgrade_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -408,7 +409,7 @@ func prepareMockRelease(t *testing.T, releaseName string) (func(n string, v int,
 			Description: "A Helm chart for Kubernetes",
 			Version:     "0.1.0",
 		},
-		Templates: []*common.File{{Name: "templates/configmap.yaml", Data: configmapData}},
+		Templates: []*common.File{{Name: "templates/configmap.yaml", ModTime: time.Now(), Data: configmapData}},
 	}
 	chartPath := filepath.Join(tmpChart, cfile.Metadata.Name)
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
@@ -513,6 +514,7 @@ func prepareMockReleaseWithSecret(t *testing.T, releaseName string) (func(n stri
 	if err != nil {
 		t.Fatalf("Error loading template yaml %v", err)
 	}
+	modTime := time.Now()
 	cfile := &chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion:  chart.APIVersionV1,
@@ -520,7 +522,7 @@ func prepareMockReleaseWithSecret(t *testing.T, releaseName string) (func(n stri
 			Description: "A Helm chart for Kubernetes",
 			Version:     "0.1.0",
 		},
-		Templates: []*common.File{{Name: "templates/configmap.yaml", Data: configmapData}, {Name: "templates/secret.yaml", Data: secretData}},
+		Templates: []*common.File{{Name: "templates/configmap.yaml", ModTime: modTime, Data: configmapData}, {Name: "templates/secret.yaml", ModTime: modTime, Data: secretData}},
 	}
 	chartPath := filepath.Join(tmpChart, cfile.Metadata.Name)
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {

--- a/pkg/release/v1/mock.go
+++ b/pkg/release/v1/mock.go
@@ -101,7 +101,7 @@ func Mock(opts *MockReleaseOptions) *Release {
 				},
 			},
 			Templates: []*common.File{
-				{Name: "templates/foo.tpl", Data: []byte(MockManifest)},
+				{Name: "templates/foo.tpl", ModTime: time.Now(), Data: []byte(MockManifest)},
 			},
 		}
 	}


### PR DESCRIPTION
Building the same chart into an archive multiple times will have the same sha256 hash.

Perviously, the time in the headers for a file was time.Now() which changed each time. The time is now collected from the operating system when the file is loaded and this time is used.

Fixes: #3612

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
