### PR TITLE
support ListPages,QueryPages pagination

### DIFF
--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -90,7 +90,7 @@ func (cfgmaps *ConfigMaps) Get(key string) (release.Releaser, error) {
 }
 
 // listPages is a common method to list release with pagination
-func (cfgmaps *ConfigMaps) listPages(f func(page []release.Releaser, lastPage bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
+func (cfgmaps *ConfigMaps) listPages(f func(page []release.Releaser, remaining bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
 	if opts.Limit == 0 {
 		opts.Limit = DefaultPaginationLimit
 	}
@@ -163,7 +163,7 @@ func (cfgmaps *ConfigMaps) List(filter func(release.Releaser) bool) ([]release.R
 }
 
 // ListPages same as List, but with pagination
-func (cfgmaps *ConfigMaps) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
+func (cfgmaps *ConfigMaps) ListPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
 	lsel := kblabels.Set{"owner": owner}.AsSelector()
 	opts := metav1.ListOptions{Limit: limit, LabelSelector: lsel.String()}
 
@@ -207,7 +207,7 @@ func (cfgmaps *ConfigMaps) Query(labels map[string]string) ([]release.Releaser, 
 }
 
 // QueryPages same as Query, but with pagination
-func (cfgmaps *ConfigMaps) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error {
+func (cfgmaps *ConfigMaps) QueryPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, labels map[string]string) error {
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -111,6 +111,20 @@ func TestConfigMapList(t *testing.T) {
 		releaseStub("key-6", 1, "default", common.StatusSuperseded),
 	}...)
 
+	// list releases with pagination
+	err := cfgmaps.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
+		// check
+		if len(page) != 2 {
+			t.Errorf("Expected 2 cfgmaps, got %d:\n%v\n", len(page), page)
+		}
+
+		return !lastPage
+	}, 2, func(rel release.Releaser) bool { return true })
+	// check
+	if err != nil {
+		t.Errorf("Failed to list cfgmaps: %s", err)
+	}
+
 	// list all deleted releases
 	del, err := cfgmaps.List(func(rel release.Releaser) bool {
 		rls := convertReleaserToV1(t, rel)
@@ -182,6 +196,18 @@ func TestConfigMapQuery(t *testing.T) {
 	_, err = cfgmaps.Query(map[string]string{"name": "notExist"})
 	if err != ErrReleaseNotFound {
 		t.Errorf("Expected {%v}, got {%v}", ErrReleaseNotFound, err)
+	}
+
+	// query cfgmaps with pagination
+	err = cfgmaps.QueryPages(func(page []release.Releaser, lastPage bool) (err bool) {
+		if len(page) != 2 {
+			t.Fatalf("Expected 2 results, actual %d", len(page))
+		}
+
+		return !lastPage
+	}, 2, map[string]string{"status": "deployed"})
+	if err != nil {
+		t.Fatalf("Failed to query: %s", err)
 	}
 }
 

--- a/pkg/storage/driver/cfgmaps_test.go
+++ b/pkg/storage/driver/cfgmaps_test.go
@@ -112,13 +112,13 @@ func TestConfigMapList(t *testing.T) {
 	}...)
 
 	// list releases with pagination
-	err := cfgmaps.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
+	err := cfgmaps.ListPages(func(page []release.Releaser, remaining bool) (end bool) {
 		// check
 		if len(page) != 2 {
 			t.Errorf("Expected 2 cfgmaps, got %d:\n%v\n", len(page), page)
 		}
 
-		return !lastPage
+		return !remaining
 	}, 2, func(rel release.Releaser) bool { return true })
 	// check
 	if err != nil {
@@ -199,12 +199,12 @@ func TestConfigMapQuery(t *testing.T) {
 	}
 
 	// query cfgmaps with pagination
-	err = cfgmaps.QueryPages(func(page []release.Releaser, lastPage bool) (err bool) {
+	err = cfgmaps.QueryPages(func(page []release.Releaser, remaining bool) (err bool) {
 		if len(page) != 2 {
 			t.Fatalf("Expected 2 results, actual %d", len(page))
 		}
 
-		return !lastPage
+		return !remaining
 	}, 2, map[string]string{"status": "deployed"})
 	if err != nil {
 		t.Fatalf("Failed to query: %s", err)

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -24,6 +24,13 @@ import (
 	rspb "helm.sh/helm/v4/pkg/release/v1"
 )
 
+const (
+	// owner is owner of the secret
+	owner = "helm"
+	// DefaultPaginationLimit .
+	DefaultPaginationLimit = 50
+)
+
 var (
 	// ErrReleaseNotFound indicates that a release is not found.
 	ErrReleaseNotFound = errors.New("release: not found")
@@ -89,7 +96,9 @@ type Deletor interface {
 type Queryor interface {
 	Get(key string) (release.Releaser, error)
 	List(filter func(release.Releaser) bool) ([]release.Releaser, error)
+	ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error
 	Query(labels map[string]string) ([]release.Releaser, error)
+	QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error
 }
 
 // Driver is the interface composed of Creator, Updator, Deletor, and Queryor

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -96,9 +96,9 @@ type Deletor interface {
 type Queryor interface {
 	Get(key string) (release.Releaser, error)
 	List(filter func(release.Releaser) bool) ([]release.Releaser, error)
-	ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error
+	ListPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, filter func(release.Releaser) bool) error
 	Query(labels map[string]string) ([]release.Releaser, error)
-	QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error
+	QueryPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, labels map[string]string) error
 }
 
 // Driver is the interface composed of Creator, Updator, Deletor, and Queryor

--- a/pkg/storage/driver/memory.go
+++ b/pkg/storage/driver/memory.go
@@ -17,7 +17,6 @@ limitations under the License.
 package driver
 
 import (
-	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -116,7 +115,7 @@ func (mem *Memory) List(filter func(release.Releaser) bool) ([]release.Releaser,
 }
 
 // ListPages is a common method to list release with pagination
-func (mem *Memory) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) (err error) {
+func (mem *Memory) ListPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, filter func(release.Releaser) bool) (err error) {
 	defer unlock(mem.rlock())
 
 	if limit == 0 {
@@ -223,7 +222,7 @@ func (mem *Memory) Query(keyvals map[string]string) ([]release.Releaser, error) 
 }
 
 // QueryPages same as Query, but with pagination
-func (mem *Memory) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, keyvals map[string]string) error {
+func (mem *Memory) QueryPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, keyvals map[string]string) error {
 	defer unlock(mem.rlock())
 
 	if limit == 0 {
@@ -234,8 +233,6 @@ func (mem *Memory) QueryPages(f func(page []release.Releaser, lastPage bool) (en
 
 	lbs.init()
 	lbs.fromMap(keyvals)
-
-	fmt.Printf("namespace: %s\n", mem.namespace)
 
 	ls := make([]release.Releaser, 0, int(limit))
 	if mem.namespace != "" {

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -107,6 +107,20 @@ func TestMemoryList(t *testing.T) {
 	ts := tsFixtureMemory(t)
 	ts.SetNamespace("default")
 
+	// list releases with pagination
+	err := ts.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
+		// check
+		if len(page) != 2 {
+			t.Errorf("Expected 2 releases, got %d:\n%v\n", len(page), page)
+		}
+
+		return !lastPage
+	}, 2, func(rel release.Releaser) bool { return true })
+	// check
+	if err != nil {
+		t.Errorf("Failed to list releases: %s", err)
+	}
+
 	// list all deployed releases
 	dpl, err := ts.List(func(rel release.Releaser) bool {
 		rls := convertReleaserToV1(t, rel)
@@ -255,6 +269,19 @@ func TestMemoryDelete(t *testing.T) {
 
 	ts := tsFixtureMemory(t)
 	ts.SetNamespace("")
+
+	// query cfgmaps with pagination
+	err := ts.QueryPages(func(page []release.Releaser, lastPage bool) (err bool) {
+		if len(page) != 1 {
+			t.Fatalf("Expected 1 results, actual %d", len(page))
+		}
+
+		return !lastPage
+	}, 1, map[string]string{"status": "deployed"})
+	if err != nil {
+		t.Fatalf("Failed to query: %s", err)
+	}
+
 	start, err := ts.Query(map[string]string{"status": "deployed"})
 	if err != nil {
 		t.Errorf("Query failed: %s", err)

--- a/pkg/storage/driver/memory_test.go
+++ b/pkg/storage/driver/memory_test.go
@@ -108,13 +108,13 @@ func TestMemoryList(t *testing.T) {
 	ts.SetNamespace("default")
 
 	// list releases with pagination
-	err := ts.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
+	err := ts.ListPages(func(page []release.Releaser, remaining bool) (end bool) {
 		// check
 		if len(page) != 2 {
 			t.Errorf("Expected 2 releases, got %d:\n%v\n", len(page), page)
 		}
 
-		return !lastPage
+		return !remaining
 	}, 2, func(rel release.Releaser) bool { return true })
 	// check
 	if err != nil {
@@ -271,12 +271,12 @@ func TestMemoryDelete(t *testing.T) {
 	ts.SetNamespace("")
 
 	// query cfgmaps with pagination
-	err := ts.QueryPages(func(page []release.Releaser, lastPage bool) (err bool) {
+	err := ts.QueryPages(func(page []release.Releaser, remaining bool) (err bool) {
 		if len(page) != 1 {
 			t.Fatalf("Expected 1 results, actual %d", len(page))
 		}
 
-		return !lastPage
+		return !remaining
 	}, 1, map[string]string{"status": "deployed"})
 	if err != nil {
 		t.Fatalf("Failed to query: %s", err)

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -19,6 +19,7 @@ package driver // import "helm.sh/helm/v4/pkg/storage/driver"
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
@@ -133,10 +134,24 @@ func (mock *MockConfigMapsInterface) List(_ context.Context, opts metav1.ListOpt
 		return nil, err
 	}
 
+	objects := make([]*v1.ConfigMap, 0, len(mock.objects))
 	for _, cfgmap := range mock.objects {
 		if labelSelector.Matches(kblabels.Set(cfgmap.Labels)) {
-			list.Items = append(list.Items, *cfgmap)
+			objects = append(objects, cfgmap)
 		}
+	}
+
+	if opts.Continue != "" {
+		i, _ := strconv.ParseInt(opts.Continue, 10, 64)
+		objects = objects[int(i):]
+	}
+
+	if opts.Limit > 0 && opts.Limit <= int64(len(objects)) {
+		objects = objects[:int(opts.Limit)]
+	}
+
+	for _, cfgmap := range objects {
+		list.Items = append(list.Items, *cfgmap)
 	}
 	return &list, nil
 }
@@ -221,10 +236,24 @@ func (mock *MockSecretsInterface) List(_ context.Context, opts metav1.ListOption
 		return nil, err
 	}
 
+	objects := make([]*v1.Secret, 0, len(mock.objects))
 	for _, secret := range mock.objects {
 		if labelSelector.Matches(kblabels.Set(secret.Labels)) {
-			list.Items = append(list.Items, *secret)
+			objects = append(objects, secret)
 		}
+	}
+
+	if opts.Continue != "" {
+		i, _ := strconv.ParseInt(opts.Continue, 10, 64)
+		objects = objects[int(i):]
+	}
+
+	if opts.Limit > 0 && opts.Limit <= int64(len(objects)) {
+		objects = objects[:int(opts.Limit)]
+	}
+
+	for _, secret := range objects {
+		list.Items = append(list.Items, *secret)
 	}
 	return &list, nil
 }

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -142,12 +142,19 @@ func (mock *MockConfigMapsInterface) List(_ context.Context, opts metav1.ListOpt
 	}
 
 	if opts.Continue != "" {
-		i, _ := strconv.ParseInt(opts.Continue, 10, 64)
+		i, err := strconv.ParseInt(opts.Continue, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid continue value %q: %w", opts.Continue, err)
+		}
 		objects = objects[int(i):]
+		list.Continue = ""
 	}
 
 	if opts.Limit > 0 && opts.Limit <= int64(len(objects)) {
 		objects = objects[:int(opts.Limit)]
+		if opts.Limit < int64(len(objects)) {
+			list.Continue = strconv.FormatInt(opts.Limit, 10)
+		}
 	}
 
 	for _, cfgmap := range objects {
@@ -244,12 +251,19 @@ func (mock *MockSecretsInterface) List(_ context.Context, opts metav1.ListOption
 	}
 
 	if opts.Continue != "" {
-		i, _ := strconv.ParseInt(opts.Continue, 10, 64)
+		i, err := strconv.ParseInt(opts.Continue, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid continue value: %v", err)
+		}
 		objects = objects[int(i):]
+		list.Continue = ""
 	}
 
 	if opts.Limit > 0 && opts.Limit <= int64(len(objects)) {
 		objects = objects[:int(opts.Limit)]
+		if opts.Limit < int64(len(objects)) {
+			list.Continue = strconv.FormatInt(opts.Limit, 10)
+		}
 	}
 
 	for _, secret := range objects {

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -164,9 +164,9 @@ func (secrets *Secrets) List(filter func(release.Releaser) bool) ([]release.Rele
 }
 
 // ListPages same as List, but with pagination
-func (secrets *Secrets) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), filter func(release.Releaser) bool) error {
+func (secrets *Secrets) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
 	lsel := kblabels.Set{"owner": owner}.AsSelector()
-	opts := metav1.ListOptions{LabelSelector: lsel.String()}
+	opts := metav1.ListOptions{Limit: limit, LabelSelector: lsel.String()}
 
 	return secrets.listPages(f, opts, filter)
 }

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -38,14 +38,8 @@ import (
 
 var _ Driver = (*Secrets)(nil)
 
-const (
-	// SecretsDriverName is the string name of the driver.
-	SecretsDriverName = "Secret"
-	// owner is owner of the secret
-	owner = "helm"
-	// DefaultPaginationLimit .
-	DefaultPaginationLimit = 50
-)
+// SecretsDriverName is the string name of the driver.
+const SecretsDriverName = "Secret"
 
 // Secrets is a wrapper around an implementation of a kubernetes
 // SecretsInterface.
@@ -90,7 +84,7 @@ func (secrets *Secrets) Get(key string) (release.Releaser, error) {
 	return r, nil
 }
 
-// listPages common methods to list release pagination
+// listPages is a common method to list release with pagination
 func (secrets *Secrets) listPages(f func(page []release.Releaser, lastPage bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
 	if opts.Limit == 0 {
 		opts.Limit = DefaultPaginationLimit
@@ -206,7 +200,7 @@ func (secrets *Secrets) Query(labels map[string]string) ([]release.Releaser, err
 }
 
 // QueryPages same as Query, but with pagination
-func (secrets *Secrets) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), labels map[string]string) error {
+func (secrets *Secrets) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error {
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
@@ -215,7 +209,7 @@ func (secrets *Secrets) QueryPages(f func(page []release.Releaser, lastPage bool
 		ls[k] = v
 	}
 
-	opts := metav1.ListOptions{LabelSelector: ls.AsSelector().String()}
+	opts := metav1.ListOptions{Limit: limit, LabelSelector: ls.AsSelector().String()}
 
 	return secrets.listPages(f, opts, func(release.Releaser) bool { return true })
 }

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -92,7 +92,6 @@ func (secrets *Secrets) Get(key string) (release.Releaser, error) {
 
 // listPages common methods to list release pagination
 func (secrets *Secrets) listPages(f func(page []release.Releaser, lastPage bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
-	token := ""
 	if opts.Limit == 0 {
 		opts.Limit = DefaultPaginationLimit
 	}
@@ -103,7 +102,7 @@ Loop:
 		if nil != err {
 			return err
 		}
-		token = list.Continue
+		opts.Continue = list.Continue
 
 		var results []release.Releaser
 
@@ -123,7 +122,7 @@ Loop:
 			}
 		}
 
-		if f(results, token != "") {
+		if f(results, list.Continue != "") {
 			break Loop
 		}
 	}

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -85,7 +85,7 @@ func (secrets *Secrets) Get(key string) (release.Releaser, error) {
 }
 
 // listPages is a common method to list release with pagination
-func (secrets *Secrets) listPages(f func(page []release.Releaser, lastPage bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
+func (secrets *Secrets) listPages(f func(page []release.Releaser, remaining bool) (end bool), opts metav1.ListOptions, filter func(release.Releaser) bool) (err error) {
 	if opts.Limit == 0 {
 		opts.Limit = DefaultPaginationLimit
 	}
@@ -157,7 +157,7 @@ func (secrets *Secrets) List(filter func(release.Releaser) bool) ([]release.Rele
 }
 
 // ListPages same as List, but with pagination
-func (secrets *Secrets) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
+func (secrets *Secrets) ListPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
 	lsel := kblabels.Set{"owner": owner}.AsSelector()
 	opts := metav1.ListOptions{Limit: limit, LabelSelector: lsel.String()}
 
@@ -200,7 +200,7 @@ func (secrets *Secrets) Query(labels map[string]string) ([]release.Releaser, err
 }
 
 // QueryPages same as Query, but with pagination
-func (secrets *Secrets) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error {
+func (secrets *Secrets) QueryPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, labels map[string]string) error {
 	ls := kblabels.Set{}
 	for k, v := range labels {
 		if errs := validation.IsValidLabelValue(v); len(errs) != 0 {

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -99,15 +99,15 @@ func TestSecretList(t *testing.T) {
 	// list releases with pagination
 	err := secrets.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
 		// check
-		if len(page) != 6 {
-			t.Errorf("Expected 6 secrets, got %d:\n%v\n", len(page), page)
+		if len(page) != 2 {
+			t.Errorf("Expected 2 secrets, got %d:\n%v\n", len(page), page)
 		}
 
 		return !lastPage
-	}, func(rel release.Releaser) bool { return true })
+	}, 2, func(rel release.Releaser) bool { return true })
 	// check
 	if err != nil {
-		t.Errorf("Failed to list deleted: %s", err)
+		t.Errorf("Failed to list secrets: %s", err)
 	}
 
 	// list all deleted releases
@@ -190,7 +190,7 @@ func TestSecretQuery(t *testing.T) {
 		}
 
 		return !lastPage
-	}, map[string]string{"status": "deployed"})
+	}, 2, map[string]string{"status": "deployed"})
 	if err != nil {
 		t.Fatalf("Failed to query: %s", err)
 	}

--- a/pkg/storage/driver/secrets_test.go
+++ b/pkg/storage/driver/secrets_test.go
@@ -97,13 +97,13 @@ func TestSecretList(t *testing.T) {
 	}...)
 
 	// list releases with pagination
-	err := secrets.ListPages(func(page []release.Releaser, lastPage bool) (end bool) {
+	err := secrets.ListPages(func(page []release.Releaser, remaining bool) (end bool) {
 		// check
 		if len(page) != 2 {
 			t.Errorf("Expected 2 secrets, got %d:\n%v\n", len(page), page)
 		}
 
-		return !lastPage
+		return !remaining
 	}, 2, func(rel release.Releaser) bool { return true })
 	// check
 	if err != nil {
@@ -184,12 +184,12 @@ func TestSecretQuery(t *testing.T) {
 	}
 
 	// query releases with pagination
-	err = secrets.QueryPages(func(page []release.Releaser, lastPage bool) (err bool) {
+	err = secrets.QueryPages(func(page []release.Releaser, remaining bool) (err bool) {
 		if len(page) != 2 {
 			t.Fatalf("Expected 2 results, actual %d", len(page))
 		}
 
-		return !lastPage
+		return !remaining
 	}, 2, map[string]string{"status": "deployed"})
 	if err != nil {
 		t.Fatalf("Failed to query: %s", err)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -314,8 +314,14 @@ func (d *MaxHistoryMockDriver) Get(key string) (release.Releaser, error) {
 func (d *MaxHistoryMockDriver) List(filter func(release.Releaser) bool) ([]release.Releaser, error) {
 	return d.Driver.List(filter)
 }
+func (d *MaxHistoryMockDriver) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
+	return d.Driver.ListPages(f, limit, filter)
+}
 func (d *MaxHistoryMockDriver) Query(labels map[string]string) ([]release.Releaser, error) {
 	return d.Driver.Query(labels)
+}
+func (d *MaxHistoryMockDriver) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error {
+	return d.Driver.QueryPages(f, limit, labels)
 }
 func (d *MaxHistoryMockDriver) Name() string {
 	return d.Driver.Name()

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -314,13 +314,13 @@ func (d *MaxHistoryMockDriver) Get(key string) (release.Releaser, error) {
 func (d *MaxHistoryMockDriver) List(filter func(release.Releaser) bool) ([]release.Releaser, error) {
 	return d.Driver.List(filter)
 }
-func (d *MaxHistoryMockDriver) ListPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
+func (d *MaxHistoryMockDriver) ListPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, filter func(release.Releaser) bool) error {
 	return d.Driver.ListPages(f, limit, filter)
 }
 func (d *MaxHistoryMockDriver) Query(labels map[string]string) ([]release.Releaser, error) {
 	return d.Driver.Query(labels)
 }
-func (d *MaxHistoryMockDriver) QueryPages(f func(page []release.Releaser, lastPage bool) (end bool), limit int64, labels map[string]string) error {
+func (d *MaxHistoryMockDriver) QueryPages(f func(page []release.Releaser, remaining bool) (end bool), limit int64, labels map[string]string) error {
 	return d.Driver.QueryPages(f, limit, labels)
 }
 func (d *MaxHistoryMockDriver) Name() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
I have over 1000 apps and 3000 helm release secrets in a namespace. When I list secrets with driver.Secrets.List, it receives all secrets and consumes plenty of memory (nearly 2GB). I do not need to get all secrets at one time yet.
In order to reduce memory consumption, I think we may have a pagination.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
