### PR TITLE
Revert "pkg/registry: Login option for passing TLS config in memory"

### DIFF
--- a/pkg/registry/client_tls_test.go
+++ b/pkg/registry/client_tls_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"os"
 	"testing"
 
@@ -51,30 +49,6 @@ func (suite *TLSRegistryClientTestSuite) Test_0_Login() {
 	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth(testUsername, testPassword),
 		LoginOptTLSClientConfig(tlsCert, tlsKey, tlsCA))
-	suite.Nil(err, "no error logging into registry with good credentials")
-}
-
-func (suite *TLSRegistryClientTestSuite) Test_1_Login() {
-	err := suite.RegistryClient.Login(suite.DockerRegistryHost,
-		LoginOptBasicAuth("badverybad", "ohsobad"),
-		LoginOptTLSClientConfigFromConfig(&tls.Config{}))
-	suite.NotNil(err, "error logging into registry with bad credentials")
-
-	// Create a *tls.Config from tlsCert, tlsKey, and tlsCA.
-	cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-	suite.Nil(err, "error loading x509 key pair")
-	rootCAs := x509.NewCertPool()
-	caCert, err := os.ReadFile(tlsCA)
-	suite.Nil(err, "error reading CA certificate")
-	rootCAs.AppendCertsFromPEM(caCert)
-	conf := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      rootCAs,
-	}
-
-	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
-		LoginOptBasicAuth(testUsername, testPassword),
-		LoginOptTLSClientConfigFromConfig(conf))
 	suite.Nil(err, "no error logging into registry with good credentials")
 }
 


### PR DESCRIPTION
Reverts helm/helm#31284

31284 needs to be reverted because it was in after the v3 feature freeze. Making the PR and merging was an understandable mistake as there was a lot going on leading up to and after the v3 feature freeze 🙇

The code is not part of any release, so it is safe to revert from `dev-v3` without breaking SDK users. This code will not be released, because only k8s package upgrades will be part of upcoming v3 MINOR versions, and this will not be part of those releases.