### PR TITLE
feat: `helm version` print Kubernetes (client-go) version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMajor=$(K8S_M
 LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
+LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMajor=$(K8S_MODULES_MAJOR_VER)
+LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMinor=$(K8S_MODULES_MINOR_VER)
 
 .PHONY: all
 all: build

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,6 +18,7 @@ package version // import "helm.sh/helm/v4/internal/version"
 
 import (
 	"flag"
+	"fmt"
 	"runtime"
 	"strings"
 )
@@ -37,6 +38,11 @@ var (
 	gitCommit = ""
 	// gitTreeState is the state of the git tree
 	gitTreeState = ""
+
+	// The Kubernetes version can be set by LDFLAGS. In order to do that the value
+	// must be a string.
+	kubeClientVersionMajor = ""
+	kubeClientVersionMinor = ""
 )
 
 // BuildInfo describes the compile time information.
@@ -49,6 +55,8 @@ type BuildInfo struct {
 	GitTreeState string `json:"git_tree_state,omitempty"`
 	// GoVersion is the version of the Go compiler used.
 	GoVersion string `json:"go_version,omitempty"`
+	// KubeClientVersion is the version of client-go Helm was build with
+	KubeClientVersion string `json:"kube_client_version"`
 }
 
 // GetVersion returns the semver string of the version
@@ -67,10 +75,11 @@ func GetUserAgent() string {
 // Get returns build info
 func Get() BuildInfo {
 	v := BuildInfo{
-		Version:      GetVersion(),
-		GitCommit:    gitCommit,
-		GitTreeState: gitTreeState,
-		GoVersion:    runtime.Version(),
+		Version:           GetVersion(),
+		GitCommit:         gitCommit,
+		GitTreeState:      gitTreeState,
+		GoVersion:         runtime.Version(),
+		KubeClientVersion: fmt.Sprintf("v%s.%s", kubeClientVersionMajor, kubeClientVersionMinor),
 	}
 
 	// HACK(bacongobbler): strip out GoVersion during a test run for consistent test output

--- a/pkg/cmd/testdata/output/version.txt
+++ b/pkg/cmd/testdata/output/version.txt
@@ -1,1 +1,1 @@
-version.BuildInfo{Version:"v4.0", GitCommit:"", GitTreeState:"", GoVersion:""}
+version.BuildInfo{Version:"v4.0", GitCommit:"", GitTreeState:"", GoVersion:"", KubeClientVersion:"v."}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Enable the output of `helm version` to print the Kubernetes client library version (client-go version) that Helm was built against. This allows Helm users to easily discover this information, which can be useful for understanding Kubernetes compatibility.

**Special notes for your reviewer**:
This conflicts with https://github.com/helm/helm/pull/31296 (this PR/change would need to be adapted to be based on this method eventually, depending on which is merged first)

Also note, test coverage is limited. As these values change "dynamically". So is not easy to validate the actual expected version (see the modification to `version.txt`)


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
