### PR TITLE
deepcopy original before upgradeClientSideFieldManager

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -736,7 +736,10 @@ func (c *Client) Update(originals, targets ResourceList, options ...ClientUpdate
 					slog.String("gvk", target.Mapping.GroupVersionKind.String()))
 
 				if updateOptions.upgradeClientSideFieldManager {
-					patched, err := upgradeClientSideFieldManager(original, updateOptions.dryRun, updateOptions.fieldValidationDirective)
+					// target and original shares same Object, deep copy original to avoid changing target
+					copiedOriginal := *original
+					copiedOriginal.Object = original.Object.DeepCopyObject()
+					patched, err := upgradeClientSideFieldManager(&copiedOriginal, updateOptions.dryRun, updateOptions.fieldValidationDirective)
 					if err != nil {
 						slog.Debug("Error patching resource to replace CSA field management", slog.Any("error", err))
 						return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: 

This PR made a deep copy of original before upgradeClientSideFieldManager, and use the deep copy to call upgradeClientSideFieldManager

why we need it?

original and target share the same object, this is done by requireAdoption

While upgradeClientSideFieldManager will call Get() on original, which will refresh original with live info from cluster, and the consequence is, target is refreshed as well, as it shares the same object with original

So next when applying target to cluster, the patch data will have the info loaded from cluster, such as managedfields (if SSA is already used in install), status, etc., and can cause unexpected consequences, such as patch rejection due to non-nil managedfields as "metadata.managedFields must be nil."

From k8s source code:

```
// Apply implements Manager.
func (f *structuredMergeManager) Apply(liveObj, patchObj runtime.Object, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
        // Check that the patch object has the same version as the live object
        if patchVersion := patchObj.GetObjectKind().GroupVersionKind().GroupVersion(); patchVersion != f.groupVersion {
                return nil, nil,
                        errors.NewBadRequest(
                                fmt.Sprintf("Incorrect version specified in apply patch. "+
                                        "Specified patch version: %s, expected: %s",
                                        patchVersion, f.groupVersion))
        }

        patchObjMeta, err := meta.Accessor(patchObj)
        if err != nil {
                return nil, nil, fmt.Errorf("couldn't get accessor: %v", err)
        }
        if patchObjMeta.GetManagedFields() != nil {
                return nil, nil, errors.NewBadRequest("metadata.managedFields must be nil")
        }

```
**Special notes for your reviewer**:
This is only applicable for helm4 where SSA is enabled, no impact to helm3 as helm3 does not have SSA

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
