### PR TITLE
Refactor optimize oci registry calls

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -30,8 +30,10 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -667,33 +669,53 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 		}
 	}
 
-	ctx := context.Background()
-
-	memoryStore := memory.New()
-	chartDescriptor, err := oras.PushBytes(ctx, memoryStore, ChartLayerMediaType, data)
+	repository, err := remote.NewRepository(parsedRef.String())
 	if err != nil {
 		return nil, err
+	}
+	repository.PlainHTTP = c.plainHTTP
+	repository.Client = c.authorizer
+
+	ctx := context.Background()
+	ctx = auth.AppendRepositoryScope(ctx, repository.Reference, auth.ActionPull, auth.ActionPush)
+
+	chartBlob := newBlob(repository, ChartLayerMediaType, data)
+	exists, err := chartBlob.exists(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	layers := []ocispec.Descriptor{chartBlob.descriptor}
+	var wg sync.WaitGroup
+	if !exists {
+		wg.Go(func() { chartBlob.push(ctx) })
 	}
 
 	configData, err := json.Marshal(meta)
 	if err != nil {
 		return nil, err
 	}
+	configBlob := newBlob(repository, ConfigMediaType, configData)
+	wg.Go(func() { configBlob.pushNew(ctx) })
 
-	configDescriptor, err := oras.PushBytes(ctx, memoryStore, ConfigMediaType, configData)
-	if err != nil {
-		return nil, err
-	}
-
-	layers := []ocispec.Descriptor{chartDescriptor}
-	var provDescriptor ocispec.Descriptor
+	var provBlob blob
 	if operation.provData != nil {
-		provDescriptor, err = oras.PushBytes(ctx, memoryStore, ProvLayerMediaType, operation.provData)
-		if err != nil {
-			return nil, err
-		}
+		provBlob = newBlob(repository, ProvLayerMediaType, operation.provData)
+		wg.Go(func() { provBlob.pushNew(ctx) })
+	}
+	wg.Wait()
 
-		layers = append(layers, provDescriptor)
+	if chartBlob.err != nil {
+		return nil, chartBlob.err
+	}
+	if configBlob.err != nil {
+		return nil, configBlob.err
+	}
+	if provBlob.err != nil {
+		return nil, provBlob.err
+	}
+	if operation.provData != nil {
+		layers = append(layers, provBlob.descriptor)
 	}
 
 	// sort layers for determinism, similar to how ORAS v1 does it
@@ -703,22 +725,20 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 
 	ociAnnotations := generateOCIAnnotations(meta, operation.creationTime)
 
-	manifestDescriptor, err := c.tagManifest(ctx, memoryStore, configDescriptor,
-		layers, ociAnnotations, parsedRef)
+	manifest := ocispec.Manifest{
+		Versioned:   specs.Versioned{SchemaVersion: 2},
+		Config:      configBlob.descriptor,
+		Layers:      layers,
+		Annotations: ociAnnotations,
+	}
+
+	manifestData, err := json.Marshal(manifest)
 	if err != nil {
 		return nil, err
 	}
 
-	repository, err := remote.NewRepository(parsedRef.String())
-	if err != nil {
-		return nil, err
-	}
-	repository.PlainHTTP = c.plainHTTP
-	repository.Client = c.authorizer
-
-	ctx = withScopeHint(ctx, repository, auth.ActionPull, auth.ActionPush)
-
-	manifestDescriptor, err = oras.ExtendedCopy(ctx, memoryStore, parsedRef.String(), repository, parsedRef.String(), oras.DefaultExtendedCopyOptions)
+	manifestDescriptor, err := oras.TagBytes(ctx, repository, ocispec.MediaTypeImageManifest,
+		manifestData, parsedRef.String())
 	if err != nil {
 		return nil, err
 	}
@@ -726,16 +746,16 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	chartSummary := &descriptorPushSummaryWithMeta{
 		Meta: meta,
 	}
-	chartSummary.Digest = chartDescriptor.Digest.String()
-	chartSummary.Size = chartDescriptor.Size
+	chartSummary.Digest = chartBlob.descriptor.Digest.String()
+	chartSummary.Size = chartBlob.descriptor.Size
 	result := &PushResult{
 		Manifest: &descriptorPushSummary{
 			Digest: manifestDescriptor.Digest.String(),
 			Size:   manifestDescriptor.Size,
 		},
 		Config: &descriptorPushSummary{
-			Digest: configDescriptor.Digest.String(),
-			Size:   configDescriptor.Size,
+			Digest: configBlob.descriptor.Digest.String(),
+			Size:   configBlob.descriptor.Size,
 		},
 		Chart: chartSummary,
 		Prov:  &descriptorPushSummary{}, // prevent nil references
@@ -743,8 +763,8 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	}
 	if operation.provData != nil {
 		result.Prov = &descriptorPushSummary{
-			Digest: provDescriptor.Digest.String(),
-			Size:   provDescriptor.Size,
+			Digest: provBlob.descriptor.Digest.String(),
+			Size:   provBlob.descriptor.Size,
 		}
 	}
 	_, _ = fmt.Fprintf(c.out, "Pushed: %s\n", result.Ref)
@@ -929,13 +949,53 @@ func (c *Client) tagManifest(ctx context.Context, memoryStore *memory.Store,
 		manifestData, parsedRef.String())
 }
 
-// add actions when request a registry authentication token(jwt)
-// example1. when we want to pull 'testrepo/local-subchart' we can send below url, and 'pull' is the action
-// auth?scope=repository%3Atestrepo%2Flocal-subchart%3Apull&service=testservice
-// example2. when we want to push 'testrepo/local-subchart' we can send below url, and 'pull%2Cpush' are the actions
-// auth?scope=repository%3Atestrepo%2Flocal-subchart%3Apull%2Cpush&service=testservice
-// we can set the actions like below
-// example) ctx = withScopeHint(ctx, repository, auth.ActionPush, auth.ActionPull)
-func withScopeHint(ctx context.Context, repo *remote.Repository, actions ...string) context.Context {
-	return auth.AppendRepositoryScope(ctx, repo.Reference, actions...)
+// blob represents a content-addressable blob to be pushed to an OCI registry.
+// It encapsulates the data, media type, and destination repository, and tracks
+// the resulting descriptor and any error from push operations.
+type blob struct {
+	dst        *remote.Repository
+	mediaType  string
+	data       []byte
+	descriptor ocispec.Descriptor
+	err        error
+}
+
+// newBlob creates a new blob with the given repository, media type, and data.
+func newBlob(dst *remote.Repository, mediaType string, data []byte) blob {
+	return blob{
+		dst:       dst,
+		mediaType: mediaType,
+		data:      data,
+	}
+}
+
+// exists checks if the blob already exists in the registry by computing its
+// digest and querying the repository. It also populates the blob's descriptor
+// with size, media type, and digest information.
+func (b *blob) exists(ctx context.Context) (bool, error) {
+	b.descriptor.Size = int64(len(b.data))
+	b.descriptor.MediaType = b.mediaType
+	b.descriptor.Digest = digest.FromBytes(b.data)
+	return b.dst.Exists(ctx, b.descriptor)
+}
+
+// pushNew checks if the blob exists in the registry first, and only pushes
+// if it doesn't exist. This avoids redundant uploads for blobs that are
+// already present. Any error is stored in b.err.
+func (b *blob) pushNew(ctx context.Context) {
+	var exists bool
+	exists, b.err = b.exists(ctx)
+	if b.err != nil {
+		return
+	}
+	if exists {
+		return
+	}
+	b.descriptor, b.err = oras.PushBytes(ctx, b.dst, b.mediaType, b.data)
+}
+
+// push unconditionally pushes the blob to the registry without checking
+// for existence first. Any error is stored in b.err.
+func (b *blob) push(ctx context.Context) {
+	b.descriptor, b.err = oras.PushBytes(ctx, b.dst, b.mediaType, b.data)
 }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package registry
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -151,5 +155,100 @@ func TestWarnIfHostHasPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantWarn, warnIfHostHasPath(tt.host))
 		})
