### PR TITLE
Fix rollback for missing resources

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -532,7 +532,32 @@ func (c *Client) update(originals, targets ResourceList, updateApplyFunc UpdateA
 		original := originals.Get(target)
 		if original == nil {
 			kind := target.Mapping.GroupVersionKind.Kind
-			return fmt.Errorf("original object %s with the name %q not found", kind, target.Name)
+
+			slog.Warn("resource exists on cluster but not in original release, using cluster state as baseline",
+				"namespace", target.Namespace, "name", target.Name, "kind", kind)
+
+			currentObj, err := helper.Get(target.Namespace, target.Name)
+			if err != nil {
+				return fmt.Errorf("original object %s with the name %q not found", kind, target.Name)
+			}
+
+			// Create a temporary Info with the current cluster state to use as "original"
+			currentInfo := &resource.Info{
+				Client:    target.Client,
+				Mapping:   target.Mapping,
+				Namespace: target.Namespace,
+				Name:      target.Name,
+				Object:    currentObj,
+			}
+
+			if err := updateApplyFunc(currentInfo, target); err != nil {
+				updateErrors = append(updateErrors, err)
+			}
+
+			// Because we check for errors later, append the info regardless
+			res.Updated = append(res.Updated, target)
+
+			return nil
 		}
 
 		if err := updateApplyFunc(original, target); err != nil {
@@ -570,7 +595,9 @@ func (c *Client) update(originals, targets ResourceList, updateApplyFunc UpdateA
 		if err := deleteResource(info, metav1.DeletePropagationBackground); err != nil {
 			slog.Debug("failed to delete resource", "namespace", info.Namespace, "name", info.Name, "kind", info.Mapping.GroupVersionKind.Kind, slog.Any("error", err))
 			if !apierrors.IsNotFound(err) {
-				updateErrors = append(updateErrors, fmt.Errorf("failed to delete resource %s: %w", info.Name, err))
+				updateErrors = append(updateErrors, fmt.Errorf(
+					"failed to delete resource namespace=%s, name=%s, kind=%s: %w",
+					info.Namespace, info.Name, info.Mapping.GroupVersionKind.Kind, err))
 			}
 			continue
 		}

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -412,7 +412,25 @@ func TestUpdate(t *testing.T) {
 				"/namespaces/default/pods/forbidden:GET",
 				"/namespaces/default/pods/forbidden:DELETE",
 			),
-			ExpectedError: "failed to delete resource forbidden:",
+			ExpectedError: "failed to delete resource namespace=default, name=forbidden, kind=Pod:",
+		},
+		"rollback after failed upgrade with removed resource": {
+			// Simulates rollback scenario:
+			// - Revision 1 had "newpod"
+			// - Revision 2 removed "newpod" but upgrade failed (OriginalPods is empty)
+			// - Cluster still has "newpod" from Revision 1
+			// - Rolling back to Revision 1 (TargetPods with "newpod") should succeed
+			OriginalPods:                 v1.PodList{},         // Revision 2 (failed) - resource was removed
+			TargetPods:                   newPodList("newpod"), // Revision 1 - rolling back to this
+			ThreeWayMergeForUnstructured: false,
+			ServerSideApply:              true,
+			ExpectedActions: []string{
+				"/namespaces/default/pods/newpod:GET",   // Check if resource exists
+				"/namespaces/default/pods/newpod:GET",   // Get current state (first call in update path)
+				"/namespaces/default/pods/newpod:GET",   // Get current cluster state to use as baseline
+				"/namespaces/default/pods/newpod:PATCH", // Update using cluster state as baseline
+			},
+			ExpectedError: "",
 		},
 	}
 
@@ -429,6 +447,10 @@ func TestUpdate(t *testing.T) {
 				p, m := req.URL.Path, req.Method
 
 				switch {
+				case p == "/namespaces/default/pods/newpod" && m == http.MethodGet:
+					return newResponse(http.StatusOK, &listTarget.Items[0])
+				case p == "/namespaces/default/pods/newpod" && m == http.MethodPatch:
+					return newResponse(http.StatusOK, &listTarget.Items[0])
 				case p == "/namespaces/default/pods/starfish" && m == http.MethodGet:
 					return newResponse(http.StatusOK, &listOriginal.Items[0])
 				case p == "/namespaces/default/pods/otter" && m == http.MethodGet:
@@ -519,9 +541,23 @@ func TestUpdate(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Len(t, result.Created, 1, "expected 1 resource created, got %d", len(result.Created))
-			assert.Len(t, result.Updated, 2, "expected 2 resource updated, got %d", len(result.Updated))
-			assert.Len(t, result.Deleted, 1, "expected 1 resource deleted, got %d", len(result.Deleted))
+			// Special handling for the rollback test case
+			if name == "rollback after failed upgrade with removed resource" {
+				assert.Len(t, result.Created, 0, "expected 0 resource created, got %d", len(result.Created))
+				assert.Len(t, result.Updated, 1, "expected 1 resource updated, got %d", len(result.Updated))
+				assert.Len(t, result.Deleted, 0, "expected 0 resource deleted, got %d", len(result.Deleted))
+			} else {
+				assert.Len(t, result.Created, 1, "expected 1 resource created, got %d", len(result.Created))
+				assert.Len(t, result.Updated, 2, "expected 2 resource updated, got %d", len(result.Updated))
+				assert.Len(t, result.Deleted, 1, "expected 1 resource deleted, got %d", len(result.Deleted))
+			}
+
+			if tc.ExpectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.ExpectedError)
+			} else {
+				require.NoError(t, err)
+			}
 
 			actions := []string{}
 			for _, action := range client.Actions {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix rollback for missing resources.
Fixes: https://github.com/helm/helm/issues/13437 

How to test:

Build the helm binary
```
$ make build
$ helm version
  version.BuildInfo{Version:"v4.0+unreleased", GitCommit:"f82e2b3c50d346948ce42e6a4f1348dee29aba31", GitTreeState:"dirty", GoVersion:"go1.24.7", KubeClientVersion:"v1.34"}
```
A quick test can be performed by creating a following charts directory:
```sh
├── v1
│   ├── Chart.yaml
│   ├── templates
│   │   ├── configmap.yaml
│   │   └── failure-hook.yaml
│   └── values.yaml
└── v2
    ├── Chart.yaml
    ├── templates
    │   └── failure-hook.yaml
    └── values.yaml
```

```YAML
{{- if .Release.IsInstall }}
apiVersion: v1
kind: ConfigMap
metadata:
  name: cfg
data:
  foo: bar
{{- end }}
```
```YAML
{{- if .Release.IsUpgrade }}
apiVersion: batch/v1
kind: Job
metadata:
  name: failurecauser
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
spec:
  template:
    spec:
      terminationGracePeriodSeconds: 1
      containers:
        - name: never
          image: busybox:latest
          args: ["/bin/sh", "-c", "false"]
          imagePullPolicy: Always
      restartPolicy: Never
  backoffLimit: 0
{{- end }}
```

```shell
helm install test ./v1
NAME: test
LAST DEPLOYED: Wed Oct 22 12:34:41 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
```
```sh
helm upgrade test ./v2
^CRelease test has been cancelled.
level=WARN msg="upgrade failed" name=test error="context canceled"
Error: UPGRADE FAILED: context canceled
```
```sh
helm list -A
NAME	NAMESPACE	REVISION	UPDATED                              	STATUS	CHART              	APP VERSION
test	default  	2       	2025-10-22 12:35:55.186407 +0300 EEST	failed	helm-bug-demo-2.0.0	1.0
```
```sh
helm rollback test 1
Rollback was a success! Happy Helming!
```
```sh
helm list -A
NAME	NAMESPACE	REVISION	UPDATED                              	STATUS  	CHART              	APP VERSION
test	default  	3       	2025-10-22 12:37:00.757802 +0300 EEST	deployed	helm-bug-demo-1.0.0	1.0
```
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

