### PR TITLE
feat: add plugin existence check before installation

### DIFF
--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -91,7 +91,12 @@ func (i *HTTPInstaller) Install() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-	tarballPath := helmpath.DataPath("plugins", filename)
+	pluginsPath := helmpath.DataPath("plugins")
+	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if len(foundPlugins) > 0 {
+		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
+	}
+	tarballPath := filepath.Join(pluginsPath, filename)
 	if err := os.MkdirAll(filepath.Dir(tarballPath), 0755); err != nil {
 		return fmt.Errorf("failed to create plugins directory: %w", err)
 	}

--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -91,7 +91,7 @@ func (i *HTTPInstaller) Install() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-	pluginsPath := helmpath.DataPath("plugins")
+	pluginsPath := filepath.Dir(i.Path())
 	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
 	if err != nil {
 		return fmt.Errorf("failed to search for existing plugins: %w", err)

--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -92,7 +92,10 @@ func (i *HTTPInstaller) Install() error {
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
 	pluginsPath := helmpath.DataPath("plugins")
-	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if err != nil {
+		return fmt.Errorf("failed to search for existing plugins: %w", err)
+	}
 	if len(foundPlugins) > 0 {
 		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
 	}

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -106,7 +106,10 @@ func (i *LocalInstaller) installFromDirectory() error {
 	metadata := p.Metadata()
 
 	pluginsPath := helmpath.DataPath("plugins")
-	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if err != nil {
+		return fmt.Errorf("failed to search for existing plugins: %w", err)
+	}
 	if len(foundPlugins) > 0 {
 		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
 	}
@@ -131,7 +134,10 @@ func (i *LocalInstaller) installFromArchive() error {
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
 	pluginsPath := helmpath.DataPath("plugins")
-	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if err != nil {
+		return fmt.Errorf("failed to search for existing plugins: %w", err)
+	}
 	if len(foundPlugins) > 0 {
 		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
 	}

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -97,6 +97,20 @@ func (i *LocalInstaller) installFromDirectory() error {
 	if !isPlugin(i.Source) {
 		return ErrMissingMetadata
 	}
+
+	// Load plugin to get metadata and check for existing plugin with same name
+	p, err := plugin.LoadDir(i.Source)
+	if err != nil {
+		return fmt.Errorf("failed to load plugin: %w", err)
+	}
+	metadata := p.Metadata()
+
+	pluginsPath := helmpath.DataPath("plugins")
+	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if len(foundPlugins) > 0 {
+		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
+	}
+
 	slog.Debug("symlinking", "source", i.Source, "path", i.Path())
 	return os.Symlink(i.Source, i.Path())
 }
@@ -116,7 +130,12 @@ func (i *LocalInstaller) installFromArchive() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-	tarballPath := helmpath.DataPath("plugins", filename)
+	pluginsPath := helmpath.DataPath("plugins")
+	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if len(foundPlugins) > 0 {
+		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
+	}
+	tarballPath := filepath.Join(pluginsPath, filename)
 	if err := os.MkdirAll(filepath.Dir(tarballPath), 0755); err != nil {
 		return fmt.Errorf("failed to create plugins directory: %w", err)
 	}

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -133,7 +133,7 @@ func (i *LocalInstaller) installFromArchive() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-	pluginsPath := helmpath.DataPath("plugins")
+	pluginsPath := filepath.Dir(i.Path())
 	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
 	if err != nil {
 		return fmt.Errorf("failed to search for existing plugins: %w", err)

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -102,7 +102,10 @@ func (i *OCIInstaller) Install() error {
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
 	pluginsPath := helmpath.DataPath("plugins")
-	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if err != nil {
+		return fmt.Errorf("failed to search for existing plugins: %w", err)
+	}
 	if len(foundPlugins) > 0 {
 		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
 	}

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -101,7 +101,7 @@ func (i *OCIInstaller) Install() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-	pluginsPath := helmpath.DataPath("plugins")
+	pluginsPath := filepath.Dir(i.Path())
 	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
 	if err != nil {
 		return fmt.Errorf("failed to search for existing plugins: %w", err)

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -101,8 +101,12 @@ func (i *OCIInstaller) Install() error {
 		return fmt.Errorf("failed to extract plugin metadata from tarball: %w", err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", metadata.Name, metadata.Version)
-
-	tarballPath := helmpath.DataPath("plugins", filename)
+	pluginsPath := helmpath.DataPath("plugins")
+	foundPlugins, _ := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if len(foundPlugins) > 0 {
+		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
+	}
+	tarballPath := filepath.Join(pluginsPath, filename)
 	if err := os.MkdirAll(filepath.Dir(tarballPath), 0755); err != nil {
 		return fmt.Errorf("failed to create plugins directory: %w", err)
 	}

--- a/internal/plugin/installer/vcs_installer.go
+++ b/internal/plugin/installer/vcs_installer.go
@@ -21,6 +21,7 @@ import (
 	stdfs "io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
@@ -100,7 +101,11 @@ func (i *VCSInstaller) Install() error {
 	metadata := p.Metadata()
 
 	// Check if a plugin with the same name already exists
-	foundPlugins, _ := plugin.FindPlugins([]string{i.PluginsDirectory}, plugin.Descriptor{Name: metadata.Name})
+	pluginsPath := filepath.Dir(i.Path())
+	foundPlugins, err := plugin.FindPlugins([]string{pluginsPath}, plugin.Descriptor{Name: metadata.Name})
+	if err != nil {
+		return fmt.Errorf("failed to search for existing plugins: %w", err)
+	}
 	if len(foundPlugins) > 0 {
 		return fmt.Errorf("plugin %q already exists at %q", metadata.Name, foundPlugins[0].Dir())
 	}

--- a/internal/test/ensure/ensure.go
+++ b/internal/test/ensure/ensure.go
@@ -29,7 +29,7 @@ import (
 func HelmHome(t *testing.T) {
 	t.Helper()
 	base := t.TempDir()
-	t.Setenv(xdg.CacheHomeEnvVar, base)
+	t.Setenv(xdg.CacheHomeEnvVar, filepath.Join(base, "cache"))
 	t.Setenv(xdg.ConfigHomeEnvVar, base)
 	t.Setenv(xdg.DataHomeEnvVar, base)
 	t.Setenv(helmpath.CacheHomeEnvVar, "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When installing a plugin multiple times from different sources:
```bash
helm plugin install https://github.com/idsulik/helm-cel
helm plugin install https://github.com/idsulik/helm-cel/archive/refs/tags/v3.0.2.tar.gz
```
This created two directories (`helm-cel` and `v3.0.2`) for the same plugin, resulting in:
Error: two plugins claim the name "cel" at "/Users/main/Library/helm/plugins/helm-cel" and "/Users/main/Library/helm/plugins/v3.0efore installation

**Solution**:
Added duplicate plugin detection in all installer types (HTTP, OCI, VCS, Local) by:
1. Extracting plugin metadata before installation
2. Checking if a plugin with the same name already exists in the plugins directory
3. Returning a clear error message if duplicate is found
