### PR TITLE
fix: improve pkg/cmd/list test coverage

### DIFF
--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -245,3 +245,373 @@ func TestListOutputCompletion(t *testing.T) {
 func TestListFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "list", false)
 }
+
+func TestListOutputFormats(t *testing.T) {
+	defaultNamespace := "default"
+	timestamp := time.Unix(1452902400, 0).UTC()
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "1.0.0",
+			AppVersion: "0.0.1",
+		},
+	}
+
+	releaseFixture := []*release.Release{
+		{
+			Name:      "test-release",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp,
+				Status:       common.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+	}
+
+	tests := []cmdTestCase{{
+		name:   "list releases in json format",
+		cmd:    "list --output json",
+		golden: "output/list-json.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list releases in yaml format",
+		cmd:    "list --output yaml",
+		golden: "output/list-yaml.txt",
+		rels:   releaseFixture,
+	}}
+	runTestCmd(t, tests)
+}
+
+func TestReleaseListWriter(t *testing.T) {
+	timestamp := time.Unix(1452902400, 0).UTC()
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "1.0.0",
+			AppVersion: "0.0.1",
+		},
+	}
+
+	releases := []*release.Release{
+		{
+			Name:      "test-release",
+			Version:   1,
+			Namespace: "default",
+			Info: &release.Info{
+				LastDeployed: timestamp,
+				Status:       common.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		releases   []*release.Release
+		timeFormat string
+		noHeaders  bool
+		noColor    bool
+	}{
+		{
+			name:       "empty releases list",
+			releases:   []*release.Release{},
+			timeFormat: "",
+			noHeaders:  false,
+			noColor:    false,
+		},
+		{
+			name:       "custom time format",
+			releases:   releases,
+			timeFormat: "2006-01-02",
+			noHeaders:  false,
+			noColor:    false,
+		},
+		{
+			name:       "no headers",
+			releases:   releases,
+			timeFormat: "",
+			noHeaders:  true,
+			noColor:    false,
+		},
+		{
+			name:       "no color",
+			releases:   releases,
+			timeFormat: "",
+			noHeaders:  false,
+			noColor:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := newReleaseListWriter(tt.releases, tt.timeFormat, tt.noHeaders, tt.noColor)
+
+			if writer == nil {
+				t.Error("Expected writer to be non-nil")
+			} else {
+				if len(writer.releases) != len(tt.releases) {
+					t.Errorf("Expected %d releases, got %d", len(tt.releases), len(writer.releases))
+				}
+			}
+		})
+	}
+}
+
+func TestReleaseListWriterMethods(t *testing.T) {
+	timestamp := time.Unix(1452902400, 0).UTC()
+	zeroTimestamp := time.Time{}
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "1.0.0",
+			AppVersion: "0.0.1",
+		},
+	}
+
+	releases := []*release.Release{
+		{
+			Name:      "test-release",
+			Version:   1,
+			Namespace: "default",
+			Info: &release.Info{
+				LastDeployed: timestamp,
+				Status:       common.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+		{
+			Name:      "zero-time-release",
+			Version:   1,
+			Namespace: "default",
+			Info: &release.Info{
+				LastDeployed: zeroTimestamp,
+				Status:       common.StatusFailed,
+			},
+			Chart: chartInfo,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		status common.Status
+	}{
+		{"deployed", common.StatusDeployed},
+		{"failed", common.StatusFailed},
+		{"pending-install", common.StatusPendingInstall},
+		{"pending-upgrade", common.StatusPendingUpgrade},
+		{"pending-rollback", common.StatusPendingRollback},
+		{"uninstalling", common.StatusUninstalling},
+		{"uninstalled", common.StatusUninstalled},
+		{"superseded", common.StatusSuperseded},
+		{"unknown", common.StatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testReleases := []*release.Release{
+				{
+					Name:      "test-release",
+					Version:   1,
+					Namespace: "default",
+					Info: &release.Info{
+						LastDeployed: timestamp,
+						Status:       tt.status,
+					},
+					Chart: chartInfo,
+				},
+			}
+
+			writer := newReleaseListWriter(testReleases, "", false, false)
+
+			var buf []byte
+			out := &bytesWriter{buf: &buf}
+
+			err := writer.WriteJSON(out)
+			if err != nil {
+				t.Errorf("WriteJSON failed: %v", err)
+			}
+
+			err = writer.WriteYAML(out)
+			if err != nil {
+				t.Errorf("WriteYAML failed: %v", err)
+			}
+
+			err = writer.WriteTable(out)
+			if err != nil {
+				t.Errorf("WriteTable failed: %v", err)
+			}
+		})
+	}
+
+	writer := newReleaseListWriter(releases, "", false, false)
+
+	var buf []byte
+	out := &bytesWriter{buf: &buf}
+
+	err := writer.WriteJSON(out)
+	if err != nil {
+		t.Errorf("WriteJSON failed: %v", err)
+	}
+
+	err = writer.WriteYAML(out)
+	if err != nil {
+		t.Errorf("WriteYAML failed: %v", err)
+	}
+
+	err = writer.WriteTable(out)
+	if err != nil {
+		t.Errorf("WriteTable failed: %v", err)
+	}
+}
+
+func TestFilterReleases(t *testing.T) {
+	releases := []*release.Release{
+		{Name: "release1"},
+		{Name: "release2"},
+		{Name: "release3"},
+	}
+
+	tests := []struct {
+		name                string
+		releases            []*release.Release
+		ignoredReleaseNames []string
+		expectedCount       int
+	}{
+		{
+			name:                "nil ignored list",
+			releases:            releases,
+			ignoredReleaseNames: nil,
+			expectedCount:       3,
+		},
+		{
+			name:                "empty ignored list",
+			releases:            releases,
+			ignoredReleaseNames: []string{},
+			expectedCount:       3,
+		},
+		{
+			name:                "filter one release",
+			releases:            releases,
+			ignoredReleaseNames: []string{"release1"},
+			expectedCount:       2,
+		},
+		{
+			name:                "filter multiple releases",
+			releases:            releases,
+			ignoredReleaseNames: []string{"release1", "release3"},
+			expectedCount:       1,
+		},
+		{
+			name:                "filter non-existent release",
+			releases:            releases,
+			ignoredReleaseNames: []string{"non-existent"},
+			expectedCount:       3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterReleases(tt.releases, tt.ignoredReleaseNames)
+			if len(result) != tt.expectedCount {
+				t.Errorf("Expected %d releases, got %d", tt.expectedCount, len(result))
+			}
+		})
+	}
+}
+
+type bytesWriter struct {
+	buf *[]byte
+}
+
+func (b *bytesWriter) Write(p []byte) (n int, err error) {
+	*b.buf = append(*b.buf, p...)
+	return len(p), nil
+}
+
+func TestListCustomTimeFormat(t *testing.T) {
+	defaultNamespace := "default"
+	timestamp := time.Unix(1452902400, 0).UTC()
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "1.0.0",
+			AppVersion: "0.0.1",
+		},
+	}
+
+	releaseFixture := []*release.Release{
+		{
+			Name:      "test-release",
+			Version:   1,
+			Namespace: defaultNamespace,
+			Info: &release.Info{
+				LastDeployed: timestamp,
+				Status:       common.StatusDeployed,
+			},
+			Chart: chartInfo,
+		},
+	}
+
+	tests := []cmdTestCase{{
+		name:   "list releases with custom time format",
+		cmd:    "list --time-format '2006-01-02 15:04:05'",
+		golden: "output/list-time-format.txt",
+		rels:   releaseFixture,
+	}}
+	runTestCmd(t, tests)
+}
+
+func TestListStatusMapping(t *testing.T) {
+	defaultNamespace := "default"
+	timestamp := time.Unix(1452902400, 0).UTC()
+	chartInfo := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "1.0.0",
+			AppVersion: "0.0.1",
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		status common.Status
+	}{
+		{"deployed", common.StatusDeployed},
+		{"failed", common.StatusFailed},
+		{"pending-install", common.StatusPendingInstall},
+		{"pending-upgrade", common.StatusPendingUpgrade},
+		{"pending-rollback", common.StatusPendingRollback},
+		{"uninstalling", common.StatusUninstalling},
+		{"uninstalled", common.StatusUninstalled},
+		{"superseded", common.StatusSuperseded},
+		{"unknown", common.StatusUnknown},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			releaseFixture := []*release.Release{
+				{
+					Name:      "test-release",
+					Version:   1,
+					Namespace: defaultNamespace,
+					Info: &release.Info{
+						LastDeployed: timestamp,
+						Status:       tc.status,
+					},
+					Chart: chartInfo,
+				},
+			}
+
+			writer := newReleaseListWriter(releaseFixture, "", false, false)
+			if len(writer.releases) != 1 {
+				t.Errorf("Expected 1 release, got %d", len(writer.releases))
+			}
+
+			if writer.releases[0].Status != tc.status.String() {
+				t.Errorf("Expected status %s, got %s", tc.status.String(), writer.releases[0].Status)
+			}
+		})
+	}
+}

