### PR TITLE
fix: include version test for --dependency-update

### DIFF
--- a/pkg/action/dependency_test.go
+++ b/pkg/action/dependency_test.go
@@ -59,7 +59,7 @@ func TestList(t *testing.T) {
 		if err := NewDependency().List(tcase.chart, &buf); err != nil {
 			t.Fatal(err)
 		}
-		test.AssertGoldenString(t, buf.String(), tcase.golden)
+		test.AssertGoldenString(t, buf.String(), tcase.golden, map[string]string{})
 	}
 }
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -812,7 +812,7 @@ OUTER:
 			if err != nil {
 				return err
 			}
-			if dac.Name() == rac.Name() {
+			if dac.Name() == rac.Name() && dac.Version() == rac.Version() {
 				continue OUTER
 			}
 		}

--- a/pkg/chart/common.go
+++ b/pkg/chart/common.go
@@ -52,6 +52,10 @@ func (r *v2Accessor) Name() string {
 	return r.chrt.Metadata.Name
 }
 
+func (r *v2Accessor) Version() string {
+	return r.chrt.Metadata.Version
+}
+
 func (r *v2Accessor) IsRoot() bool {
 	return r.chrt.IsRoot()
 }
@@ -119,6 +123,10 @@ type v3Accessor struct {
 
 func (r *v3Accessor) Name() string {
 	return r.chrt.Metadata.Name
+}
+
+func (r *v3Accessor) Version() string {
+	return r.chrt.Metadata.Version
 }
 
 func (r *v3Accessor) IsRoot() bool {

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -47,6 +47,10 @@ func (r *v2DependencyAccessor) Name() string {
 	return r.dep.Name
 }
 
+func (r *v2DependencyAccessor) Version() string {
+	return r.dep.Version
+}
+
 func (r *v2DependencyAccessor) Alias() string {
 	return r.dep.Alias
 }
@@ -57,6 +61,10 @@ type v3DependencyAccessor struct {
 
 func (r *v3DependencyAccessor) Name() string {
 	return r.dep.Name
+}
+
+func (r *v3DependencyAccessor) Version() string {
+	return r.dep.Version
 }
 
 func (r *v3DependencyAccessor) Alias() string {

--- a/pkg/chart/interfaces.go
+++ b/pkg/chart/interfaces.go
@@ -25,6 +25,7 @@ type Dependency interface{}
 
 type Accessor interface {
 	Name() string
+	Version() string
 	IsRoot() bool
 	MetadataAsMap() map[string]interface{}
 	Files() []*common.File
@@ -40,5 +41,6 @@ type Accessor interface {
 
 type DependencyAccessor interface {
 	Name() string
+	Version() string
 	Alias() string
 }

--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -69,7 +69,7 @@ func runTestCmd(t *testing.T, tests []cmdTestCase) {
 					t.Errorf("expected no error, got: '%v'", err)
 				}
 				if tt.golden != "" {
-					test.AssertGoldenString(t, out, tt.golden)
+					test.AssertGoldenString(t, out, tt.golden, tt.goldenArgs)
 				}
 			})
 		}
@@ -129,10 +129,11 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 
 // cmdTestCase describes a test case that works with releases.
 type cmdTestCase struct {
-	name      string
-	cmd       string
-	golden    string
-	wantError bool
+	name       string
+	cmd        string
+	golden     string
+	goldenArgs map[string]string
+	wantError  bool
 	// Rels are the available releases at the start of the test.
 	rels []*release.Release
 	// Number of repeats (in case a feature was previously flaky and the test checks

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -153,6 +153,15 @@ func TestInstall(t *testing.T) {
 			cmd:    "install --dependency-update updeps testdata/testcharts/chart-with-subchart-update",
 			golden: "output/chart-with-subchart-update.txt",
 		},
+		// Install chart with update-dependency
+		{
+			name:   "install chart with outdated dependencies",
+			cmd:    fmt.Sprintf("install --dependency-update --repository-cache %s --repository-config %s updeps testdata/testcharts/chart-with-outdated-dependency --username username --password password", srv.Root(), repoFile),
+			golden: "output/install-with-outdated-deps.txt",
+			goldenArgs: map[string]string{
+				"repoUrl": srv.URL(),
+			},
+		},
 		// Install, chart with bad dependencies in Chart.yaml in /charts
 		{
 			name:      "install chart with bad dependencies in Chart.yaml",

--- a/pkg/cmd/testdata/output/install-with-outdated-deps.txt
+++ b/pkg/cmd/testdata/output/install-with-outdated-deps.txt
@@ -1,0 +1,12 @@
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "test" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Saving 1 charts
+Downloading oci-dependent-chart from repo {{ .repoUrl }}
+Deleting outdated charts
+NAME: updeps
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.helmignore
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart-with-outdated-dependency
+version: 0.1.0
+dependencies:
+  - name: oci-dependent-chart
+    version: 0.1.0
+    repository: "@test"

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/.helmignore
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: oci-dependent-chart
+type: application
+version: 0.0.1

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/NOTES.txt
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oci-dependent-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "oci-dependent-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oci-dependent-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oci-dependent-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/tests/test-connection.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "oci-dependent-chart.fullname" . }}-test-connection"
+  labels:
+    {{- include "oci-dependent-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "oci-dependent-chart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/values.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/values.yaml
@@ -1,0 +1,3 @@
+# Default values for oci-dependent-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/values.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/values.yaml
@@ -1,0 +1,4 @@
+# Default values for reqtest.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value


### PR DESCRIPTION
Closes #31455 

**What this PR does / why we need it**:
When using `--dependency-update`, helm does not update dependencies if an outdated version exists in `charts/`.
This PR includes a version check when attempting to match `Chart.yaml` deps to the ones in `charts/`

**Special notes for your reviewer**:

- Since this is my first PR in helm, I am not familiar with the testing env. I've modified internal test func to allow templating...
- Upon validating modifications for `install`, I'll add tests for `update` and `template`.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
