### PR TITLE
fix: reinstate logger parameter to actions package

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -97,6 +97,7 @@ type LoggerSetterGetter interface {
 
 type LogHolder struct {
 	// logger is an atomic.Pointer[slog.Logger] to store the slog.Logger
+	// We use atomic.Pointer for thread safety
 	logger atomic.Pointer[slog.Logger]
 }
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -89,14 +89,14 @@ func NewLogger(debugEnabled DebugEnabledFunc) *slog.Logger {
 
 // LoggerSetterGetter is an interface that can set and get a logger
 type LoggerSetterGetter interface {
-	// SetLogger sets the logger for the object
-	SetLogger(logger *slog.Logger)
-	// Logger returns the logger for the object
+	// SetLogger sets a new slog.Handler
+	SetLogger(newLogger slog.Handler)
+	// Logger returns the slog.Logger created from the slog.Handler
 	Logger() *slog.Logger
 }
 
 type LogHolder struct {
-	// logger is an slog.Logger pointer to use the driver
+	// logger is an atomic.Pointer[slog.Logger] to store the slog.Logger
 	logger atomic.Pointer[slog.Logger]
 }
 
@@ -109,12 +109,12 @@ func (l *LogHolder) Logger() *slog.Logger {
 }
 
 // SetLogger sets the logger for the LogHolder. If nil, sets the default logger.
-func (l *LogHolder) SetLogger(newLogger *slog.Logger) {
+func (l *LogHolder) SetLogger(newLogger slog.Handler) {
 	if newLogger == nil {
 		l.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
-	l.logger.Store(newLogger)
+	l.logger.Store(slog.New(newLogger))
 }
 
 // Ensure LogHolder implements LoggerSetterGetter

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -90,7 +90,7 @@ func NewLogger(debugEnabled DebugEnabledFunc) *slog.Logger {
 // LoggerSetterGetter is an interface that can set and get a logger
 type LoggerSetterGetter interface {
 	// SetLogger sets a new slog.Handler
-	SetLogger(newLogger slog.Handler)
+	SetLogger(newHandler slog.Handler)
 	// Logger returns the slog.Logger created from the slog.Handler
 	Logger() *slog.Logger
 }
@@ -109,12 +109,12 @@ func (l *LogHolder) Logger() *slog.Logger {
 }
 
 // SetLogger sets the logger for the LogHolder. If nil, sets the default logger.
-func (l *LogHolder) SetLogger(newLogger slog.Handler) {
-	if newLogger == nil {
+func (l *LogHolder) SetLogger(newHandler slog.Handler) {
+	if newHandler == nil {
 		l.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
-	l.logger.Store(slog.New(newLogger))
+	l.logger.Store(slog.New(newHandler))
 }
 
 // Ensure LogHolder implements LoggerSetterGetter

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -85,3 +85,11 @@ func NewLogger(debugEnabled DebugEnabledFunc) *slog.Logger {
 
 	return slog.New(dynamicHandler)
 }
+
+// LoggerSetterGetter is an interface that can set and get a logger
+type LoggerSetterGetter interface {
+	// SetLogger sets the logger for the object
+	SetLogger(logger *slog.Logger)
+	// Logger returns the logger for the object
+	Logger() *slog.Logger
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -106,7 +106,7 @@ func (l *LogHolder) Logger() *slog.Logger {
 	if lg := l.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just being defensive
+	return slog.New(slog.DiscardHandler) // Should never be reached
 }
 
 // SetLogger sets the logger for the LogHolder. If nil, sets the default logger.

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -44,7 +44,7 @@ func TestLogHolder_Logger(t *testing.T) {
 		holder := &LogHolder{}
 		logger := holder.Logger()
 
-		assert.Equal(t, slog.Default().Handler(), logger.Handler())
+		assert.Equal(t, slog.Handler(slog.DiscardHandler), logger.Handler())
 	})
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogHolder_Logger(t *testing.T) {
+	t.Run("should return new logger with a then set handler", func(t *testing.T) {
+		holder := &LogHolder{}
+		buf := &bytes.Buffer{}
+		handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+		holder.SetLogger(handler)
+		logger := holder.Logger()
+
+		assert.NotNil(t, logger)
+
+		// Test that the logger works
+		logger.Info("test message")
+		assert.Contains(t, buf.String(), "test message")
+	})
+
+	t.Run("should return discard - defaultlogger when no handler is set", func(t *testing.T) {
+		holder := &LogHolder{}
+		logger := holder.Logger()
+
+		assert.Equal(t, slog.Default().Handler(), logger.Handler())
+	})
+}
+
+func TestLogHolder_SetLogger(t *testing.T) {
+	t.Run("sets logger with valid handler", func(t *testing.T) {
+		holder := &LogHolder{}
+		buf := &bytes.Buffer{}
+		handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+		holder.SetLogger(handler)
+		logger := holder.Logger()
+
+		assert.NotNil(t, logger)
+
+		// Compare the handler directly
+		assert.Equal(t, handler, logger.Handler())
+	})
+
+	t.Run("sets discard logger with nil handler", func(t *testing.T) {
+		holder := &LogHolder{}
+
+		holder.SetLogger(nil)
+		logger := holder.Logger()
+
+		assert.NotNil(t, logger)
+
+		assert.Equal(t, slog.Handler(slog.DiscardHandler), logger.Handler())
+	})
+
+	t.Run("can replace existing logger", func(t *testing.T) {
+		holder := &LogHolder{}
+
+		// Set first logger
+		buf1 := &bytes.Buffer{}
+		handler1 := slog.NewTextHandler(buf1, &slog.HandlerOptions{Level: slog.LevelDebug})
+		holder.SetLogger(handler1)
+
+		logger1 := holder.Logger()
+		assert.Equal(t, handler1, logger1.Handler())
+
+		// Replace with second logger
+		buf2 := &bytes.Buffer{}
+		handler2 := slog.NewTextHandler(buf2, &slog.HandlerOptions{Level: slog.LevelDebug})
+		holder.SetLogger(handler2)
+
+		logger2 := holder.Logger()
+		assert.Equal(t, handler2, logger2.Handler())
+	})
+}
+
+func TestLogHolder_InterfaceCompliance(t *testing.T) {
+	t.Run("implements LoggerSetterGetter interface", func(_ *testing.T) {
+		var _ LoggerSetterGetter = &LogHolder{}
+	})
+
+	t.Run("interface methods work correctly", func(t *testing.T) {
+		var holder LoggerSetterGetter = &LogHolder{}
+
+		buf := &bytes.Buffer{}
+		handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+		holder.SetLogger(handler)
+		logger := holder.Logger()
+
+		assert.NotNil(t, logger)
+		assert.Equal(t, handler, logger.Handler())
+	})
+}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -535,6 +535,7 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 		if err != nil {
 			return fmt.Errorf("unable to instantiate SQL driver: %w", err)
 		}
+		d.SetLogger(cfg.Logger())
 		store = storage.Init(d)
 	default:
 		return fmt.Errorf("unknown driver %q", helmDriver)
@@ -543,7 +544,6 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	cfg.RESTClientGetter = getter
 	cfg.KubeClient = kc
 	cfg.Releases = store
-	cfg.Releases.SetLogger(cfg.Logger())
 	cfg.HookOutputFunc = func(_, _, _ string) io.Writer { return io.Discard }
 
 	return nil

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -564,9 +564,8 @@ func (cfg *Configuration) Logger() *slog.Logger {
 
 // SetLogger sets the logger for the Configuration. If nil, sets the default logger.
 func (cfg *Configuration) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		cfg.logger.Store(slog.Default()) // We never want to set the logger to nil
+		cfg.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	cfg.logger.Store(newLogger)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -530,7 +530,6 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	case "sql":
 		d, err := driver.NewSQL(
 			os.Getenv("HELM_DRIVER_SQL_CONNECTION_STRING"),
-			cfg.Logger(),
 			namespace,
 		)
 		if err != nil {

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -117,9 +117,26 @@ type Configuration struct {
 	logging.LogHolder
 }
 
-func NewConfiguration() *Configuration {
+type ConfigurationOption func(c *Configuration)
+
+// Override the default logging handler
+// If unspecified, the default logger will be used
+func ConfigurationSetLogger(h slog.Handler) ConfigurationOption {
+	return func(c *Configuration) {
+		c.SetLogger(h)
+	}
+}
+
+func NewConfiguration(options ...ConfigurationOption) *Configuration {
 	c := &Configuration{}
-	c.SetLogger(slog.Default().Handler())
+	for _, o := range options {
+		o(c)
+	}
+
+	if c.Logger() == nil {
+		c.SetLogger(slog.Default().Handler())
+	}
+
 	return c
 }
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -129,6 +129,8 @@ func ConfigurationSetLogger(h slog.Handler) ConfigurationOption {
 
 func NewConfiguration(options ...ConfigurationOption) *Configuration {
 	c := &Configuration{}
+	c.SetLogger(slog.Default().Handler())
+
 	for _, o := range options {
 		o(c)
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -119,7 +119,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	c := &Configuration{}
-	c.SetLogger(slog.Default())
+	c.SetLogger(slog.Default().Handler())
 	return c
 }
 
@@ -494,7 +494,7 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 // Init initializes the action configuration
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string) error {
 	kc := kube.New(getter)
-	kc.SetLogger(cfg.Logger())
+	kc.SetLogger(cfg.Logger().Handler())
 
 	lazyClient := &lazyClient{
 		namespace: namespace,
@@ -505,11 +505,11 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	switch helmDriver {
 	case "secret", "secrets", "":
 		d := driver.NewSecrets(newSecretClient(lazyClient))
-		d.SetLogger(cfg.Logger())
+		d.SetLogger(cfg.Logger().Handler())
 		store = storage.Init(d)
 	case "configmap", "configmaps":
 		d := driver.NewConfigMaps(newConfigMapClient(lazyClient))
-		d.SetLogger(cfg.Logger())
+		d.SetLogger(cfg.Logger().Handler())
 		store = storage.Init(d)
 	case "memory":
 		var d *driver.Memory
@@ -524,7 +524,7 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 		if d == nil {
 			d = driver.NewMemory()
 		}
-		d.SetLogger(cfg.Logger())
+		d.SetLogger(cfg.Logger().Handler())
 		d.SetNamespace(namespace)
 		store = storage.Init(d)
 	case "sql":
@@ -535,7 +535,7 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 		if err != nil {
 			return fmt.Errorf("unable to instantiate SQL driver: %w", err)
 		}
-		d.SetLogger(cfg.Logger())
+		d.SetLogger(cfg.Logger().Handler())
 		store = storage.Init(d)
 	default:
 		return fmt.Errorf("unknown driver %q", helmDriver)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -133,10 +133,6 @@ func NewConfiguration(options ...ConfigurationOption) *Configuration {
 		o(c)
 	}
 
-	if c.Logger() == nil {
-		c.SetLogger(slog.Default().Handler())
-	}
-
 	return c
 }
 

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -344,7 +344,7 @@ func TestConfiguration_Init(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Configuration{}
+			cfg := NewConfiguration()
 
 			actualErr := cfg.Init(nil, "default", tt.helmDriver)
 			if tt.expectErr {

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -17,8 +17,6 @@ limitations under the License.
 package action
 
 import (
-	"log/slog"
-
 	"fmt"
 
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
@@ -55,6 +53,6 @@ func (h *History) Run(name string) ([]release.Releaser, error) {
 		return nil, fmt.Errorf("release name is invalid: %s", name)
 	}
 
-	slog.Debug("getting history for release", "release", name)
+	h.cfg.Logger().Debug("getting history for release", "release", name)
 	return h.cfg.Releases.History(name)
 }

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -119,7 +119,7 @@ func (u *Uninstall) Run(name string) (*releasei.UninstallReleaseResponse, error)
 		return nil, fmt.Errorf("the release named %q is already deleted", name)
 	}
 
-	slog.Debug("uninstall: deleting release", "name", name)
+	u.cfg.Logger().Debug("uninstall: deleting release", "name", name)
 	rel.Info.Status = common.StatusUninstalling
 	rel.Info.Deleted = time.Now()
 	rel.Info.Description = "Deletion in progress (or silently failed)"
@@ -131,18 +131,18 @@ func (u *Uninstall) Run(name string) (*releasei.UninstallReleaseResponse, error)
 			return res, err
 		}
 	} else {
-		slog.Debug("delete hooks disabled", "release", name)
+		u.cfg.Logger().Debug("delete hooks disabled", "release", name)
 	}
 
 	// From here on out, the release is currently considered to be in StatusUninstalling
 	// state.
 	if err := u.cfg.Releases.Update(rel); err != nil {
-		slog.Debug("uninstall: Failed to store updated release", slog.Any("error", err))
+		u.cfg.Logger().Debug("uninstall: Failed to store updated release", slog.Any("error", err))
 	}
 
 	deletedResources, kept, errs := u.deleteRelease(rel)
 	if errs != nil {
-		slog.Debug("uninstall: Failed to delete release", slog.Any("error", errs))
+		u.cfg.Logger().Debug("uninstall: Failed to delete release", slog.Any("error", errs))
 		return nil, fmt.Errorf("failed to delete release: %s", name)
 	}
 
@@ -170,7 +170,7 @@ func (u *Uninstall) Run(name string) (*releasei.UninstallReleaseResponse, error)
 	}
 
 	if !u.KeepHistory {
-		slog.Debug("purge requested", "release", name)
+		u.cfg.Logger().Debug("purge requested", "release", name)
 		err := u.purgeReleases(rels...)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("uninstall: Failed to purge the release: %w", err))
@@ -185,7 +185,7 @@ func (u *Uninstall) Run(name string) (*releasei.UninstallReleaseResponse, error)
 	}
 
 	if err := u.cfg.Releases.Update(rel); err != nil {
-		slog.Debug("uninstall: Failed to store updated release", slog.Any("error", err))
+		u.cfg.Logger().Debug("uninstall: Failed to store updated release", slog.Any("error", err))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -185,7 +185,7 @@ func (u *Upgrade) RunWithContext(ctx context.Context, name string, ch chart.Char
 		return nil, fmt.Errorf("release name is invalid: %s", name)
 	}
 
-	slog.Debug("preparing upgrade", "name", name)
+	u.cfg.Logger().Debug("preparing upgrade", "name", name)
 	currentRelease, upgradedRelease, serverSideApply, err := u.prepareUpgrade(name, chrt, vals)
 	if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func (u *Upgrade) RunWithContext(ctx context.Context, name string, ch chart.Char
 
 	u.cfg.Releases.MaxHistory = u.MaxHistory
 
-	slog.Debug("performing update", "name", name)
+	u.cfg.Logger().Debug("performing update", "name", name)
 	res, err := u.performUpgrade(ctx, currentRelease, upgradedRelease, serverSideApply)
 	if err != nil {
 		return res, err
@@ -201,7 +201,7 @@ func (u *Upgrade) RunWithContext(ctx context.Context, name string, ch chart.Char
 
 	// Do not update for dry runs
 	if !isDryRun(u.DryRunStrategy) {
-		slog.Debug("updating status for upgraded release", "name", name)
+		u.cfg.Logger().Debug("updating status for upgraded release", "name", name)
 		if err := u.cfg.Releases.Update(upgradedRelease); err != nil {
 			return res, err
 		}
@@ -308,7 +308,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chartv2.Chart, vals map[str
 		return nil, nil, false, err
 	}
 
-	slog.Debug("determined release apply method", slog.Bool("server_side_apply", serverSideApply), slog.String("previous_release_apply_method", lastRelease.ApplyMethod))
+	u.cfg.Logger().Debug("determined release apply method", slog.Bool("server_side_apply", serverSideApply), slog.String("previous_release_apply_method", lastRelease.ApplyMethod))
 
 	// Store an upgraded release.
 	upgradedRelease := &release.Release{
@@ -391,7 +391,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 	})
 
 	if isDryRun(u.DryRunStrategy) {
-		slog.Debug("dry run for release", "name", upgradedRelease.Name)
+		u.cfg.Logger().Debug("dry run for release", "name", upgradedRelease.Name)
 		if len(u.Description) > 0 {
 			upgradedRelease.Info.Description = u.Description
 		} else {
@@ -400,7 +400,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		return upgradedRelease, nil
 	}
 
-	slog.Debug("creating upgraded release", "name", upgradedRelease.Name)
+	u.cfg.Logger().Debug("creating upgraded release", "name", upgradedRelease.Name)
 	if err := u.cfg.Releases.Create(upgradedRelease); err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 			return
 		}
 	} else {
-		slog.Debug("upgrade hooks disabled", "name", upgradedRelease.Name)
+		u.cfg.Logger().Debug("upgrade hooks disabled", "name", upgradedRelease.Name)
 	}
 
 	upgradeClientSideFieldManager := isReleaseApplyMethodClientSideApply(originalRelease.ApplyMethod) && serverSideApply // Update client-side field manager if transitioning from client-side to server-side apply
@@ -515,13 +515,13 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 
 func (u *Upgrade) failRelease(rel *release.Release, created kube.ResourceList, err error) (*release.Release, error) {
 	msg := fmt.Sprintf("Upgrade %q failed: %s", rel.Name, err)
-	slog.Warn("upgrade failed", "name", rel.Name, slog.Any("error", err))
+	u.cfg.Logger().Warn("upgrade failed", "name", rel.Name, slog.Any("error", err))
 
 	rel.Info.Status = rcommon.StatusFailed
 	rel.Info.Description = msg
 	u.cfg.recordRelease(rel)
 	if u.CleanupOnFail && len(created) > 0 {
-		slog.Debug("cleanup on fail set", "cleaning_resources", len(created))
+		u.cfg.Logger().Debug("cleanup on fail set", "cleaning_resources", len(created))
 		_, errs := u.cfg.KubeClient.Delete(created, metav1.DeletePropagationBackground)
 		if errs != nil {
 			return rel, fmt.Errorf(
@@ -533,11 +533,11 @@ func (u *Upgrade) failRelease(rel *release.Release, created kube.ResourceList, e
 				),
 			)
 		}
-		slog.Debug("resource cleanup complete")
+		u.cfg.Logger().Debug("resource cleanup complete")
 	}
 
 	if u.RollbackOnFailure {
-		slog.Debug("Upgrade failed and rollback-on-failure is set, rolling back to previous successful release")
+		u.cfg.Logger().Debug("Upgrade failed and rollback-on-failure is set, rolling back to previous successful release")
 
 		// As a protection, get the last successful release before rollback.
 		// If there are no successful releases, bail out
@@ -594,13 +594,13 @@ func (u *Upgrade) failRelease(rel *release.Release, created kube.ResourceList, e
 func (u *Upgrade) reuseValues(chart *chartv2.Chart, current *release.Release, newVals map[string]interface{}) (map[string]interface{}, error) {
 	if u.ResetValues {
 		// If ResetValues is set, we completely ignore current.Config.
-		slog.Debug("resetting values to the chart's original version")
+		u.cfg.Logger().Debug("resetting values to the chart's original version")
 		return newVals, nil
 	}
 
 	// If the ReuseValues flag is set, we always copy the old values over the new config's values.
 	if u.ReuseValues {
-		slog.Debug("reusing the old release's values")
+		u.cfg.Logger().Debug("reusing the old release's values")
 
 		// We have to regenerate the old coalesced values:
 		oldVals, err := util.CoalesceValues(current.Chart, current.Config)
@@ -617,7 +617,7 @@ func (u *Upgrade) reuseValues(chart *chartv2.Chart, current *release.Release, ne
 
 	// If the ResetThenReuseValues flag is set, we use the new chart's values, but we copy the old config's values over the new config's values.
 	if u.ResetThenReuseValues {
-		slog.Debug("merging values from old release to new values")
+		u.cfg.Logger().Debug("merging values from old release to new values")
 
 		newVals = util.CoalesceTables(newVals, current.Config)
 
@@ -625,7 +625,7 @@ func (u *Upgrade) reuseValues(chart *chartv2.Chart, current *release.Release, ne
 	}
 
 	if len(newVals) == 0 && len(current.Config) > 0 {
-		slog.Debug("copying values from old release", "name", current.Name, "version", current.Version)
+		u.cfg.Logger().Debug("copying values from old release", "name", current.Name, "version", current.Version)
 		newVals = current.Config
 	}
 	return newVals, nil

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -103,7 +103,7 @@ By default, the default directories depend on the Operating System. The defaults
 var settings = cli.New()
 
 func NewRootCmd(out io.Writer, args []string, logSetup func(bool)) (*cobra.Command, error) {
-	actionConfig := new(action.Configuration)
+	actionConfig := action.NewConfiguration()
 	cmd, err := newRootCmdWithConfig(actionConfig, out, args, logSetup)
 	if err != nil {
 		return nil, err

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1208,9 +1208,8 @@ func (c *Client) Logger() *slog.Logger {
 }
 
 func (c *Client) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		c.logger.Store(slog.Default()) // We never want to set the logger to nil
+		c.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	c.logger.Store(newLogger)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1204,7 +1204,7 @@ func (c *Client) Logger() *slog.Logger {
 	if lg := c.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (c *Client) SetLogger(newLogger *slog.Logger) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -182,7 +182,7 @@ func New(getter genericclioptions.RESTClientGetter) *Client {
 	c := &Client{
 		Factory: factory,
 	}
-	c.SetLogger(slog.Default())
+	c.SetLogger(slog.Default().Handler())
 	return c
 }
 

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -56,7 +56,7 @@ func NewConfigMaps(impl corev1.ConfigMapInterface) *ConfigMaps {
 	c := &ConfigMaps{
 		impl: impl,
 	}
-	c.SetLogger(slog.Default())
+	c.SetLogger(slog.Default().Handler())
 	return c
 }
 

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -291,9 +291,8 @@ func (cfgmaps *ConfigMaps) Logger() *slog.Logger {
 }
 
 func (cfgmaps *ConfigMaps) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		cfgmaps.logger.Store(slog.Default()) // We never want to set the logger to nil
+		cfgmaps.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	cfgmaps.logger.Store(newLogger)

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -287,7 +287,7 @@ func (cfgmaps *ConfigMaps) Logger() *slog.Logger {
 	if lg := cfgmaps.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (cfgmaps *ConfigMaps) SetLogger(newLogger *slog.Logger) {

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -258,7 +258,7 @@ func (mem *Memory) Logger() *slog.Logger {
 	if lg := mem.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (mem *Memory) SetLogger(newLogger *slog.Logger) {

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -51,7 +51,7 @@ type Memory struct {
 // NewMemory initializes a new memory driver.
 func NewMemory() *Memory {
 	m := &Memory{cache: map[string]memReleases{}, namespace: "default"}
-	m.SetLogger(slog.Default())
+	m.SetLogger(slog.Default().Handler())
 	return m
 }
 

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -262,9 +262,8 @@ func (mem *Memory) Logger() *slog.Logger {
 }
 
 func (mem *Memory) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		mem.logger.Store(slog.Default()) // We never want to set the logger to nil
+		mem.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	mem.logger.Store(newLogger)

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -284,7 +284,7 @@ func (secrets *Secrets) Logger() *slog.Logger {
 	if lg := secrets.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (secrets *Secrets) SetLogger(newLogger *slog.Logger) {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -55,7 +55,7 @@ func NewSecrets(impl corev1.SecretInterface) *Secrets {
 	s := &Secrets{
 		impl: impl,
 	}
-	s.SetLogger(slog.Default())
+	s.SetLogger(slog.Default().Handler())
 	return s
 }
 

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -288,9 +288,8 @@ func (secrets *Secrets) Logger() *slog.Logger {
 }
 
 func (secrets *Secrets) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		secrets.logger.Store(slog.Default()) // We never want to set the logger to nil
+		secrets.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	secrets.logger.Store(newLogger)

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -89,6 +90,8 @@ type SQL struct {
 	db               *sqlx.DB
 	namespace        string
 	statementBuilder sq.StatementBuilderType
+	// logger is an slog.Logger pointer to use the driver
+	logger atomic.Pointer[slog.Logger]
 }
 
 // Name returns the name of the driver.
@@ -109,13 +112,13 @@ func (s *SQL) checkAlreadyApplied(migrations []*migrate.Migration) bool {
 	records, err := migrate.GetMigrationRecords(s.db.DB, postgreSQLDialect)
 	migrate.SetDisableCreateTable(false)
 	if err != nil {
-		slog.Debug("failed to get migration records", slog.Any("error", err))
+		s.Logger().Debug("failed to get migration records", slog.Any("error", err))
 		return false
 	}
 
 	for _, record := range records {
 		if _, ok := migrationsIDs[record.Id]; ok {
-			slog.Debug("found previous migration", "id", record.Id, "appliedAt", record.AppliedAt)
+			s.Logger().Debug("found previous migration", "id", record.Id, "appliedAt", record.AppliedAt)
 			delete(migrationsIDs, record.Id)
 		}
 	}
@@ -123,7 +126,7 @@ func (s *SQL) checkAlreadyApplied(migrations []*migrate.Migration) bool {
 	// check if all migrations applied
 	if len(migrationsIDs) != 0 {
 		for id := range migrationsIDs {
-			slog.Debug("find unapplied migration", "id", id)
+			s.Logger().Debug("find unapplied migration", "id", id)
 		}
 		return false
 	}
@@ -157,9 +160,9 @@ func (s *SQL) ensureDBSetup() error {
 						CREATE INDEX ON %s (%s);
 						CREATE INDEX ON %s (%s);
 						CREATE INDEX ON %s (%s);
-	
+
 						GRANT ALL ON %s TO PUBLIC;
-	
+
 						ALTER TABLE %s ENABLE ROW LEVEL SECURITY;
 					`,
 						sqlReleaseTableName,
@@ -209,7 +212,7 @@ func (s *SQL) ensureDBSetup() error {
 							%s VARCHAR(%d)
 						);
 						CREATE INDEX ON %s (%s, %s);
-						
+
 						GRANT ALL ON %s TO PUBLIC;
 						ALTER TABLE %s ENABLE ROW LEVEL SECURITY;
 					`,
@@ -277,7 +280,7 @@ type SQLReleaseCustomLabelWrapper struct {
 }
 
 // NewSQL initializes a new sql driver.
-func NewSQL(connectionString string, namespace string) (*SQL, error) {
+func NewSQL(connectionString string, logger *slog.Logger, namespace string) (*SQL, error) {
 	db, err := sqlx.Connect(postgreSQLDialect, connectionString)
 	if err != nil {
 		return nil, err
@@ -293,6 +296,7 @@ func NewSQL(connectionString string, namespace string) (*SQL, error) {
 	}
 
 	driver.namespace = namespace
+	driver.SetLogger(logger)
 
 	return driver, nil
 }
@@ -309,24 +313,24 @@ func (s *SQL) Get(key string) (release.Releaser, error) {
 
 	query, args, err := qb.ToSql()
 	if err != nil {
-		slog.Debug("failed to build query", slog.Any("error", err))
+		s.Logger().Debug("failed to build query", slog.Any("error", err))
 		return nil, err
 	}
 
 	// Get will return an error if the result is empty
 	if err := s.db.Get(&record, query, args...); err != nil {
-		slog.Debug("got SQL error when getting release", "key", key, slog.Any("error", err))
+		s.Logger().Debug("got SQL error when getting release", "key", key, slog.Any("error", err))
 		return nil, ErrReleaseNotFound
 	}
 
 	release, err := decodeRelease(record.Body)
 	if err != nil {
-		slog.Debug("failed to decode data", "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to decode data", "key", key, slog.Any("error", err))
 		return nil, err
 	}
 
 	if release.Labels, err = s.getReleaseCustomLabels(key, s.namespace); err != nil {
-		slog.Debug("failed to get release custom labels", "namespace", s.namespace, "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to get release custom labels", "namespace", s.namespace, "key", key, slog.Any("error", err))
 		return nil, err
 	}
 
@@ -347,13 +351,13 @@ func (s *SQL) List(filter func(release.Releaser) bool) ([]release.Releaser, erro
 
 	query, args, err := sb.ToSql()
 	if err != nil {
-		slog.Debug("failed to build query", slog.Any("error", err))
+		s.Logger().Debug("failed to build query", slog.Any("error", err))
 		return nil, err
 	}
 
 	var records = []SQLReleaseWrapper{}
 	if err := s.db.Select(&records, query, args...); err != nil {
-		slog.Debug("failed to list", slog.Any("error", err))
+		s.Logger().Debug("failed to list", slog.Any("error", err))
 		return nil, err
 	}
 
@@ -361,12 +365,12 @@ func (s *SQL) List(filter func(release.Releaser) bool) ([]release.Releaser, erro
 	for _, record := range records {
 		release, err := decodeRelease(record.Body)
 		if err != nil {
-			slog.Debug("failed to decode release", "record", record, slog.Any("error", err))
+			s.Logger().Debug("failed to decode release", "record", record, slog.Any("error", err))
 			continue
 		}
 
 		if release.Labels, err = s.getReleaseCustomLabels(record.Key, record.Namespace); err != nil {
-			slog.Debug("failed to get release custom labels", "namespace", record.Namespace, "key", record.Key, slog.Any("error", err))
+			s.Logger().Debug("failed to get release custom labels", "namespace", record.Namespace, "key", record.Key, slog.Any("error", err))
 			return nil, err
 		}
 		maps.Copy(release.Labels, getReleaseSystemLabels(release))
@@ -394,7 +398,7 @@ func (s *SQL) Query(labels map[string]string) ([]release.Releaser, error) {
 		if _, ok := labelMap[key]; ok {
 			sb = sb.Where(sq.Eq{key: labels[key]})
 		} else {
-			slog.Debug("unknown label", "key", key)
+			s.Logger().Debug("unknown label", "key", key)
 			return nil, fmt.Errorf("unknown label %s", key)
 		}
 	}
@@ -407,13 +411,13 @@ func (s *SQL) Query(labels map[string]string) ([]release.Releaser, error) {
 	// Build our query
 	query, args, err := sb.ToSql()
 	if err != nil {
-		slog.Debug("failed to build query", slog.Any("error", err))
+		s.Logger().Debug("failed to build query", slog.Any("error", err))
 		return nil, err
 	}
 
 	var records = []SQLReleaseWrapper{}
 	if err := s.db.Select(&records, query, args...); err != nil {
-		slog.Debug("failed to query with labels", slog.Any("error", err))
+		s.Logger().Debug("failed to query with labels", slog.Any("error", err))
 		return nil, err
 	}
 
@@ -425,12 +429,12 @@ func (s *SQL) Query(labels map[string]string) ([]release.Releaser, error) {
 	for _, record := range records {
 		release, err := decodeRelease(record.Body)
 		if err != nil {
-			slog.Debug("failed to decode release", "record", record, slog.Any("error", err))
+			s.Logger().Debug("failed to decode release", "record", record, slog.Any("error", err))
 			continue
 		}
 
 		if release.Labels, err = s.getReleaseCustomLabels(record.Key, record.Namespace); err != nil {
-			slog.Debug("failed to get release custom labels", "namespace", record.Namespace, "key", record.Key, slog.Any("error", err))
+			s.Logger().Debug("failed to get release custom labels", "namespace", record.Namespace, "key", record.Key, slog.Any("error", err))
 			return nil, err
 		}
 
@@ -459,13 +463,13 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 
 	body, err := encodeRelease(rls)
 	if err != nil {
-		slog.Debug("failed to encode release", slog.Any("error", err))
+		s.Logger().Debug("failed to encode release", slog.Any("error", err))
 		return err
 	}
 
 	transaction, err := s.db.Beginx()
 	if err != nil {
-		slog.Debug("failed to start SQL transaction", slog.Any("error", err))
+		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
 		return fmt.Errorf("error beginning transaction: %v", err)
 	}
 
@@ -494,7 +498,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 			int(time.Now().Unix()),
 		).ToSql()
 	if err != nil {
-		slog.Debug("failed to build insert query", slog.Any("error", err))
+		s.Logger().Debug("failed to build insert query", slog.Any("error", err))
 		return err
 	}
 
@@ -508,17 +512,17 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 			Where(sq.Eq{sqlReleaseTableNamespaceColumn: s.namespace}).
 			ToSql()
 		if buildErr != nil {
-			slog.Debug("failed to build select query", "error", buildErr)
+			s.Logger().Debug("failed to build select query", "error", buildErr)
 			return err
 		}
 
 		var record SQLReleaseWrapper
 		if err := transaction.Get(&record, selectQuery, args...); err == nil {
-			slog.Debug("release already exists", "key", key)
+			s.Logger().Debug("release already exists", "key", key)
 			return ErrReleaseExists
 		}
 
-		slog.Debug("failed to store release in SQL database", "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to store release in SQL database", "key", key, slog.Any("error", err))
 		return err
 	}
 
@@ -541,13 +545,13 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 
 		if err != nil {
 			defer transaction.Rollback()
-			slog.Debug("failed to build insert query", slog.Any("error", err))
+			s.Logger().Debug("failed to build insert query", slog.Any("error", err))
 			return err
 		}
 
 		if _, err := transaction.Exec(insertLabelsQuery, args...); err != nil {
 			defer transaction.Rollback()
-			slog.Debug("failed to write Labels", slog.Any("error", err))
+			s.Logger().Debug("failed to write Labels", slog.Any("error", err))
 			return err
 		}
 	}
@@ -570,7 +574,7 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 
 	body, err := encodeRelease(rls)
 	if err != nil {
-		slog.Debug("failed to encode release", slog.Any("error", err))
+		s.Logger().Debug("failed to encode release", slog.Any("error", err))
 		return err
 	}
 
@@ -587,12 +591,12 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 		ToSql()
 
 	if err != nil {
-		slog.Debug("failed to build update query", slog.Any("error", err))
+		s.Logger().Debug("failed to build update query", slog.Any("error", err))
 		return err
 	}
 
 	if _, err := s.db.Exec(query, args...); err != nil {
-		slog.Debug("failed to update release in SQL database", "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to update release in SQL database", "key", key, slog.Any("error", err))
 		return err
 	}
 
@@ -603,7 +607,7 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 func (s *SQL) Delete(key string) (release.Releaser, error) {
 	transaction, err := s.db.Beginx()
 	if err != nil {
-		slog.Debug("failed to start SQL transaction", slog.Any("error", err))
+		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
 		return nil, fmt.Errorf("error beginning transaction: %v", err)
 	}
 
@@ -614,20 +618,20 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		Where(sq.Eq{sqlReleaseTableNamespaceColumn: s.namespace}).
 		ToSql()
 	if err != nil {
-		slog.Debug("failed to build select query", slog.Any("error", err))
+		s.Logger().Debug("failed to build select query", slog.Any("error", err))
 		return nil, err
 	}
 
 	var record SQLReleaseWrapper
 	err = transaction.Get(&record, selectQuery, args...)
 	if err != nil {
-		slog.Debug("release not found", "key", key, slog.Any("error", err))
+		s.Logger().Debug("release not found", "key", key, slog.Any("error", err))
 		return nil, ErrReleaseNotFound
 	}
 
 	release, err := decodeRelease(record.Body)
 	if err != nil {
-		slog.Debug("failed to decode release", "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to decode release", "key", key, slog.Any("error", err))
 		transaction.Rollback()
 		return nil, err
 	}
@@ -639,18 +643,18 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		Where(sq.Eq{sqlReleaseTableNamespaceColumn: s.namespace}).
 		ToSql()
 	if err != nil {
-		slog.Debug("failed to build delete query", slog.Any("error", err))
+		s.Logger().Debug("failed to build delete query", slog.Any("error", err))
 		return nil, err
 	}
 
 	_, err = transaction.Exec(deleteQuery, args...)
 	if err != nil {
-		slog.Debug("failed perform delete query", slog.Any("error", err))
+		s.Logger().Debug("failed perform delete query", slog.Any("error", err))
 		return release, err
 	}
 
 	if release.Labels, err = s.getReleaseCustomLabels(key, s.namespace); err != nil {
-		slog.Debug("failed to get release custom labels", "namespace", s.namespace, "key", key, slog.Any("error", err))
+		s.Logger().Debug("failed to get release custom labels", "namespace", s.namespace, "key", key, slog.Any("error", err))
 		return nil, err
 	}
 
@@ -661,7 +665,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		ToSql()
 
 	if err != nil {
-		slog.Debug("failed to build delete Labels query", slog.Any("error", err))
+		s.Logger().Debug("failed to build delete Labels query", slog.Any("error", err))
 		return nil, err
 	}
 	_, err = transaction.Exec(deleteCustomLabelsQuery, args...)
@@ -701,4 +705,21 @@ func getReleaseSystemLabels(rls *rspb.Release) map[string]string {
 		"status":  rls.Info.Status.String(),
 		"version": strconv.Itoa(rls.Version),
 	}
+}
+
+// logger returns the logger for the SQL driver. If nil, returns slog.Default().
+func (s *SQL) Logger() *slog.Logger {
+	if lg := s.logger.Load(); lg != nil {
+		return lg
+	}
+	return slog.Default() // We rarely get here, just be defensive
+}
+
+func (s *SQL) SetLogger(newLogger *slog.Logger) {
+	// Only set logger if it's currently nil
+	if newLogger == nil {
+		s.logger.Store(slog.Default()) // We never want to set the logger to nil
+		return
+	}
+	s.logger.Store(newLogger)
 }

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -716,9 +716,8 @@ func (s *SQL) Logger() *slog.Logger {
 }
 
 func (s *SQL) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		s.logger.Store(slog.Default()) // We never want to set the logger to nil
+		s.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	s.logger.Store(newLogger)

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -296,7 +296,7 @@ func NewSQL(connectionString string, namespace string) (*SQL, error) {
 	}
 
 	driver.namespace = namespace
-	driver.SetLogger(slog.Default())
+	driver.SetLogger(slog.Default().Handler())
 
 	return driver, nil
 }

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -280,7 +280,7 @@ type SQLReleaseCustomLabelWrapper struct {
 }
 
 // NewSQL initializes a new sql driver.
-func NewSQL(connectionString string, logger *slog.Logger, namespace string) (*SQL, error) {
+func NewSQL(connectionString string, namespace string) (*SQL, error) {
 	db, err := sqlx.Connect(postgreSQLDialect, connectionString)
 	if err != nil {
 		return nil, err
@@ -296,7 +296,7 @@ func NewSQL(connectionString string, logger *slog.Logger, namespace string) (*SQ
 	}
 
 	driver.namespace = namespace
-	driver.SetLogger(logger)
+	driver.SetLogger(slog.Default())
 
 	return driver, nil
 }
@@ -712,7 +712,7 @@ func (s *SQL) Logger() *slog.Logger {
 	if lg := s.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (s *SQL) SetLogger(newLogger *slog.Logger) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
@@ -44,13 +45,16 @@ type Storage struct {
 	// be retained, including the most recent release. Values of 0 or less are
 	// ignored (meaning no limits are imposed).
 	MaxHistory int
+
+	// logger is an slog.Logger pointer to use the storage engine
+	logger atomic.Pointer[slog.Logger]
 }
 
 // Get retrieves the release from storage. An error is returned
 // if the storage driver failed to fetch the release, or the
 // release identified by the key, version pair does not exist.
 func (s *Storage) Get(name string, version int) (release.Releaser, error) {
-	slog.Debug("getting release", "key", makeKey(name, version))
+	s.Logger().Debug("getting release", "key", makeKey(name, version))
 	return s.Driver.Get(makeKey(name, version))
 }
 
@@ -62,7 +66,7 @@ func (s *Storage) Create(rls release.Releaser) error {
 	if err != nil {
 		return err
 	}
-	slog.Debug("creating release", "key", makeKey(rac.Name(), rac.Version()))
+	s.Logger().Debug("creating release", "key", makeKey(rac.Name(), rac.Version()))
 	if s.MaxHistory > 0 {
 		// Want to make space for one more release.
 		if err := s.removeLeastRecent(rac.Name(), s.MaxHistory-1); err != nil &&
@@ -81,7 +85,7 @@ func (s *Storage) Update(rls release.Releaser) error {
 	if err != nil {
 		return err
 	}
-	slog.Debug("updating release", "key", makeKey(rac.Name(), rac.Version()))
+	s.Logger().Debug("updating release", "key", makeKey(rac.Name(), rac.Version()))
 	return s.Driver.Update(makeKey(rac.Name(), rac.Version()), rls)
 }
 
@@ -89,14 +93,14 @@ func (s *Storage) Update(rls release.Releaser) error {
 // the storage backend fails to delete the release or if the release
 // does not exist.
 func (s *Storage) Delete(name string, version int) (release.Releaser, error) {
-	slog.Debug("deleting release", "key", makeKey(name, version))
+	s.Logger().Debug("deleting release", "key", makeKey(name, version))
 	return s.Driver.Delete(makeKey(name, version))
 }
 
 // ListReleases returns all releases from storage. An error is returned if the
 // storage backend fails to retrieve the releases.
 func (s *Storage) ListReleases() ([]release.Releaser, error) {
-	slog.Debug("listing all releases in storage")
+	s.Logger().Debug("listing all releases in storage")
 	return s.List(func(_ release.Releaser) bool { return true })
 }
 
@@ -118,13 +122,13 @@ func releaserToV1Release(rel release.Releaser) (*rspb.Release, error) {
 // ListUninstalled returns all releases with Status == UNINSTALLED. An error is returned
 // if the storage backend fails to retrieve the releases.
 func (s *Storage) ListUninstalled() ([]release.Releaser, error) {
-	slog.Debug("listing uninstalled releases in storage")
+	s.Logger().Debug("listing uninstalled releases in storage")
 	return s.List(func(rls release.Releaser) bool {
 		rel, err := releaserToV1Release(rls)
 		if err != nil {
 			// This will only happen if calling code does not pass the proper types. This is
 			// a problem with the application and not user data.
-			slog.Error("unable to convert release to typed release", slog.Any("error", err))
+			s.Logger().Error("unable to convert release to typed release", slog.Any("error", err))
 			panic(fmt.Sprintf("unable to convert release to typed release: %s", err))
 		}
 		return relutil.StatusFilter(common.StatusUninstalled).Check(rel)
@@ -134,13 +138,13 @@ func (s *Storage) ListUninstalled() ([]release.Releaser, error) {
 // ListDeployed returns all releases with Status == DEPLOYED. An error is returned
 // if the storage backend fails to retrieve the releases.
 func (s *Storage) ListDeployed() ([]release.Releaser, error) {
-	slog.Debug("listing all deployed releases in storage")
+	s.Logger().Debug("listing all deployed releases in storage")
 	return s.List(func(rls release.Releaser) bool {
 		rel, err := releaserToV1Release(rls)
 		if err != nil {
 			// This will only happen if calling code does not pass the proper types. This is
 			// a problem with the application and not user data.
-			slog.Error("unable to convert release to typed release", slog.Any("error", err))
+			s.Logger().Error("unable to convert release to typed release", slog.Any("error", err))
 			panic(fmt.Sprintf("unable to convert release to typed release: %s", err))
 		}
 		return relutil.StatusFilter(common.StatusDeployed).Check(rel)
@@ -187,7 +191,7 @@ func releaseListToV1List(ls []release.Releaser) ([]*rspb.Release, error) {
 // DeployedAll returns all deployed releases with the provided name, or
 // returns driver.NewErrNoDeployedReleases if not found.
 func (s *Storage) DeployedAll(name string) ([]release.Releaser, error) {
-	slog.Debug("getting deployed releases", "name", name)
+	s.Logger().Debug("getting deployed releases", "name", name)
 
 	ls, err := s.Query(map[string]string{
 		"name":   name,
@@ -206,7 +210,7 @@ func (s *Storage) DeployedAll(name string) ([]release.Releaser, error) {
 // History returns the revision history for the release with the provided name, or
 // returns driver.ErrReleaseNotFound if no such release name exists.
 func (s *Storage) History(name string) ([]release.Releaser, error) {
-	slog.Debug("getting release history", "name", name)
+	s.Logger().Debug("getting release history", "name", name)
 
 	return s.Query(map[string]string{"name": name, "owner": "helm"})
 }
@@ -274,7 +278,7 @@ func (s *Storage) removeLeastRecent(name string, maximum int) error {
 		}
 	}
 
-	slog.Debug("pruned records", "count", len(toDelete), "release", name, "errors", len(errs))
+	s.Logger().Debug("pruned records", "count", len(toDelete), "release", name, "errors", len(errs))
 	switch c := len(errs); c {
 	case 0:
 		return nil
@@ -289,7 +293,7 @@ func (s *Storage) deleteReleaseVersion(name string, version int) error {
 	key := makeKey(name, version)
 	_, err := s.Delete(name, version)
 	if err != nil {
-		slog.Debug("error pruning release", "key", key, slog.Any("error", err))
+		s.Logger().Debug("error pruning release", "key", key, slog.Any("error", err))
 		return err
 	}
 	return nil
@@ -297,7 +301,7 @@ func (s *Storage) deleteReleaseVersion(name string, version int) error {
 
 // Last fetches the last revision of the named release.
 func (s *Storage) Last(name string) (release.Releaser, error) {
-	slog.Debug("getting last revision", "name", name)
+	s.Logger().Debug("getting last revision", "name", name)
 	h, err := s.History(name)
 	if err != nil {
 		return nil, err
@@ -331,7 +335,26 @@ func Init(d driver.Driver) *Storage {
 	if d == nil {
 		d = driver.NewMemory()
 	}
-	return &Storage{
+	s := &Storage{
 		Driver: d,
 	}
+	s.SetLogger(slog.Default())
+	return s
+}
+
+// logger returns the logger for the Storage. If nil, returns slog.Default().
+func (s *Storage) Logger() *slog.Logger {
+	if lg := s.logger.Load(); lg != nil {
+		return lg
+	}
+	return slog.Default() // We rarely get here, just be defensive
+}
+
+func (s *Storage) SetLogger(newLogger *slog.Logger) {
+	// Only set logger if it's currently nil
+	if newLogger == nil {
+		s.logger.Store(slog.Default()) // We never want to set the logger to nil
+		return
+	}
+	s.logger.Store(newLogger)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"helm.sh/helm/v4/internal/logging"
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
@@ -338,7 +339,14 @@ func Init(d driver.Driver) *Storage {
 	s := &Storage{
 		Driver: d,
 	}
-	s.SetLogger(slog.Default())
+
+	// Get logger from driver if it implements the LoggerSetterGetter interface
+	if ls, ok := d.(logging.LoggerSetterGetter); ok {
+		ls.SetLogger(s.Logger())
+	} else {
+		// If the driver does not implement the LoggerSetterGetter interface, set the default logger
+		s.SetLogger(slog.Default())
+	}
 	return s
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync/atomic"
 
 	"helm.sh/helm/v4/internal/logging"
 	"helm.sh/helm/v4/pkg/release"
@@ -47,8 +46,8 @@ type Storage struct {
 	// ignored (meaning no limits are imposed).
 	MaxHistory int
 
-	// logger is an slog.Logger pointer to use the storage engine
-	logger atomic.Pointer[slog.Logger]
+	// Embed a LogHolder to provide logger functionality
+	logging.LogHolder
 }
 
 // Get retrieves the release from storage. An error is returned
@@ -348,20 +347,4 @@ func Init(d driver.Driver) *Storage {
 		s.SetLogger(slog.Default())
 	}
 	return s
-}
-
-// logger returns the logger for the Storage. If nil, returns slog.Default().
-func (s *Storage) Logger() *slog.Logger {
-	if lg := s.logger.Load(); lg != nil {
-		return lg
-	}
-	return slog.Default() // We rarely get here, just being defensive
-}
-
-func (s *Storage) SetLogger(newLogger *slog.Logger) {
-	if newLogger == nil {
-		s.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
-		return
-	}
-	s.logger.Store(newLogger)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -351,9 +351,8 @@ func (s *Storage) Logger() *slog.Logger {
 }
 
 func (s *Storage) SetLogger(newLogger *slog.Logger) {
-	// Only set logger if it's currently nil
 	if newLogger == nil {
-		s.logger.Store(slog.Default()) // We never want to set the logger to nil
+		s.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
 		return
 	}
 	s.logger.Store(newLogger)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -341,10 +341,10 @@ func Init(d driver.Driver) *Storage {
 
 	// Get logger from driver if it implements the LoggerSetterGetter interface
 	if ls, ok := d.(logging.LoggerSetterGetter); ok {
-		ls.SetLogger(s.Logger())
+		ls.SetLogger(s.Logger().Handler())
 	} else {
 		// If the driver does not implement the LoggerSetterGetter interface, set the default logger
-		s.SetLogger(slog.Default())
+		s.SetLogger(slog.Default().Handler())
 	}
 	return s
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -347,7 +347,7 @@ func (s *Storage) Logger() *slog.Logger {
 	if lg := s.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.Default() // We rarely get here, just be defensive
+	return slog.Default() // We rarely get here, just being defensive
 }
 
 func (s *Storage) SetLogger(newLogger *slog.Logger) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add ability to override logger when creating new actions

Here is an example of how to use it

```go
package main

import (
	"log/slog"
	"os"

	"helm.sh/helm/v4/pkg/action"
	"helm.sh/helm/v4/pkg/cli"
)

func main() {
	settings := cli.New()

	mylogger := slog.New(slog.NewTextHandler(os.Stdout, nil))

	actionConfig := action.NewConfiguration()
	actionConfig.SetLogger(mylogger)              // <------ New method to set logger

	// You can pass an empty string instead of settings.Namespace() to list
	// all namespaces
	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER")); err != nil {
		mylogger.Error("failed to init action config", "error", err)
		os.Exit(1)
	}
}
```

Fixes: #31399

**Special notes for your reviewer**:
- As opposed to v3, the logger is set using a `SetLogger()` method instead of passing the logger in `action.Configuration.Init()` function, or setting it via `action.Configuration.Log`
- The logger is an `slog.Logger` instead of the older `log` logger library in v3

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
