### PR TITLE
chore: add warning for registry login with namespace

### DIFF
--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -120,3 +120,49 @@ func TestLogin_ResetsForceAttemptOAuth2_OnFailure(t *testing.T) {
 		t.Errorf("ForceAttemptOAuth2 should be false after failed Login")
 	}
 }
+
+// TestWarnIfHostHasPath verifies that warnIfHostHasPath correctly detects path components.
+func TestWarnIfHostHasPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		host     string
+		wantWarn bool
+	}{
+		{
+			name:     "domain only",
+			host:     "ghcr.io",
+			wantWarn: false,
+		},
+		{
+			name:     "domain with port",
+			host:     "localhost:8000",
+			wantWarn: false,
+		},
+		{
+			name:     "domain with repository path",
+			host:     "ghcr.io/terryhowe",
+			wantWarn: true,
+		},
+		{
+			name:     "domain with nested path",
+			host:     "ghcr.io/terryhowe/myrepo",
+			wantWarn: true,
+		},
+		{
+			name:     "localhost with port and path",
+			host:     "localhost:8000/myrepo",
+			wantWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := warnIfHostHasPath(tt.host)
+			if got != tt.wantWarn {
+				t.Errorf("warnIfHostHasPath(%q) = %v, want %v", tt.host, got, tt.wantWarn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a breaking change in Helm v4 where `registry login` no longer supports a path in the login so that we can roll out namespaced logins of the same registry in the future. This pull request adds a warning to give more context around the login failure.

Partial: https://github.com/helm/helm/issues/31499

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
