### PR TITLE
refactor: remove unused err from pkg/registry/client.go

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -75,11 +75,11 @@ type (
 		credentialsStore   credentials.Store
 		httpClient         *http.Client
 		plainHTTP          bool
-		err                error // pass any errors from the ClientOption functions
 	}
 
 	// ClientOption allows specifying various settings configurable by the user for overriding the defaults
 	// used when creating a new default client
+	// TODO(TerryHowe): ClientOption should return error in v5
 	ClientOption func(*Client)
 )
 
@@ -90,9 +90,6 @@ func NewClient(options ...ClientOption) (*Client, error) {
 	}
 	for _, option := range options {
 		option(client)
-		if client.err != nil {
-			return nil, client.err
-		}
 	}
 	if client.credentialsFile == "" {
 		client.credentialsFile = helmpath.ConfigPath(CredentialsFileBasename)


### PR DESCRIPTION

**What this PR does / why we need it**:

The client member err was not being used.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
