### PR TITLE
chore: rename test registry

### DIFF
--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -27,16 +27,16 @@ import (
 )
 
 type HTTPRegistryClientTestSuite struct {
-	TestSuite
+	TestRegistry
 }
 
 func (suite *HTTPRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	setup(&suite.TestSuite, false, false)
+	setup(&suite.TestRegistry, false, false)
 }
 
 func (suite *HTTPRegistryClientTestSuite) TearDownSuite() {
-	teardown(&suite.TestSuite)
+	teardown(&suite.TestRegistry)
 	os.RemoveAll(suite.WorkspaceDir)
 }
 
@@ -53,15 +53,15 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
-	testPush(&suite.TestSuite)
+	testPush(&suite.TestRegistry)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_2_Pull() {
-	testPull(&suite.TestSuite)
+	testPull(&suite.TestRegistry)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
-	testTags(&suite.TestSuite)
+	testTags(&suite.TestRegistry)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {

--- a/pkg/registry/client_insecure_tls_test.go
+++ b/pkg/registry/client_insecure_tls_test.go
@@ -24,16 +24,16 @@ import (
 )
 
 type InsecureTLSRegistryClientTestSuite struct {
-	TestSuite
+	TestRegistry
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	setup(&suite.TestSuite, true, true)
+	setup(&suite.TestRegistry, true, true)
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) TearDownSuite() {
-	teardown(&suite.TestSuite)
+	teardown(&suite.TestRegistry)
 	os.RemoveAll(suite.WorkspaceDir)
 }
 
@@ -50,15 +50,15 @@ func (suite *InsecureTLSRegistryClientTestSuite) Test_0_Login() {
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) Test_1_Push() {
-	testPush(&suite.TestSuite)
+	testPush(&suite.TestRegistry)
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) Test_2_Pull() {
-	testPull(&suite.TestSuite)
+	testPull(&suite.TestRegistry)
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) Test_3_Tags() {
-	testTags(&suite.TestSuite)
+	testTags(&suite.TestRegistry)
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) Test_4_Logout() {

--- a/pkg/registry/client_tls_test.go
+++ b/pkg/registry/client_tls_test.go
@@ -26,16 +26,16 @@ import (
 )
 
 type TLSRegistryClientTestSuite struct {
-	TestSuite
+	TestRegistry
 }
 
 func (suite *TLSRegistryClientTestSuite) SetupSuite() {
 	// init test client
-	setup(&suite.TestSuite, true, false)
+	setup(&suite.TestRegistry, true, false)
 }
 
 func (suite *TLSRegistryClientTestSuite) TearDownSuite() {
-	teardown(&suite.TestSuite)
+	teardown(&suite.TestRegistry)
 	os.RemoveAll(suite.WorkspaceDir)
 }
 
@@ -76,15 +76,15 @@ func (suite *TLSRegistryClientTestSuite) Test_1_Login() {
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_1_Push() {
-	testPush(&suite.TestSuite)
+	testPush(&suite.TestRegistry)
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_2_Pull() {
-	testPull(&suite.TestSuite)
+	testPull(&suite.TestRegistry)
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_3_Tags() {
-	testTags(&suite.TestSuite)
+	testTags(&suite.TestRegistry)
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_4_Logout() {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -56,7 +56,7 @@ var (
 	testPassword             = "mypass"
 )
 
-type TestSuite struct {
+type TestRegistry struct {
 	suite.Suite
 	Out                     io.Writer
 	DockerRegistryHost      string
@@ -66,7 +66,7 @@ type TestSuite struct {
 	dockerRegistry          *registry.Registry
 }
 
-func setup(suite *TestSuite, tlsEnabled, insecure bool) {
+func setup(suite *TestRegistry, tlsEnabled, insecure bool) {
 	suite.WorkspaceDir = testWorkspaceDir
 	os.RemoveAll(suite.WorkspaceDir)
 	os.Mkdir(suite.WorkspaceDir, 0700)
@@ -164,7 +164,7 @@ func setup(suite *TestSuite, tlsEnabled, insecure bool) {
 	}()
 }
 
-func teardown(suite *TestSuite) {
+func teardown(suite *TestRegistry) {
 	if suite.dockerRegistry != nil {
 		_ = suite.dockerRegistry.Shutdown(context.Background())
 	}
@@ -208,7 +208,7 @@ func initCompromisedRegistryTestServer() string {
 	return fmt.Sprintf("localhost:%s", u.Port())
 }
 
-func testPush(suite *TestSuite) {
+func testPush(suite *TestRegistry) {
 
 	testingChartCreationTime := "1977-09-02T22:04:05Z"
 
@@ -295,7 +295,7 @@ func testPush(suite *TestSuite) {
 		result.Prov.Digest)
 }
 
-func testPull(suite *TestSuite) {
+func testPull(suite *TestRegistry) {
 	// bad/missing ref
 	ref := fmt.Sprintf("%s/testrepo/no-existy:1.2.3", suite.DockerRegistryHost)
 	_, err := suite.RegistryClient.Pull(ref)
@@ -374,7 +374,7 @@ func testPull(suite *TestSuite) {
 	suite.Equal(provData, result.Prov.Data)
 }
 
-func testTags(suite *TestSuite) {
+func testTags(suite *TestRegistry) {
 	// Load test chart (to build ref pushed in previous test)
 	chartData, err := os.ReadFile("../downloader/testdata/local-subchart-0.1.0.tgz")
 	suite.Nil(err, "no error loading test chart")


### PR DESCRIPTION

**What this PR does / why we need it**:

Rename TestSuite to TestRegistry because it is a test registry.

Rename the file from utils_test.go to registry_test.go 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
