### PR TITLE
Support oci repo/chart:version and add --ensure-version check

### DIFF
--- a/pkg/action/push.go
+++ b/pkg/action/push.go
@@ -38,6 +38,7 @@ type Push struct {
 	insecureSkipTLSVerify bool
 	plainHTTP             bool
 	out                   io.Writer
+	expectedVersion       string
 }
 
 // PushOpt is a type of function that sets options for a push action.
@@ -80,6 +81,13 @@ func WithPushOptWriter(out io.Writer) PushOpt {
 	}
 }
 
+// WithExpectedVersion configures an expected chart version that must match Chart.yaml.
+func WithExpectedVersion(version string) PushOpt {
+	return func(p *Push) {
+		p.expectedVersion = version
+	}
+}
+
 // NewPushWithOpts creates a new push, with configuration options.
 func NewPushWithOpts(opts ...PushOpt) *Push {
 	p := &Push{}
@@ -101,6 +109,10 @@ func (p *Push) Run(chartRef string, remote string) (string, error) {
 			pusher.WithInsecureSkipTLSVerify(p.insecureSkipTLSVerify),
 			pusher.WithPlainHTTP(p.plainHTTP),
 		},
+	}
+
+	if p.expectedVersion != "" {
+		c.Options = append(c.Options, pusher.WithExpectedVersion(p.expectedVersion))
 	}
 
 	if registry.IsOCI(remote) {

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -32,14 +32,23 @@ Upload a chart to a registry.
 
 If the chart has an associated provenance file, it will also be uploaded.
 
-You can optionally specify --version or oci://...:version as a safety check. When provided,
-it must match the version from Chart.yaml; otherwise the command will fail.
+Remote target formats:
+- oci://REGISTRY/REPO
+- oci://REGISTRY/REPO/CHART
+- oci://REGISTRY/REPO/CHART:VERSION
+
+When CHART is omitted, the chart name is derived from the package. When VERSION is omitted,
+it comes from Chart.yaml. Use --version as an optional verification. If set, it must match
+Chart.yaml or the command fails.
+
+Note: OCI tags do not support "+". Helm replaces "+" with "_" in tags when pushing and restores
+"+" when pulling.
 
 Examples:
 
 	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts
 	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts --version 0.1.0
-	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts:0.1.0
+	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts/mychart:0.1.0
 `
 
 type registryPushOptions struct {
@@ -113,7 +122,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&o.plainHTTP, "plain-http", false, "use insecure HTTP connections for the chart upload")
 	f.StringVar(&o.username, "username", "", "chart repository username where to locate the requested chart")
 	f.StringVar(&o.password, "password", "", "chart repository password where to locate the requested chart")
-	f.StringVar(&o.version, "version", "", "specify the exact chart version to push. If this is not specified, the version from Chart.yaml is used")
+	f.StringVar(&o.version, "version", "", "verify the chart version; must match Chart.yaml (optional check)")
 
 	return cmd
 }

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -38,8 +38,8 @@ Remote target formats:
 - oci://REGISTRY/REPO/CHART:VERSION
 
 When CHART is omitted, the chart name is derived from the package. When VERSION is omitted,
-it comes from Chart.yaml. Use --version as an optional verification. If set, it must match
-Chart.yaml or the command fails.
+it comes from Chart.yaml. Use --ensure-version as an optional verification. If set, it
+must match Chart.yaml or the command fails.
 
 Note: OCI tags do not support "+". Helm replaces "+" with "_" in tags when pushing and restores
 "+" when pulling.
@@ -47,7 +47,7 @@ Note: OCI tags do not support "+". Helm replaces "+" with "_" in tags when pushi
 Examples:
 
 	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts
-	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts --version 0.1.0
+	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts --ensure-version 0.1.0
 	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts/mychart:0.1.0
 `
 
@@ -59,7 +59,7 @@ type registryPushOptions struct {
 	plainHTTP             bool
 	password              string
 	username              string
-	version               string
+	ensureVersion         string
 }
 
 func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
@@ -102,7 +102,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				action.WithTLSClientConfig(o.certFile, o.keyFile, o.caFile),
 				action.WithInsecureSkipTLSVerify(o.insecureSkipTLSVerify),
 				action.WithPlainHTTP(o.plainHTTP),
-				action.WithExpectedVersion(o.version),
+				action.WithExpectedVersion(o.ensureVersion),
 				action.WithPushOptWriter(out))
 			client.Settings = settings
 			output, err := client.Run(chartRef, remote)
