### PR TITLE
[v3 backport] Fix `helm pull` untar dir check with repo urls

### DIFF
--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -148,6 +148,18 @@ func TestPullCmd(t *testing.T) {
 			wantError:  true,
 		},
 		{
+			name:       "Chart fetch using repo URL with untardir",
+			args:       "signtest --version=0.1.0 --untar --untardir repo-url-test --repo " + srv.URL(),
+			expectFile: "./signtest",
+			expectDir:  true,
+		},
+		{
+			name:       "Chart fetch using repo URL with untardir and previous pull",
+			args:       "signtest --version=0.1.0 --untar --untardir repo-url-test --repo " + srv.URL(),
+			failExpect: "failed to untar",
+			wantError:  true,
+		},
+		{
 			name:       "Fetch OCI Chart",
 			args:       fmt.Sprintf("oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0", ociSrv.RegistryURL),
 			expectFile: "./oci-dependent-chart-0.1.0.tgz",

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -121,15 +121,16 @@ func (p *Pull) Run(chartRef string) (string, error) {
 		defer os.RemoveAll(dest)
 	}
 
+	downloadSourceRef := chartRef
 	if p.RepoURL != "" {
 		chartURL, err := repo.FindChartInAuthAndTLSAndPassRepoURL(p.RepoURL, p.Username, p.Password, chartRef, p.Version, p.CertFile, p.KeyFile, p.CaFile, p.InsecureSkipTLSverify, p.PassCredentialsAll, getter.All(p.Settings))
 		if err != nil {
 			return out.String(), err
 		}
-		chartRef = chartURL
+		downloadSourceRef = chartURL
 	}
 
-	saved, v, err := c.DownloadTo(chartRef, p.Version, dest)
+	saved, v, err := c.DownloadTo(downloadSourceRef, p.Version, dest)
 	if err != nil {
 		return out.String(), err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix https://github.com/helm/helm/issues/31414

Helm pull --repo --untar create an empty folder alongside the correct untar folder

**Special notes for your reviewer**:

Backport of https://github.com/helm/helm/pull/31050 cherry pick of 1031b67fffc8ecd5e6a280bfef2e73ebad32bb54

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
