### PR TITLE
fix: Use PAX tar format for accurate timestamps

### DIFF
--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -233,6 +233,7 @@ func writeToTar(out *tar.Writer, name string, body []byte) error {
 		Mode:    0644,
 		Size:    int64(len(body)),
 		ModTime: time.Now(),
+		Format:  tar.FormatPAX,
 	}
 	if err := out.WriteHeader(h); err != nil {
 		return err

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -137,10 +137,7 @@ func Indent(n int, text string) string {
 }
 
 func TestSavePreservesTimestamps(t *testing.T) {
-	// Test executes so quickly that if we don't subtract a second, the
-	// check will fail because `initialCreateTime` will be identical to the
-	// written timestamp for the files.
-	initialCreateTime := time.Now().Add(-1 * time.Second)
+	initialCreateTime := time.Now()
 
 	tmp := t.TempDir()
 

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -245,6 +245,7 @@ func writeToTar(out *tar.Writer, name string, body []byte) error {
 		Mode:    0644,
 		Size:    int64(len(body)),
 		ModTime: time.Now(),
+		Format:  tar.FormatPAX,
 	}
 	if err := out.WriteHeader(h); err != nil {
 		return err

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -140,10 +140,7 @@ func Indent(n int, text string) string {
 }
 
 func TestSavePreservesTimestamps(t *testing.T) {
-	// Test executes so quickly that if we don't subtract a second, the
-	// check will fail because `initialCreateTime` will be identical to the
-	// written timestamp for the files.
-	initialCreateTime := time.Now().Add(-1 * time.Second)
+	initialCreateTime := time.Now()
 
 	tmp := t.TempDir()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Go's `archive/tar` package rounds archive member file timestamps to the closest second unless the POSIX.1-2001 "PAX" tar format is used (see https://pkg.go.dev/archive/tar#Format). This results in noise in processes where the helm charts are immediately extracted by (at least) GNU tar for repackaging/modification/inspection, where tar complains (if the original creation time ended up being rounded up) that `time stamp 2025-10-02 12:06:47 is 0.469095762 s in the future` or similar. This behavior is unlikely to be changed in the the `archive/tar` package; ref comments in golang/go#48275. Using the PAX header format resolves this.

An alternative fix is to truncate the file mtimes to the nearest second in the past using `ModTime: time.Now().Truncate(time.Second)`, as also suggested in the golang issue referenced above.