### PR TITLE
No longer accept to download dependencies from unknown https repo

### DIFF
--- a/pkg/cmd/dependency_update_test.go
+++ b/pkg/cmd/dependency_update_test.go
@@ -242,15 +242,14 @@ func TestDependencyUpdateCmd_WithRepoThatWasNotAdded(t *testing.T) {
 			dir("repositories.yaml"), dir(), contentCache),
 	)
 
-	if err != nil {
-		t.Logf("Output: %s", out)
-		t.Fatal(err)
+	// In Helm v4, using a repository that hasn't been explicitly configured should fail
+	if err == nil {
+		t.Fatalf("expected error for unconfigured repository, got nil. Output: %s", out)
 	}
 
-	// This is written directly to stdout, so we have to capture as is
-	if !strings.Contains(out, `Getting updates for unmanaged Helm repositories...`) {
-		t.Errorf("No ‘unmanaged’ Helm repo used in test chartdependency or it doesn’t cause the creation "+
-			"of an ‘ad hoc’ repo index cache file\n%s", out)
+	missingRepoURL := srvForUnmanagedRepo.URL()
+	if !strings.Contains(out, fmt.Sprintf("repository \"%s\" is not configured.", missingRepoURL)) {
+		t.Fatalf("expected error to mention unconfigured repo URL %s. Output:\n%s", missingRepoURL, out)
 	}
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

BREAKING CHANGE: as a security measure charts that declare http(s) dependencies using full URLs (without adding the repo via `helm repo add`) will now fail during dependency update/build.

Closes: https://github.com/helm/helm/issues/13461

**Special notes for your reviewer**:

Should we add documentation? Maybe tag this pull request to be included in the Helm v4 migration guide?

For manual testing:

```sh
$ cat myapp/Chart.yaml
apiVersion: v2
name: demo-auto-deps
description: Hello Terry
type: application
version: 0.1.0
appVersion: "1.0.0"

dependencies:
  - name: redis
    version: ">= 19.0.0"
    repository: "https://charts.bitnami.com/bitnami"% 

$ bin/helm repo add bitnami https://charts.bitnami.com/bitnami

"bitnami" already exists with the same configuration, skipping

$ bin/helm dependency update myapp --skip-refresh             
Saving 1 charts
Downloading redis from repo https://charts.bitnami.com/bitnami
Pulled: registry-1.docker.io/bitnamicharts/redis:22.0.7
Digest: sha256:3251a7c972d1d605c1e41a5f58d9804e363cdd81fce9a51343add88545b63a83
Deleting outdated charts

$ helm repo remove bitnami                                    
"bitnami" has been removed from your repositories

$ bin/helm dependency update myapp --skip-refresh             
Error: repository "https://charts.bitnami.com/bitnami" is not configured.
Add it and retry:
  helm repo add <REPO_NAME> https://charts.bitnami.com/bitnami
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
