### PR TITLE
feat: add latest version and outdated flag to plugin list command

### DIFF
--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -146,6 +146,11 @@ func (i *HTTPInstaller) Update() error {
 	return fmt.Errorf("method Update() not implemented for HttpInstaller")
 }
 
+// GetLatestVersion fetches the latest version of the plugin.Add a comment on lines R158 to R160Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a reviewReturn to code
+func (i *HTTPInstaller) GetLatestVersion() (string, error) {
+	return "", fmt.Errorf("not supported")
+}
+
 // Path is overridden because we want to join on the plugin name not the file name
 func (i HTTPInstaller) Path() string {
 	if i.Source == "" {

--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -146,7 +146,7 @@ func (i *HTTPInstaller) Update() error {
 	return fmt.Errorf("method Update() not implemented for HttpInstaller")
 }
 
-// GetLatestVersion fetches the latest version of the plugin.Add a comment on lines R158 to R160Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a reviewReturn to code
+// GetLatestVersion fetches the latest version of the plugin.
 func (i *HTTPInstaller) GetLatestVersion() (string, error) {
 	return "", fmt.Errorf("not supported")
 }

--- a/internal/plugin/installer/installer.go
+++ b/internal/plugin/installer/installer.go
@@ -50,6 +50,8 @@ type Installer interface {
 	Path() string
 	// Update updates a plugin.
 	Update() error
+	// GetLatestVersion fetches the latest version of the plugin.
+	GetLatestVersion() (string, error)
 }
 
 // Verifier provides an interface for installers that support verification.

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -164,6 +164,10 @@ func (i *LocalInstaller) Update() error {
 	return nil
 }
 
+func (i *LocalInstaller) GetLatestVersion() (string, error) {
+	return "", fmt.Errorf("not supported")
+}
+
 // Path is overridden to handle archive plugin names properly
 func (i *LocalInstaller) Path() string {
 	if i.Source == "" {

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -197,6 +197,10 @@ func (i OCIInstaller) Path() string {
 	return filepath.Join(i.settings.PluginsDirectory, i.PluginName)
 }
 
+func (i *OCIInstaller) GetLatestVersion() (string, error) {
+	return "", fmt.Errorf("not supported")
+}
+
 // extractTarGz extracts a gzipped tar archive to a directory
 func extractTarGz(r io.Reader, targetDir string) error {
 	gzr, err := gzip.NewReader(r)

--- a/internal/plugin/installer/vcs_installer.go
+++ b/internal/plugin/installer/vcs_installer.go
@@ -110,6 +110,26 @@ func (i *VCSInstaller) Update() error {
 	return nil
 }
 
+func (i *VCSInstaller) GetLatestVersion() (string, error) {
+	_, err := i.Repo.RunFromDir("git", "fetch", "-q", "--tags")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch tags: %w", err)
+	}
+
+	refs, err := i.Repo.Tags()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tags: %w", err)
+	}
+
+	semvers := getSemVers(refs)
+	if len(semvers) == 0 {
+		return "", fmt.Errorf("no valid semver tags found in repository")
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	return semvers[0].Original(), nil
+}
+
 func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
 	if i.Version == "" {
 		return "", nil

--- a/pkg/cmd/plugin_list.go
+++ b/pkg/cmd/plugin_list.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v4/internal/plugin/installer"
 
 	"helm.sh/helm/v4/internal/plugin"
+	"helm.sh/helm/v4/internal/plugin/installer"
 	"helm.sh/helm/v4/internal/plugin/schema"
 )
 

--- a/pkg/cmd/plugin_list.go
+++ b/pkg/cmd/plugin_list.go
@@ -78,7 +78,7 @@ func newPluginListCmd(out io.Writer) *cobra.Command {
 				if o.showOutdated {
 					latest, err := getLatestVersion(p)
 					if err != nil {
-						slog.Debug("getLatestVersion", err.Error())
+						slog.Debug("getLatestVersion", slog.Any("error", err))
 						latest = "unknown"
 					}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `LATEST` column to plugin list output and `--outdated` flag to show only plugins with available updates, helping users identify plugins that need updating.

before:
<img width="577" height="92" alt="image" src="https://github.com/user-attachments/assets/76b0429d-ed3c-46d2-b34c-870974fdf6a8" />

after:
<img width="577" height="92" alt="image" src="https://github.com/user-attachments/assets/f9ca70f0-ec98-4038-a020-f6f5e51866a5" />

