### PR TITLE
fix: clean up coverage script temp file

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 covermode=${COVERMODE:-atomic}
 coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
+trap 'rm -rf "${coverdir}"' EXIT
 profile="${coverdir}/cover.out"
 html=false
 target="./..." # by default the whole repository is tested
@@ -47,7 +48,7 @@ generate_cover_data() {
 generate_cover_data
 go tool cover -func "${profile}"
 
-if [ "${html}" == "true" ] ; then
+if [ "${html}" = "true" ] ; then
     go tool cover -html "${profile}"
 fi
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Remove the temp file on exit and use posix `=` over `==`

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
