### PR TITLE
fix: Use server-side apply for object create during update

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -419,6 +419,7 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 		if err != nil {
 			return nil, err
 		}
+
 		if _, err := i.cfg.KubeClient.Create(
 			resourceList,
 			kube.ClientCreateOptionServerSideApply(i.ServerSideApply, false)); err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -545,7 +545,7 @@ func (c *Client) update(originals, targets ResourceList, createApplyFunc CreateA
 			res.Created = append(res.Created, target)
 
 			// Since the resource does not exist, create it.
-			if err := createResource(target); err != nil {
+			if err := createApplyFunc(target); err != nil {
 				return fmt.Errorf("failed to create resource: %w", err)
 			}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -287,11 +287,11 @@ func (c *Client) makeCreateApplyFunc(serverSideApply, forceConflicts, dryRun boo
 				slog.String("name", target.Name),
 				slog.String("gvk", target.Mapping.GroupVersionKind.String()))
 			if err != nil {
-				logger.Debug("Error patching resource", slog.Any("error", err))
+				logger.Debug("Error creating resource via patch", slog.Any("error", err))
 				return err
 			}
 
-			logger.Debug("Patched resource")
+			logger.Debug("Created resource via patch")
 
 			return nil
 		}

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -350,9 +350,7 @@ func TestUpdate(t *testing.T) {
 		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/otter:PATCH",
 		"/namespaces/default/pods/dolphin:GET",
-		"/namespaces/default/pods:POST", // create dolphin
-		"/namespaces/default/pods:POST", // retry due to 409
-		"/namespaces/default/pods:POST", // retry due to 409
+		"/namespaces/default/pods/dolphin:PATCH", // create dolphin
 		"/namespaces/default/pods/squid:GET",
 		"/namespaces/default/pods/squid:DELETE",
 		"/namespaces/default/pods/notfound:GET",
@@ -465,6 +463,8 @@ func TestUpdate(t *testing.T) {
 					}
 
 					return newResponse(http.StatusOK, &listTarget.Items[1])
+				case p == "/namespaces/default/pods/dolphin" && m == http.MethodPatch:
+					return newResponse(http.StatusOK, &listTarget.Items[1])
 				case p == "/namespaces/default/pods/squid" && m == http.MethodDelete:
 					return newResponse(http.StatusOK, &listTarget.Items[1])
 				case p == "/namespaces/default/pods/squid" && m == http.MethodGet:
@@ -485,10 +485,9 @@ func TestUpdate(t *testing.T) {
 						Reason:  metav1.StatusReasonForbidden,
 						Code:    http.StatusForbidden,
 					})
-				default:
 				}
 
-				t.Fail()
+				t.FailNow()
 				return nil, nil
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
It was missed during server-side apply development that the Kube client "update" method also creates resources.
Fix this creation to use server-side apply based methods (if server-side apply enabled)

fixes: #31516

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
