### PR TITLE
fix: clear managed fields before SSA request

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1101,8 +1101,8 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 		WithFieldManager(getManagedFieldsManager()).
 		WithFieldValidation(string(fieldValidationDirective))
 
-	// Kubernetes looks at the server side state when evaluating conflicts in field manager rather than the field manager field in the request
-	// therefore when using the Apply operation you cannot define managedFields in the body of the request that you submit
+	// Kubernetes looks at the state of the object in the cluster when evaluating conflicts in field manager rather than the object in the request
+	// therefore when using the Apply operation we cannot define managedFields in the body of the request that we submit
 	// This is according to https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
 	if u, ok := target.Object.(*unstructured.Unstructured); ok {
 		u.SetManagedFields(nil)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1101,6 +1101,13 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 		WithFieldManager(getManagedFieldsManager()).
 		WithFieldValidation(string(fieldValidationDirective))
 
+	// Kubernetes looks at the server side state when evaluating conflicts in field manager rather than the field manager field in the request
+	// therefore when using the Apply operation you cannot define managedFields in the body of the request that you submit
+	// This is according to https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
+	if u, ok := target.Object.(*unstructured.Unstructured); ok {
+		u.SetManagedFields(nil)
+	}
+
 	// Send the full object to be applied on the server side.
 	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, target.Object)
 	if err != nil {

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -2244,10 +2244,9 @@ func TestPatchResourceServerSide_ClearsManagedFields(t *testing.T) {
 		Client: fakeClient,
 	}
 
-	// Call patchResourceServerSide
 	err := patchResourceServerSide(target, false, false, FieldValidationDirectiveStrict)
 	require.NoError(t, err)
 
-	// Verify the patched data doesn't contain managedFields
-	assert.NotContains(t, string(patchedData), "managedFields", "patched data should not contain managedFields")
+	// Verify the data that the fake client received did not container managedFields
+	assert.NotContains(t, string(patchedData), "managedFields")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR clears managed fields on the client object before creating the SSA request. This is important when Helm is taking ownership of another resource.

Fixes: #31510

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
