### PR TITLE
Rename copilot-instructions.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for Helm
+# AGENTS.md
 
 ## Overview
 Helm is a package manager for Kubernetes written in Go, supporting v3 (stable) and v4 (unstable) APIs.


### PR DESCRIPTION
As of https://github.blog/changelog/2025-08-28-copilot-coding-agent-now-supports-agents-md-custom-instructions/, AGENTS.md is supported.

- Closes #31456
