### PR TITLE
Increase test count from 1 to 2 for improved reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ACCEPTANCE_RUN_TESTS = .
 PKG         := ./...
 TAGS        :=
 TESTS       := .
-TESTFLAGS   := -shuffle=on -count=1
+TESTFLAGS   := -shuffle=on -count=2
 LDFLAGS     := -w -s
 GOFLAGS     :=
 CGO_ENABLED ?= 0


### PR DESCRIPTION
## Summary
Increases the test count in TESTFLAGS from 1 to 2 to better detect flakey tests and order-dependent issues as recommended in issue #30892.

## Changes
- Updated  in Makefile to use  instead of 
- Tests will now run twice per execution, helping identify:
  - Order-dependent tests
  - Flakey/inconsistent test results
  - Race conditions

## Testing
The  flag was already in place, so combined with , the test suite will:
1. Randomize test execution order
2. Run each test twice
3. Surface any tests that fail inconsistently

Closes #30892