### PR TITLE
Avoid accessing .Items on nil object

### DIFF
--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -455,5 +455,8 @@ func getPods(ctx context.Context, client kubernetes.Interface, namespace, select
 	list, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
-	return list.Items, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+	return list.Items, nil
 }


### PR DESCRIPTION
When listing fails for whatever reason, the return value is nil, err. so handle err explicitly.

