### PR TITLE
feat: add missing context to debug logs

### DIFF
--- a/pkg/chart/common/util/jsonschema.go
+++ b/pkg/chart/common/util/jsonschema.go
@@ -87,7 +87,7 @@ func ValidateAgainstSchema(ch chart.Charter, values map[string]interface{}) erro
 			sb.WriteString(err.Error())
 		}
 	}
-	slog.Debug("number of dependencies in the chart", "dependencies", len(chrt.Dependencies()))
+	slog.Debug("number of dependencies in the chart", "chart", chrt.Name(), "dependencies", len(chrt.Dependencies()))
 	// For each dependency, recursively call this function with the coalesced values
 	for _, subchart := range chrt.Dependencies() {
 		sub, err := chart.NewAccessor(subchart)

--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -231,6 +231,7 @@ func statusObserver(cancel context.CancelFunc, desired status.Status) collector.
 		}
 
 		if aggregator.AggregateStatus(rss, desired) == desired {
+			slog.Debug("all resources achieved desired status", "desiredStatus", desired, "resourceCount", len(rss))
 			cancel()
 			return
 		}
@@ -241,7 +242,7 @@ func statusObserver(cancel context.CancelFunc, desired status.Status) collector.
 				return nonDesiredResources[i].Identifier.Name < nonDesiredResources[j].Identifier.Name
 			})
 			first := nonDesiredResources[0]
-			slog.Debug("waiting for resource", "name", first.Identifier.Name, "kind", first.Identifier.GroupKind.Kind, "expectedStatus", desired, "actualStatus", first.Status)
+			slog.Debug("waiting for resource", "namespace", first.Identifier.Namespace, "name", first.Identifier.Name, "kind", first.Identifier.GroupKind.Kind, "expectedStatus", desired, "actualStatus", first.Status)
 		}
 	}
 }


### PR DESCRIPTION
Closes #31520

**What this PR does / why we need it**:
Adds chart name to dependency logs, namespace to resource waiting logs, and confirmation message when all resources are ready.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
