### PR TITLE
fix: flake upgrade test

### DIFF
--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -60,9 +60,9 @@ func TestUpgradeRelease_Success(t *testing.T) {
 
 	ctx, done := context.WithCancel(t.Context())
 	res, err := upAction.RunWithContext(ctx, rel.Name, buildChart(), vals)
-	done()
 	req.NoError(err)
 	is.Equal(res.Info.Status, release.StatusDeployed)
+	done()
 
 	// Detecting previous bug where context termination after successful release
 	// caused release to fail.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for flake upgrade test. I don't think this is the best approach, but created as strawman. It does stop the test from failing though.

```
-test.shuffle 1759247387369482727
level=WARN msg="upgrade failed" name=come-fail-away error="I timed out"
level=WARN msg="upgrade failed" name=previous-release error="context canceled"
--- FAIL: TestUpgradeRelease_Success (0.20s)
    upgrade_test.go:72: 
        	Error Trace:	/home/runner/work/helm/helm/pkg/action/upgrade_test.go:72
        	Error:      	Not equal: 
        	            	expected: "failed"
        	            	actual  : "deployed"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-(v1.Status) (len=6) "failed"
        	            	+(v1.Status) (len=8) "deployed"
        	            	 
        	Test:       	TestUpgradeRelease_Success
```

Partial: https://github.com/helm/helm/issues/31016

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
