### PR TITLE
feat: improve plugin name validation error messages and field name detection (v1)

### DIFF
--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -47,6 +47,7 @@ func loadMetadataLegacy(metadataData []byte) (*Metadata, error) {
 
 	var ml MetadataLegacy
 	d := yaml.NewDecoder(bytes.NewReader(metadataData))
+	// NOTE: No strict unmarshalling for legacy plugins - maintain backwards compatibility
 	if err := d.Decode(&ml); err != nil {
 		return nil, err
 	}
@@ -66,6 +67,7 @@ func loadMetadataV1(metadataData []byte) (*Metadata, error) {
 
 	var mv1 MetadataV1
 	d := yaml.NewDecoder(bytes.NewReader(metadataData))
+	d.KnownFields(true)
 	if err := d.Decode(&mv1); err != nil {
 		return nil, err
 	}

--- a/internal/plugin/metadata.go
+++ b/internal/plugin/metadata.go
@@ -54,7 +54,7 @@ func (m Metadata) Validate() error {
 	var errs []error
 
 	if !validPluginName.MatchString(m.Name) {
-		errs = append(errs, fmt.Errorf("invalid name"))
+		errs = append(errs, fmt.Errorf("invalid name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name))
 	}
 
 	if m.APIVersion == "" {

--- a/internal/plugin/metadata.go
+++ b/internal/plugin/metadata.go
@@ -54,7 +54,7 @@ func (m Metadata) Validate() error {
 	var errs []error
 
 	if !validPluginName.MatchString(m.Name) {
-		errs = append(errs, fmt.Errorf("invalid name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name))
+		errs = append(errs, fmt.Errorf("invalid plugin name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name))
 	}
 
 	if m.APIVersion == "" {

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -68,11 +68,11 @@ type MetadataLegacy struct {
 }
 
 func (m *MetadataLegacy) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("missing plugin name")
+	}
 	if !validPluginName.MatchString(m.Name) {
-		if m.Name == "" {
-			return fmt.Errorf("plugin name is empty or missing: ensure plugin.yaml contains 'name:' field (lowercase)")
-		}
-		return fmt.Errorf("invalid plugin name %q: plugin names can only contain ASCII characters a-z, A-Z, 0-9, _ and -", m.Name)
+		return fmt.Errorf("invalid plugin name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
 	}
 	m.Usage = sanitizeString(m.Usage)
 

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -69,7 +69,7 @@ type MetadataLegacy struct {
 
 func (m *MetadataLegacy) Validate() error {
 	if !validPluginName.MatchString(m.Name) {
-		return fmt.Errorf("invalid plugin name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
+		return fmt.Errorf("invalid name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
 	}
 	m.Usage = sanitizeString(m.Usage)
 

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -68,9 +68,6 @@ type MetadataLegacy struct {
 }
 
 func (m *MetadataLegacy) Validate() error {
-	if m.Name == "" {
-		return fmt.Errorf("missing plugin name")
-	}
 	if !validPluginName.MatchString(m.Name) {
 		return fmt.Errorf("invalid plugin name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
 	}

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -69,7 +69,7 @@ type MetadataLegacy struct {
 
 func (m *MetadataLegacy) Validate() error {
 	if !validPluginName.MatchString(m.Name) {
-		return fmt.Errorf("invalid name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
+		return fmt.Errorf("invalid plugin name %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
 	}
 	m.Usage = sanitizeString(m.Usage)
 

--- a/internal/plugin/metadata_legacy.go
+++ b/internal/plugin/metadata_legacy.go
@@ -69,7 +69,10 @@ type MetadataLegacy struct {
 
 func (m *MetadataLegacy) Validate() error {
 	if !validPluginName.MatchString(m.Name) {
-		return fmt.Errorf("invalid plugin name")
+		if m.Name == "" {
+			return fmt.Errorf("plugin name is empty or missing: ensure plugin.yaml contains 'name:' field (lowercase)")
+		}
+		return fmt.Errorf("invalid plugin name %q: plugin names can only contain ASCII characters a-z, A-Z, 0-9, _ and -", m.Name)
 	}
 	m.Usage = sanitizeString(m.Usage)
 

--- a/internal/plugin/metadata_legacy_test.go
+++ b/internal/plugin/metadata_legacy_test.go
@@ -25,23 +25,8 @@ func TestMetadataLegacyValidate_PluginName(t *testing.T) {
 		pluginName string
 		shouldPass bool
 	}{
-		// Valid names
-		{"lowercase", "myplugin", true},
-		{"uppercase", "MYPLUGIN", true},
-		{"mixed case", "MyPlugin", true},
-		{"with digits", "plugin123", true},
-		{"with hyphen", "my-plugin", true},
-		{"with underscore", "my_plugin", true},
-		{"mixed chars", "my-awesome_plugin_123", true},
-
-		// Invalid names
-		{"empty", "", false},
-		{"space", "my plugin", false},
-		{"colon", "Name:", false},
-		{"period", "my.plugin", false},
-		{"slash", "my/plugin", false},
-		{"dollar", "$plugin", false},
-		{"unicode", "plügîn", false},
+		{"valid name", "my-plugin", true},
+		{"invalid with space", "my plugin", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/plugin/metadata_legacy_test.go
+++ b/internal/plugin/metadata_legacy_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetadataLegacyValidate_EmptyName(t *testing.T) {
+	metadata := MetadataLegacy{
+		Name:    "",
+		Version: "1.0.0",
+	}
+
+	err := metadata.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty plugin name")
+	}
+
+	expectedMsg := "plugin name is empty or missing"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("expected error to contain %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestMetadataLegacyValidate_InvalidName(t *testing.T) {
+	metadata := MetadataLegacy{
+		Name:    "invalid name",
+		Version: "1.0.0",
+	}
+
+	err := metadata.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid plugin name")
+	}
+
+	expectedMsg := "plugin names can only contain ASCII characters"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("expected error to contain %q, got %q", expectedMsg, err.Error())
+	}
+}

--- a/internal/plugin/metadata_test.go
+++ b/internal/plugin/metadata_test.go
@@ -53,10 +53,10 @@ func TestValidatePluginData(t *testing.T) {
 	}{
 		{true, mockSubprocessCLIPlugin(t, "abcdefghijklmnopqrstuvwxyz0123456789_-ABC"), ""},
 		{true, mockSubprocessCLIPlugin(t, "foo-bar-FOO-BAR_1234"), ""},
-		{false, mockSubprocessCLIPlugin(t, "foo -bar"), "invalid name"},
-		{false, mockSubprocessCLIPlugin(t, "$foo -bar"), "invalid name"}, // Test leading chars
-		{false, mockSubprocessCLIPlugin(t, "foo -bar "), "invalid name"}, // Test trailing chars
-		{false, mockSubprocessCLIPlugin(t, "foo\nbar"), "invalid name"},  // Test newline
+		{false, mockSubprocessCLIPlugin(t, "foo -bar"), "invalid plugin name"},
+		{false, mockSubprocessCLIPlugin(t, "$foo -bar"), "invalid plugin name"}, // Test leading chars
+		{false, mockSubprocessCLIPlugin(t, "foo -bar "), "invalid plugin name"}, // Test trailing chars
+		{false, mockSubprocessCLIPlugin(t, "foo\nbar"), "invalid plugin name"},  // Test newline
 		{true, mockNoCommand, ""},     // Test no command metadata works
 		{true, mockLegacyCommand, ""}, // Test legacy command metadata works
 	} {
@@ -92,7 +92,7 @@ func TestMetadataValidateMultipleErrors(t *testing.T) {
 
 	// Check that all expected errors are present in the joined error
 	expectedErrors := []string{
-		"invalid name",
+		"invalid plugin name",
 		"empty APIVersion",
 		"empty type field",
 		"empty runtime field",

--- a/internal/plugin/metadata_test.go
+++ b/internal/plugin/metadata_test.go
@@ -66,8 +66,8 @@ func TestValidatePluginData(t *testing.T) {
 		} else if !item.pass && err == nil {
 			t.Errorf("expected case %d to fail", i)
 		}
-		if !item.pass && err.Error() != item.errString {
-			t.Errorf("index [%d]: expected the following error: %s, but got: %s", i, item.errString, err.Error())
+		if !item.pass && !strings.Contains(err.Error(), item.errString) {
+			t.Errorf("index [%d]: expected error to contain: %s, but got: %s", i, item.errString, err.Error())
 		}
 	}
 }

--- a/internal/plugin/metadata_v1.go
+++ b/internal/plugin/metadata_v1.go
@@ -47,11 +47,8 @@ type MetadataV1 struct {
 }
 
 func (m *MetadataV1) Validate() error {
-	if m.Name == "" {
-		return fmt.Errorf("missing plugin `name`")
-	}
 	if !validPluginName.MatchString(m.Name) {
-		return fmt.Errorf("invalid plugin `name` %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
+		return fmt.Errorf("invalid plugin `name`")
 	}
 
 	if m.APIVersion != "v1" {

--- a/internal/plugin/metadata_v1.go
+++ b/internal/plugin/metadata_v1.go
@@ -47,8 +47,11 @@ type MetadataV1 struct {
 }
 
 func (m *MetadataV1) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("missing plugin `name`")
+	}
 	if !validPluginName.MatchString(m.Name) {
-		return fmt.Errorf("invalid plugin `name`")
+		return fmt.Errorf("invalid plugin `name` %q: must contain only a-z, A-Z, 0-9, _ and -", m.Name)
 	}
 
 	if m.APIVersion != "v1" {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestValidPluginName(t *testing.T) {
 	validNames := map[string]string{
-		"lowercase":      "myplugin",
-		"uppercase":      "MYPLUGIN",
-		"mixed case":     "MyPlugin",
-		"with digits":    "plugin123",
-		"with hyphen":    "my-plugin",
+		"lowercase":       "myplugin",
+		"uppercase":       "MYPLUGIN",
+		"mixed case":      "MyPlugin",
+		"with digits":     "plugin123",
+		"with hyphen":     "my-plugin",
 		"with underscore": "my_plugin",
-		"mixed chars":    "my-awesome_plugin_123",
+		"mixed chars":     "my-awesome_plugin_123",
 	}
 
 	for name, pluginName := range validNames {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -22,38 +22,38 @@ import (
 )
 
 func TestValidPluginName(t *testing.T) {
-	tests := []struct {
-		name       string
-		pluginName string
-		shouldPass bool
-	}{
-		// Valid names
-		{"lowercase", "myplugin", true},
-		{"uppercase", "MYPLUGIN", true},
-		{"mixed case", "MyPlugin", true},
-		{"with digits", "plugin123", true},
-		{"with hyphen", "my-plugin", true},
-		{"with underscore", "my_plugin", true},
-		{"mixed chars", "my-awesome_plugin_123", true},
-
-		// Invalid names
-		{"empty", "", false},
-		{"space", "my plugin", false},
-		{"colon", "plugin:", false},
-		{"period", "my.plugin", false},
-		{"slash", "my/plugin", false},
-		{"dollar", "$plugin", false},
-		{"unicode", "plügîn", false},
+	validNames := map[string]string{
+		"lowercase":      "myplugin",
+		"uppercase":      "MYPLUGIN",
+		"mixed case":     "MyPlugin",
+		"with digits":    "plugin123",
+		"with hyphen":    "my-plugin",
+		"with underscore": "my_plugin",
+		"mixed chars":    "my-awesome_plugin_123",
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := validPluginName.MatchString(tt.pluginName)
-			if tt.shouldPass && !matches {
-				t.Errorf("expected %q to match validPluginName regex", tt.pluginName)
+	for name, pluginName := range validNames {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if !validPluginName.MatchString(pluginName) {
+				t.Errorf("expected %q to match validPluginName regex", pluginName)
 			}
-			if !tt.shouldPass && matches {
-				t.Errorf("expected %q to not match validPluginName regex", tt.pluginName)
+		})
+	}
+
+	invalidNames := map[string]string{
+		"empty":   "",
+		"space":   "my plugin",
+		"colon":   "plugin:",
+		"period":  "my.plugin",
+		"slash":   "my/plugin",
+		"dollar":  "$plugin",
+		"unicode": "plügîn",
+	}
+
+	for name, pluginName := range invalidNames {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			if validPluginName.MatchString(pluginName) {
+				t.Errorf("expected %q to not match validPluginName regex", pluginName)
 			}
 		})
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -21,6 +21,44 @@ import (
 	"helm.sh/helm/v4/internal/plugin/schema"
 )
 
+func TestValidPluginName(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginName string
+		shouldPass bool
+	}{
+		// Valid names
+		{"lowercase", "myplugin", true},
+		{"uppercase", "MYPLUGIN", true},
+		{"mixed case", "MyPlugin", true},
+		{"with digits", "plugin123", true},
+		{"with hyphen", "my-plugin", true},
+		{"with underscore", "my_plugin", true},
+		{"mixed chars", "my-awesome_plugin_123", true},
+
+		// Invalid names
+		{"empty", "", false},
+		{"space", "my plugin", false},
+		{"colon", "plugin:", false},
+		{"period", "my.plugin", false},
+		{"slash", "my/plugin", false},
+		{"dollar", "$plugin", false},
+		{"unicode", "plügîn", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := validPluginName.MatchString(tt.pluginName)
+			if tt.shouldPass && !matches {
+				t.Errorf("expected %q to match validPluginName regex", tt.pluginName)
+			}
+			if !tt.shouldPass && matches {
+				t.Errorf("expected %q to not match validPluginName regex", tt.pluginName)
+			}
+		})
+	}
+}
+
 func mockSubprocessCLIPlugin(t *testing.T, pluginName string) *SubprocessPluginRuntime {
 	t.Helper()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- Clarifies and harmonizes plugin name validation error messages across legacy and v1 plugin metadata.
- Introduces strict YAML unmarshalling for v1 plugin metadata to fail fast on unknown fields (e.g., capitalized Name).
- Coverage for valid/invalid name patterns via validPluginName regex in tests.

Why:
- Users received errors that were hard to action (e.g., “invalid name”). I think clear messages reduce confusion. We print regex expected + if the field match to nothing.
- Strict decoding for v1 catches schema mistakes early (e.g., “Name” vs “name”) while preserving backward compatibility for legacy metadata.

Backward compatibility:
- "Legacy" plugin decoding remains non-strict
- V1 manifests now fail fast on unknown fields

Related:
 - https://github.com/helm/helm/issues/31490

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
