### PR TITLE
feat(repo): add --no-headers option to 'helm repo list'

### DIFF
--- a/pkg/cmd/repo_list.go
+++ b/pkg/cmd/repo_list.go
@@ -30,6 +30,7 @@ import (
 
 func newRepoListCmd(out io.Writer) *cobra.Command {
 	var outfmt output.Format
+	var noHeaders bool
 	cmd := &cobra.Command{
 		Use:               "list",
 		Aliases:           []string{"ls"},
@@ -46,12 +47,17 @@ func newRepoListCmd(out io.Writer) *cobra.Command {
 				return nil
 			}
 
-			return outfmt.Write(out, &repoListWriter{f.Repositories})
+			w := &repoListWriter{
+				repos:     f.Repositories,
+				noHeaders: noHeaders,
+			}
+
+			return outfmt.Write(out, w)
 		},
 	}
 
+	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "suppress headers in the output")
 	bindOutputFlag(cmd, &outfmt)
-
 	return cmd
 }
 
@@ -61,12 +67,15 @@ type repositoryElement struct {
 }
 
 type repoListWriter struct {
-	repos []*repo.Entry
+	repos     []*repo.Entry
+	noHeaders bool
 }
 
 func (r *repoListWriter) WriteTable(out io.Writer) error {
 	table := uitable.New()
-	table.AddRow("NAME", "URL")
+	if !r.noHeaders {
+		table.AddRow("NAME", "URL")
+	}
 	for _, re := range r.repos {
 		table.AddRow(re.Name, re.URL)
 	}

--- a/pkg/cmd/repo_list_test.go
+++ b/pkg/cmd/repo_list_test.go
@@ -48,6 +48,12 @@ func TestRepoList(t *testing.T) {
 			golden:    "output/repo-list.txt",
 			wantError: false,
 		},
+		{
+			name:      "list without headers",
+			cmd:       fmt.Sprintf("repo list --repository-config %s --repository-cache %s --no-headers", repoFile2, rootDir),
+			golden:    "output/repo-list-no-headers.txt",
+			wantError: false,
+		},
 	}
 
 	runTestCmd(t, tests)

--- a/pkg/cmd/testdata/output/repo-list-no-headers.txt
+++ b/pkg/cmd/testdata/output/repo-list-no-headers.txt
@@ -1,0 +1,3 @@
+charts       	https://charts.helm.sh/stable
+firstexample 	http://firstexample.com      
+secondexample	http://secondexample.com     


### PR DESCRIPTION
This adds a --no-headers flag to the 'helm repo list' command, allowing users to suppress table headers in the output. Useful for scripting and automation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
- Closes: https://github.com/helm/helm/issues/31449"
- Introduces a boolean flag `--no-headers` to `helm repo list`.
- Default behavior remains unchanged (headers are shown).
- Makes output easier to parse in scripts or automation.
- Includes unit test to verify no-header output.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