--- a/pkg/cmd/testdata/output/list-json.txt
+++ b/pkg/cmd/testdata/output/list-json.txt
@@ -1,0 +1,1 @@
+[{"name":"test-release","namespace":"default","revision":"1","updated":"2016-01-16 00:00:00 +0000 UTC","status":"deployed","chart":"test-chart-1.0.0","app_version":"0.0.1"}]

--- a/pkg/cmd/testdata/output/list-time-format.txt
+++ b/pkg/cmd/testdata/output/list-time-format.txt
@@ -1,0 +1,2 @@
+NAME        	NAMESPACE	REVISION	UPDATED            	STATUS  	CHART           	APP VERSION
+test-release	default  	1       	2016-01-16 00:00:00	deployed	test-chart-1.0.0	0.0.1      

--- a/pkg/cmd/testdata/output/list-yaml.txt
+++ b/pkg/cmd/testdata/output/list-yaml.txt
@@ -1,0 +1,7 @@
+- app_version: 0.0.1
+  chart: test-chart-1.0.0
+  name: test-release
+  namespace: default
+  revision: "1"
+  status: deployed
+  updated: 2016-01-16 00:00:00 +0000 UTC


### PR DESCRIPTION

**What this PR does / why we need it**:

Improve pkg/cmd/list test coverage

Before:
```
helm.sh/helm/v4/pkg/cmd/list.go:65:								newListCmd					91.3%
helm.sh/helm/v4/pkg/cmd/list.go:158:								newReleaseListWriter				90.9%
helm.sh/helm/v4/pkg/cmd/list.go:186:								WriteTable					77.8%
helm.sh/helm/v4/pkg/cmd/list.go:229:								WriteJSON					0.0%
helm.sh/helm/v4/pkg/cmd/list.go:233:								WriteYAML					0.0%
helm.sh/helm/v4/pkg/cmd/list.go:238:								filterReleases					87.5%
helm.sh/helm/v4/pkg/cmd/list.go:256:								compListReleases				87.5%
```

After
```
helm.sh/helm/v4/pkg/cmd/list.go:65:								newListCmd					91.3%
helm.sh/helm/v4/pkg/cmd/list.go:158:								newReleaseListWriter				100.0%
helm.sh/helm/v4/pkg/cmd/list.go:186:								WriteTable					94.4%
helm.sh/helm/v4/pkg/cmd/list.go:229:								WriteJSON					100.0%
helm.sh/helm/v4/pkg/cmd/list.go:233:								WriteYAML					100.0%
helm.sh/helm/v4/pkg/cmd/list.go:238:								filterReleases					100.0%
helm.sh/helm/v4/pkg/cmd/list.go:256:								compListReleases				87.5%
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
