### PR TITLE
fix: prevent reporting fallback on version when none specified

### DIFF
--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -215,7 +215,9 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 		}
 
 		if constraint.Check(test) {
-			slog.Warn("unable to find exact version; falling back to closest available version", "chart", name, "requested", version, "selected", ver.Version)
+			if len(version) != 0 {
+				slog.Warn("unable to find exact version requested; falling back to closest available version", "chart", name, "requested", version, "selected", ver.Version)
+			}
 			return ver, nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

I inserted a regression via https://github.com/helm/helm/pull/31254. 

Fixes: https://github.com/helm/helm/issues/31548

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewer**:

Tested via

```sh
❯ helm pull rancher/longhorn-crd --version 106.2.0+up1.8.2 --destination /tmp/

level=WARN msg="unable to find exact version; falling back to closest available version" chart=longhorn-crd requested=106.2.0+up1.8.2 selected=106.2.0+up1.8.1

❯ bin/helm show chart brigade/brigade

apiVersion: v1
appVersion: v1.5.0
dependencies:
- condition: kashti.enabled
  name: kashti
  repository: https://brigadecore.github.io/charts
  version: 0.7.0
- condition: brigade-github-app.enabled
  name: brigade-github-app
  repository: https://brigadecore.github.io/charts
  version: 0.8.0
- alias: gw
  condition: gw.enabled
  name: brigade-github-oauth
  repository: https://brigadecore.github.io/charts
  version: 0.4.0
description: Brigade provides event-driven scripting of Kubernetes pipelines.
name: brigade
version: 1.10.0
```


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
