### PR TITLE
Clarify the intent of the resource instructions

### DIFF
--- a/internal/chart/v3/util/create.go
+++ b/internal/chart/v3/util/create.go
@@ -218,9 +218,10 @@ httpRoute:
   #       value: v2
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # For publicly distributed charts, we recommend leaving 'resources' commented out.
+  # This makes resource allocation a conscious choice for the user and increases the chances
+  # charts run on a wide range of environments from low-resource clusters like Minikube to those
+  # with strict resource policies. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR refactors the boilerplate comment in values.yaml to clarify the intent behind the recommendation on setting resource requests and limits.

The current advice to omit default resources is a critical best practice for publicly distributed charts, as it ensures maximum portability across unknown user environments with varying resource policies and capacities. However, this guidance can be misleading for the large number of developers creating charts solely for internal use, where setting a baseline is a valid and often beneficial strategy.   

This change clarifies that the recommendation is primarily aimed at public charts, providing better context for all users and reducing ambiguity for those developing in a controlled, internal environment.

**Special notes for your reviewer**:
I have assumed that this was the original intent, but maybe it wasn't.

**None of the checks were applicable as this is documentation only**
