### PR TITLE
Unify --wait strategy inputs, clarify defaults and docs; avoid SDK timeout footgun

### DIFF
--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -81,7 +81,7 @@ func (ws *waitValue) String() string {
 
 func (ws *waitValue) Set(s string) error {
 	switch s {
-	case string(kube.StatusWatcherStrategy), string(kube.LegacyStrategy):
+	case string(kube.StatusWatcherStrategy), string(kube.LegacyStrategy), string(kube.HookOnlyStrategy):
 		*ws = waitValue(s)
 		return nil
 	case "true":
@@ -93,7 +93,7 @@ func (ws *waitValue) Set(s string) error {
 		*ws = waitValue(kube.HookOnlyStrategy)
 		return nil
 	default:
-		return fmt.Errorf("invalid wait input %q. Valid inputs are %s, and %s", s, kube.StatusWatcherStrategy, kube.LegacyStrategy)
+		return fmt.Errorf("invalid wait input %q. Valid inputs are %s, %s, and %s", s, kube.StatusWatcherStrategy, kube.LegacyStrategy, kube.HookOnlyStrategy)
 	}
 }
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -93,7 +93,7 @@ func (ws *waitValue) Set(s string) error {
 		*ws = waitValue(kube.HookOnlyStrategy)
 		return nil
 	default:
-		return fmt.Errorf("invalid wait input %q. Valid inputs are %s, %s, and %s", s, kube.StatusWatcherStrategy, kube.LegacyStrategy, kube.HookOnlyStrategy)
+		return fmt.Errorf("invalid wait input %q. Valid inputs are %s, %s, and %s", s, kube.StatusWatcherStrategy, kube.HookOnlyStrategy, kube.LegacyStrategy)
 	}
 }
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -57,9 +57,9 @@ func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 
 func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
-		newWaitValue(kube.StatusWatcherStrategy, wait),
+		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'hookOnly', and 'legacy'",
+		"wait until resources are ready (up to --timeout). Values: 'watcher', 'hookOnly' (default), and 'legacy'",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,7 +59,7 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'legacy'. '--wait' without value = 'watcher'. Booleans deprecated; '--wait=false' does hook-only.",
+		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'legacy', and 'hookOnly'",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,7 +59,7 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"wait until resources are ready (up to --timeout). Values: 'watcher', 'hookOnly' (default), and 'legacy'",
+		"if specified, wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'hookOnly', and 'legacy'.",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,7 +59,7 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"if specified, will wait until all resources are in the expected state before marking the operation as successful. It will wait for as long as --timeout. Valid inputs are 'watcher' and 'legacy'",
+		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'legacy'. '--wait' without value = 'watcher'. Booleans deprecated; '--wait=false' does hook-only.",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -89,7 +89,7 @@ func (ws *waitValue) Set(s string) error {
 		*ws = waitValue(kube.StatusWatcherStrategy)
 		return nil
 	case "false":
-		slog.Warn("--wait=false is deprecated (boolean value) and can be replaced by omitting the --wait flag")
+		slog.Warn("--wait=false is deprecated (boolean value) and can be replaced with --wait=hookOnly")
 		*ws = waitValue(kube.HookOnlyStrategy)
 		return nil
 	default:

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -57,9 +57,9 @@ func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 
 func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
-		newWaitValue(kube.HookOnlyStrategy, wait),
+		newWaitValue(kube.StatusWatcherStrategy, wait),
 		"wait",
-		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'legacy', and 'hookOnly'",
+		"wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'hookOnly', and 'legacy'",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -98,12 +98,23 @@ type Client struct {
 
 var _ Interface = (*Client)(nil)
 
+// WaitStrategy represents the algorithm used to wait for Kubernetes
+// resources to reach their desired state.
 type WaitStrategy string
 
 const (
+	// StatusWatcherStrategy: event-driven waits using kstatus (watches + aggregated readers).
+	// Default for --wait. More accurate and responsive; waits CRs and full reconciliation.
+	// Requires: reachable API server, list+watch RBAC on deployed resources, and a non-zero timeout.
 	StatusWatcherStrategy WaitStrategy = "watcher"
-	LegacyStrategy        WaitStrategy = "legacy"
-	HookOnlyStrategy      WaitStrategy = "hookOnly"
+
+	// LegacyStrategy: Helm 3-style periodic polling until ready or timeout.
+	// Use when watches aren’t available/reliable, or for compatibility/simple CI.
+	// Requires only list RBAC for polled resources.
+	LegacyStrategy WaitStrategy = "legacy"
+
+	// HookOnlyStrategy: wait only for hook Pods/Jobs to complete; does not wait for general chart resources.
+	HookOnlyStrategy WaitStrategy = "hookOnly"
 )
 
 type FieldValidationDirective string

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -176,8 +176,10 @@ func (c *Client) GetWaiter(strategy WaitStrategy) (Waiter, error) {
 			return nil, err
 		}
 		return &hookOnlyWaiter{sw: sw}, nil
+	case "":
+		return nil, errors.New("wait strategy not set. Choose one of: " + string(StatusWatcherStrategy) + ", " + string(HookOnlyStrategy) + ", " + string(LegacyStrategy))
 	default:
-		return nil, errors.New("unknown wait strategy")
+		return nil, errors.New("unknown wait strategy (s" + string(strategy) + "). Valid values are: " + string(StatusWatcherStrategy) + ", " + string(HookOnlyStrategy) + ", " + string(LegacyStrategy))
 	}
 }
 

