### PR TITLE
fix: correct LDFLAGS path for default Kubernetes version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ LDFLAGS += -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMajor=$(K8S_MODU
 LDFLAGS += -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
-LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
+LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
+LDFLAGS += -X helm.sh/helm/v4/pkg/chart/common.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMajor=$(K8S_MODULES_MAJOR_VER)
 LDFLAGS += -X helm.sh/helm/v4/internal/version.kubeClientVersionMinor=$(K8S_MODULES_MINOR_VER)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Makefile LDFLAGS were pointing to an incorrect package path (helm.sh/helm/v4/pkg/chart/common/util) where variables don't exist, causing the `k8sVersionMajor` and `k8sVersionMinor` variables to silently fail to be set. This left the hardcoded defaults (1.20 from `capabilities.go`) in place.

After this fix, `helm template` for example now correctly defaults to Kubernetes v1.34.0 (matching the bundled client-go version) instead of v1.20.0, ensuring charts render with current stable API versions.

Testing scenario:

```sh
cat > /tmp/test-chart/Chart.yaml << 'EOF'
apiVersion: v2
name: test-chart
version: 1.0.0
kubeVersion: ">= 1.28.0-0"
EOF

./bin/helm template test-release /tmp/test-chart
# success

cat > /tmp/test-chart-fail/Chart.yaml << 'EOF'
apiVersion: v2
name: test-chart-fail
version: 1.0.0
kubeVersion: ">= 1.35.0-0"
EOF

./bin/helm template test-release /tmp/test-chart-fail

Exit code 1
Error: chart requires kubeVersion: >= 1.35.0-0 which is incompatible with Kubernetes v1.34.0
```

Fixes #31508
Closes #31501
Closes #31502

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
