### PR TITLE
fix(lint): prevent segmentation violation on only comment yaml in multidoc

### DIFF
--- a/internal/chart/v3/lint/rules/crds.go
+++ b/internal/chart/v3/lint/rules/crds.go
@@ -80,8 +80,10 @@ func Crds(linter *support.Linter) {
 				return
 			}
 
-			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdAPIVersion(yamlStruct))
-			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdKind(yamlStruct))
+			if yamlStruct != nil {
+				linter.RunLinterRule(support.ErrorSev, fpath, validateCrdAPIVersion(yamlStruct))
+				linter.RunLinterRule(support.ErrorSev, fpath, validateCrdKind(yamlStruct))
+			}
 		}
 	}
 }

--- a/internal/chart/v3/lint/rules/crds_test.go
+++ b/internal/chart/v3/lint/rules/crds_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package rules
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +35,32 @@ func TestInvalidCrdsDir(t *testing.T) {
 
 	assert.Len(t, res, 1)
 	assert.ErrorContains(t, res[0].Err, "not a directory")
+}
+
+// multi-document YAML with empty documents would panic
+func TestCrdWithEmptyDocument(t *testing.T) {
+	chartDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(
+		`apiVersion: v1
+name: test
+version: 0.1.0
+`), 0644)
+
+	// CRD with comments before --- (creates empty document)
+	crdsDir := filepath.Join(chartDir, "crds")
+	os.Mkdir(crdsDir, 0755)
+	os.WriteFile(filepath.Join(crdsDir, "test.yaml"), []byte(
+		`# Comments create empty document
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.example.io
+`), 0644)
+
+	linter := support.Linter{ChartDir: chartDir}
+	Crds(&linter)
+
+	assert.Len(t, linter.Messages, 0)
 }

--- a/pkg/chart/v2/lint/rules/crds.go
+++ b/pkg/chart/v2/lint/rules/crds.go
@@ -80,8 +80,10 @@ func Crds(linter *support.Linter) {
 				return
 			}
 
-			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdAPIVersion(yamlStruct))
-			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdKind(yamlStruct))
+			if yamlStruct != nil {
+				linter.RunLinterRule(support.ErrorSev, fpath, validateCrdAPIVersion(yamlStruct))
+				linter.RunLinterRule(support.ErrorSev, fpath, validateCrdKind(yamlStruct))
+			}
 		}
 	}
 }

--- a/pkg/chart/v2/lint/rules/crds_test.go
+++ b/pkg/chart/v2/lint/rules/crds_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package rules
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +35,32 @@ func TestInvalidCrdsDir(t *testing.T) {
 
 	assert.Len(t, res, 1)
 	assert.ErrorContains(t, res[0].Err, "not a directory")
+}
+
+// multi-document YAML with empty documents would panic
+func TestCrdWithEmptyDocument(t *testing.T) {
+	chartDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(
+		`apiVersion: v1
+name: test
+version: 0.1.0
+`), 0644)
+
+	// CRD with comments before --- (creates empty document)
+	crdsDir := filepath.Join(chartDir, "crds")
+	os.Mkdir(crdsDir, 0755)
+	os.WriteFile(filepath.Join(crdsDir, "test.yaml"), []byte(
+		`# Comments create empty document
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.example.io
+`), 0644)
+
+	linter := support.Linter{ChartDir: chartDir}
+	Crds(&linter)
+
+	assert.Len(t, linter.Messages, 0)
 }


### PR DESCRIPTION
Fixes: https://github.com/helm/helm/issues/31544, #31571, https://github.com/helm/helm/issues/31588

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

During testing with the [chart provided](https://github.com/traefik/traefik-helm-chart/traefik), I added some logs. Yaml was `nil` and error `too`.

It is because of this https://github.com/traefik/traefik-helm-chart/blob/5d03b0ccf87ea2f64d9473ad365671f1972f3af2/traefik/crds/gateway-standard-install.yaml#L1-L18

We should continue if the yaml parsing is nil.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