@@ -122,7 +122,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&o.plainHTTP, "plain-http", false, "use insecure HTTP connections for the chart upload")
 	f.StringVar(&o.username, "username", "", "chart repository username where to locate the requested chart")
 	f.StringVar(&o.password, "password", "", "chart repository password where to locate the requested chart")
-	f.StringVar(&o.version, "version", "", "verify the chart version; must match Chart.yaml (optional check)")
+	f.StringVar(&o.ensureVersion, "ensure-version", "", "verify the chart version; must match Chart.yaml (optional check)")
 
 	return cmd
 }

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -34,10 +34,12 @@ If the chart has an associated provenance file, it will also be uploaded.
 
 Remote target formats:
 - oci://REGISTRY/REPO
+- oci://REGISTRY/REPO:VERSION
 - oci://REGISTRY/REPO/CHART
 - oci://REGISTRY/REPO/CHART:VERSION
 
-When CHART is omitted, the chart name is derived from the package. When VERSION is omitted,
+When CHART is omitted, the chart name is derived from the package (and must match the
+repo basename when using oci://REGISTRY/REPO:VERSION). When VERSION is omitted,
 it comes from Chart.yaml. Use --ensure-version as an optional verification. If set, it
 must match Chart.yaml or the command fails.
 

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -30,8 +30,16 @@ import (
 const pushDesc = `
 Upload a chart to a registry.
 
-If the chart has an associated provenance file,
-it will also be uploaded.
+If the chart has an associated provenance file, it will also be uploaded.
+
+You can optionally specify --version or oci://...:version as a safety check. When provided,
+it must match the version from Chart.yaml; otherwise the command will fail.
+
+Examples:
+
+	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts
+	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts --version 0.1.0
+	$ helm push mychart-0.1.0.tgz oci://my-registry.io/helm/charts:0.1.0
 `
 
 type registryPushOptions struct {
@@ -42,6 +50,7 @@ type registryPushOptions struct {
 	plainHTTP             bool
 	password              string
 	username              string
+	version               string
 }
 
 func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
@@ -84,6 +93,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				action.WithTLSClientConfig(o.certFile, o.keyFile, o.caFile),
 				action.WithInsecureSkipTLSVerify(o.insecureSkipTLSVerify),
 				action.WithPlainHTTP(o.plainHTTP),
+				action.WithExpectedVersion(o.version),
 				action.WithPushOptWriter(out))
 			client.Settings = settings
 			output, err := client.Run(chartRef, remote)
@@ -103,6 +113,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&o.plainHTTP, "plain-http", false, "use insecure HTTP connections for the chart upload")
 	f.StringVar(&o.username, "username", "", "chart repository username where to locate the requested chart")
 	f.StringVar(&o.password, "password", "", "chart repository password where to locate the requested chart")
+	f.StringVar(&o.version, "version", "", "specify the exact chart version to push. If this is not specified, the version from Chart.yaml is used")
 
 	return cmd
 }

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -59,6 +59,11 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		return err
 	}
 
+	// If an expected version is specified via --version, enforce it matches Chart.yaml
+	if pusher.opts.expectedVersion != "" && pusher.opts.expectedVersion != meta.Metadata.Version {
+		return fmt.Errorf("specified --version %q does not match chart version %q", pusher.opts.expectedVersion, meta.Metadata.Version)
+	}
+
 	ref, err := registry.BuildPushRef(href, meta.Metadata.Name, meta.Metadata.Version)
 	if err != nil {
 		return err

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -61,7 +61,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 
 	// If an expected version is specified via --version, enforce it matches Chart.yaml
 	if pusher.opts.expectedVersion != "" && pusher.opts.expectedVersion != meta.Metadata.Version {
-		return fmt.Errorf("specified --version %q does not match chart version %q", pusher.opts.expectedVersion, meta.Metadata.Version)
+		return fmt.Errorf("specified --ensure-version %q does not match chart version %q", pusher.opts.expectedVersion, meta.Metadata.Version)
 	}
 
 	ref, err := registry.BuildPushRef(href, meta.Metadata.Name, meta.Metadata.Version)

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -59,7 +59,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		return err
 	}
 
-	// If an expected version is specified via --version, enforce it matches Chart.yaml
+	// If an expected version is specified via --ensure-version, enforce it matches Chart.yaml
 	if pusher.opts.expectedVersion != "" && pusher.opts.expectedVersion != meta.Metadata.Version {
 		return fmt.Errorf("specified --ensure-version %q does not match chart version %q", pusher.opts.expectedVersion, meta.Metadata.Version)
 	}

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -22,8 +22,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
-	"strings"
 	"time"
 
 	"helm.sh/helm/v4/internal/tlsutil"
@@ -61,6 +59,11 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		return err
 	}
 
+	ref, err := registry.BuildPushRef(href, meta.Metadata.Name, meta.Metadata.Version)
+	if err != nil {
+		return err
+	}
+
 	client := pusher.opts.registryClient
 	if client == nil {
 		c, err := pusher.newRegistryClient()
@@ -84,10 +87,6 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 		}
 		pushOpts = append(pushOpts, registry.PushOptProvData(provBytes))
 	}
-
-	ref := fmt.Sprintf("%s:%s",
-		path.Join(strings.TrimPrefix(href, registry.OCIScheme+"://"), meta.Metadata.Name),
-		meta.Metadata.Version)
 
 	// The time the chart was "created" is semantically the time the chart archive file was last written(modified)
 	chartArchiveFileCreatedTime := stat.ModTime()

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -393,35 +393,6 @@ func TestOCIPusher_Push_ChartOperations(t *testing.T) {
 	}
 }
 
-func TestOCIPusher_Push_InvalidChartVersion(t *testing.T) {
-	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
-
-	// Skip test if chart file doesn't exist
-	if _, err := os.Stat(chartPath); err != nil {
-		t.Skipf("Test chart %s not found, skipping test", chartPath)
-	}
-
-	pusher, err := NewOCIPusher()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Test that multiple options are applied correctly
-	err = pusher.Push(chartPath, "oci://localhost:5000/test:0.2.0",
-		WithPlainHTTP(true),
-		WithInsecureSkipTLSVerify(true),
-	)
-
-	// We expect an error since we're not actually pushing to a registry
-	if err == nil {
-		t.Fatal("Expected error when pushing without a valid registry")
-	}
-
-	if !strings.Contains(err.Error(), "does not match provided chart version") {
-		t.Error("Expected error to mention tag mismatch")
-	}
-}
-
 func TestOCIPusher_Push_MultipleOptions(t *testing.T) {
 	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
 
@@ -456,6 +427,29 @@ func TestOCIPusher_Push_MultipleOptions(t *testing.T) {
 	}
 }
 
+func TestOCIPusher_Push_InvalidChartVersion(t *testing.T) {
+	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
+
+	// Skip test if chart file doesn't exist
+	if _, err := os.Stat(chartPath); err != nil {
+		t.Skipf("Test chart %s not found, skipping test", chartPath)
+	}
+
+	pusher, err := NewOCIPusher()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pusher.Push(chartPath, "oci://localhost:5000/test:0.2.0")
+
+	if err == nil {
+		t.Fatal("Expected error when pushing without a valid registry")
+	}
+	if !strings.Contains(err.Error(), "does not match provided chart version") {
+		t.Error("Expected error to mention tag mismatch")
+	}
+}
+
 func TestOCIPusher_Push_ExpectedVersionMismatch(t *testing.T) {
 	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
 
@@ -464,13 +458,13 @@ func TestOCIPusher_Push_ExpectedVersionMismatch(t *testing.T) {
 		t.Skipf("Test chart %s not found, skipping test", chartPath)
 	}
 
-	p, err := NewOCIPusher()
+	pusher, err := NewOCIPusher()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Provide an expected version that does not match the chart's version
-	err = p.Push(chartPath, "oci://localhost:5000/test",
+	err = pusher.Push(chartPath, "oci://localhost:5000/test",
 		WithExpectedVersion("0.2.0"),
 	)
 

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -472,7 +472,7 @@ func TestOCIPusher_Push_ExpectedVersionMismatch(t *testing.T) {
 		t.Fatal("Expected error when --version does not match chart version")
 	}
 
-	if !strings.Contains(err.Error(), "specified --version") {
+	if !strings.Contains(err.Error(), "specified --ensure-version") {
 		t.Errorf("Expected error to mention version mismatch check, got %q", err.Error())
 	}
 }

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -393,6 +393,35 @@ func TestOCIPusher_Push_ChartOperations(t *testing.T) {
 	}
 }
 
+func TestOCIPusher_Push_InvalidChartVersion(t *testing.T) {
+	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
+
+	// Skip test if chart file doesn't exist
+	if _, err := os.Stat(chartPath); err != nil {
+		t.Skipf("Test chart %s not found, skipping test", chartPath)
+	}
+
+	pusher, err := NewOCIPusher()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that multiple options are applied correctly
+	err = pusher.Push(chartPath, "oci://localhost:5000/test:0.2.0",
+		WithPlainHTTP(true),
+		WithInsecureSkipTLSVerify(true),
+	)
+
+	// We expect an error since we're not actually pushing to a registry
+	if err == nil {
+		t.Fatal("Expected error when pushing without a valid registry")
+	}
+
+	if !strings.Contains(err.Error(), "does not match provided chart version") {
+		t.Error("Expected error to mention tag mismatch")
+	}
+}
+
 func TestOCIPusher_Push_MultipleOptions(t *testing.T) {
 	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
 

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -455,3 +455,30 @@ func TestOCIPusher_Push_MultipleOptions(t *testing.T) {
 		t.Error("Expected insecureSkipTLSVerify option to be applied")
 	}
 }
+
+func TestOCIPusher_Push_ExpectedVersionMismatch(t *testing.T) {
+	chartPath := "../../pkg/cmd/testdata/testcharts/compressedchart-0.1.0.tgz"
+
+	// Skip test if chart file doesn't exist
+	if _, err := os.Stat(chartPath); err != nil {
+		t.Skipf("Test chart %s not found, skipping test", chartPath)
+	}
+
+	p, err := NewOCIPusher()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Provide an expected version that does not match the chart's version
+	err = p.Push(chartPath, "oci://localhost:5000/test",
+		WithExpectedVersion("0.2.0"),
+	)
+
+	if err == nil {
+		t.Fatal("Expected error when --version does not match chart version")
+	}
+
+	if !strings.Contains(err.Error(), "specified --version") {
+		t.Errorf("Expected error to mention version mismatch check, got %q", err.Error())
+	}
+}

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -443,7 +443,7 @@ func TestOCIPusher_Push_InvalidChartVersion(t *testing.T) {
 	err = pusher.Push(chartPath, "oci://localhost:5000/test:0.2.0")
 
 	if err == nil {
-		t.Fatal("Expected error when pushing without a valid registry")
+		t.Fatal("Expected error due to tag/chart version mismatch")
 	}
 	if !strings.Contains(err.Error(), "does not match provided chart version") {
 		t.Error("Expected error to mention tag mismatch")
@@ -469,7 +469,7 @@ func TestOCIPusher_Push_ExpectedVersionMismatch(t *testing.T) {
 	)
 
 	if err == nil {
-		t.Fatal("Expected error when --version does not match chart version")
+		t.Fatal("Expected error when --ensure-version does not match chart version")
 	}
 
 	if !strings.Contains(err.Error(), "specified --ensure-version") {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -34,6 +34,7 @@ type options struct {
 	caFile                string
 	insecureSkipTLSVerify bool
 	plainHTTP             bool
+	expectedVersion       string
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -66,6 +67,14 @@ func WithInsecureSkipTLSVerify(insecureSkipTLSVerify bool) Option {
 func WithPlainHTTP(plainHTTP bool) Option {
 	return func(opts *options) {
 		opts.plainHTTP = plainHTTP
+	}
+}
+
+// WithExpectedVersion sets a specific chart version to check against the chart metadata.
+// If the chart's version differs, the push will fail.
+func WithExpectedVersion(version string) Option {
+	return func(opts *options) {
+		opts.expectedVersion = version
 	}
 }
 

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func BuildPushRef(href, chartName, chartVersion string) (string, error) {
+	ref, err := newReference(href)
+	if err != nil {
+		return "", err
+	}
+
+	if ref.Digest != "" {
+		return "", fmt.Errorf("cannot push to a reference with a digest: %q. Only tags are allowed", href)
+	}
+
+	// Normalize chart version for tag comparison/build (registry tags cannot contain '+')
+	normalizedVersion := strings.ReplaceAll(chartVersion, "+", "_")
+
+	// Determine final tag:
+	// - if href tag present, it must match normalized chart version
+	// - else use chart version
+	finalTag := normalizedVersion
+	if ref.Tag != "" {
+		if ref.Tag != normalizedVersion {
+			return "", fmt.Errorf("tag %q does not match provided chart version %q", ref.Tag, chartVersion)
+		}
+		finalTag = ref.Tag
+	}
+
+	// Ensure repository ends with the chart name once (avoid duplication)
+	finalRepo := ref.Repository
+	if chartName != "" {
+		last := chartName
+		// Extract last segment of current repository path
+		if idx := strings.LastIndex(finalRepo, "/"); idx >= 0 {
+			last = finalRepo[idx+1:]
+		} else {
+			last = finalRepo
+		}
+		if last != chartName {
+			finalRepo = path.Join(finalRepo, chartName)
+		}
+	}
+
+	return fmt.Sprintf("%s/%s:%s", ref.Registry, finalRepo, finalTag), nil
+}

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -36,7 +36,8 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 	normalizedVersion := strings.ReplaceAll(chartVersion, "+", "_")
 	// if href tag present, it must match normalized chart version
 	if ref.Tag != "" && ref.Tag != normalizedVersion {
-		return "", fmt.Errorf("tag %q does not match provided chart version %q", ref.Tag, chartVersion)
+		normalizedTag := strings.ReplaceAll(ref.Tag, "_", "+")
+		return "", fmt.Errorf("tag %q does not match provided chart version %q", normalizedTag, chartVersion)
 	}
 
 	// Ensure repository ends with the chart name once (avoid duplication)

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -42,8 +42,8 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 	// Ensure repository ends with the chart name once (avoid duplication)
 	finalRepo := ref.Repository
 	if chartName != "" {
-		last := chartName
 		// Extract last segment of current repository path
+		var last string
 		if idx := strings.LastIndex(finalRepo, "/"); idx >= 0 {
 			last = finalRepo[idx+1:]
 		} else {

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -34,16 +34,9 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 
 	// Normalize chart version for tag comparison/build (registry tags cannot contain '+')
 	normalizedVersion := strings.ReplaceAll(chartVersion, "+", "_")
-
-	// Determine final tag:
-	// - if href tag present, it must match normalized chart version
-	// - else use chart version
-	finalTag := normalizedVersion
-	if ref.Tag != "" {
-		if ref.Tag != normalizedVersion {
-			return "", fmt.Errorf("tag %q does not match provided chart version %q", ref.Tag, chartVersion)
-		}
-		finalTag = ref.Tag
+	// if href tag present, it must match normalized chart version
+	if ref.Tag != "" && ref.Tag != normalizedVersion {
+		return "", fmt.Errorf("tag %q does not match provided chart version %q", ref.Tag, chartVersion)
 	}
 
 	// Ensure repository ends with the chart name once (avoid duplication)
@@ -61,5 +54,5 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%s/%s:%s", ref.Registry, finalRepo, finalTag), nil
+	return fmt.Sprintf("%s/%s:%s", ref.Registry, finalRepo, chartVersion), nil
 }

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -32,7 +32,7 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 		return "", fmt.Errorf("cannot push to a reference with a digest: %q. Only tags are allowed", href)
 	}
 
-	// Normalize chart version for tag comparison/build (registry tags cannot contain '+')
+	// Normalize for comparison only; the registry client converts '+' to '_' for the actual tag
 	normalizedVersion := strings.ReplaceAll(chartVersion, "+", "_")
 	// if href tag present, it must match normalized chart version
 	if ref.Tag != "" && ref.Tag != normalizedVersion {

--- a/pkg/registry/pushref.go
+++ b/pkg/registry/pushref.go
@@ -51,6 +51,9 @@ func BuildPushRef(href, chartName, chartVersion string) (string, error) {
 			last = finalRepo
 		}
 		if last != chartName {
+			if ref.Tag != "" {
+				return "", fmt.Errorf("repository %q does not match chart name %q; the tagged reference %q indicates an explicit push target", finalRepo, chartName, href)
+			}
 			finalRepo = path.Join(finalRepo, chartName)
 		}
 	}

--- a/pkg/registry/pushref_test.go
+++ b/pkg/registry/pushref_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry // import "helm.sh/helm/v4/pkg/registry"
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildPushRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		chart    string
+		version  string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "simple case",
+			registry: "oci://my-registry.io/my-repo:1.0.0",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "my-registry.io/my-repo:1.0.0",
+			wantErr:  false,
+		},
+		{
+			name:     "append chart name to repo",
+			registry: "oci://my-registry.io/ns",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "my-registry.io/ns/my-repo:1.0.0",
+			wantErr:  false,
+		},
+		{
+			name:     "digest not allowed",
+			registry: "oci://my-registry.io/my-repo@sha256:abcdef1234567890",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid registry",
+			registry: "invalid-registry",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "",
+			wantErr:  true,
+		},
+		{
+			name:     "tag mismatch",
+			registry: "oci://my-registry.io/my-repo:2.0.0",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "",
+			wantErr:  true,
+		},
+		{
+			name:     "plus to underscore normalization",
+			registry: "oci://my-registry.io/my-repo:1.0.0_abc",
+			chart:    "my-repo",
+			version:  "1.0.0+abc",
+			want:     "my-registry.io/my-repo:1.0.0_abc",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if tt.wantErr {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := BuildPushRef(tt.registry, tt.chart, tt.version)
+				if err == nil {
+					t.Errorf("BuildPushRef() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+			})
+		} else {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := BuildPushRef(tt.registry, tt.chart, tt.version)
+				if err != nil {
+					t.Errorf("BuildPushRef() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("BuildPushRef() got = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	}
+}

--- a/pkg/registry/pushref_test.go
+++ b/pkg/registry/pushref_test.go
@@ -75,8 +75,15 @@ func TestBuildPushRef(t *testing.T) {
 			registry: "oci://my-registry.io/my-repo:1.0.0_abc",
 			chart:    "my-repo",
 			version:  "1.0.0+abc",
-			want:     "my-registry.io/my-repo:1.0.0_abc",
+			want:     "my-registry.io/my-repo:1.0.0+abc",
 			wantErr:  false,
+		},
+		{
+			name:     "repo already includes chart name",
+			registry: "oci://my-registry.io/namespace/my-repo:1.0.0",
+			chart:    "my-repo",
+			version:  "1.0.0",
+			want:     "my-registry.io/namespace/my-repo:1.0.0",
 		},
 	}
 

--- a/pkg/registry/pushref_test.go
+++ b/pkg/registry/pushref_test.go
@@ -85,10 +85,17 @@ func TestBuildPushRef(t *testing.T) {
 			version:  "1.0.0",
 			want:     "my-registry.io/namespace/my-repo:1.0.0",
 		},
+		{
+			name:     "tagged href with mismatched chart name should error",
+			registry: "oci://my-registry.io/repo/other:1.2.3",
+			chart:    "mychart",
+			version:  "1.2.3",
+			want:     "",
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
-
 		if tt.wantErr {
 			t.Run(tt.name, func(t *testing.T) {
 				_, err := BuildPushRef(tt.registry, tt.chart, tt.version)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes: https://github.com/helm/helm/issues/11736

- Allow specifying chart and version in OCI push targets, e.g. oci://ghcr.io/org/repo/mychart:1.2.3.
- Same with `--ensure-version` flag as a safety check. If provided and it differs, the command fails.
- Reject digest references for push.

**Special notes for your reviewer**:

1. Aligns with prior work in #12690, but implements via a small centralized helper and a check-only flag.
2. ~~I am not sure we want to add `--version`, as it seems a little misleading to me. One could expect it to push a specific version. Curious to hear what you think. 🤷 Maybe `:version` is good enough.~~

Tested via:

```sh
$ bin/helm create myapp
Creating myapp

$ sed -i '' 's/^version:.*/version: 0.1.0+meta/' myapp/Chart.yaml

$ bin/helm package myapp
Successfully packaged chart and saved it to: /Users/benoit.tigeot/projects/lifen/helm/myapp-0.1.0+meta.tgz

$ bin/helm push myapp-0.1.0+meta.tgz oci://ghcr.io/benoittgt/my-app 
Pushed: ghcr.io/benoittgt/my-app/myapp:0.1.0_meta
Digest: sha256:e232ddea0dd3f93dfc978df1e3a9db586fce0ef292a7f3f502c494218a8670f3
ghcr.io/benoittgt/my-app/myapp:0.1.0_meta contains an underscore.

OCI artifact references (e.g. tags) do not support the plus sign (+). To support
storing semantic versions, Helm adopts the convention of changing plus (+) to
an underscore (_) in chart version tags when pushing to a registry and back to
a plus (+) when pulling from a registry.

$ bin/helm push myapp-0.1.0+meta.tgz oci://ghcr.io/benoittgt/my-app --ensure-version 0.1.0+meta
Pushed: [...redacted...]

$ bin/helm push myapp-0.1.0+meta.tgz oci://ghcr.io/benoittgt/my-app --ensure-version 0.2.0+meta
Error: specified --ensure-version "0.2.0+meta" does not match chart version "0.1.0+meta"

$ bin/helm push myapp-0.1.0+meta.tgz oci://ghcr.io/benoittgt/my-app:0.1.0+meta
Pushed: [...redacted...]

$ bin/helm push myapp-0.1.0+meta.tgz oci://ghcr.io/benoittgt/my-app:0.2.0+meta
Error: tag "0.2.0+meta" does not match provided chart version "0.1.0+meta"
```

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
