### PR TITLE
fix: statusWait race condition

### DIFF
--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -163,7 +163,7 @@ func getGVR(t *testing.T, mapper meta.RESTMapper, obj *unstructured.Unstructured
 
 func getRuntimeObjFromManifests(t *testing.T, manifests []string) []runtime.Object {
 	t.Helper()
-	objects := []runtime.Object{}
+	var objects []runtime.Object
 	for _, manifest := range manifests {
 		m := make(map[string]interface{})
 		err := yaml.Unmarshal([]byte(manifest), &m)

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -163,7 +163,7 @@ func getGVR(t *testing.T, mapper meta.RESTMapper, obj *unstructured.Unstructured
 
 func getRuntimeObjFromManifests(t *testing.T, manifests []string) []runtime.Object {
 	t.Helper()
-	var objects []runtime.Object
+	objects := []runtime.Object{}
 	for _, manifest := range manifests {
 		m := make(map[string]interface{})
 		err := yaml.Unmarshal([]byte(manifest), &m)


### PR DESCRIPTION

**What this PR does / why we need it**:
Fix for race condition on statusWait:
```
-test.shuffle 1759272660789896550
2025/09/30 22:51:00 ERROR job failed job=test-job reason=FailedReason
2025/09/30 22:51:06 ERROR pod failed pod=pod2
2025/09/30 22:51:25 ERROR job failed job=test-job reason=FailedReason
2025/09/30 22:51:31 ERROR pod failed pod=pod2
--- FAIL: TestStatusWaitForDelete (0.00s)
    --- FAIL: TestStatusWaitForDelete/error_when_not_all_objects_are_deleted (0.00s)
        statuswait_test.go:244: 
            	Error Trace:	/home/runner/work/helm/helm/pkg/kube/statuswait_test.go:244
            	Error:      	An error is expected but got nil.
            	Test:       	TestStatusWaitForDelete/error_when_not_all_objects_are_deleted
FAIL
FAIL	helm.sh/helm/v4/pkg/kube	48.901s
```

Partial: https://github.com/helm/helm/issues/31016

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
