### PR TITLE
Enable Releases To Have Multiple Versions

### DIFF
--- a/internal/cli/output/color.go
+++ b/internal/cli/output/color.go
@@ -19,24 +19,24 @@ package output
 import (
 	"github.com/fatih/color"
 
-	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 // ColorizeStatus returns a colorized version of the status string based on the status value
-func ColorizeStatus(status release.Status, noColor bool) string {
+func ColorizeStatus(status common.Status, noColor bool) string {
 	// Disable color if requested
 	if noColor {
 		return status.String()
 	}
 
 	switch status {
-	case release.StatusDeployed:
+	case common.StatusDeployed:
 		return color.GreenString(status.String())
-	case release.StatusFailed:
+	case common.StatusFailed:
 		return color.RedString(status.String())
-	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback, release.StatusUninstalling:
+	case common.StatusPendingInstall, common.StatusPendingUpgrade, common.StatusPendingRollback, common.StatusUninstalling:
 		return color.YellowString(status.String())
-	case release.StatusUnknown:
+	case common.StatusUnknown:
 		return color.RedString(status.String())
 	default:
 		// For uninstalled, superseded, and any other status

--- a/internal/cli/output/color_test.go
+++ b/internal/cli/output/color_test.go
@@ -20,63 +20,63 @@ import (
 	"strings"
 	"testing"
 
-	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 func TestColorizeStatus(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		status     release.Status
+		status     common.Status
 		noColor    bool
 		envNoColor string
 		wantColor  bool // whether we expect color codes in output
 	}{
 		{
 			name:       "deployed status with color",
-			status:     release.StatusDeployed,
+			status:     common.StatusDeployed,
 			noColor:    false,
 			envNoColor: "",
 			wantColor:  true,
 		},
 		{
 			name:       "deployed status without color flag",
-			status:     release.StatusDeployed,
+			status:     common.StatusDeployed,
 			noColor:    true,
 			envNoColor: "",
 			wantColor:  false,
 		},
 		{
 			name:       "deployed status with NO_COLOR env",
-			status:     release.StatusDeployed,
+			status:     common.StatusDeployed,
 			noColor:    false,
 			envNoColor: "1",
 			wantColor:  false,
 		},
 		{
 			name:       "failed status with color",
-			status:     release.StatusFailed,
+			status:     common.StatusFailed,
 			noColor:    false,
 			envNoColor: "",
 			wantColor:  true,
 		},
 		{
 			name:       "pending install status with color",
-			status:     release.StatusPendingInstall,
+			status:     common.StatusPendingInstall,
 			noColor:    false,
 			envNoColor: "",
 			wantColor:  true,
 		},
 		{
 			name:       "unknown status with color",
-			status:     release.StatusUnknown,
+			status:     common.StatusUnknown,
 			noColor:    false,
 			envNoColor: "",
 			wantColor:  true,
 		},
 		{
 			name:       "superseded status with color",
-			status:     release.StatusSuperseded,
+			status:     common.StatusSuperseded,
 			noColor:    false,
 			envNoColor: "",
 			wantColor:  false, // superseded doesn't get colored

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -47,6 +47,7 @@ import (
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/postrenderer"
 	"helm.sh/helm/v4/pkg/registry"
+	ri "helm.sh/helm/v4/pkg/release"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
 	"helm.sh/helm/v4/pkg/storage"
@@ -412,7 +413,7 @@ func (cfg *Configuration) Now() time.Time {
 	return Timestamper()
 }
 
-func (cfg *Configuration) releaseContent(name string, version int) (*release.Release, error) {
+func (cfg *Configuration) releaseContent(name string, version int) (ri.Releaser, error) {
 	if err := chartutil.ValidateReleaseName(name); err != nil {
 		return nil, fmt.Errorf("releaseContent: Release name is invalid: %s", name)
 	}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -36,6 +36,7 @@ import (
 	"helm.sh/helm/v4/pkg/kube"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
 	"helm.sh/helm/v4/pkg/registry"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage"
 	"helm.sh/helm/v4/pkg/storage/driver"
@@ -249,10 +250,10 @@ func withKube(version string) chartOption {
 
 // releaseStub creates a release stub, complete with the chartStub as its chart.
 func releaseStub() *release.Release {
-	return namedReleaseStub("angry-panda", release.StatusDeployed)
+	return namedReleaseStub("angry-panda", rcommon.StatusDeployed)
 }
 
-func namedReleaseStub(name string, status release.Status) *release.Release {
+func namedReleaseStub(name string, status rcommon.Status) *release.Release {
 	now := time.Now()
 	return &release.Release{
 		Name: name,

--- a/pkg/action/get.go
+++ b/pkg/action/get.go
@@ -17,7 +17,7 @@ limitations under the License.
 package action
 
 import (
-	release "helm.sh/helm/v4/pkg/release/v1"
+	release "helm.sh/helm/v4/pkg/release"
 )
 
 // Get is the action for checking a given release's information.
@@ -38,7 +38,7 @@ func NewGet(cfg *Configuration) *Get {
 }
 
 // Run executes 'helm get' against the given release.
-func (g *Get) Run(name string) (*release.Release, error) {
+func (g *Get) Run(name string) (release.Releaser, error) {
 	if err := g.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}

--- a/pkg/action/get_metadata.go
+++ b/pkg/action/get_metadata.go
@@ -17,12 +17,15 @@ limitations under the License.
 package action
 
 import (
+	"errors"
 	"log/slog"
 	"sort"
 	"strings"
 	"time"
 
 	ci "helm.sh/helm/v4/pkg/chart"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release"
 )
 
 // GetMetadata is the action for checking a given release's metadata.
@@ -69,24 +72,40 @@ func (g *GetMetadata) Run(name string) (*Metadata, error) {
 		return nil, err
 	}
 
-	ac, err := ci.NewAccessor(rel.Chart)
+	rac, err := release.NewAccessor(rel)
+	if err != nil {
+		return nil, err
+	}
+	ac, err := ci.NewAccessor(rac.Chart())
 	if err != nil {
 		return nil, err
 	}
 
+	charti := rac.Chart()
+
+	var chrt *chart.Chart
+	switch c := charti.(type) {
+	case *chart.Chart:
+		chrt = c
+	case chart.Chart:
+		chrt = &c
+	default:
+		return nil, errors.New("invalid chart apiVersion")
+	}
+
 	return &Metadata{
-		Name:         rel.Name,
-		Chart:        rel.Chart.Metadata.Name,
-		Version:      rel.Chart.Metadata.Version,
-		AppVersion:   rel.Chart.Metadata.AppVersion,
+		Name:         rac.Name(),
+		Chart:        chrt.Metadata.Name,
+		Version:      chrt.Metadata.Version,
+		AppVersion:   chrt.Metadata.AppVersion,
 		Dependencies: ac.MetaDependencies(),
-		Annotations:  rel.Chart.Metadata.Annotations,
-		Labels:       rel.Labels,
-		Namespace:    rel.Namespace,
-		Revision:     rel.Version,
-		Status:       rel.Info.Status.String(),
-		DeployedAt:   rel.Info.LastDeployed.Format(time.RFC3339),
-		ApplyMethod:  rel.ApplyMethod,
+		Annotations:  chrt.Metadata.Annotations,
+		Labels:       rac.Labels(),
+		Namespace:    rac.Namespace(),
+		Revision:     rac.Version(),
+		Status:       rac.Status(),
+		DeployedAt:   rac.DeployedAt().Format(time.RFC3339),
+		ApplyMethod:  rac.ApplyMethod(),
 	}, nil
 }
 

--- a/pkg/action/get_metadata_test.go
+++ b/pkg/action/get_metadata_test.go
@@ -28,6 +28,7 @@ import (
 	ci "helm.sh/helm/v4/pkg/chart"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -50,7 +51,7 @@ func TestGetMetadata_Run_BasicMetadata(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -64,7 +65,8 @@ func TestGetMetadata_Run_BasicMetadata(t *testing.T) {
 		Namespace: "default",
 	}
 
-	cfg.Releases.Create(rel)
+	err := cfg.Releases.Create(rel)
+	require.NoError(t, err)
 
 	result, err := client.Run(releaseName)
 	require.NoError(t, err)
@@ -104,7 +106,7 @@ func TestGetMetadata_Run_WithDependencies(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -163,7 +165,7 @@ func TestGetMetadata_Run_WithDependenciesAliases(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -234,7 +236,7 @@ func TestGetMetadata_Run_WithMixedDependencies(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -298,7 +300,7 @@ func TestGetMetadata_Run_WithAnnotations(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -337,7 +339,7 @@ func TestGetMetadata_Run_SpecificVersion(t *testing.T) {
 	rel1 := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusSuperseded,
+			Status:       common.StatusSuperseded,
 			LastDeployed: deployedTime.Add(-time.Hour),
 		},
 		Chart: &chart.Chart{
@@ -354,7 +356,7 @@ func TestGetMetadata_Run_SpecificVersion(t *testing.T) {
 	rel2 := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -388,16 +390,16 @@ func TestGetMetadata_Run_DifferentStatuses(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		status   release.Status
+		status   common.Status
 		expected string
 	}{
-		{"deployed", release.StatusDeployed, "deployed"},
-		{"failed", release.StatusFailed, "failed"},
-		{"uninstalled", release.StatusUninstalled, "uninstalled"},
-		{"pending-install", release.StatusPendingInstall, "pending-install"},
-		{"pending-upgrade", release.StatusPendingUpgrade, "pending-upgrade"},
-		{"pending-rollback", release.StatusPendingRollback, "pending-rollback"},
-		{"superseded", release.StatusSuperseded, "superseded"},
+		{"deployed", common.StatusDeployed, "deployed"},
+		{"failed", common.StatusFailed, "failed"},
+		{"uninstalled", common.StatusUninstalled, "uninstalled"},
+		{"pending-install", common.StatusPendingInstall, "pending-install"},
+		{"pending-upgrade", common.StatusPendingUpgrade, "pending-upgrade"},
+		{"pending-rollback", common.StatusPendingRollback, "pending-rollback"},
+		{"superseded", common.StatusSuperseded, "superseded"},
 	}
 
 	for _, tc := range testCases {
@@ -464,7 +466,7 @@ func TestGetMetadata_Run_EmptyAppVersion(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status:       release.StatusDeployed,
+			Status:       common.StatusDeployed,
 			LastDeployed: deployedTime,
 		},
 		Chart: &chart.Chart{
@@ -640,7 +642,7 @@ func TestMetadata_FormattedDepNames_WithAliases(t *testing.T) {
 
 func TestGetMetadata_Labels(t *testing.T) {
 	rel := releaseStub()
-	rel.Info.Status = release.StatusDeployed
+	rel.Info.Status = common.StatusDeployed
 	customLabels := map[string]string{"key1": "value1", "key2": "value2"}
 	rel.Labels = customLabels
 

--- a/pkg/action/get_values_test.go
+++ b/pkg/action/get_values_test.go
@@ -26,6 +26,7 @@ import (
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -58,7 +59,7 @@ func TestGetValues_Run_UserConfigOnly(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		},
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -112,7 +113,7 @@ func TestGetValues_Run_AllValues(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		},
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -147,7 +148,7 @@ func TestGetValues_Run_EmptyValues(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		},
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -198,7 +199,7 @@ func TestGetValues_Run_NilConfig(t *testing.T) {
 	rel := &release.Release{
 		Name: releaseName,
 		Info: &release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		},
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
-	release "helm.sh/helm/v4/pkg/release/v1"
+	release "helm.sh/helm/v4/pkg/release"
 )
 
 // History is the action for checking the release's ledger.
@@ -46,7 +46,7 @@ func NewHistory(cfg *Configuration) *History {
 }
 
 // Run executes 'helm history' against the given release.
-func (h *History) Run(name string) ([]*release.Release, error) {
+func (h *History) Run(name string) ([]release.Releaser, error) {
 	if err := h.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -33,6 +33,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/kube"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage"
 	"helm.sh/helm/v4/pkg/storage/driver"
@@ -187,7 +188,7 @@ func runInstallForHooksWithSuccess(t *testing.T, manifest, expectedNamespace str
 	res, err := instAction.Run(buildChartWithTemplates(templates), vals)
 	is.NoError(err)
 	is.Equal(expectedOutput, outBuffer.String())
-	is.Equal(release.StatusDeployed, res.Info.Status)
+	is.Equal(rcommon.StatusDeployed, res.Info.Status)
 }
 
 func runInstallForHooksWithFailure(t *testing.T, manifest, expectedNamespace string, shouldOutput bool) {
@@ -215,7 +216,7 @@ func runInstallForHooksWithFailure(t *testing.T, manifest, expectedNamespace str
 	is.Error(err)
 	is.Contains(res.Info.Description, "failed pre-install")
 	is.Equal(expectedOutput, outBuffer.String())
-	is.Equal(release.StatusFailed, res.Info.Status)
+	is.Equal(rcommon.StatusFailed, res.Info.Status)
 }
 
 type HookFailedError struct{}

--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -185,7 +185,9 @@ func runInstallForHooksWithSuccess(t *testing.T, manifest, expectedNamespace str
 	}
 	vals := map[string]interface{}{}
 
-	res, err := instAction.Run(buildChartWithTemplates(templates), vals)
+	resi, err := instAction.Run(buildChartWithTemplates(templates), vals)
+	is.NoError(err)
+	res, err := releaserToV1Release(resi)
 	is.NoError(err)
 	is.Equal(expectedOutput, outBuffer.String())
 	is.Equal(rcommon.StatusDeployed, res.Info.Status)
@@ -212,8 +214,10 @@ func runInstallForHooksWithFailure(t *testing.T, manifest, expectedNamespace str
 	}
 	vals := map[string]interface{}{}
 
-	res, err := instAction.Run(buildChartWithTemplates(templates), vals)
+	resi, err := instAction.Run(buildChartWithTemplates(templates), vals)
 	is.Error(err)
+	res, err := releaserToV1Release(resi)
+	is.NoError(err)
 	is.Contains(res.Info.Description, "failed pre-install")
 	is.Equal(expectedOutput, outBuffer.String())
 	is.Equal(rcommon.StatusFailed, res.Info.Status)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -245,7 +245,7 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 //
 // If DryRun is set to true, this will prepare the release, but not install it
 
-func (i *Install) Run(chrt ci.Charter, vals map[string]interface{}) (*release.Release, error) {
+func (i *Install) Run(chrt ci.Charter, vals map[string]interface{}) (ri.Releaser, error) {
 	ctx := context.Background()
 	return i.RunWithContext(ctx, chrt, vals)
 }
@@ -254,7 +254,7 @@ func (i *Install) Run(chrt ci.Charter, vals map[string]interface{}) (*release.Re
 //
 // When the task is cancelled through ctx, the function returns and the install
 // proceeds in the background.
-func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[string]interface{}) (*release.Release, error) {
+func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[string]interface{}) (ri.Releaser, error) {
 	var chrt *chart.Chart
 	switch c := ch.(type) {
 	case *chart.Chart:

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -53,6 +53,8 @@ import (
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
 	"helm.sh/helm/v4/pkg/postrenderer"
 	"helm.sh/helm/v4/pkg/registry"
+	ri "helm.sh/helm/v4/pkg/release"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
 	"helm.sh/helm/v4/pkg/repo/v1"
@@ -353,13 +355,13 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	}
 	// Check error from render
 	if err != nil {
-		rel.SetStatus(release.StatusFailed, fmt.Sprintf("failed to render resource: %s", err.Error()))
+		rel.SetStatus(rcommon.StatusFailed, fmt.Sprintf("failed to render resource: %s", err.Error()))
 		// Return a release with partial data so that the client can show debugging information.
 		return rel, err
 	}
 
 	// Mark this release as in-progress
-	rel.SetStatus(release.StatusPendingInstall, "Initial install underway")
+	rel.SetStatus(rcommon.StatusPendingInstall, "Initial install underway")
 
 	var toBeAdopted kube.ResourceList
 	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), !i.DisableOpenAPIValidation)
@@ -524,9 +526,9 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	}
 
 	if len(i.Description) > 0 {
-		rel.SetStatus(release.StatusDeployed, i.Description)
+		rel.SetStatus(rcommon.StatusDeployed, i.Description)
 	} else {
-		rel.SetStatus(release.StatusDeployed, "Install complete")
+		rel.SetStatus(rcommon.StatusDeployed, "Install complete")
 	}
 
 	// This is a tricky case. The release has been created, but the result
@@ -544,7 +546,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 }
 
 func (i *Install) failRelease(rel *release.Release, err error) (*release.Release, error) {
-	rel.SetStatus(release.StatusFailed, fmt.Sprintf("Release %q failed: %s", i.ReleaseName, err.Error()))
+	rel.SetStatus(rcommon.StatusFailed, fmt.Sprintf("Release %q failed: %s", i.ReleaseName, err.Error()))
 	if i.RollbackOnFailure {
 		slog.Debug("install failed and rollback-on-failure is set, uninstalling release", "release", i.ReleaseName)
 		uninstall := NewUninstall(i.cfg)
@@ -583,13 +585,41 @@ func (i *Install) availableName() error {
 	if err != nil || len(h) < 1 {
 		return nil
 	}
-	releaseutil.Reverse(h, releaseutil.SortByRevision)
-	rel := h[0]
 
-	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed) {
+	hl, err := releaseListToV1List(h)
+	if err != nil {
+		return err
+	}
+
+	releaseutil.Reverse(hl, releaseutil.SortByRevision)
+	rel := hl[0]
+
+	if st := rel.Info.Status; i.Replace && (st == rcommon.StatusUninstalled || st == rcommon.StatusFailed) {
 		return nil
 	}
 	return errors.New("cannot reuse a name that is still in use")
+}
+
+func releaseListToV1List(ls []ri.Releaser) ([]*release.Release, error) {
+	rls := make([]*release.Release, 0, len(ls))
+	for _, val := range ls {
+		rel, err := releaserToV1Release(val)
+		if err != nil {
+			return nil, err
+		}
+		rls = append(rls, rel)
+	}
+
+	return rls, nil
+}
+
+func releaseV1ListToReleaserList(ls []*release.Release) ([]ri.Releaser, error) {
+	rls := make([]ri.Releaser, 0, len(ls))
+	for _, val := range ls {
+		rls = append(rls, val)
+	}
+
+	return rls, nil
 }
 
 // createRelease creates a new release object
@@ -604,7 +634,7 @@ func (i *Install) createRelease(chrt *chart.Chart, rawVals map[string]interface{
 		Info: &release.Info{
 			FirstDeployed: ts,
 			LastDeployed:  ts,
-			Status:        release.StatusUnknown,
+			Status:        rcommon.StatusUnknown,
 		},
 		Version:     1,
 		Labels:      labels,
@@ -630,20 +660,24 @@ func (i *Install) replaceRelease(rel *release.Release) error {
 		// No releases exist for this name, so we can return early
 		return nil
 	}
+	hl, err := releaseListToV1List(hist)
+	if err != nil {
+		return err
+	}
 
-	releaseutil.Reverse(hist, releaseutil.SortByRevision)
-	last := hist[0]
+	releaseutil.Reverse(hl, releaseutil.SortByRevision)
+	last := hl[0]
 
 	// Update version to the next available
 	rel.Version = last.Version + 1
 
 	// Do not change the status of a failed release.
-	if last.Info.Status == release.StatusFailed {
+	if last.Info.Status == rcommon.StatusFailed {
 		return nil
 	}
 
 	// For any other status, mark it as superseded and store the old record
-	last.SetStatus(release.StatusSuperseded, "superseded by new release")
+	last.SetStatus(rcommon.StatusSuperseded, "superseded by new release")
 	return i.recordRelease(last)
 }
 

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	ri "helm.sh/helm/v4/pkg/release"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
 )
@@ -145,7 +146,7 @@ func NewList(cfg *Configuration) *List {
 }
 
 // Run executes the list command, returning a set of matches.
-func (l *List) Run() ([]*release.Release, error) {
+func (l *List) Run() ([]ri.Releaser, error) {
 	if err := l.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}
@@ -159,9 +160,13 @@ func (l *List) Run() ([]*release.Release, error) {
 		}
 	}
 
-	results, err := l.cfg.Releases.List(func(rel *release.Release) bool {
+	results, err := l.cfg.Releases.List(func(rel ri.Releaser) bool {
+		r, err := releaserToV1Release(rel)
+		if err != nil {
+			return false
+		}
 		// Skip anything that doesn't match the filter.
-		if filter != nil && !filter.MatchString(rel.Name) {
+		if filter != nil && !filter.MatchString(r.Name) {
 			return false
 		}
 
@@ -176,30 +181,35 @@ func (l *List) Run() ([]*release.Release, error) {
 		return results, nil
 	}
 
+	rresults, err := releaseListToV1List(results)
+	if err != nil {
+		return nil, err
+	}
+
 	// by definition, superseded releases are never shown if
 	// only the latest releases are returned. so if requested statemask
 	// is _only_ ListSuperseded, skip the latest release filter
 	if l.StateMask != ListSuperseded {
-		results = filterLatestReleases(results)
+		rresults = filterLatestReleases(rresults)
 	}
 
 	// State mask application must occur after filtering to
 	// latest releases, otherwise outdated entries can be returned
-	results = l.filterStateMask(results)
+	rresults = l.filterStateMask(rresults)
 
 	// Skip anything that doesn't match the selector
 	selectorObj, err := labels.Parse(l.Selector)
 	if err != nil {
 		return nil, err
 	}
-	results = l.filterSelector(results, selectorObj)
+	rresults = l.filterSelector(rresults, selectorObj)
 
 	// Unfortunately, we have to sort before truncating, which can incur substantial overhead
-	l.sort(results)
+	l.sort(rresults)
 
 	// Guard on offset
-	if l.Offset >= len(results) {
-		return []*release.Release{}, nil
+	if l.Offset >= len(rresults) {
+		return releaseV1ListToReleaserList([]*release.Release{})
 	}
 
 	// Calculate the limit and offset, and then truncate results if necessary.
@@ -208,12 +218,12 @@ func (l *List) Run() ([]*release.Release, error) {
 		limit = l.Limit
 	}
 	last := l.Offset + limit
-	if l := len(results); l < last {
+	if l := len(rresults); l < last {
 		last = l
 	}
-	results = results[l.Offset:last]
+	rresults = rresults[l.Offset:last]
 
-	return results, err
+	return releaseV1ListToReleaserList(rresults)
 }
 
 // sort is an in-place sort where order is based on the value of a.Sort

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -28,6 +28,7 @@ import (
 
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/kube"
+	ri "helm.sh/helm/v4/pkg/release"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -56,7 +57,7 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 }
 
 // Run executes 'helm test' against the given release.
-func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
+func (r *ReleaseTesting) Run(name string) (ri.Releaser, error) {
 	if err := r.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}
@@ -66,7 +67,12 @@ func (r *ReleaseTesting) Run(name string) (*release.Release, error) {
 	}
 
 	// finds the non-deleted release with the given name
-	rel, err := r.cfg.Releases.Last(name)
+	reli, err := r.cfg.Releases.Last(name)
+	if err != nil {
+		return reli, err
+	}
+
+	rel, err := releaserToV1Release(reli)
 	if err != nil {
 		return rel, err
 	}

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -25,6 +25,7 @@ import (
 
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/kube"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -111,7 +112,12 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 		return nil, nil, false, errInvalidRevision
 	}
 
-	currentRelease, err := r.cfg.Releases.Last(name)
+	currentReleasei, err := r.cfg.Releases.Last(name)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	currentRelease, err := releaserToV1Release(currentReleasei)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -128,7 +134,11 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 
 	// Check if the history version to be rolled back exists
 	previousVersionExist := false
-	for _, historyRelease := range historyReleases {
+	for _, historyReleasei := range historyReleases {
+		historyRelease, err := releaserToV1Release(historyReleasei)
+		if err != nil {
+			return nil, nil, false, err
+		}
 		version := historyRelease.Version
 		if previousVersion == version {
 			previousVersionExist = true
@@ -141,7 +151,11 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 
 	slog.Debug("rolling back", "name", name, "currentVersion", currentRelease.Version, "targetVersion", previousVersion)
 
-	previousRelease, err := r.cfg.Releases.Get(name, previousVersion)
+	previousReleasei, err := r.cfg.Releases.Get(name, previousVersion)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	previousRelease, err := releaserToV1Release(previousReleasei)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -160,7 +174,7 @@ func (r *Rollback) prepareRollback(name string) (*release.Release, *release.Rele
 		Info: &release.Info{
 			FirstDeployed: currentRelease.Info.FirstDeployed,
 			LastDeployed:  time.Now(),
-			Status:        release.StatusPendingRollback,
+			Status:        common.StatusPendingRollback,
 			Notes:         previousRelease.Info.Notes,
 			// Because we lose the reference to previous version elsewhere, we set the
 			// message here, and only override it later if we experience failure.
@@ -217,8 +231,8 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	if err != nil {
 		msg := fmt.Sprintf("Rollback %q failed: %s", targetRelease.Name, err)
 		slog.Warn(msg)
-		currentRelease.Info.Status = release.StatusSuperseded
-		targetRelease.Info.Status = release.StatusFailed
+		currentRelease.Info.Status = common.StatusSuperseded
+		targetRelease.Info.Status = common.StatusFailed
 		targetRelease.Info.Description = msg
 		r.cfg.recordRelease(currentRelease)
 		r.cfg.recordRelease(targetRelease)
@@ -241,14 +255,14 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 	}
 	if r.WaitForJobs {
 		if err := waiter.WaitWithJobs(target, r.Timeout); err != nil {
-			targetRelease.SetStatus(release.StatusFailed, fmt.Sprintf("Release %q failed: %s", targetRelease.Name, err.Error()))
+			targetRelease.SetStatus(common.StatusFailed, fmt.Sprintf("Release %q failed: %s", targetRelease.Name, err.Error()))
 			r.cfg.recordRelease(currentRelease)
 			r.cfg.recordRelease(targetRelease)
 			return targetRelease, fmt.Errorf("release %s failed: %w", targetRelease.Name, err)
 		}
 	} else {
 		if err := waiter.Wait(target, r.Timeout); err != nil {
-			targetRelease.SetStatus(release.StatusFailed, fmt.Sprintf("Release %q failed: %s", targetRelease.Name, err.Error()))
+			targetRelease.SetStatus(common.StatusFailed, fmt.Sprintf("Release %q failed: %s", targetRelease.Name, err.Error()))
 			r.cfg.recordRelease(currentRelease)
 			r.cfg.recordRelease(targetRelease)
 			return targetRelease, fmt.Errorf("release %s failed: %w", targetRelease.Name, err)
@@ -267,13 +281,17 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		return nil, err
 	}
 	// Supersede all previous deployments, see issue #2941.
-	for _, rel := range deployed {
+	for _, reli := range deployed {
+		rel, err := releaserToV1Release(reli)
+		if err != nil {
+			return nil, err
+		}
 		slog.Debug("superseding previous deployment", "version", rel.Version)
-		rel.Info.Status = release.StatusSuperseded
+		rel.Info.Status = common.StatusSuperseded
 		r.cfg.recordRelease(rel)
 	}
 
-	targetRelease.Info.Status = release.StatusDeployed
+	targetRelease.Info.Status = common.StatusDeployed
 
 	return targetRelease, nil
 }

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	"helm.sh/helm/v4/pkg/kube"
-	release "helm.sh/helm/v4/pkg/release/v1"
+	ri "helm.sh/helm/v4/pkg/release"
 )
 
 // Status is the action for checking the deployment status of releases.
@@ -45,7 +45,7 @@ func NewStatus(cfg *Configuration) *Status {
 }
 
 // Run executes 'helm status' against the given release.
-func (s *Status) Run(name string) (*release.Release, error) {
+func (s *Status) Run(name string) (ri.Releaser, error) {
 	if err := s.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -50,7 +50,12 @@ func (s *Status) Run(name string) (*release.Release, error) {
 		return nil, err
 	}
 
-	rel, err := s.cfg.releaseContent(name, s.Version)
+	reli, err := s.cfg.releaseContent(name, s.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	rel, err := releaserToV1Release(reli)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -27,6 +27,7 @@ import (
 
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/kube"
+	releasei "helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
@@ -57,7 +58,7 @@ func NewUninstall(cfg *Configuration) *Uninstall {
 }
 
 // Run uninstalls the given release.
-func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) {
+func (u *Uninstall) Run(name string) (*releasei.UninstallReleaseResponse, error) {
 	if err := u.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}
@@ -74,13 +75,13 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 			if u.IgnoreNotFound && errors.Is(err, driver.ErrReleaseNotFound) {
 				return nil, nil
 			}
-			return &release.UninstallReleaseResponse{}, err
+			return &releasei.UninstallReleaseResponse{}, err
 		}
 		r, err := releaserToV1Release(ri)
 		if err != nil {
 			return nil, err
 		}
-		return &release.UninstallReleaseResponse{Release: r}, nil
+		return &releasei.UninstallReleaseResponse{Release: r}, nil
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
@@ -113,7 +114,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 			if err := u.purgeReleases(rels...); err != nil {
 				return nil, fmt.Errorf("uninstall: Failed to purge the release: %w", err)
 			}
-			return &release.UninstallReleaseResponse{Release: rel}, nil
+			return &releasei.UninstallReleaseResponse{Release: rel}, nil
 		}
 		return nil, fmt.Errorf("the release named %q is already deleted", name)
 	}
@@ -122,7 +123,7 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 	rel.Info.Status = common.StatusUninstalling
 	rel.Info.Deleted = time.Now()
 	rel.Info.Description = "Deletion in progress (or silently failed)"
-	res := &release.UninstallReleaseResponse{Release: rel}
+	res := &releasei.UninstallReleaseResponse{Release: rel}
 
 	if !u.DisableHooks {
 		serverSideApply := true

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -27,7 +27,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/kube"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
-	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 func uninstallAction(t *testing.T) *Uninstall {
@@ -119,7 +119,7 @@ func TestUninstallRelease_Wait(t *testing.T) {
 	res, err := unAction.Run(rel.Name)
 	is.Error(err)
 	is.Contains(err.Error(), "U timed out")
-	is.Equal(res.Release.Info.Status, release.StatusUninstalled)
+	is.Equal(res.Release.Info.Status, common.StatusUninstalled)
 }
 
 func TestUninstallRelease_Cascade(t *testing.T) {

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -116,10 +116,12 @@ func TestUninstallRelease_Wait(t *testing.T) {
 	failer := unAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
 	failer.WaitForDeleteError = fmt.Errorf("U timed out")
 	unAction.cfg.KubeClient = failer
-	res, err := unAction.Run(rel.Name)
+	resi, err := unAction.Run(rel.Name)
 	is.Error(err)
 	is.Contains(err.Error(), "U timed out")
-	is.Equal(res.Release.Info.Status, common.StatusUninstalled)
+	res, err := releaserToV1Release(resi.Release)
+	is.NoError(err)
+	is.Equal(res.Info.Status, common.StatusUninstalled)
 }
 
 func TestUninstallRelease_Cascade(t *testing.T) {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -36,6 +36,7 @@ import (
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/postrenderer"
 	"helm.sh/helm/v4/pkg/registry"
+	ri "helm.sh/helm/v4/pkg/release"
 	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
@@ -152,13 +153,13 @@ func (u *Upgrade) SetRegistryClient(client *registry.Client) {
 }
 
 // Run executes the upgrade on the given release.
-func (u *Upgrade) Run(name string, chart chart.Charter, vals map[string]interface{}) (*release.Release, error) {
+func (u *Upgrade) Run(name string, chart chart.Charter, vals map[string]interface{}) (ri.Releaser, error) {
 	ctx := context.Background()
 	return u.RunWithContext(ctx, name, chart, vals)
 }
 
 // RunWithContext executes the upgrade on the given release with context.
-func (u *Upgrade) RunWithContext(ctx context.Context, name string, ch chart.Charter, vals map[string]interface{}) (*release.Release, error) {
+func (u *Upgrade) RunWithContext(ctx context.Context, name string, ch chart.Charter, vals map[string]interface{}) (ri.Releaser, error) {
 	if err := u.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
 	}

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -47,10 +47,18 @@ func (r *v2DependencyAccessor) Name() string {
 	return r.dep.Name
 }
 
+func (r *v2DependencyAccessor) Alias() string {
+	return r.dep.Alias
+}
+
 type v3DependencyAccessor struct {
 	dep *v3chart.Dependency
 }
 
 func (r *v3DependencyAccessor) Name() string {
 	return r.dep.Name
+}
+
+func (r *v3DependencyAccessor) Alias() string {
+	return r.dep.Alias
 }

--- a/pkg/chart/interfaces.go
+++ b/pkg/chart/interfaces.go
@@ -40,4 +40,5 @@ type Accessor interface {
 
 type DependencyAccessor interface {
 	Name() string
+	Alias() string
 }

--- a/pkg/cmd/completion_test.go
+++ b/pkg/cmd/completion_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -31,7 +32,7 @@ func checkFileCompletion(t *testing.T, cmdName string, shouldBePerformed bool) {
 	storage := storageFixture()
 	storage.Create(&release.Release{
 		Name: "myrelease",
-		Info: &release.Info{Status: release.StatusDeployed},
+		Info: &release.Info{Status: common.StatusDeployed},
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{
 				Name:    "Myrelease-Chart",

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/action"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -64,35 +65,35 @@ func outputFlagCompletionTest(t *testing.T, cmdName string) {
 		cmd:    fmt.Sprintf("__complete %s --output ''", cmdName),
 		golden: "output/output-comp.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}, {
 		name:   "completion for output flag long and after arg",
 		cmd:    fmt.Sprintf("__complete %s aramis --output ''", cmdName),
 		golden: "output/output-comp.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}, {
 		name:   "completion for output flag short and before arg",
 		cmd:    fmt.Sprintf("__complete %s -o ''", cmdName),
 		golden: "output/output-comp.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}, {
 		name:   "completion for output flag short and after arg",
 		cmd:    fmt.Sprintf("__complete %s aramis -o ''", cmdName),
 		golden: "output/output-comp.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}, {
 		name:   "completion for output flag, no filter",
 		cmd:    fmt.Sprintf("__complete %s --output jso", cmdName),
 		golden: "output/output-comp.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}}
 	runTestCmd(t, tests)

--- a/pkg/cmd/get_hooks.go
+++ b/pkg/cmd/get_hooks.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cmd/require"
+	"helm.sh/helm/v4/pkg/release"
 )
 
 const getHooksHelp = `
@@ -52,8 +53,16 @@ func newGetHooksCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			for _, hook := range res.Hooks {
-				fmt.Fprintf(out, "---\n# Source: %s\n%s\n", hook.Path, hook.Manifest)
+			rac, err := release.NewAccessor(res)
+			if err != nil {
+				return err
+			}
+			for _, hook := range rac.Hooks() {
+				hac, err := release.NewHookAccessor(hook)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(out, "---\n# Source: %s\n%s\n", hac.Path(), hac.Manifest())
 			}
 			return nil
 		},

--- a/pkg/cmd/get_manifest.go
+++ b/pkg/cmd/get_manifest.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cmd/require"
+	"helm.sh/helm/v4/pkg/release"
 )
 
 var getManifestHelp = `
@@ -54,7 +55,11 @@ func newGetManifestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(out, res.Manifest)
+			rac, err := release.NewAccessor(res)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out, rac.Manifest())
 			return nil
 		},
 	}

--- a/pkg/cmd/get_notes.go
+++ b/pkg/cmd/get_notes.go
@@ -25,6 +25,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cmd/require"
+	"helm.sh/helm/v4/pkg/release"
 )
 
 var getNotesHelp = `
@@ -50,8 +51,12 @@ func newGetNotesCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(res.Info.Notes) > 0 {
-				fmt.Fprintf(out, "NOTES:\n%s\n", res.Info.Notes)
+			rac, err := release.NewAccessor(res)
+			if err != nil {
+				return err
+			}
+			if len(rac.Notes()) > 0 {
+				fmt.Fprintf(out, "NOTES:\n%s\n", rac.Notes())
 			}
 			return nil
 		},

--- a/pkg/cmd/history.go
+++ b/pkg/cmd/history.go
@@ -111,7 +111,11 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 }
 
 func getHistory(client *action.History, name string) (releaseHistory, error) {
-	hist, err := client.Run(name)
+	histi, err := client.Run(name)
+	if err != nil {
+		return nil, err
+	}
+	hist, err := releaseListToV1List(histi)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +184,11 @@ func compListRevisions(_ string, cfg *action.Configuration, releaseName string) 
 	client := action.NewHistory(cfg)
 
 	var revisions []string
-	if hist, err := client.Run(releaseName); err == nil {
+	if histi, err := client.Run(releaseName); err == nil {
+		hist, err := releaseListToV1List(histi)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
 		for _, version := range hist {
 			appVersion := fmt.Sprintf("App: %s", version.Chart.Metadata.AppVersion)
 			chartDesc := fmt.Sprintf("Chart: %s-%s", version.Chart.Metadata.Name, version.Chart.Metadata.Version)

--- a/pkg/cmd/history_test.go
+++ b/pkg/cmd/history_test.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
 func TestHistoryCmd(t *testing.T) {
-	mk := func(name string, vers int, status release.Status) *release.Release {
+	mk := func(name string, vers int, status common.Status) *release.Release {
 		return release.Mock(&release.MockReleaseOptions{
 			Name:    name,
 			Version: vers,
@@ -36,34 +37,34 @@ func TestHistoryCmd(t *testing.T) {
 		name: "get history for release",
 		cmd:  "history angry-bird",
 		rels: []*release.Release{
-			mk("angry-bird", 4, release.StatusDeployed),
-			mk("angry-bird", 3, release.StatusSuperseded),
-			mk("angry-bird", 2, release.StatusSuperseded),
-			mk("angry-bird", 1, release.StatusSuperseded),
+			mk("angry-bird", 4, common.StatusDeployed),
+			mk("angry-bird", 3, common.StatusSuperseded),
+			mk("angry-bird", 2, common.StatusSuperseded),
+			mk("angry-bird", 1, common.StatusSuperseded),
 		},
 		golden: "output/history.txt",
 	}, {
 		name: "get history with max limit set",
 		cmd:  "history angry-bird --max 2",
 		rels: []*release.Release{
-			mk("angry-bird", 4, release.StatusDeployed),
-			mk("angry-bird", 3, release.StatusSuperseded),
+			mk("angry-bird", 4, common.StatusDeployed),
+			mk("angry-bird", 3, common.StatusSuperseded),
 		},
 		golden: "output/history-limit.txt",
 	}, {
 		name: "get history with yaml output format",
 		cmd:  "history angry-bird --output yaml",
 		rels: []*release.Release{
-			mk("angry-bird", 4, release.StatusDeployed),
-			mk("angry-bird", 3, release.StatusSuperseded),
+			mk("angry-bird", 4, common.StatusDeployed),
+			mk("angry-bird", 3, common.StatusSuperseded),
 		},
 		golden: "output/history.yaml",
 	}, {
 		name: "get history with json output format",
 		cmd:  "history angry-bird --output json",
 		rels: []*release.Release{
-			mk("angry-bird", 4, release.StatusDeployed),
-			mk("angry-bird", 3, release.StatusSuperseded),
+			mk("angry-bird", 4, common.StatusDeployed),
+			mk("angry-bird", 3, common.StatusSuperseded),
 		},
 		golden: "output/history.json",
 	}}
@@ -76,7 +77,7 @@ func TestHistoryOutputCompletion(t *testing.T) {
 
 func revisionFlagCompletionTest(t *testing.T, cmdName string) {
 	t.Helper()
-	mk := func(name string, vers int, status release.Status) *release.Release {
+	mk := func(name string, vers int, status common.Status) *release.Release {
 		return release.Mock(&release.MockReleaseOptions{
 			Name:    name,
 			Version: vers,
@@ -85,10 +86,10 @@ func revisionFlagCompletionTest(t *testing.T, cmdName string) {
 	}
 
 	releases := []*release.Release{
-		mk("musketeers", 11, release.StatusDeployed),
-		mk("musketeers", 10, release.StatusSuperseded),
-		mk("musketeers", 9, release.StatusSuperseded),
-		mk("musketeers", 8, release.StatusSuperseded),
+		mk("musketeers", 11, common.StatusDeployed),
+		mk("musketeers", 10, common.StatusSuperseded),
+		mk("musketeers", 9, common.StatusSuperseded),
+		mk("musketeers", 8, common.StatusSuperseded),
 	}
 
 	tests := []cmdTestCase{{

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -323,7 +323,12 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		cancel()
 	}()
 
-	return client.RunWithContext(ctx, chartRequested, vals)
+	ri, err := client.RunWithContext(ctx, chartRequested, vals)
+	rel, rerr := releaserToV1Release(ri)
+	if rerr != nil {
+		return nil, rerr
+	}
+	return rel, err
 }
 
 // checkIfInstallable validates if a chart can be installed

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -47,7 +48,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusSuperseded,
+				Status:       common.StatusSuperseded,
 			},
 			Chart: chartInfo,
 		},
@@ -57,7 +58,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusDeployed,
+				Status:       common.StatusDeployed,
 			},
 			Chart: chartInfo,
 		},
@@ -67,7 +68,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusUninstalled,
+				Status:       common.StatusUninstalled,
 			},
 			Chart: chartInfo,
 		},
@@ -77,7 +78,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusSuperseded,
+				Status:       common.StatusSuperseded,
 			},
 			Chart: chartInfo,
 		},
@@ -87,7 +88,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp2,
-				Status:       release.StatusFailed,
+				Status:       common.StatusFailed,
 			},
 			Chart: chartInfo,
 		},
@@ -97,7 +98,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusUninstalling,
+				Status:       common.StatusUninstalling,
 			},
 			Chart: chartInfo,
 		},
@@ -107,7 +108,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusPendingInstall,
+				Status:       common.StatusPendingInstall,
 			},
 			Chart: chartInfo,
 		},
@@ -117,7 +118,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp3,
-				Status:       release.StatusDeployed,
+				Status:       common.StatusDeployed,
 			},
 			Chart: chartInfo,
 		},
@@ -127,7 +128,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: defaultNamespace,
 			Info: &release.Info{
 				LastDeployed: timestamp4,
-				Status:       release.StatusDeployed,
+				Status:       common.StatusDeployed,
 			},
 			Chart: chartInfo,
 		},
@@ -137,7 +138,7 @@ func TestListCmd(t *testing.T) {
 			Namespace: "milano",
 			Info: &release.Info{
 				LastDeployed: timestamp1,
-				Status:       release.StatusDeployed,
+				Status:       common.StatusDeployed,
 			},
 			Chart: chartInfo,
 		},

--- a/pkg/cmd/release_testing.go
+++ b/pkg/cmd/release_testing.go
@@ -65,12 +65,16 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 					client.Filters[action.ExcludeNameFilter] = append(client.Filters[action.ExcludeNameFilter], notName.ReplaceAllLiteralString(f, ""))
 				}
 			}
-			rel, runErr := client.Run(args[0])
+			reli, runErr := client.Run(args[0])
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs
 			// if requested
-			if runErr != nil && rel == nil {
+			if runErr != nil && reli == nil {
 				return runErr
+			}
+			rel, err := releaserToV1Release(reli)
+			if err != nil {
+				return err
 			}
 
 			if err := outfmt.Write(out, &statusPrinter{

--- a/pkg/cmd/release_testing_test.go
+++ b/pkg/cmd/release_testing_test.go
@@ -26,6 +26,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -46,7 +47,7 @@ func TestReleaseTestNotesHandling(t *testing.T) {
 		Name:      "test-release",
 		Namespace: "default",
 		Info: &release.Info{
-			Status: release.StatusDeployed,
+			Status: rcommon.StatusDeployed,
 			Notes:  "Some important notes that should be hidden by default",
 		},
 		Chart: &chart.Chart{Metadata: &chart.Metadata{Name: "test", Version: "1.0.0"}},

--- a/pkg/cmd/rollback_test.go
+++ b/pkg/cmd/rollback_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -29,13 +30,13 @@ func TestRollbackCmd(t *testing.T) {
 	rels := []*release.Release{
 		{
 			Name:    "funny-honey",
-			Info:    &release.Info{Status: release.StatusSuperseded},
+			Info:    &release.Info{Status: common.StatusSuperseded},
 			Chart:   &chart.Chart{},
 			Version: 1,
 		},
 		{
 			Name:    "funny-honey",
-			Info:    &release.Info{Status: release.StatusDeployed},
+			Info:    &release.Info{Status: common.StatusDeployed},
 			Chart:   &chart.Chart{},
 			Version: 2,
 		},
@@ -83,7 +84,7 @@ func TestRollbackCmd(t *testing.T) {
 }
 
 func TestRollbackRevisionCompletion(t *testing.T) {
-	mk := func(name string, vers int, status release.Status) *release.Release {
+	mk := func(name string, vers int, status common.Status) *release.Release {
 		return release.Mock(&release.MockReleaseOptions{
 			Name:    name,
 			Version: vers,
@@ -92,11 +93,11 @@ func TestRollbackRevisionCompletion(t *testing.T) {
 	}
 
 	releases := []*release.Release{
-		mk("musketeers", 11, release.StatusDeployed),
-		mk("musketeers", 10, release.StatusSuperseded),
-		mk("musketeers", 9, release.StatusSuperseded),
-		mk("musketeers", 8, release.StatusSuperseded),
-		mk("carabins", 1, release.StatusSuperseded),
+		mk("musketeers", 11, common.StatusDeployed),
+		mk("musketeers", 10, common.StatusSuperseded),
+		mk("musketeers", 9, common.StatusSuperseded),
+		mk("musketeers", 8, common.StatusSuperseded),
+		mk("carabins", 1, common.StatusSuperseded),
 	}
 
 	tests := []cmdTestCase{{
@@ -132,14 +133,14 @@ func TestRollbackWithLabels(t *testing.T) {
 	rels := []*release.Release{
 		{
 			Name:    releaseName,
-			Info:    &release.Info{Status: release.StatusSuperseded},
+			Info:    &release.Info{Status: common.StatusSuperseded},
 			Chart:   &chart.Chart{},
 			Version: 1,
 			Labels:  labels1,
 		},
 		{
 			Name:    releaseName,
-			Info:    &release.Info{Status: release.StatusDeployed},
+			Info:    &release.Info{Status: common.StatusDeployed},
 			Chart:   &chart.Chart{},
 			Version: 2,
 			Labels:  labels2,
@@ -155,7 +156,11 @@ func TestRollbackWithLabels(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
-	updatedRel, err := storage.Get(releaseName, 3)
+	updatedReli, err := storage.Get(releaseName, 3)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -39,6 +39,7 @@ import (
 	"helm.sh/helm/v4/pkg/cli"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
 	"helm.sh/helm/v4/pkg/registry"
+	ri "helm.sh/helm/v4/pkg/release"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/repo/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
@@ -464,4 +465,32 @@ func newRegistryClientWithTLS(
 type CommandError struct {
 	error
 	ExitCode int
+}
+
+// releaserToV1Release is a helper function to convert a v1 release passed by interface
+// into the type object.
+func releaserToV1Release(rel ri.Releaser) (*release.Release, error) {
+	switch r := rel.(type) {
+	case release.Release:
+		return &r, nil
+	case *release.Release:
+		return r, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported release type: %T", rel)
+	}
+}
+
+func releaseListToV1List(ls []ri.Releaser) ([]*release.Release, error) {
+	rls := make([]*release.Release, 0, len(ls))
+	for _, val := range ls {
+		rel, err := releaserToV1Release(val)
+		if err != nil {
+			return nil, err
+		}
+		rls = append(rls, rel)
+	}
+
+	return rls, nil
 }

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -73,7 +73,11 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if outfmt == output.Table {
 				client.ShowResourcesTable = true
 			}
-			rel, err := client.Run(args[0])
+			reli, err := client.Run(args[0])
+			if err != nil {
+				return err
+			}
+			rel, err := releaserToV1Release(reli)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -33,7 +33,8 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common/util"
 	"helm.sh/helm/v4/pkg/cli/output"
 	"helm.sh/helm/v4/pkg/cmd/require"
-	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release"
+	releasev1 "helm.sh/helm/v4/pkg/release/v1"
 )
 
 // NOTE: Keep the list of statuses up-to-date with pkg/release/status.go.
@@ -110,54 +111,66 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type statusPrinter struct {
-	release      *release.Release
+	release      release.Releaser
 	debug        bool
 	showMetadata bool
 	hideNotes    bool
 	noColor      bool
 }
 
+func (s statusPrinter) getV1Release() *releasev1.Release {
+	switch rel := s.release.(type) {
+	case releasev1.Release:
+		return &rel
+	case *releasev1.Release:
+		return rel
+	}
+	return &releasev1.Release{}
+}
+
 func (s statusPrinter) WriteJSON(out io.Writer) error {
-	return output.EncodeJSON(out, s.release)
+	return output.EncodeJSON(out, s.getV1Release())
 }
 
 func (s statusPrinter) WriteYAML(out io.Writer) error {
-	return output.EncodeYAML(out, s.release)
+	return output.EncodeYAML(out, s.getV1Release())
 }
 
 func (s statusPrinter) WriteTable(out io.Writer) error {
 	if s.release == nil {
 		return nil
 	}
-	_, _ = fmt.Fprintf(out, "NAME: %s\n", s.release.Name)
-	if !s.release.Info.LastDeployed.IsZero() {
-		_, _ = fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Format(time.ANSIC))
+	rel := s.getV1Release()
+	fmt.Printf("%+v", rel)
+	_, _ = fmt.Fprintf(out, "NAME: %s\n", rel.Name)
+	if !rel.Info.LastDeployed.IsZero() {
+		_, _ = fmt.Fprintf(out, "LAST DEPLOYED: %s\n", rel.Info.LastDeployed.Format(time.ANSIC))
 	}
-	_, _ = fmt.Fprintf(out, "NAMESPACE: %s\n", coloroutput.ColorizeNamespace(s.release.Namespace, s.noColor))
-	_, _ = fmt.Fprintf(out, "STATUS: %s\n", coloroutput.ColorizeStatus(s.release.Info.Status, s.noColor))
-	_, _ = fmt.Fprintf(out, "REVISION: %d\n", s.release.Version)
+	_, _ = fmt.Fprintf(out, "NAMESPACE: %s\n", coloroutput.ColorizeNamespace(rel.Namespace, s.noColor))
+	_, _ = fmt.Fprintf(out, "STATUS: %s\n", coloroutput.ColorizeStatus(rel.Info.Status, s.noColor))
+	_, _ = fmt.Fprintf(out, "REVISION: %d\n", rel.Version)
 	if s.showMetadata {
-		_, _ = fmt.Fprintf(out, "CHART: %s\n", s.release.Chart.Metadata.Name)
-		_, _ = fmt.Fprintf(out, "VERSION: %s\n", s.release.Chart.Metadata.Version)
-		_, _ = fmt.Fprintf(out, "APP_VERSION: %s\n", s.release.Chart.Metadata.AppVersion)
+		_, _ = fmt.Fprintf(out, "CHART: %s\n", rel.Chart.Metadata.Name)
+		_, _ = fmt.Fprintf(out, "VERSION: %s\n", rel.Chart.Metadata.Version)
+		_, _ = fmt.Fprintf(out, "APP_VERSION: %s\n", rel.Chart.Metadata.AppVersion)
 	}
-	_, _ = fmt.Fprintf(out, "DESCRIPTION: %s\n", s.release.Info.Description)
+	_, _ = fmt.Fprintf(out, "DESCRIPTION: %s\n", rel.Info.Description)
 
-	if len(s.release.Info.Resources) > 0 {
+	if len(rel.Info.Resources) > 0 {
 		buf := new(bytes.Buffer)
 		printFlags := get.NewHumanPrintFlags()
 		typePrinter, _ := printFlags.ToPrinter("")
 		printer := &get.TablePrinter{Delegate: typePrinter}
 
 		var keys []string
-		for key := range s.release.Info.Resources {
+		for key := range rel.Info.Resources {
 			keys = append(keys, key)
 		}
 
 		for _, t := range keys {
 			_, _ = fmt.Fprintf(buf, "==> %s\n", t)
 
-			vk := s.release.Info.Resources[t]
+			vk := rel.Info.Resources[t]
 			for _, resource := range vk {
 				if err := printer.PrintObj(resource, buf); err != nil {
 					_, _ = fmt.Fprintf(buf, "failed to print object type %s: %v\n", t, err)
@@ -170,8 +183,8 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		_, _ = fmt.Fprintf(out, "RESOURCES:\n%s\n", buf.String())
 	}
 
-	executions := executionsByHookEvent(s.release)
-	if tests, ok := executions[release.HookTest]; !ok || len(tests) == 0 {
+	executions := executionsByHookEvent(rel)
+	if tests, ok := executions[releasev1.HookTest]; !ok || len(tests) == 0 {
 		_, _ = fmt.Fprintln(out, "TEST SUITE: None")
 	} else {
 		for _, h := range tests {
@@ -190,14 +203,14 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 
 	if s.debug {
 		_, _ = fmt.Fprintln(out, "USER-SUPPLIED VALUES:")
-		err := output.EncodeYAML(out, s.release.Config)
+		err := output.EncodeYAML(out, rel.Config)
 		if err != nil {
 			return err
 		}
 		// Print an extra newline
 		_, _ = fmt.Fprintln(out)
 
-		cfg, err := util.CoalesceValues(s.release.Chart, s.release.Config)
+		cfg, err := util.CoalesceValues(rel.Chart, rel.Config)
 		if err != nil {
 			return err
 		}
@@ -211,28 +224,28 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		_, _ = fmt.Fprintln(out)
 	}
 
-	if strings.EqualFold(s.release.Info.Description, "Dry run complete") || s.debug {
+	if strings.EqualFold(rel.Info.Description, "Dry run complete") || s.debug {
 		_, _ = fmt.Fprintln(out, "HOOKS:")
-		for _, h := range s.release.Hooks {
+		for _, h := range rel.Hooks {
 			_, _ = fmt.Fprintf(out, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
 		}
-		_, _ = fmt.Fprintf(out, "MANIFEST:\n%s\n", s.release.Manifest)
+		_, _ = fmt.Fprintf(out, "MANIFEST:\n%s\n", rel.Manifest)
 	}
 
 	// Hide notes from output - option in install and upgrades
-	if !s.hideNotes && len(s.release.Info.Notes) > 0 {
-		_, _ = fmt.Fprintf(out, "NOTES:\n%s\n", strings.TrimSpace(s.release.Info.Notes))
+	if !s.hideNotes && len(rel.Info.Notes) > 0 {
+		_, _ = fmt.Fprintf(out, "NOTES:\n%s\n", strings.TrimSpace(rel.Info.Notes))
 	}
 	return nil
 }
 
-func executionsByHookEvent(rel *release.Release) map[release.HookEvent][]*release.Hook {
-	result := make(map[release.HookEvent][]*release.Hook)
+func executionsByHookEvent(rel *releasev1.Release) map[releasev1.HookEvent][]*releasev1.Hook {
+	result := make(map[releasev1.HookEvent][]*releasev1.Hook)
 	for _, h := range rel.Hooks {
 		for _, e := range h.Events {
 			executions, ok := result[e]
 			if !ok {
-				executions = []*release.Hook{}
+				executions = []*releasev1.Hook{}
 			}
 			result[e] = append(executions, h)
 		}

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -145,7 +145,6 @@ func (s statusPrinter) WriteTable(out io.Writer) error {
 		return nil
 	}
 	rel := s.getV1Release()
-	fmt.Printf("%+v", rel)
 	_, _ = fmt.Fprintf(out, "NAME: %s\n", rel.Name)
 	if !rel.Info.LastDeployed.IsZero() {
 		_, _ = fmt.Fprintf(out, "LAST DEPLOYED: %s\n", rel.Info.LastDeployed.Format(time.ANSIC))

--- a/pkg/cmd/status_test.go
+++ b/pkg/cmd/status_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -41,14 +42,14 @@ func TestStatusCmd(t *testing.T) {
 		cmd:    "status flummoxed-chickadee",
 		golden: "output/status.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 		}),
 	}, {
 		name:   "get status of a deployed release, with desc",
 		cmd:    "status flummoxed-chickadee",
 		golden: "output/status-with-desc.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status:      release.StatusDeployed,
+			Status:      common.StatusDeployed,
 			Description: "Mock description",
 		}),
 	}, {
@@ -56,7 +57,7 @@ func TestStatusCmd(t *testing.T) {
 		cmd:    "status flummoxed-chickadee",
 		golden: "output/status-with-notes.txt",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 			Notes:  "release notes",
 		}),
 	}, {
@@ -64,7 +65,7 @@ func TestStatusCmd(t *testing.T) {
 		cmd:    "status flummoxed-chickadee -o json",
 		golden: "output/status.json",
 		rels: releasesMockWithStatus(&release.Info{
-			Status: release.StatusDeployed,
+			Status: common.StatusDeployed,
 			Notes:  "release notes",
 		}),
 	}, {
@@ -73,7 +74,7 @@ func TestStatusCmd(t *testing.T) {
 		golden: "output/status-with-resources.txt",
 		rels: releasesMockWithStatus(
 			&release.Info{
-				Status: release.StatusDeployed,
+				Status: common.StatusDeployed,
 			},
 		),
 	}, {
@@ -82,7 +83,7 @@ func TestStatusCmd(t *testing.T) {
 		golden: "output/status-with-resources.json",
 		rels: releasesMockWithStatus(
 			&release.Info{
-				Status: release.StatusDeployed,
+				Status: common.StatusDeployed,
 			},
 		),
 	}, {
@@ -91,7 +92,7 @@ func TestStatusCmd(t *testing.T) {
 		golden: "output/status-with-test-suite.txt",
 		rels: releasesMockWithStatus(
 			&release.Info{
-				Status: release.StatusDeployed,
+				Status: common.StatusDeployed,
 			},
 			&release.Hook{
 				Name:   "never-run-test",
@@ -140,7 +141,7 @@ func TestStatusCompletion(t *testing.T) {
 			Name:      "athos",
 			Namespace: "default",
 			Info: &release.Info{
-				Status: release.StatusDeployed,
+				Status: common.StatusDeployed,
 			},
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{
@@ -152,7 +153,7 @@ func TestStatusCompletion(t *testing.T) {
 			Name:      "porthos",
 			Namespace: "default",
 			Info: &release.Info{
-				Status: release.StatusFailed,
+				Status: common.StatusFailed,
 			},
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{
@@ -164,7 +165,7 @@ func TestStatusCompletion(t *testing.T) {
 			Name:      "aramis",
 			Namespace: "default",
 			Info: &release.Info{
-				Status: release.StatusUninstalled,
+				Status: common.StatusUninstalled,
 			},
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{
@@ -176,7 +177,7 @@ func TestStatusCompletion(t *testing.T) {
 			Name:      "dartagnan",
 			Namespace: "gascony",
 			Info: &release.Info{
-				Status: release.StatusUnknown,
+				Status: common.StatusUnknown,
 			},
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -37,7 +37,8 @@ import (
 	"helm.sh/helm/v4/pkg/cmd/require"
 	"helm.sh/helm/v4/pkg/downloader"
 	"helm.sh/helm/v4/pkg/getter"
-	release "helm.sh/helm/v4/pkg/release/v1"
+	ri "helm.sh/helm/v4/pkg/release"
+	"helm.sh/helm/v4/pkg/release/common"
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
 
@@ -318,6 +319,11 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func isReleaseUninstalled(versions []*release.Release) bool {
-	return len(versions) > 0 && versions[len(versions)-1].Info.Status == release.StatusUninstalled
+func isReleaseUninstalled(versionsi []ri.Releaser) bool {
+	versions, err := releaseListToV1List(versionsi)
+	if err != nil {
+		slog.Error("cannot convert release list to v1 release list", "error", err)
+		return false
+	}
+	return len(versions) > 0 && versions[len(versions)-1].Info.Status == common.StatusUninstalled
 }

--- a/pkg/cmd/upgrade_test.go
+++ b/pkg/cmd/upgrade_test.go
@@ -28,6 +28,7 @@ import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -82,7 +83,7 @@ func TestUpgradeCmd(t *testing.T) {
 	badDepsPath := "testdata/testcharts/chart-bad-requirements"
 	presentDepsPath := "testdata/testcharts/chart-with-subchart-update"
 
-	relWithStatusMock := func(n string, v int, ch *chart.Chart, status release.Status) *release.Release {
+	relWithStatusMock := func(n string, v int, ch *chart.Chart, status rcommon.Status) *release.Release {
 		return release.Mock(&release.MockReleaseOptions{Name: n, Version: v, Chart: ch, Status: status})
 	}
 
@@ -173,20 +174,20 @@ func TestUpgradeCmd(t *testing.T) {
 			name:   "upgrade a failed release",
 			cmd:    fmt.Sprintf("upgrade funny-bunny '%s'", chartPath),
 			golden: "output/upgrade.txt",
-			rels:   []*release.Release{relWithStatusMock("funny-bunny", 2, ch, release.StatusFailed)},
+			rels:   []*release.Release{relWithStatusMock("funny-bunny", 2, ch, rcommon.StatusFailed)},
 		},
 		{
 			name:      "upgrade a pending install release",
 			cmd:       fmt.Sprintf("upgrade funny-bunny '%s'", chartPath),
 			golden:    "output/upgrade-with-pending-install.txt",
 			wantError: true,
-			rels:      []*release.Release{relWithStatusMock("funny-bunny", 2, ch, release.StatusPendingInstall)},
+			rels:      []*release.Release{relWithStatusMock("funny-bunny", 2, ch, rcommon.StatusPendingInstall)},
 		},
 		{
 			name:   "install a previously uninstalled release with '--keep-history' using 'upgrade --install'",
 			cmd:    fmt.Sprintf("upgrade funny-bunny -i '%s'", chartPath),
 			golden: "output/upgrade-uninstalled-with-keep-history.txt",
-			rels:   []*release.Release{relWithStatusMock("funny-bunny", 2, ch, release.StatusUninstalled)},
+			rels:   []*release.Release{relWithStatusMock("funny-bunny", 2, ch, rcommon.StatusUninstalled)},
 		},
 	}
 	runTestCmd(t, tests)
@@ -208,7 +209,11 @@ func TestUpgradeWithValue(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 4)
+	updatedReli, err := store.Get(releaseName, 4)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -235,7 +240,11 @@ func TestUpgradeWithStringValue(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 4)
+	updatedReli, err := store.Get(releaseName, 4)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -263,7 +272,11 @@ func TestUpgradeInstallWithSubchartNotes(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	upgradedRel, err := store.Get(releaseName, 2)
+	upgradedReli, err := store.Get(releaseName, 2)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	upgradedRel, err := releaserToV1Release(upgradedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -295,7 +308,11 @@ func TestUpgradeWithValuesFile(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 4)
+	updatedReli, err := store.Get(releaseName, 4)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -328,7 +345,11 @@ func TestUpgradeWithValuesFromStdin(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 4)
+	updatedReli, err := store.Get(releaseName, 4)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -358,7 +379,11 @@ func TestUpgradeInstallWithValuesFromStdin(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 1)
+	updatedReli, err := store.Get(releaseName, 1)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
@@ -463,7 +488,11 @@ func TestUpgradeInstallWithLabels(t *testing.T) {
 		t.Errorf("unexpected error, got '%v'", err)
 	}
 
-	updatedRel, err := store.Get(releaseName, 1)
+	updatedReli, err := store.Get(releaseName, 1)
+	if err != nil {
+		t.Errorf("unexpected error, got '%v'", err)
+	}
+	updatedRel, err := releaserToV1Release(updatedReli)
 	if err != nil {
 		t.Errorf("unexpected error, got '%v'", err)
 	}

--- a/pkg/release/common.go
+++ b/pkg/release/common.go
@@ -18,7 +18,10 @@ package release
 
 import (
 	"errors"
+	"fmt"
+	"time"
 
+	"helm.sh/helm/v4/pkg/chart"
 	v1release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -33,7 +36,7 @@ func NewDefaultAccessor(rel Releaser) (Accessor, error) {
 	case *v1release.Release:
 		return &v1Accessor{v}, nil
 	default:
-		return nil, errors.New("unsupported release type")
+		return nil, fmt.Errorf("unsupported release type: %T", rel)
 	}
 }
 
@@ -52,6 +55,18 @@ type v1Accessor struct {
 	rel *v1release.Release
 }
 
+func (a *v1Accessor) Name() string {
+	return a.rel.Name
+}
+
+func (a *v1Accessor) Namespace() string {
+	return a.rel.Namespace
+}
+
+func (a *v1Accessor) Version() int {
+	return a.rel.Version
+}
+
 func (a *v1Accessor) Hooks() []Hook {
 	var hooks = make([]Hook, len(a.rel.Hooks))
 	for i, h := range a.rel.Hooks {
@@ -66,6 +81,26 @@ func (a *v1Accessor) Manifest() string {
 
 func (a *v1Accessor) Notes() string {
 	return a.rel.Info.Notes
+}
+
+func (a *v1Accessor) Labels() map[string]string {
+	return a.rel.Labels
+}
+
+func (a *v1Accessor) Chart() chart.Charter {
+	return a.rel.Chart
+}
+
+func (a *v1Accessor) Status() string {
+	return a.rel.Info.Status.String()
+}
+
+func (a *v1Accessor) ApplyMethod() string {
+	return a.rel.ApplyMethod
+}
+
+func (a *v1Accessor) DeployedAt() time.Time {
+	return a.rel.Info.LastDeployed
 }
 
 type v1HookAccessor struct {

--- a/pkg/release/common.go
+++ b/pkg/release/common.go
@@ -25,11 +25,11 @@ import (
 	v1release "helm.sh/helm/v4/pkg/release/v1"
 )
 
-var NewAccessor func(rel Releaser) (Accessor, error) = NewDefaultAccessor //nolint:revive
+var NewAccessor func(rel Releaser) (Accessor, error) = newDefaultAccessor //nolint:revive
 
-var NewHookAccessor func(rel Hook) (HookAccessor, error) = NewDefaultHookAccessor //nolint:revive
+var NewHookAccessor func(rel Hook) (HookAccessor, error) = newDefaultHookAccessor //nolint:revive
 
-func NewDefaultAccessor(rel Releaser) (Accessor, error) {
+func newDefaultAccessor(rel Releaser) (Accessor, error) {
 	switch v := rel.(type) {
 	case v1release.Release:
 		return &v1Accessor{&v}, nil
@@ -40,7 +40,7 @@ func NewDefaultAccessor(rel Releaser) (Accessor, error) {
 	}
 }
 
-func NewDefaultHookAccessor(hook Hook) (HookAccessor, error) {
+func newDefaultHookAccessor(hook Hook) (HookAccessor, error) {
 	switch h := hook.(type) {
 	case v1release.Hook:
 		return &v1HookAccessor{&h}, nil

--- a/pkg/release/common.go
+++ b/pkg/release/common.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"errors"
+
+	v1release "helm.sh/helm/v4/pkg/release/v1"
+)
+
+var NewAccessor func(rel Releaser) (Accessor, error) = NewDefaultAccessor //nolint:revive
+
+var NewHookAccessor func(rel Hook) (HookAccessor, error) = NewDefaultHookAccessor //nolint:revive
+
+func NewDefaultAccessor(rel Releaser) (Accessor, error) {
+	switch v := rel.(type) {
+	case v1release.Release:
+		return &v1Accessor{&v}, nil
+	case *v1release.Release:
+		return &v1Accessor{v}, nil
+	default:
+		return nil, errors.New("unsupported release type")
+	}
+}
+
+func NewDefaultHookAccessor(hook Hook) (HookAccessor, error) {
+	switch h := hook.(type) {
+	case v1release.Hook:
+		return &v1HookAccessor{&h}, nil
+	case *v1release.Hook:
+		return &v1HookAccessor{h}, nil
+	default:
+		return nil, errors.New("unsupported release hook type")
+	}
+}
+
+type v1Accessor struct {
+	rel *v1release.Release
+}
+
+func (a *v1Accessor) Hooks() []Hook {
+	var hooks = make([]Hook, len(a.rel.Hooks))
+	for i, h := range a.rel.Hooks {
+		hooks[i] = h
+	}
+	return hooks
+}
+
+func (a *v1Accessor) Manifest() string {
+	return a.rel.Manifest
+}
+
+func (a *v1Accessor) Notes() string {
+	return a.rel.Info.Notes
+}
+
+type v1HookAccessor struct {
+	hook *v1release.Hook
+}
+
+func (a *v1HookAccessor) Path() string {
+	return a.hook.Path
+}
+
+func (a *v1HookAccessor) Manifest() string {
+	return a.hook.Manifest
+}

--- a/pkg/release/common/status.go
+++ b/pkg/release/common/status.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package common
 
 // Status is the status of a release
 type Status string

--- a/pkg/release/common_test.go
+++ b/pkg/release/common_test.go
@@ -44,7 +44,7 @@ func TestNewDefaultAccessor(t *testing.T) {
 		ApplyMethod: "csa",
 	}
 
-	// NewDefaultAccessor should not be called directly Instead, NewAccessor should be
+	// newDefaultAccessor should not be called directly Instead, NewAccessor should be
 	// called and it will call NewDefaultAccessor. NewAccessor can be changed to a
 	// non-default accessor by a user so the test calls the default implementation.
 	// The accessor provides a means to access data on resources that are different types
@@ -53,7 +53,7 @@ func TestNewDefaultAccessor(t *testing.T) {
 	// and unmarshalling data (e.g. coming and going from JSON or YAML). But, structs
 	// can't be used with interfaces. The accessors enable access to the underlying data
 	// in a manner that works with Go interfaces.
-	accessor, err := NewDefaultAccessor(rel)
+	accessor, err := newDefaultAccessor(rel)
 	is.NoError(err)
 
 	// Verify information

--- a/pkg/release/common_test.go
+++ b/pkg/release/common_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/v4/pkg/release/common"
+	rspb "helm.sh/helm/v4/pkg/release/v1"
+)
+
+func TestNewDefaultAccessor(t *testing.T) {
+	// Testing the default implementation rather than NewAccessor which can be
+	// overridden by developers.
+	is := assert.New(t)
+
+	// Create release
+	info := &rspb.Info{Status: common.StatusDeployed, LastDeployed: time.Now().Add(1000)}
+	labels := make(map[string]string)
+	labels["foo"] = "bar"
+	rel := &rspb.Release{
+		Name:        "happy-cats",
+		Version:     2,
+		Info:        info,
+		Labels:      labels,
+		Namespace:   "default",
+		ApplyMethod: "csa",
+	}
+
+	// NewDefaultAccessor should not be called directly Instead, NewAccessor should be
+	// called and it will call NewDefaultAccessor. NewAccessor can be changed to a
+	// non-default accessor by a user so the test calls the default implementation.
+	// The accessor provides a means to access data on resources that are different types
+	// but have the same interface. Instead of properties, methods are used to access
+	// information. Structs with properties are useful in Go when it comes to marshalling
+	// and unmarshalling data (e.g. coming and going from JSON or YAML). But, structs
+	// can't be used with interfaces. The accessors enable access to the underlying data
+	// in a manner that works with Go interfaces.
+	accessor, err := NewDefaultAccessor(rel)
+	is.NoError(err)
+
+	// Verify information
+	is.Equal(rel.Name, accessor.Name())
+	is.Equal(rel.Namespace, accessor.Namespace())
+	is.Equal(rel.Version, accessor.Version())
+	is.Equal(rel.ApplyMethod, accessor.ApplyMethod())
+	is.Equal(rel.Labels, accessor.Labels())
+}

--- a/pkg/release/interfaces.go
+++ b/pkg/release/interfaces.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+type Releaser interface{}
+
+type Hook interface{}
+
+type Accessor interface {
+	Hooks() []Hook
+	Manifest() string
+	Notes() string
+}
+
+type HookAccessor interface {
+	Path() string
+	Manifest() string
+}

--- a/pkg/release/interfaces.go
+++ b/pkg/release/interfaces.go
@@ -16,14 +16,28 @@ limitations under the License.
 
 package release
 
+import (
+	"time"
+
+	"helm.sh/helm/v4/pkg/chart"
+)
+
 type Releaser interface{}
 
 type Hook interface{}
 
 type Accessor interface {
+	Name() string
+	Namespace() string
+	Version() int
 	Hooks() []Hook
 	Manifest() string
 	Notes() string
+	Labels() map[string]string
+	Chart() chart.Charter
+	Status() string
+	ApplyMethod() string
+	DeployedAt() time.Time
 }
 
 type HookAccessor interface {

--- a/pkg/release/responses.go
+++ b/pkg/release/responses.go
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package release
 
 // UninstallReleaseResponse represents a successful response to an uninstall request.
 type UninstallReleaseResponse struct {
 	// Release is the release that was marked deleted.
-	Release *Release `json:"release,omitempty"`
+	Release Releaser `json:"release,omitempty"`
 	// Info is an uninstall message
 	Info string `json:"info,omitempty"`
 }

--- a/pkg/release/v1/info.go
+++ b/pkg/release/v1/info.go
@@ -18,6 +18,7 @@ package v1
 import (
 	"time"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -32,7 +33,7 @@ type Info struct {
 	// Description is human-friendly "log entry" about this release.
 	Description string `json:"description,omitempty"`
 	// Status is the current state of the release
-	Status Status `json:"status,omitempty"`
+	Status common.Status `json:"status,omitempty"`
 	// Contains the rendered templates/NOTES.txt if available
 	Notes string `json:"notes,omitempty"`
 	// Contains the deployed resources information

--- a/pkg/release/v1/info.go
+++ b/pkg/release/v1/info.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"helm.sh/helm/v4/pkg/release/common"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/release/v1/mock.go
+++ b/pkg/release/v1/mock.go
@@ -23,6 +23,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 )
 
 // MockHookTemplate is the hook template used for all mock release objects.
@@ -45,7 +46,7 @@ type MockReleaseOptions struct {
 	Name      string
 	Version   int
 	Chart     *chart.Chart
-	Status    Status
+	Status    rcommon.Status
 	Namespace string
 	Labels    map[string]string
 }
@@ -105,7 +106,7 @@ func Mock(opts *MockReleaseOptions) *Release {
 		}
 	}
 
-	scode := StatusDeployed
+	scode := rcommon.StatusDeployed
 	if len(opts.Status) > 0 {
 		scode = opts.Status
 	}

--- a/pkg/release/v1/release.go
+++ b/pkg/release/v1/release.go
@@ -17,6 +17,7 @@ package v1
 
 import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 type ApplyMethod string
@@ -53,7 +54,7 @@ type Release struct {
 }
 
 // SetStatus is a helper for setting the status on a release.
-func (r *Release) SetStatus(status Status, msg string) {
+func (r *Release) SetStatus(status common.Status, msg string) {
 	r.Info.Status = status
 	r.Info.Description = msg
 }

--- a/pkg/release/v1/util/filter.go
+++ b/pkg/release/v1/util/filter.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package util // import "helm.sh/helm/v4/pkg/release/v1/util"
 
-import rspb "helm.sh/helm/v4/pkg/release/v1"
+import (
+	"helm.sh/helm/v4/pkg/release/common"
+	rspb "helm.sh/helm/v4/pkg/release/v1"
+)
 
 // FilterFunc returns true if the release object satisfies
 // the predicate of the underlying filter func.
@@ -68,7 +71,7 @@ func All(filters ...FilterFunc) FilterFunc {
 }
 
 // StatusFilter filters a set of releases by status code.
-func StatusFilter(status rspb.Status) FilterFunc {
+func StatusFilter(status common.Status) FilterFunc {
 	return FilterFunc(func(rls *rspb.Release) bool {
 		if rls == nil {
 			return true

--- a/pkg/release/v1/util/filter_test.go
+++ b/pkg/release/v1/util/filter_test.go
@@ -19,20 +19,21 @@ package util // import "helm.sh/helm/v4/pkg/release/v1/util"
 import (
 	"testing"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 )
 
 func TestFilterAny(t *testing.T) {
-	ls := Any(StatusFilter(rspb.StatusUninstalled)).Filter(releases)
+	ls := Any(StatusFilter(common.StatusUninstalled)).Filter(releases)
 	if len(ls) != 2 {
 		t.Fatalf("expected 2 results, got '%d'", len(ls))
 	}
 
 	r0, r1 := ls[0], ls[1]
 	switch {
-	case r0.Info.Status != rspb.StatusUninstalled:
+	case r0.Info.Status != common.StatusUninstalled:
 		t.Fatalf("expected UNINSTALLED result, got '%s'", r1.Info.Status.String())
-	case r1.Info.Status != rspb.StatusUninstalled:
+	case r1.Info.Status != common.StatusUninstalled:
 		t.Fatalf("expected UNINSTALLED result, got '%s'", r1.Info.Status.String())
 	}
 }
@@ -40,7 +41,7 @@ func TestFilterAny(t *testing.T) {
 func TestFilterAll(t *testing.T) {
 	fn := FilterFunc(func(rls *rspb.Release) bool {
 		// true if not uninstalled and version < 4
-		v0 := !StatusFilter(rspb.StatusUninstalled).Check(rls)
+		v0 := !StatusFilter(common.StatusUninstalled).Check(rls)
 		v1 := rls.Version < 4
 		return v0 && v1
 	})
@@ -53,7 +54,7 @@ func TestFilterAll(t *testing.T) {
 	switch r0 := ls[0]; {
 	case r0.Version == 4:
 		t.Fatal("got release with status revision 4")
-	case r0.Info.Status == rspb.StatusUninstalled:
+	case r0.Info.Status == common.StatusUninstalled:
 		t.Fatal("got release with status UNINSTALLED")
 	}
 }

--- a/pkg/release/v1/util/sorter_test.go
+++ b/pkg/release/v1/util/sorter_test.go
@@ -20,19 +20,20 @@ import (
 	"testing"
 	"time"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 )
 
 // note: this test data is shared with filter_test.go.
 
 var releases = []*rspb.Release{
-	tsRelease("quiet-bear", 2, 2000, rspb.StatusSuperseded),
-	tsRelease("angry-bird", 4, 3000, rspb.StatusDeployed),
-	tsRelease("happy-cats", 1, 4000, rspb.StatusUninstalled),
-	tsRelease("vocal-dogs", 3, 6000, rspb.StatusUninstalled),
+	tsRelease("quiet-bear", 2, 2000, common.StatusSuperseded),
+	tsRelease("angry-bird", 4, 3000, common.StatusDeployed),
+	tsRelease("happy-cats", 1, 4000, common.StatusUninstalled),
+	tsRelease("vocal-dogs", 3, 6000, common.StatusUninstalled),
 }
 
-func tsRelease(name string, vers int, dur time.Duration, status rspb.Status) *rspb.Release {
+func tsRelease(name string, vers int, dur time.Duration, status common.Status) *rspb.Release {
 	info := &rspb.Info{Status: status, LastDeployed: time.Now().Add(dur)}
 	return &rspb.Release{
 		Name:    name,

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	rspb "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release"
 )
 
 var _ Driver = (*Memory)(nil)
@@ -61,7 +61,7 @@ func (mem *Memory) Name() string {
 }
 
 // Get returns the release named by key or returns ErrReleaseNotFound.
-func (mem *Memory) Get(key string) (*rspb.Release, error) {
+func (mem *Memory) Get(key string) (release.Releaser, error) {
 	defer unlock(mem.rlock())
 
 	keyWithoutPrefix := strings.TrimPrefix(key, "sh.helm.release.v1.")
@@ -83,10 +83,10 @@ func (mem *Memory) Get(key string) (*rspb.Release, error) {
 }
 
 // List returns the list of all releases such that filter(release) == true
-func (mem *Memory) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
+func (mem *Memory) List(filter func(release.Releaser) bool) ([]release.Releaser, error) {
 	defer unlock(mem.rlock())
 
-	var ls []*rspb.Release
+	var ls []release.Releaser
 	for namespace := range mem.cache {
 		if mem.namespace != "" {
 			// Should only list releases of this namespace
@@ -109,7 +109,7 @@ func (mem *Memory) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error
 }
 
 // Query returns the set of releases that match the provided set of labels
-func (mem *Memory) Query(keyvals map[string]string) ([]*rspb.Release, error) {
+func (mem *Memory) Query(keyvals map[string]string) ([]release.Releaser, error) {
 	defer unlock(mem.rlock())
 
 	var lbs labels
@@ -117,7 +117,7 @@ func (mem *Memory) Query(keyvals map[string]string) ([]*rspb.Release, error) {
 	lbs.init()
 	lbs.fromMap(keyvals)
 
-	var ls []*rspb.Release
+	var ls []release.Releaser
 	for namespace := range mem.cache {
 		if mem.namespace != "" {
 			// Should only query releases of this namespace
@@ -150,9 +150,13 @@ func (mem *Memory) Query(keyvals map[string]string) ([]*rspb.Release, error) {
 }
 
 // Create creates a new release or returns ErrReleaseExists.
-func (mem *Memory) Create(key string, rls *rspb.Release) error {
+func (mem *Memory) Create(key string, rel release.Releaser) error {
 	defer unlock(mem.wlock())
 
+	rls, err := releaserToV1Release(rel)
+	if err != nil {
+		return err
+	}
 	// For backwards compatibility, we protect against an unset namespace
 	namespace := rls.Namespace
 	if namespace == "" {
@@ -176,8 +180,13 @@ func (mem *Memory) Create(key string, rls *rspb.Release) error {
 }
 
 // Update updates a release or returns ErrReleaseNotFound.
-func (mem *Memory) Update(key string, rls *rspb.Release) error {
+func (mem *Memory) Update(key string, rel release.Releaser) error {
 	defer unlock(mem.wlock())
+
+	rls, err := releaserToV1Release(rel)
+	if err != nil {
+		return err
+	}
 
 	// For backwards compatibility, we protect against an unset namespace
 	namespace := rls.Namespace
@@ -196,7 +205,7 @@ func (mem *Memory) Update(key string, rls *rspb.Release) error {
 }
 
 // Delete deletes a release or returns ErrReleaseNotFound.
-func (mem *Memory) Delete(key string) (*rspb.Release, error) {
+func (mem *Memory) Delete(key string) (release.Releaser, error) {
 	defer unlock(mem.wlock())
 
 	keyWithoutPrefix := strings.TrimPrefix(key, "sh.helm.release.v1.")

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -21,6 +21,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v4/pkg/release"
+	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -38,22 +41,22 @@ func TestMemoryCreate(t *testing.T) {
 	}{
 		{
 			"create should succeed",
-			releaseStub("rls-c", 1, "default", rspb.StatusDeployed),
+			releaseStub("rls-c", 1, "default", common.StatusDeployed),
 			false,
 		},
 		{
 			"create should fail (release already exists)",
-			releaseStub("rls-a", 1, "default", rspb.StatusDeployed),
+			releaseStub("rls-a", 1, "default", common.StatusDeployed),
 			true,
 		},
 		{
 			"create in namespace should succeed",
-			releaseStub("rls-a", 1, "mynamespace", rspb.StatusDeployed),
+			releaseStub("rls-a", 1, "mynamespace", common.StatusDeployed),
 			false,
 		},
 		{
 			"create in other namespace should fail (release already exists)",
-			releaseStub("rls-c", 1, "mynamespace", rspb.StatusDeployed),
+			releaseStub("rls-c", 1, "mynamespace", common.StatusDeployed),
 			true,
 		},
 	}
@@ -104,8 +107,9 @@ func TestMemoryList(t *testing.T) {
 	ts.SetNamespace("default")
 
 	// list all deployed releases
-	dpl, err := ts.List(func(rel *rspb.Release) bool {
-		return rel.Info.Status == rspb.StatusDeployed
+	dpl, err := ts.List(func(rel release.Releaser) bool {
+		rls := convertReleaserToV1(t, rel)
+		return rls.Info.Status == common.StatusDeployed
 	})
 	// check
 	if err != nil {
@@ -116,8 +120,9 @@ func TestMemoryList(t *testing.T) {
 	}
 
 	// list all superseded releases
-	ssd, err := ts.List(func(rel *rspb.Release) bool {
-		return rel.Info.Status == rspb.StatusSuperseded
+	ssd, err := ts.List(func(rel release.Releaser) bool {
+		rls := convertReleaserToV1(t, rel)
+		return rls.Info.Status == common.StatusSuperseded
 	})
 	// check
 	if err != nil {
@@ -128,8 +133,9 @@ func TestMemoryList(t *testing.T) {
 	}
 
 	// list all deleted releases
-	del, err := ts.List(func(rel *rspb.Release) bool {
-		return rel.Info.Status == rspb.StatusUninstalled
+	del, err := ts.List(func(rel release.Releaser) bool {
+		rls := convertReleaserToV1(t, rel)
+		return rls.Info.Status == common.StatusUninstalled
 	})
 	// check
 	if err != nil {
@@ -185,25 +191,25 @@ func TestMemoryUpdate(t *testing.T) {
 		{
 			"update release status",
 			"rls-a.v4",
-			releaseStub("rls-a", 4, "default", rspb.StatusSuperseded),
+			releaseStub("rls-a", 4, "default", common.StatusSuperseded),
 			false,
 		},
 		{
 			"update release does not exist",
 			"rls-c.v1",
-			releaseStub("rls-c", 1, "default", rspb.StatusUninstalled),
+			releaseStub("rls-c", 1, "default", common.StatusUninstalled),
 			true,
 		},
 		{
 			"update release status in namespace",
 			"rls-c.v4",
-			releaseStub("rls-c", 4, "mynamespace", rspb.StatusSuperseded),
+			releaseStub("rls-c", 4, "mynamespace", common.StatusSuperseded),
 			false,
 		},
 		{
 			"update release in namespace does not exist",
 			"rls-a.v1",
-			releaseStub("rls-a", 1, "mynamespace", rspb.StatusUninstalled),
+			releaseStub("rls-a", 1, "mynamespace", common.StatusUninstalled),
 			true,
 		},
 	}
@@ -255,17 +261,23 @@ func TestMemoryDelete(t *testing.T) {
 	startLen := len(start)
 	for _, tt := range tests {
 		ts.SetNamespace(tt.namespace)
-		if rel, err := ts.Delete(tt.key); err != nil {
+
+		rel, err := ts.Delete(tt.key)
+		var rls *rspb.Release
+		if err == nil {
+			rls = convertReleaserToV1(t, rel)
+		}
+		if err != nil {
 			if !tt.err {
 				t.Fatalf("Failed %q to get '%s': %q\n", tt.desc, tt.key, err)
 			}
 			continue
 		} else if tt.err {
 			t.Fatalf("Did not get expected error for %q '%s'\n", tt.desc, tt.key)
-		} else if fmt.Sprintf("%s.v%d", rel.Name, rel.Version) != tt.key {
-			t.Fatalf("Asked for delete on %s, but deleted %d", tt.key, rel.Version)
+		} else if fmt.Sprintf("%s.v%d", rls.Name, rls.Version) != tt.key {
+			t.Fatalf("Asked for delete on %s, but deleted %d", tt.key, rls.Version)
 		}
-		_, err := ts.Get(tt.key)
+		_, err = ts.Get(tt.key)
 		if err == nil {
 			t.Errorf("Expected an error when asking for a deleted key")
 		}
@@ -282,7 +294,9 @@ func TestMemoryDelete(t *testing.T) {
 	if startLen-2 != endLen {
 		t.Errorf("expected end to be %d instead of %d", startLen-2, endLen)
 		for _, ee := range end {
-			t.Logf("Name: %s, Version: %d", ee.Name, ee.Version)
+			rac, err := release.NewAccessor(ee)
+			assert.NoError(t, err, "unable to get release accessor")
+			t.Logf("Name: %s, Version: %d", rac.Name(), rac.Version())
 		}
 	}
 

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -31,10 +31,11 @@ import (
 	kblabels "k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 )
 
-func releaseStub(name string, vers int, namespace string, status rspb.Status) *rspb.Release {
+func releaseStub(name string, vers int, namespace string, status common.Status) *rspb.Release {
 	return &rspb.Release{
 		Name:      name,
 		Version:   vers,
@@ -55,20 +56,20 @@ func tsFixtureMemory(t *testing.T) *Memory {
 	t.Helper()
 	hs := []*rspb.Release{
 		// rls-a
-		releaseStub("rls-a", 4, "default", rspb.StatusDeployed),
-		releaseStub("rls-a", 1, "default", rspb.StatusSuperseded),
-		releaseStub("rls-a", 3, "default", rspb.StatusSuperseded),
-		releaseStub("rls-a", 2, "default", rspb.StatusSuperseded),
+		releaseStub("rls-a", 4, "default", common.StatusDeployed),
+		releaseStub("rls-a", 1, "default", common.StatusSuperseded),
+		releaseStub("rls-a", 3, "default", common.StatusSuperseded),
+		releaseStub("rls-a", 2, "default", common.StatusSuperseded),
 		// rls-b
-		releaseStub("rls-b", 4, "default", rspb.StatusDeployed),
-		releaseStub("rls-b", 1, "default", rspb.StatusSuperseded),
-		releaseStub("rls-b", 3, "default", rspb.StatusSuperseded),
-		releaseStub("rls-b", 2, "default", rspb.StatusSuperseded),
+		releaseStub("rls-b", 4, "default", common.StatusDeployed),
+		releaseStub("rls-b", 1, "default", common.StatusSuperseded),
+		releaseStub("rls-b", 3, "default", common.StatusSuperseded),
+		releaseStub("rls-b", 2, "default", common.StatusSuperseded),
 		// rls-c in other namespace
-		releaseStub("rls-c", 4, "mynamespace", rspb.StatusDeployed),
-		releaseStub("rls-c", 1, "mynamespace", rspb.StatusSuperseded),
-		releaseStub("rls-c", 3, "mynamespace", rspb.StatusSuperseded),
-		releaseStub("rls-c", 2, "mynamespace", rspb.StatusSuperseded),
+		releaseStub("rls-c", 4, "mynamespace", common.StatusDeployed),
+		releaseStub("rls-c", 1, "mynamespace", common.StatusSuperseded),
+		releaseStub("rls-c", 3, "mynamespace", common.StatusSuperseded),
+		releaseStub("rls-c", 2, "mynamespace", common.StatusSuperseded),
 	}
 
 	mem := NewMemory()

--- a/pkg/storage/driver/records_test.go
+++ b/pkg/storage/driver/records_test.go
@@ -20,13 +20,13 @@ import (
 	"reflect"
 	"testing"
 
-	rspb "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 func TestRecordsAdd(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	var tests = []struct {
@@ -39,13 +39,13 @@ func TestRecordsAdd(t *testing.T) {
 			"add valid key",
 			"rls-a.v3",
 			false,
-			newRecord("rls-a.v3", releaseStub("rls-a", 3, "default", rspb.StatusSuperseded)),
+			newRecord("rls-a.v3", releaseStub("rls-a", 3, "default", common.StatusSuperseded)),
 		},
 		{
 			"add already existing key",
 			"rls-a.v1",
 			true,
-			newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusDeployed)),
+			newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusDeployed)),
 		},
 	}
 
@@ -70,8 +70,8 @@ func TestRecordsRemove(t *testing.T) {
 	}
 
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	startLen := rs.Len()
@@ -98,8 +98,8 @@ func TestRecordsRemove(t *testing.T) {
 
 func TestRecordsRemoveAt(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	if len(rs) != 2 {
@@ -114,8 +114,8 @@ func TestRecordsRemoveAt(t *testing.T) {
 
 func TestRecordsGet(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	var tests = []struct {
@@ -126,7 +126,7 @@ func TestRecordsGet(t *testing.T) {
 		{
 			"get valid key",
 			"rls-a.v1",
-			newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
+			newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
 		},
 		{
 			"get invalid key",
@@ -145,8 +145,8 @@ func TestRecordsGet(t *testing.T) {
 
 func TestRecordsIndex(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	var tests = []struct {
@@ -176,8 +176,8 @@ func TestRecordsIndex(t *testing.T) {
 
 func TestRecordsExists(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	var tests = []struct {
@@ -207,8 +207,8 @@ func TestRecordsExists(t *testing.T) {
 
 func TestRecordsReplace(t *testing.T) {
 	rs := records([]*record{
-		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", rspb.StatusSuperseded)),
-		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+		newRecord("rls-a.v1", releaseStub("rls-a", 1, "default", common.StatusSuperseded)),
+		newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 	})
 
 	var tests = []struct {
@@ -220,13 +220,13 @@ func TestRecordsReplace(t *testing.T) {
 		{
 			"replace with existing key",
 			"rls-a.v2",
-			newRecord("rls-a.v3", releaseStub("rls-a", 3, "default", rspb.StatusSuperseded)),
-			newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", rspb.StatusDeployed)),
+			newRecord("rls-a.v3", releaseStub("rls-a", 3, "default", common.StatusSuperseded)),
+			newRecord("rls-a.v2", releaseStub("rls-a", 2, "default", common.StatusDeployed)),
 		},
 		{
 			"replace with non existing key",
 			"rls-a.v4",
-			newRecord("rls-a.v4", releaseStub("rls-a", 4, "default", rspb.StatusDeployed)),
+			newRecord("rls-a.v4", releaseStub("rls-a", 4, "default", common.StatusDeployed)),
 			nil,
 		},
 	}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -22,6 +22,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v4/pkg/release"
+	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
@@ -56,13 +59,13 @@ func TestStorageUpdate(t *testing.T) {
 	rls := ReleaseTestData{
 		Name:    "angry-beaver",
 		Version: 1,
-		Status:  rspb.StatusDeployed,
+		Status:  common.StatusDeployed,
 	}.ToRelease()
 
 	assertErrNil(t.Fatal, storage.Create(rls), "StoreRelease")
 
 	// modify the release
-	rls.Info.Status = rspb.StatusUninstalled
+	rls.Info.Status = common.StatusUninstalled
 	assertErrNil(t.Fatal, storage.Update(rls), "UpdateRelease")
 
 	// retrieve the updated release
@@ -106,13 +109,16 @@ func TestStorageDelete(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 
+	rhist, err := releaseListToV1List(hist)
+	assert.NoError(t, err)
+
 	// We have now deleted one of the two records.
-	if len(hist) != 1 {
+	if len(rhist) != 1 {
 		t.Errorf("expected 1 record for deleted release version, got %d", len(hist))
 	}
 
-	if hist[0].Version != 2 {
-		t.Errorf("Expected version to be 2, got %d", hist[0].Version)
+	if rhist[0].Version != 2 {
+		t.Errorf("Expected version to be 2, got %d", rhist[0].Version)
 	}
 }
 
@@ -123,13 +129,13 @@ func TestStorageList(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: "happy-catdog", Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: "livid-human", Status: rspb.StatusSuperseded}.ToRelease()
-		rls2 := ReleaseTestData{Name: "relaxed-cat", Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: "hungry-hippo", Status: rspb.StatusDeployed}.ToRelease()
-		rls4 := ReleaseTestData{Name: "angry-beaver", Status: rspb.StatusDeployed}.ToRelease()
-		rls5 := ReleaseTestData{Name: "opulent-frog", Status: rspb.StatusUninstalled}.ToRelease()
-		rls6 := ReleaseTestData{Name: "happy-liger", Status: rspb.StatusUninstalled}.ToRelease()
+		rls0 := ReleaseTestData{Name: "happy-catdog", Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: "livid-human", Status: common.StatusSuperseded}.ToRelease()
+		rls2 := ReleaseTestData{Name: "relaxed-cat", Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: "hungry-hippo", Status: common.StatusDeployed}.ToRelease()
+		rls4 := ReleaseTestData{Name: "angry-beaver", Status: common.StatusDeployed}.ToRelease()
+		rls5 := ReleaseTestData{Name: "opulent-frog", Status: common.StatusUninstalled}.ToRelease()
+		rls6 := ReleaseTestData{Name: "happy-liger", Status: common.StatusUninstalled}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'rls0'")
@@ -144,7 +150,7 @@ func TestStorageList(t *testing.T) {
 	var listTests = []struct {
 		Description string
 		NumExpected int
-		ListFunc    func() ([]*rspb.Release, error)
+		ListFunc    func() ([]release.Releaser, error)
 	}{
 		{"ListDeployed", 2, storage.ListDeployed},
 		{"ListReleases", 7, storage.ListReleases},
@@ -175,10 +181,10 @@ func TestStorageDeployed(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusSuperseded}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusDeployed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusSuperseded}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusDeployed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -194,15 +200,18 @@ func TestStorageDeployed(t *testing.T) {
 		t.Fatalf("Failed to query for deployed release: %s\n", err)
 	}
 
+	rel, err := releaserToV1Release(rls)
+	assert.NoError(t, err)
+
 	switch {
 	case rls == nil:
 		t.Fatalf("Release is nil")
-	case rls.Name != name:
-		t.Fatalf("Expected release name %q, actual %q\n", name, rls.Name)
-	case rls.Version != vers:
-		t.Fatalf("Expected release version %d, actual %d\n", vers, rls.Version)
-	case rls.Info.Status != rspb.StatusDeployed:
-		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rls.Info.Status.String())
+	case rel.Name != name:
+		t.Fatalf("Expected release name %q, actual %q\n", name, rel.Name)
+	case rel.Version != vers:
+		t.Fatalf("Expected release version %d, actual %d\n", vers, rel.Version)
+	case rel.Info.Status != common.StatusDeployed:
+		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rel.Info.Status.String())
 	}
 }
 
@@ -215,10 +224,10 @@ func TestStorageDeployedWithCorruption(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records (notice odd order and corruption)
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusDeployed}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusDeployed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusDeployed}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusDeployed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -234,15 +243,18 @@ func TestStorageDeployedWithCorruption(t *testing.T) {
 		t.Fatalf("Failed to query for deployed release: %s\n", err)
 	}
 
+	rel, err := releaserToV1Release(rls)
+	assert.NoError(t, err)
+
 	switch {
 	case rls == nil:
 		t.Fatalf("Release is nil")
-	case rls.Name != name:
-		t.Fatalf("Expected release name %q, actual %q\n", name, rls.Name)
-	case rls.Version != vers:
-		t.Fatalf("Expected release version %d, actual %d\n", vers, rls.Version)
-	case rls.Info.Status != rspb.StatusDeployed:
-		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rls.Info.Status.String())
+	case rel.Name != name:
+		t.Fatalf("Expected release name %q, actual %q\n", name, rel.Name)
+	case rel.Version != vers:
+		t.Fatalf("Expected release version %d, actual %d\n", vers, rel.Version)
+	case rel.Info.Status != common.StatusDeployed:
+		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rel.Info.Status.String())
 	}
 }
 
@@ -254,10 +266,10 @@ func TestStorageHistory(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusSuperseded}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusDeployed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusSuperseded}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusDeployed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -286,22 +298,22 @@ type MaxHistoryMockDriver struct {
 func NewMaxHistoryMockDriver(d driver.Driver) *MaxHistoryMockDriver {
 	return &MaxHistoryMockDriver{Driver: d}
 }
-func (d *MaxHistoryMockDriver) Create(key string, rls *rspb.Release) error {
+func (d *MaxHistoryMockDriver) Create(key string, rls release.Releaser) error {
 	return d.Driver.Create(key, rls)
 }
-func (d *MaxHistoryMockDriver) Update(key string, rls *rspb.Release) error {
+func (d *MaxHistoryMockDriver) Update(key string, rls release.Releaser) error {
 	return d.Driver.Update(key, rls)
 }
-func (d *MaxHistoryMockDriver) Delete(_ string) (*rspb.Release, error) {
+func (d *MaxHistoryMockDriver) Delete(_ string) (release.Releaser, error) {
 	return nil, errMaxHistoryMockDriverSomethingHappened
 }
-func (d *MaxHistoryMockDriver) Get(key string) (*rspb.Release, error) {
+func (d *MaxHistoryMockDriver) Get(key string) (release.Releaser, error) {
 	return d.Driver.Get(key)
 }
-func (d *MaxHistoryMockDriver) List(filter func(*rspb.Release) bool) ([]*rspb.Release, error) {
+func (d *MaxHistoryMockDriver) List(filter func(release.Releaser) bool) ([]release.Releaser, error) {
 	return d.Driver.List(filter)
 }
-func (d *MaxHistoryMockDriver) Query(labels map[string]string) ([]*rspb.Release, error) {
+func (d *MaxHistoryMockDriver) Query(labels map[string]string) ([]release.Releaser, error) {
 	return d.Driver.Query(labels)
 }
 func (d *MaxHistoryMockDriver) Name() string {
@@ -319,14 +331,14 @@ func TestMaxHistoryErrorHandling(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls1 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Driver.Create(makeKey(rls1.Name, rls1.Version), rls1), "Storing release 'angry-bird' (v1)")
 	}
 	setup()
 
-	rls2 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusSuperseded}.ToRelease()
+	rls2 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusSuperseded}.ToRelease()
 	wantErr := errMaxHistoryMockDriverSomethingHappened
 	gotErr := storage.Create(rls2)
 	if !errors.Is(gotErr, wantErr) {
@@ -345,10 +357,10 @@ func TestStorageRemoveLeastRecent(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusSuperseded}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusDeployed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusSuperseded}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusDeployed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -367,22 +379,24 @@ func TestStorageRemoveLeastRecent(t *testing.T) {
 	}
 
 	storage.MaxHistory = 3
-	rls5 := ReleaseTestData{Name: name, Version: 5, Status: rspb.StatusDeployed}.ToRelease()
+	rls5 := ReleaseTestData{Name: name, Version: 5, Status: common.StatusDeployed}.ToRelease()
 	assertErrNil(t.Fatal, storage.Create(rls5), "Storing release 'angry-bird' (v5)")
 
 	// On inserting the 5th record, we expect two records to be pruned from history.
 	hist, err := storage.History(name)
+	rhist, err := releaseListToV1List(hist)
+	assert.NoError(t, err)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(hist) != storage.MaxHistory {
-		for _, item := range hist {
+	} else if len(rhist) != storage.MaxHistory {
+		for _, item := range rhist {
 			t.Logf("%s %v", item.Name, item.Version)
 		}
-		t.Fatalf("expected %d items in history, got %d", storage.MaxHistory, len(hist))
+		t.Fatalf("expected %d items in history, got %d", storage.MaxHistory, len(rhist))
 	}
 
 	// We expect the existing records to be 3, 4, and 5.
-	for i, item := range hist {
+	for i, item := range rhist {
 		v := item.Version
 		if expect := i + 3; v != expect {
 			t.Errorf("Expected release %d, got %d", expect, v)
@@ -399,10 +413,10 @@ func TestStorageDoNotDeleteDeployed(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusDeployed}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusFailed}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusFailed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusDeployed}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusFailed}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusFailed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -412,7 +426,7 @@ func TestStorageDoNotDeleteDeployed(t *testing.T) {
 	}
 	setup()
 
-	rls5 := ReleaseTestData{Name: name, Version: 5, Status: rspb.StatusFailed}.ToRelease()
+	rls5 := ReleaseTestData{Name: name, Version: 5, Status: common.StatusFailed}.ToRelease()
 	assertErrNil(t.Fatal, storage.Create(rls5), "Storing release 'angry-bird' (v5)")
 
 	// On inserting the 5th record, we expect a total of 3 releases, but we expect version 2
@@ -421,10 +435,12 @@ func TestStorageDoNotDeleteDeployed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hist) != storage.MaxHistory {
-		for _, item := range hist {
+		rhist, err := releaseListToV1List(hist)
+		assert.NoError(t, err)
+		for _, item := range rhist {
 			t.Logf("%s %v", item.Name, item.Version)
 		}
-		t.Fatalf("expected %d items in history, got %d", storage.MaxHistory, len(hist))
+		t.Fatalf("expected %d items in history, got %d", storage.MaxHistory, len(rhist))
 	}
 
 	expectedVersions := map[int]bool{
@@ -433,7 +449,9 @@ func TestStorageDoNotDeleteDeployed(t *testing.T) {
 		5: true,
 	}
 
-	for _, item := range hist {
+	rhist, err := releaseListToV1List(hist)
+	assert.NoError(t, err)
+	for _, item := range rhist {
 		if !expectedVersions[item.Version] {
 			t.Errorf("Release version %d, found when not expected", item.Version)
 		}
@@ -448,10 +466,10 @@ func TestStorageLast(t *testing.T) {
 	// Set up storage with test releases.
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusSuperseded}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusSuperseded}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusSuperseded}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusFailed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusSuperseded}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusSuperseded}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusSuperseded}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusFailed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -467,8 +485,11 @@ func TestStorageLast(t *testing.T) {
 		t.Fatalf("Failed to query for release history (%q): %s\n", name, err)
 	}
 
-	if h.Version != 4 {
-		t.Errorf("Expected revision 4, got %d", h.Version)
+	rel, err := releaserToV1Release(h)
+	assert.NoError(t, err)
+
+	if rel.Version != 4 {
+		t.Errorf("Expected revision 4, got %d", rel.Version)
 	}
 }
 
@@ -483,10 +504,10 @@ func TestUpgradeInitiallyFailedReleaseWithHistoryLimit(t *testing.T) {
 	// setup storage with test releases
 	setup := func() {
 		// release records
-		rls0 := ReleaseTestData{Name: name, Version: 1, Status: rspb.StatusFailed}.ToRelease()
-		rls1 := ReleaseTestData{Name: name, Version: 2, Status: rspb.StatusFailed}.ToRelease()
-		rls2 := ReleaseTestData{Name: name, Version: 3, Status: rspb.StatusFailed}.ToRelease()
-		rls3 := ReleaseTestData{Name: name, Version: 4, Status: rspb.StatusFailed}.ToRelease()
+		rls0 := ReleaseTestData{Name: name, Version: 1, Status: common.StatusFailed}.ToRelease()
+		rls1 := ReleaseTestData{Name: name, Version: 2, Status: common.StatusFailed}.ToRelease()
+		rls2 := ReleaseTestData{Name: name, Version: 3, Status: common.StatusFailed}.ToRelease()
+		rls3 := ReleaseTestData{Name: name, Version: 4, Status: common.StatusFailed}.ToRelease()
 
 		// create the release records in the storage
 		assertErrNil(t.Fatal, storage.Create(rls0), "Storing release 'angry-bird' (v1)")
@@ -507,7 +528,7 @@ func TestUpgradeInitiallyFailedReleaseWithHistoryLimit(t *testing.T) {
 
 	setup()
 
-	rls5 := ReleaseTestData{Name: name, Version: 5, Status: rspb.StatusFailed}.ToRelease()
+	rls5 := ReleaseTestData{Name: name, Version: 5, Status: common.StatusFailed}.ToRelease()
 	err := storage.Create(rls5)
 	if err != nil {
 		t.Fatalf("Failed to create a new release version: %s", err)
@@ -518,13 +539,15 @@ func TestUpgradeInitiallyFailedReleaseWithHistoryLimit(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	for i, rel := range hist {
+	rhist, err := releaseListToV1List(hist)
+	assert.NoError(t, err)
+	for i, rel := range rhist {
 		wantVersion := i + 2
 		if rel.Version != wantVersion {
 			t.Fatalf("Expected history release %d version to equal %d, got %d", i+1, wantVersion, rel.Version)
 		}
 
-		wantStatus := rspb.StatusFailed
+		wantStatus := common.StatusFailed
 		if rel.Info.Status != wantStatus {
 			t.Fatalf("Expected history release %d status to equal %q, got %q", i+1, wantStatus, rel.Info.Status)
 		}
@@ -536,7 +559,7 @@ type ReleaseTestData struct {
 	Version   int
 	Manifest  string
 	Namespace string
-	Status    rspb.Status
+	Status    common.Status
 }
 
 func (test ReleaseTestData) ToRelease() *rspb.Release {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
@@ -384,6 +385,7 @@ func TestStorageRemoveLeastRecent(t *testing.T) {
 
 	// On inserting the 5th record, we expect two records to be pruned from history.
 	hist, err := storage.History(name)
+	assert.NoError(t, err)
 	rhist, err := releaseListToV1List(hist)
 	assert.NoError(t, err)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: Releases are tightly coupled to v1 charts. This change enables new versions of releases that can have different chart api versions. A new release version is not yet included. This change changes the API to enable that.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
