### PR TITLE
fix: kube client should return empty results objects instead of nil

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -689,19 +689,19 @@ func (c *Client) Update(originals, targets ResourceList, options ...ClientUpdate
 		errs = append(errs, o(&updateOptions))
 	}
 	if err := errors.Join(errs...); err != nil {
-		return nil, fmt.Errorf("invalid client update option(s): %w", err)
+		return &Result{}, fmt.Errorf("invalid client update option(s): %w", err)
 	}
 
 	if updateOptions.threeWayMergeForUnstructured && updateOptions.serverSideApply {
-		return nil, fmt.Errorf("invalid operation: cannot use three-way merge for unstructured and server-side apply together")
+		return &Result{}, fmt.Errorf("invalid operation: cannot use three-way merge for unstructured and server-side apply together")
 	}
 
 	if updateOptions.forceConflicts && updateOptions.forceReplace {
-		return nil, fmt.Errorf("invalid operation: cannot use force conflicts and force replace together")
+		return &Result{}, fmt.Errorf("invalid operation: cannot use force conflicts and force replace together")
 	}
 
 	if updateOptions.serverSideApply && updateOptions.forceReplace {
-		return nil, fmt.Errorf("invalid operation: cannot use server-side apply and force replace together")
+		return &Result{}, fmt.Errorf("invalid operation: cannot use server-side apply and force replace together")
 	}
 
 	makeUpdateApplyFunc := func() UpdateApplyFunc {

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -122,7 +122,7 @@ func (f *FailingKubeWaiter) WatchUntilReady(resources kube.ResourceList, d time.
 // Update returns the configured error if set or prints
 func (f *FailingKubeClient) Update(r, modified kube.ResourceList, options ...kube.ClientUpdateOption) (*kube.Result, error) {
 	if f.UpdateError != nil {
-		return nil, f.UpdateError
+		return &kube.Result{}, f.UpdateError
 	}
 	return f.PrintingKubeClient.Update(r, modified, options...)
 }

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -122,7 +122,7 @@ func (f *FailingKubeWaiter) WatchUntilReady(resources kube.ResourceList, d time.
 // Update returns the configured error if set or prints
 func (f *FailingKubeClient) Update(r, modified kube.ResourceList, options ...kube.ClientUpdateOption) (*kube.Result, error) {
 	if f.UpdateError != nil {
-		return &kube.Result{}, f.UpdateError
+		return nil, f.UpdateError
 	}
 	return f.PrintingKubeClient.Update(r, modified, options...)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Related to #31402 ,

**What this PR does / why we need it**:

This change changes returning `nil` on error pathways in kube client to returning an empty Result. We need this because downstream callers of this function expect to report back the status on Result.Created, but the result is `nil` so `.Created` panics.

**Special notes for your reviewer**:

Linked issue has more details

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
