### PR TITLE
fix: preserve vendor suffixes in KubeVersion.GitVersion

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -230,7 +230,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 
 	if ch.Metadata.KubeVersion != "" {
 		if !chartutil.IsCompatibleRange(ch.Metadata.KubeVersion, caps.KubeVersion.String()) {
-			return hs, b, "", fmt.Errorf("chart requires kubeVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.String())
+			return hs, b, "", fmt.Errorf("chart requires kubeVersion: %s which is incompatible with Kubernetes %s", ch.Metadata.KubeVersion, caps.KubeVersion.Version)
 		}
 	}
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -572,7 +572,7 @@ func TestInstallRelease_KubeVersion(t *testing.T) {
 	vals = map[string]interface{}{}
 	_, err = instAction.Run(buildChart(withKube(">=99.0.0")), vals)
 	is.Error(err)
-	is.Contains(err.Error(), "chart requires kubeVersion")
+	is.Contains(err.Error(), "chart requires kubeVersion: >=99.0.0 which is incompatible with Kubernetes v1.20.")
 }
 
 func TestInstallRelease_Wait(t *testing.T) {

--- a/pkg/chart/common/capabilities_test.go
+++ b/pkg/chart/common/capabilities_test.go
@@ -83,18 +83,41 @@ func TestParseKubeVersion(t *testing.T) {
 	}
 }
 
-func TestParseKubeVersionSuffix(t *testing.T) {
-	kv, err := ParseKubeVersion("v1.28+")
-	if err != nil {
-		t.Errorf("Expected v1.28+ to parse successfully")
+func TestParseKubeVersionWithVendorSuffixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantVer    string
+		wantString string
+		wantMajor  string
+		wantMinor  string
+	}{
+		{"GKE vendor suffix", "v1.33.4-gke.1245000", "v1.33.4-gke.1245000", "v1.33.4", "1", "33"},
+		{"GKE without v", "1.30.2-gke.1587003", "v1.30.2-gke.1587003", "v1.30.2", "1", "30"},
+		{"EKS trailing +", "v1.28+", "v1.28+", "v1.28", "1", "28"},
+		{"EKS + without v", "1.28+", "v1.28+", "v1.28", "1", "28"},
+		{"Standard version", "v1.31.0", "v1.31.0", "v1.31.0", "1", "31"},
+		{"Standard without v", "1.29.0", "v1.29.0", "v1.29.0", "1", "29"},
 	}
-	if kv.Version != "v1.28" {
-		t.Errorf("Expected parsed KubeVersion.Version to be v1.28, got %q", kv.String())
-	}
-	if kv.Major != "1" {
-		t.Errorf("Expected parsed KubeVersion.Major to be 1, got %q", kv.Major)
-	}
-	if kv.Minor != "28" {
-		t.Errorf("Expected parsed KubeVersion.Minor to be 28, got %q", kv.Minor)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv, err := ParseKubeVersion(tt.input)
+			if err != nil {
+				t.Fatalf("ParseKubeVersion() error = %v", err)
+			}
+			if kv.Version != tt.wantVer {
+				t.Errorf("Version = %q, want %q", kv.Version, tt.wantVer)
+			}
+			if kv.String() != tt.wantString {
+				t.Errorf("String() = %q, want %q", kv.String(), tt.wantString)
+			}
+			if kv.Major != tt.wantMajor {
+				t.Errorf("Major = %q, want %q", kv.Major, tt.wantMajor)
+			}
+			if kv.Minor != tt.wantMinor {
+				t.Errorf("Minor = %q, want %q", kv.Minor, tt.wantMinor)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Helm 3.19.0 introduced a regression where vendor-specific suffixes (e.g., -gke.1245000, -eks-4096722, +) are stripped from `.Capabilities.KubeVersion.GitVersion`, breaking charts that detect managed Kubernetes platforms (https://github.com/helm/helm/issues/31423).

The root cause was using `k8sversion.ParseGeneric().String()` which intentionally discards vendor suffixes. It is good thing for comparaison but no when return the full `GitVersion`. The fix preserves the original version string while still using `ParseGeneric()` for validation and Major/Minor extraction.

I am not super happy with the fix, especially with `String()`, but I was not able to find easier path.

Fixes #31423
Related to #31063, #31078

**Special notes for your reviewer**:

Script I used to check the behavior:

```sh
#!/bin/bash
set -e

make build

mkdir -p /tmp/test-chart/templates
cat > /tmp/test-chart/Chart.yaml <<EOF
apiVersion: v2
name: test-chart
version: 0.1.0
kubeVersion: ">= 1.21.0"
EOF

cat > /tmp/test-chart/templates/test.yaml <<'EOF'
version: {{ .Capabilities.KubeVersion.Version }}
EOF

./bin/helm template /tmp/test-chart --kube-version v1.33.4-gke.1245000 | grep -q "version: v1.33.4-gke.1245000" || {
  echo "FAIL: GKE suffix not preserved"
  exit 1
}

./bin/helm template /tmp/test-chart --kube-version 1.28+ | grep -q "version: v1.28+" || {
  echo "FAIL: + not preserved"
  exit 1
}

rm -rf /tmp/test-chart
echo "Looks good!"
```

Tiny increase in coverage 🐜 :
```
ok      helm.sh/helm/v4/pkg/chart/common        0.333s  coverage: 76.5% of statements
ok      helm.sh/helm/v4/pkg/chart/common        0.389s  coverage: 77.0% of statements
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so). Not sure it needs to be documented
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
