### PR TITLE
Restore lint rule for excluding meaningless name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,14 @@ linters:
       - legacy
       - std-error-handling
 
+    rules:
+        # This rule is triggered for packages like 'util'. When changes to those packages
+        # occur it triggers this rule. This exclusion enables making changes to existing
+        # packages.
+        - linters:
+            - revive
+          text: 'var-naming: avoid meaningless package names'
+
     warn-unused: true
 
   settings:


### PR DESCRIPTION
This rule is needed for packages like 'util'. Changes to those packages trigger this rule.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Changes to the _util_ packages trigger this rule. Until this is restored, no PR that changes those packages will pass linting.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
