### PR TITLE
fix: ClientOnly Configuration State issue in Install Action

### DIFF
--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1208,3 +1208,79 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	// Verify that WaitOptions were passed to GetWaiter
 	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
 }
+
+func TestInstallDryRunClientStatePreservation(t *testing.T) {
+	is := assert.New(t)
+
+	// Create configuration with original kube client
+	config := actionConfigFixture(t)
+	originalKubeClient := config.KubeClient
+	originalCapabilities := config.Capabilities
+	originalReleases := config.Releases
+
+	// First install action with DryRunClient
+	client1 := NewInstall(config)
+	client1.DryRunStrategy = DryRunClient
+	client1.ReleaseName = "test-client-only"
+	client1.Namespace = "test-namespace"
+
+	// Run first action
+	_, err := client1.Run(buildChart(), nil)
+	is.NoError(err)
+
+	// Verify that the configuration has been restored to original state
+	is.Equal(originalKubeClient, config.KubeClient, "KubeClient should be restored to original")
+	is.Equal(originalCapabilities, config.Capabilities, "Capabilities should be restored to original")
+	is.Equal(originalReleases, config.Releases, "Releases should be restored to original")
+
+	// Second install action with DryRunNone (should work now)
+	client2 := NewInstall(config)
+	client2.DryRunStrategy = DryRunNone
+	client2.ReleaseName = "test-real-install"
+	client2.Namespace = "test-namespace"
+
+	// Run second action - this should not fail due to fake client
+	_, err = client2.Run(buildChart(), nil)
+	is.NoError(err)
+
+	// Verify configuration was not permanently modified
+	is.Equal(originalKubeClient, config.KubeClient, "KubeClient should still be original after second action")
+}
+
+func TestInstallDryRunClientMultipleActionsWithSameConfig(t *testing.T) {
+	is := assert.New(t)
+
+	// Create configuration
+	config := actionConfigFixture(t)
+	originalKubeClient := config.KubeClient
+
+	// First action: DryRunClient
+	client1 := NewInstall(config)
+	client1.DryRunStrategy = DryRunClient
+	client1.ReleaseName = "test1"
+	client1.Namespace = "test-namespace"
+
+	_, err := client1.Run(buildChart(), nil)
+	is.NoError(err)
+
+	// Second action: DryRunNone (using same config)
+	client2 := NewInstall(config)
+	client2.DryRunStrategy = DryRunNone
+	client2.ReleaseName = "test2"
+	client2.Namespace = "test-namespace"
+
+	_, err = client2.Run(buildChart(), nil)
+	is.NoError(err)
+
+	// Third action: DryRunClient again
+	client3 := NewInstall(config)
+	client3.DryRunStrategy = DryRunClient
+	client3.ReleaseName = "test3"
+	client3.Namespace = "test-namespace"
+
+	_, err = client3.Run(buildChart(), nil)
+	is.NoError(err)
+
+	// Configuration should still be in original state
+	is.Equal(originalKubeClient, config.KubeClient, "KubeClient should be preserved across multiple actions")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
closes #11463 

**What this PR does / why we need it**:
Fixes a bug in Helm's Go API where setting ClientOnly = true on an install action would permanently modify the shared action.Configuration, causing subsequent actions using the same configuration to fail.


**Problem**
When using Helm's Go API with multiple install actions sharing the same `action.Configuration`, there was a state pollution issue:
1. **First action** sets `ClientOnly = true` (e.g., for template generation)
2. **Helm internally** replaces the real Kubernetes client with a fake client in the shared configuration
3. **Configuration remains modified** after the first action completes
4. **Subsequent actions** inherit the corrupted state and fail, even with `ClientOnly = false`

**Special notes for your reviewer**:
Changes made:
Implemented a configuration state preservation mechanism that:
  - Saves the original configuration state before ClientOnly modifications
  - Restores the original state when the function returns (using defer)
  - Ensures no permanent pollution of shared configuration

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
