### PR TITLE
Bug: fix binary plugin url support

### DIFF
--- a/internal/plugin/installer/extractor.go
+++ b/internal/plugin/installer/extractor.go
@@ -68,6 +68,10 @@ func NewExtractor(source string) (Extractor, error) {
 			return extractor, nil
 		}
 	}
+	if strings.HasPrefix(source, "http") && isGzipArchiveFromURL(source) {
+		return &TarGzExtractor{}, nil
+	}
+
 	return nil, fmt.Errorf("no extractor implemented yet for %s", source)
 }
 

--- a/internal/plugin/installer/extractor.go
+++ b/internal/plugin/installer/extractor.go
@@ -68,8 +68,15 @@ func NewExtractor(source string) (Extractor, error) {
 			return extractor, nil
 		}
 	}
-	if strings.HasPrefix(source, "http") && isGzipArchiveFromURL(source) {
-		return &TarGzExtractor{}, nil
+	if strings.HasPrefix(source, "http") {
+		isGzip, err := isGzipArchiveFromURL(source)
+		if err != nil {
+			return nil, err
+		}
+
+		if isGzip {
+			return &TarGzExtractor{}, nil
+		}
 	}
 
 	return nil, fmt.Errorf("no extractor implemented yet for %s", source)

--- a/internal/plugin/installer/gzip.go
+++ b/internal/plugin/installer/gzip.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import "net/http"
+
+// isGzipArchive checks if data represents a gzip archive by checking the magic bytes
+func isGzipArchive(data []byte) bool {
+	return len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
+}
+
+// isGzipArchiveFromURL checks if a URL points to a gzip archive by reading the magic bytes
+func isGzipArchiveFromURL(url string) bool {
+	// Make a GET request to read the first few bytes
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+
+	// Request only the first 512 bytes to check magic bytes
+	req.Header.Set("Range", "bytes=0-511")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Read the first few bytes
+	buf := make([]byte, 2)
+	n, err := resp.Body.Read(buf)
+	if err != nil || n < 2 {
+		return false
+	}
+
+	return isGzipArchive(buf)
+}

--- a/internal/plugin/installer/installer.go
+++ b/internal/plugin/installer/installer.go
@@ -196,10 +196,18 @@ func isRemoteHTTPArchive(source string) bool {
 		contentType := res.Header.Get("content-type")
 		foundSuffix, ok := mediaTypeToExtension(contentType)
 		if !ok {
-			if contentType == "application/octet-stream" && isGzipArchiveFromURL(source) {
-				// For generic binary content, try to detect the actual file type
-				// by reading the first few bytes (magic bytes)
-				return true
+			if contentType == "application/octet-stream" {
+				isGzip, err := isGzipArchiveFromURL(source)
+				if err != nil {
+					slog.Debug("isGzipArchiveFromURL", slog.Any("error", err))
+					return false
+				}
+
+				if isGzip {
+					// For generic binary content, try to detect the actual file type
+					// by reading the first few bytes (magic bytes)
+					return true
+				}
 			}
 
 			return false

--- a/internal/plugin/installer/installer.go
+++ b/internal/plugin/installer/installer.go
@@ -174,49 +174,44 @@ func isLocalReference(source string) bool {
 // It works by checking whether the source looks like a URL and, if it does, running a
 // HEAD operation to see if the remote resource is a file that we understand.
 func isRemoteHTTPArchive(source string) bool {
-	if !isHTTPURL(source) {
-		return false
-	}
-
-	contentType, err := getRemoteContentType(source)
-	if err != nil {
-		return false
-	}
-
-	// Handle octet-stream specially by checking file extension
-	if contentType == "application/octet-stream" {
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		// First, check if the URL ends with a known archive suffix
+		// This is more reliable than content-type detection
 		for suffix := range Extractors {
 			if strings.HasSuffix(source, suffix) {
 				return true
 			}
 		}
 
-		return false
-	}
+		// If no suffix match, try HEAD request to check content type
+		res, err := http.Head(source)
+		if err != nil {
+			// If we get an error at the network layer, we can't install it. So
+			// we return false.
+			return false
+		}
 
-	// Check if we have an extractor for this media type
-	if suffix, ok := mediaTypeToExtension(contentType); ok {
-		_, hasExtractor := Extractors[suffix]
-		return hasExtractor
-	}
+		// Next, we look for the content type or content disposition headers to see
+		// if they have matching extractors.
+		contentType := res.Header.Get("content-type")
+		foundSuffix, ok := mediaTypeToExtension(contentType)
+		if !ok {
+			if contentType == "application/octet-stream" && isGzipArchiveFromURL(source) {
+				// For generic binary content, try to detect the actual file type
+				// by reading the first few bytes (magic bytes)
+				return true
+			}
 
+			return false
+		}
+
+		for suffix := range Extractors {
+			if strings.HasSuffix(foundSuffix, suffix) {
+				return true
+			}
+		}
+	}
 	return false
-}
-
-// isHTTPURL checks if the source is an HTTP or HTTPS URL
-func isHTTPURL(source string) bool {
-	return strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
-}
-
-// getRemoteContentType performs a HEAD request and returns the content-type
-func getRemoteContentType(url string) (string, error) {
-	res, err := http.Head(url)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	return res.Header.Get("content-type"), nil
 }
 
 // isPlugin checks if the directory contains a plugin.yaml file.

--- a/internal/plugin/installer/installer_test.go
+++ b/internal/plugin/installer/installer_test.go
@@ -18,9 +18,13 @@ package installer
 import "testing"
 
 func TestIsRemoteHTTPArchive(t *testing.T) {
-	srv := mockArchiveServer()
+	srv := mockArchiveServer(map[string]string{
+		".tar.gz":        "application/gzip",
+		".binary.tar.gz": "application/octet-stream",
+	})
 	defer srv.Close()
 	source := srv.URL + "/plugins/fake-plugin-0.0.1.tar.gz"
+	binarySource := srv.URL + "/plugins/fake-plugin-0.0.1.binary.tar.gz"
 
 	if isRemoteHTTPArchive("/not/a/URL") {
 		t.Errorf("Expected non-URL to return false")
@@ -43,5 +47,9 @@ func TestIsRemoteHTTPArchive(t *testing.T) {
 
 	if isRemoteHTTPArchive(source + "-not-an-extension") {
 		t.Error("Expected media type match to fail")
+	}
+
+	if !isRemoteHTTPArchive(binarySource) {
+		t.Errorf("Expected %q to be a valid archive URL", binarySource)
 	}
 }

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -128,7 +128,7 @@ func (i *OCIInstaller) Install() error {
 	}
 
 	// Check if this is a gzip compressed file
-	if len(i.pluginData) < 2 || i.pluginData[0] != 0x1f || i.pluginData[1] != 0x8b {
+	if !isGzipArchive(i.pluginData) {
 		return fmt.Errorf("plugin data is not a gzip compressed archive")
 	}
 

--- a/internal/plugin/installer/oci_installer_test.go
+++ b/internal/plugin/installer/oci_installer_test.go
@@ -792,7 +792,7 @@ func TestOCIInstaller_Install_ValidationErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test the gzip validation logic that's used in the Install method
-			if len(tt.layerData) < 2 || tt.layerData[0] != 0x1f || tt.layerData[1] != 0x8b {
+			if !isGzipArchive(tt.layerData) {
 				// This matches the validation in the Install method
 				if !tt.expectError {
 					t.Error("expected valid gzip data")


### PR DESCRIPTION
The old PR https://github.com/helm/helm/pull/13225 was closed, so I created a new one(but it'll be better to reopen the old PR to keep the original history)
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes [13221](https://github.com/helm/helm/issues/13221)

**What this PR does / why we need it**:
A `tar.gz` file can have the MIME type `application/octet-stream`, so I added support for this case.
Example plugin to test the case https://gitlab.com/api/v4/projects/75420382/packages/generic/helm-cel/0.0.1/helm-cel

**If applicable**:
- [N] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [Y] this PR contains unit tests
- [N] this PR has been tested for backwards compatibility
