### PR TITLE
[backport] jsonschema: warn and ignore unresolved URN $ref to match v3.18.4

### DIFF
--- a/pkg/chartutil/jsonschema_test.go
+++ b/pkg/chartutil/jsonschema_test.go
@@ -376,3 +376,16 @@ func TestValidateAgainstSchema_InvalidSubchartValuesType_NoPanic(t *testing.T) {
 		t.Fatalf("expected an error when subchart values have invalid type, got nil")
 	}
 }
+
+// Test that an unresolved URN $ref is soft-ignored and validation succeeds.
+// it mimics the behavior of Helm 3.18.4
+func TestValidateAgainstSingleSchema_UnresolvedURN_Ignored(t *testing.T) {
+	schema := []byte(`{
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "$ref": "urn:example:helm:schemas:v1:helm-schema-validation-conditions:v1/helmSchemaValidation-true"
+    }`)
+	vals := map[string]interface{}{"any": "value"}
+	if err := ValidateAgainstSingleSchema(vals, schema); err != nil {
+		t.Fatalf("expected no error when URN unresolved is ignored, got: %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

OUPS, this is a re-openning of https://github.com/helm/helm/pull/31247

- v3.18.5 switched jsonschema and began resolving external $ref at compile-time, exposing missing urn handling (“no URLLoader registered for urn:…”).
- Add urn scheme loader and pluggable URNResolver. If unresolved, log a warning and return a permissive true schema (back-compat).
- Avoid having a duplicated warn logs when we load the schema twice on linting for example.

Close: #31170
Port of: https://github.com/helm/helm/pull/31240

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**Special notes for your reviewer**:

More context and testing procedures in main PR https://github.com/helm/helm/pull/31240#issue-3383818776


🤗

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
