### PR TITLE
fix: Copy adopted resource info

### DIFF
--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -55,7 +55,8 @@ func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
 			return fmt.Errorf("could not get information about the resource %s: %w", resourceString(info), err)
 		}
 
-		requireUpdate.Append(info)
+		infoCopy := *info
+		requireUpdate.Append(&infoCopy)
 		return nil
 	})
 
@@ -84,7 +85,8 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
 		}
 
-		requireUpdate.Append(info)
+		infoCopy := *info
+		requireUpdate.Append(&infoCopy)
 		return nil
 	})
 

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -132,6 +132,7 @@ func TestRequireAdoption(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, found, 1)
 	assert.Equal(t, found[0], existing)
+	assert.NotSame(t, found[0], existing)
 }
 
 func TestExistingResourceConflict(t *testing.T) {
@@ -156,6 +157,7 @@ func TestExistingResourceConflict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, found, 1)
 	assert.Equal(t, found[0], existing)
+	assert.NotSame(t, found[0], existing)
 
 	// Verify that an existing resource that lacks labels/annotations results in an error
 	resources = append(resources, conflict)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
`requireAdoption` (`--take-ownership`) or `existingResourceConflict` find resources that need updated by Helm. This PR adjusts these functions to return copies of these objects, rather than the pointer aliases returned today. So later operations on the original object don't affect the original.

fixes: https://github.com/helm/helm/issues/31510, https://github.com/helm/helm/pull/31384

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
