### PR TITLE
Improve error message when plugin source cannot be determined or a non-directory is passed

### DIFF
--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -29,8 +29,8 @@ import (
 	"helm.sh/helm/v4/pkg/helmpath"
 )
 
-// ErrPluginNotAFolder indicates that the plugin path is not a folder.
-var ErrPluginNotAFolder = errors.New("expected plugin to be a folder")
+// ErrPluginNotADirectory indicates that the plugin path is not a directory.
+var ErrPluginNotADirectory = errors.New("expected plugin to be a directory (containing a file 'plugin.yaml')")
 
 // LocalInstaller installs plugins from the filesystem.
 type LocalInstaller struct {
@@ -91,7 +91,7 @@ func (i *LocalInstaller) installFromDirectory() error {
 		return err
 	}
 	if !stat.IsDir() {
-		return ErrPluginNotAFolder
+		return ErrPluginNotADirectory
 	}
 
 	if !isPlugin(i.Source) {

--- a/internal/plugin/installer/local_installer_test.go
+++ b/internal/plugin/installer/local_installer_test.go
@@ -64,7 +64,7 @@ func TestLocalInstallerNotAFolder(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err != ErrPluginNotAFolder {
+	if err != ErrPluginNotADirectory {
 		t.Fatalf("expected error to equal: %q", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #31398

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
