### PR TITLE
pkg/kube: remove managed fields before SSA

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1092,6 +1092,13 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 		WithFieldManager(getManagedFieldsManager()).
 		WithFieldValidation(string(fieldValidationDirective))
 
+	// Zero-out managed fields, if any are present on our object, as patch does not allow these to be set
+	metaAccessor, err := meta.Accessor(target.Object)
+	if err != nil {
+		return fmt.Errorf("failed to get object metadata: %w", err)
+	}
+	metaAccessor.SetManagedFields(nil)
+
 	// Send the full object to be applied on the server side.
 	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, target.Object)
 	if err != nil {


### PR DESCRIPTION
Server-side apply patches cannot contain managed field data; we must zero-out this field before sending the patch.

```
$ helm status --namespace hypershift hypershift --show-desc
NAME: hypershift
LAST DEPLOYED: Tue Oct  7 08:28:25 2025
NAMESPACE: hypershift
STATUS: failed
REVISION: 1
DESCRIPTION: Release "hypershift" failed: metadata.managedFields must be nil && metadata.managedFields must be nil && metadata.managedFields must be nil && metadata.managedFields must be nil && metadata.managedFields must be nil
TEST SUITE: None
```

On install (my logger, Helm code):

```
[08:09:10.093] DEBUG: Error patching resource {
  "error": "metadata.managedFields must be nil",
  "gvk": "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition",
  "name": "routes.route.openshift.io",
  "namespace": ""
}
```