--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -47,6 +47,13 @@ type statusWaiter struct {
 	ctx        context.Context
 }
 
+// DefaultStatusWatcherTimeout is the timeout used by the status waiter when a
+// zero timeout is provided. This prevents callers from accidentally passing a
+// zero value (which would immediately cancel the context) and getting
+// "context deadline exceeded" errors. SDK callers can rely on this default
+// when they don't set a timeout.
+var DefaultStatusWatcherTimeout = 30 * time.Second
+
 func alwaysReady(_ *unstructured.Unstructured) (*status.Result, error) {
 	return &status.Result{
 		Status:  status.CurrentStatus,
@@ -55,7 +62,10 @@ func alwaysReady(_ *unstructured.Unstructured) (*status.Result, error) {
 }
 
 func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.Duration) error {
-	ctx, cancel := w.contextWithTimeout(timeout)
+	if timeout == 0 {
+		timeout = DefaultStatusWatcherTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -76,7 +86,16 @@ func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.D
 }
 
 func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) error {
+<<<<<<< HEAD
 	ctx, cancel := w.contextWithTimeout(timeout)
+||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+=======
+	if timeout == 0 {
+		timeout = DefaultStatusWatcherTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+>>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -84,7 +103,16 @@ func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) er
 }
 
 func (w *statusWaiter) WaitWithJobs(resourceList ResourceList, timeout time.Duration) error {
+<<<<<<< HEAD
 	ctx, cancel := w.contextWithTimeout(timeout)
+||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+=======
+	if timeout == 0 {
+		timeout = DefaultStatusWatcherTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+>>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -95,7 +123,16 @@ func (w *statusWaiter) WaitWithJobs(resourceList ResourceList, timeout time.Dura
 }
 
 func (w *statusWaiter) WaitForDelete(resourceList ResourceList, timeout time.Duration) error {
+<<<<<<< HEAD
 	ctx, cancel := w.contextWithTimeout(timeout)
+||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+=======
+	if timeout == 0 {
+		timeout = DefaultStatusWatcherTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+>>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
 	defer cancel()
 	slog.Debug("waiting for resources to be deleted", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)

--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -65,7 +65,7 @@ func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.D
 	if timeout == 0 {
 		timeout = DefaultStatusWatcherTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := w.contextWithTimeout(timeout)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -86,16 +86,10 @@ func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.D
 }
 
 func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) error {
-<<<<<<< HEAD
-	ctx, cancel := w.contextWithTimeout(timeout)
-||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
-=======
 	if timeout == 0 {
 		timeout = DefaultStatusWatcherTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
->>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := w.contextWithTimeout(timeout)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -103,16 +97,10 @@ func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) er
 }
 
 func (w *statusWaiter) WaitWithJobs(resourceList ResourceList, timeout time.Duration) error {
-<<<<<<< HEAD
-	ctx, cancel := w.contextWithTimeout(timeout)
-||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
-=======
 	if timeout == 0 {
 		timeout = DefaultStatusWatcherTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
->>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := w.contextWithTimeout(timeout)
 	defer cancel()
 	slog.Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
@@ -123,16 +111,10 @@ func (w *statusWaiter) WaitWithJobs(resourceList ResourceList, timeout time.Dura
 }
 
 func (w *statusWaiter) WaitForDelete(resourceList ResourceList, timeout time.Duration) error {
-<<<<<<< HEAD
-	ctx, cancel := w.contextWithTimeout(timeout)
-||||||| parent of 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
-=======
 	if timeout == 0 {
 		timeout = DefaultStatusWatcherTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
->>>>>>> 86f98f870 (Prevent surprising failure with SDK when timeout is not set)
+	ctx, cancel := w.contextWithTimeout(timeout)
 	defer cancel()
 	slog.Debug("waiting for resources to be deleted", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR improves the `--wait` flag by allowing explicit strategy selection and preventing SDK timeout errors.

### Changes

1. **Allow explicit `--wait=hookOnly`** - Previously not possible via CLI
2. **Add comprehensive Go documentation** for all wait strategies  
3. **Set 30s default timeout** for StatusWatcher to prevent SDK errors when timeout is not specified

### Background

Problem 1: SDK Timeout Error

When using StatusWatcher strategy without setting a timeout:
```go
upgradeClient := action.NewUpgrade(actionConfig)
upgradeClient.WaitStrategy = kube.StatusWatcherStrategy
// Fails with: "reporter failed to start: event funnel closed: context deadline exceeded"
```

Problem 2: Confusing CLI Mapping

Users couldn't explicitly set `hookOnly` and the strategy mapping was unclear ([Slack discussion](https://kubernetes.slack.com/archives/C51E88VDG/p1761307867307409)).

CLI Behavior


|CLI Option | Internal Strategy|
-- | --
--wait=watcher | watcher
--wait=legacy | legacy
--wait=hookOnly | hookOnly ⚡ now possible
No --wait flag | hookOnly (unchanged for backward compatibility)
--wait (no value) | watcher
--wait=false | hookOnly (deprecated)
--wait=true | watcher (deprecated)

</body></html>

Related
- Initial watcher strategy PR: #13604
- Related discussion: #31411

**Special notes for your reviewer**:

- Default behavior unchanged when --wait is omitted (remains hookOnly)
- SDK users can now omit timeout when using StatusWatcher (30s default applied)
- Still I think the current `--wait` VS no `--wait` can be quite confusing

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
