### PR TITLE
pkg/cmd: clarify install options, document them

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -106,14 +106,23 @@ type Install struct {
 	Description      string
 	OutputDir        string
 	// RollbackOnFailure enables rolling back (uninstalling) the release on failure if set
-	RollbackOnFailure        bool
+	RollbackOnFailure bool
+	// SkipCRDs opts the chart installation out of installing or upgrading CRDs.
+	//  - If set to false, CRDs are installed (or upgraded) during a chart installation and
+	//    AlreadyExists errors are ignored.
+	//  - If set to true, no operations on CRDs are performed on the cluster during installation.
 	SkipCRDs                 bool
 	SubNotes                 bool
 	HideNotes                bool
 	SkipSchemaValidation     bool
 	DisableOpenAPIValidation bool
-	IncludeCRDs              bool
-	Labels                   map[string]string
+	// IncludeCRDs configures template rendering to include rendered CRD manifests in the overall list
+	// of manifests for the chart. This is useful for operations over helm templates, but should be
+	// used with great care during installs against live clusters - including the CRD content in the
+	// release's manifests during install will cause the CRDs to be deleted during upgrade, as future
+	// releases will not include CRDs in release manifest lists.
+	IncludeCRDs bool
+	Labels      map[string]string
 	// KubeVersion allows specifying a custom kubernetes version to use and
 	// APIVersions allows a manual set of supported API Versions to be passed
 	// (for things like templating). These are ignored if ClientOnly is false

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -66,7 +66,11 @@ type Upgrade struct {
 	Devel bool
 	// Namespace is the namespace in which this operation should be performed.
 	Namespace string
-	// SkipCRDs skips installing CRDs when install flag is enabled during upgrade
+	// SkipCRDs opts the chart installation out of installing or upgrading CRs on the cluster, when
+	// Install is set in an install-or-upgrade operation.
+	//  - If set to false, CRDs are installed (or upgraded) during a chart installation and
+	//    AlreadyExists errors are ignored.
+	//  - If set to true, no operations on CRDs are performed on the cluster during installation.
 	SkipCRDs bool
 	// Timeout is the timeout for this operation
 	Timeout time.Duration


### PR DESCRIPTION
Without a careful reading of the installation code, I made a number of mistakes configuring the install client with the `IncludeCRDs` and `SkipCRDs` options. The new names proposed in this commit aim to clarify the intent of these options and make such mistakes impossible in the future.