### PR TITLE
Fixing rollback and uninstall client WaitStrategy

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -566,6 +566,7 @@ func (i *Install) failRelease(rel *release.Release, err error) (*release.Release
 		uninstall.DisableHooks = i.DisableHooks
 		uninstall.KeepHistory = false
 		uninstall.Timeout = i.Timeout
+		uninstall.WaitStrategy = i.WaitStrategy
 		if _, uninstallErr := uninstall.Run(i.ReleaseName); uninstallErr != nil {
 			return rel, fmt.Errorf("an error occurred while uninstalling the release. original install error: %w: %w", err, uninstallErr)
 		}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -235,7 +235,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 
 	waiter, err := r.cfg.KubeClient.GetWaiter(r.WaitStrategy)
 	if err != nil {
-		return nil, fmt.Errorf("unable to set metadata visitor from target release: %w", err)
+		return nil, fmt.Errorf("unable to get waiter: %w", err)
 	}
 	if r.WaitForJobs {
 		if err := waiter.WaitWithJobs(target, r.Timeout); err != nil {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -563,9 +563,7 @@ func (u *Upgrade) failRelease(rel *release.Release, created kube.ResourceList, e
 
 		rollin := NewRollback(u.cfg)
 		rollin.Version = filteredHistory[0].Version
-		if u.WaitStrategy == kube.HookOnlyStrategy {
-			rollin.WaitStrategy = kube.StatusWatcherStrategy
-		}
+		rollin.WaitStrategy = u.WaitStrategy
 		rollin.WaitForJobs = u.WaitForJobs
 		rollin.DisableHooks = u.DisableHooks
 		rollin.ForceReplace = u.ForceReplace


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly sets a WaitStrategy for the Uninstall client created when `helm install` rolls back and sets the WaitStrategy for the Rollback client created when `helm upgrade` rolls back. Also fixes an incorrect error message that occurs when the WaitStrategy is not set.

Rollback for `helm install` always fails with "unknown wait strategy".  Rollback for `helm upgrade` fails with the same error message unless the WaitStrategy is set to HookOnlyStrategy.

closes #31322
closes #31317

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
