### PR TITLE
fix: do not run release workflow on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions: read-all
 #   job is triggered by a tag push, VERSION should be the tag ref.
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'helm/helm'
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout source code
@@ -76,7 +76,7 @@ jobs:
 
   canary-release:
     runs-on: ubuntu-latest-16-cores
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.repository == 'helm/helm'
     steps:
       - name: Checkout source code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0


### PR DESCRIPTION

**What this PR does / why we need it**:
Do not run the release workflow on forks of this repository.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
