### PR TITLE
Convert pkg/cmd/load_plugins.go to slog

### DIFF
--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -63,7 +63,7 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 	}
 	found, err := plugin.FindPlugins(dirs, descriptor)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to load plugins: %s\n", err)
+		slog.Error("failed to load plugins", slog.String("error", err.Error()))
 		return
 	}
 
@@ -217,9 +217,7 @@ func loadCompletionForPlugin(pluginCmd *cobra.Command, plug plugin.Plugin) {
 
 	if err != nil {
 		// The file could be missing or invalid.  No static completion for this plugin.
-		if settings.Debug {
-			log.Output(2, fmt.Sprintf("[info] %s\n", err.Error()))
-		}
+		slog.Debug("plugin completion file loading", slog.String("error", err.Error()))
 		// Continue to setup dynamic completion.
 		cmds = &pluginCommand{}
 	}
@@ -238,10 +236,7 @@ func addPluginCommands(plug plugin.Plugin, baseCmd *cobra.Command, cmds *pluginC
 	}
 
 	if len(cmds.Name) == 0 {
-		// Missing name for a command
-		if settings.Debug {
-			log.Output(2, fmt.Sprintf("[info] sub-command name field missing for %s", baseCmd.CommandPath()))
-		}
+		slog.Debug("sub-command name field missing", slog.String("commandPath", baseCmd.CommandPath()))
 		return
 	}
 


### PR DESCRIPTION
closes #31454 
**What this PR does / why we need it**: Converts log_plugins.go to slog