+	}
+}
+
+// TestPushConcurrent verifies that concurrent Push operations on the same Client
+// do not interfere with each other. This test is designed to catch race conditions
+// when run with -race flag.
+func TestPushConcurrent(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock registry server that accepts pushes
+	var mu sync.Mutex
+	uploads := make(map[string][]byte)
+	var uploadCounter int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+			// Blob existence check - return 404 to force upload
+			w.WriteHeader(http.StatusNotFound)
+
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+			// Start upload - return upload URL with unique ID
+			mu.Lock()
+			uploadCounter++
+			uploadID := fmt.Sprintf("upload-%d", uploadCounter)
+			mu.Unlock()
+			w.Header().Set("Location", fmt.Sprintf("%s%s", r.URL.Path, uploadID))
+			w.WriteHeader(http.StatusAccepted)
+
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+			// Complete upload - extract digest from query param
+			body, _ := io.ReadAll(r.Body)
+			digest := r.URL.Query().Get("digest")
+			mu.Lock()
+			uploads[r.URL.Path] = body
+			mu.Unlock()
+			w.Header().Set("Docker-Content-Digest", digest)
+			w.WriteHeader(http.StatusCreated)
+
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+			// Manifest push - compute actual sha256 digest of the body
+			body, _ := io.ReadAll(r.Body)
+			hash := sha256.Sum256(body)
+			digest := fmt.Sprintf("sha256:%x", hash)
+			w.Header().Set("Docker-Content-Digest", digest)
+			w.WriteHeader(http.StatusCreated)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// Create client
+	credFile := filepath.Join(t.TempDir(), "config.json")
+	client, err := NewClient(
+		ClientOptWriter(io.Discard),
+		ClientOptCredentialsFile(credFile),
+		ClientOptPlainHTTP(),
+	)
+	require.NoError(t, err)
+
+	// Load test chart
+	chartData, err := os.ReadFile("../downloader/testdata/local-subchart-0.1.0.tgz")
+	require.NoError(t, err, "no error loading test chart")
+
+	meta, err := extractChartMeta(chartData)
+	require.NoError(t, err, "no error extracting chart meta")
+
+	// Run concurrent pushes
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Each goroutine pushes to a different tag to avoid conflicts
+			ref := fmt.Sprintf("%s/testrepo/%s:%s-%d", host, meta.Name, meta.Version, idx)
+			_, err := client.Push(chartData, ref, PushOptStrictMode(false))
+			if err != nil {
+				errs <- fmt.Errorf("goroutine %d: %w", idx, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	// Check for errors
+	for err := range errs {
+		t.Error(err)
 	}
 }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -199,6 +199,14 @@ func TestPushConcurrent(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+			// The optimization pushes the manifest exactly once, by tag. A PUT to a
+			// digest reference (/manifests/sha256:...) means the manifest is being
+			// uploaded a second time by digest, which this test guards against.
+			if strings.Contains(r.URL.Path, "/manifests/sha256:") {
+				t.Errorf("unexpected manifest push by digest %q; manifest should be pushed once by tag", r.URL.Path)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
 			// Manifest push - compute actual sha256 digest of the body
 			body, err := io.ReadAll(r.Body)
 			if err != nil {

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -186,7 +186,11 @@ func TestPushConcurrent(t *testing.T) {
 
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
 			// Complete upload - extract digest from query param
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			digest := r.URL.Query().Get("digest")
 			mu.Lock()
 			uploads[r.URL.Path] = body
@@ -196,7 +200,11 @@ func TestPushConcurrent(t *testing.T) {
 
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
 			// Manifest push - compute actual sha256 digest of the body
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			hash := sha256.Sum256(body)
 			digest := fmt.Sprintf("sha256:%x", hash)
 			w.Header().Set("Docker-Content-Digest", digest)


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce number of calls oras-go v2 makes.  From my testing, Helm with oras-go v2 makes 10 calls instead of 8 made with oras-go v1.

Closes: https://github.com/helm/helm/issues/30911

This change reduces the number of calls to 7.

Before:
```
level=DEBUG msg=Request id=0 url=http://127.0.0.1:15000/v2/mychart/mychart/manifests/sha256:cfda74cfd8533fcf9b7429d628afa7bcc5f99347f01926109046d89d0f597e40 method=HEAD header="   \"Accept\": \"application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.artifact.manifest.v1+json\"\n   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=1 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/sha256:97ef314b92878882396d9754e08d92d88ab24415814b2cad8d322f5b393c22d1 method=HEAD header="   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=2 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/sha256:59f181bca82ddeec178505ec4d72bcad5bd93696e74a29d630938ae66bf66e13 method=HEAD header="   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=3 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/ method=POST header="   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=4 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/ method=POST header="   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=5 url="http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/2eb6d8e7-b2fc-42bf-b474-5f84a611db6a?digest=sha256%3A97ef314b92878882396d9754e08d92d88ab24415814b2cad8d322f5b393c22d1" method=PUT header="   \"User-Agent\": \"Helm/3.19+unreleased\"\n   \"Content-Type\": \"application/octet-stream\""
level=DEBUG msg=Request id=6 url="http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/c63732de-4929-4f1e-bc51-87516cf41e24?digest=sha256%3A59f181bca82ddeec178505ec4d72bcad5bd93696e74a29d630938ae66bf66e13" method=PUT header="   \"Content-Type\": \"application/octet-stream\"\n   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=7 url=http://127.0.0.1:15000/v2/mychart/mychart/manifests/sha256:cfda74cfd8533fcf9b7429d628afa7bcc5f99347f01926109046d89d0f597e40 method=PUT header="   \"Content-Type\": \"application/vnd.oci.image.manifest.v1+json\"\n   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=8 url=http://127.0.0.1:15000/v2/mychart/mychart/manifests/sha256:cfda74cfd8533fcf9b7429d628afa7bcc5f99347f01926109046d89d0f597e40 method=GET header="   \"Accept\": \"application/vnd.oci.image.manifest.v1+json\"\n   \"User-Agent\": \"Helm/3.19+unreleased\""
level=DEBUG msg=Request id=9 url=http://127.0.0.1:15000/v2/mychart/mychart/manifests/0.1.5 method=PUT header="   \"Content-Type\": \"application/vnd.oci.image.manifest.v1+json\"\n   \"User-Agent\": \"Helm/3.19+unreleased\""
```
After:
```
level=DEBUG msg=HEAD id=0 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/sha256:34599f86d3c681917ba17608491d8fd0609c41634474acaffabdce27caee12b0 header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=POST id=1 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/ header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=HEAD id=2 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/sha256:7e890886821e83c13e968e7b6c7804a3149db6708e8850386ded7dc1ff3a7973 header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=POST id=3 url=http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/ header="   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=PUT id=4 url="http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/6167b4c7-77cf-4d30-ba35-f13bac6b40ff?digest=sha256%3A34599f86d3c681917ba17608491d8fd0609c41634474acaffabdce27caee12b0" header="   \"Content-Type\": \"application/octet-stream\"\n   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=PUT id=5 url="http://127.0.0.1:15000/v2/mychart/mychart/blobs/uploads/1df8f168-8f2a-41ee-b214-c36d624e274e?digest=sha256%3A7e890886821e83c13e968e7b6c7804a3149db6708e8850386ded7dc1ff3a7973" header="   \"Content-Type\": \"application/octet-stream\"\n   \"User-Agent\": \"Helm/4.0+unreleased\""
level=DEBUG msg=PUT id=6 url=http://127.0.0.1:15000/v2/mychart/mychart/manifests/0.1.9 header="   \"Content-Type\": \"application/vnd.oci.image.manifest.v1+json\"\n   \"User-Agent\": \"Helm/4.0+unreleased\""
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
