### PR TITLE
Convert pkg/cmd/load_plugins.go to slog

### DIFF
--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -217,9 +217,7 @@ func loadCompletionForPlugin(pluginCmd *cobra.Command, plug plugin.Plugin) {
 
 	if err != nil {
 		// The file could be missing or invalid.  No static completion for this plugin.
-		if settings.Debug {
-			log.Output(2, fmt.Sprintf("[info] %s\n", err.Error()))
-		}
+		slog.Debug("plugin completion file loading", "error", err.Error())
 		// Continue to setup dynamic completion.
 		cmds = &pluginCommand{}
 	}
@@ -239,9 +237,7 @@ func addPluginCommands(plug plugin.Plugin, baseCmd *cobra.Command, cmds *pluginC
 
 	if len(cmds.Name) == 0 {
 		// Missing name for a command
-		if settings.Debug {
-			log.Output(2, fmt.Sprintf("[info] sub-command name field missing for %s", baseCmd.CommandPath()))
-		}
+		slog.Debug("sub-command name field missing", "commandPath", baseCmd.CommandPath())
 		return
 	}
 

--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -63,7 +63,7 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 	}
 	found, err := plugin.FindPlugins(dirs, descriptor)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to load plugins: %s\n", err)
+		slog.Error("failed to load plugins", "error", err)
 		return
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Converts `pkg/cmd/load_plugins.go` to use Go's structured logging package `log/slog` instead of the standard `log` package. This improves logging consistency, enables structured logs, and aligns with Helm's modernization efforts.

Closes #31454

**Special notes for your reviewer**:

- Only internal logging is affected; no user-facing changes.
- All related tests pass.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility