### PR TITLE
test: protect unknown hook delete policies

### DIFF
--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -408,3 +408,35 @@ data:
 		})
 	}
 }
+
+func TestConfiguration_hookSetDeletePolicy(t *testing.T) {
+	tests := map[string]struct {
+		policies []release.HookDeletePolicy
+		expected []release.HookDeletePolicy
+	}{
+		"no polices specified result in the default policy": {
+			policies: nil,
+			expected: []release.HookDeletePolicy{
+				release.HookBeforeHookCreation,
+			},
+		},
+		"unknown policy is untouched": {
+			policies: []release.HookDeletePolicy{
+				release.HookDeletePolicy("never"),
+			},
+			expected: []release.HookDeletePolicy{
+				release.HookDeletePolicy("never"),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := &Configuration{}
+			h := &release.Hook{
+				DeletePolicies: tt.policies,
+			}
+			cfg.hookSetDeletePolicy(h)
+			assert.Equal(t, tt.expected, h.DeletePolicies)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Make sure the current behaviour w.r.t. unrecognized hook deletion policies is not changed by accident.

No changes to production code.


**Special notes for your reviewer**:

The behaviour for charts API v3 might be different, this test just enforces that behaviour of v2 does not change unintentionally.

Refs:
- https://github.com/helm/community/pull/403
- https://github.com/helm/helm/issues/13627

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
