### PR TITLE
Fix passing manifests to extism post-renderer plugins

### DIFF
--- a/internal/plugin/runtime_extismv1_test.go
+++ b/internal/plugin/runtime_extismv1_test.go
@@ -16,9 +16,6 @@ limitations under the License.
 package plugin
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
 	extism "github.com/extism/go-sdk"
@@ -29,34 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type pluginRaw struct {
-	Metadata Metadata
-	Dir      string
-}
-
-func buildLoadExtismPlugin(t *testing.T, dir string) pluginRaw {
-	t.Helper()
-
-	pluginFile := filepath.Join(dir, PluginFileName)
-
-	metadataData, err := os.ReadFile(pluginFile)
-	require.NoError(t, err)
-
-	m, err := loadMetadata(metadataData)
-	require.NoError(t, err)
-	require.Equal(t, "extism/v1", m.Runtime, "expected plugin runtime to be extism/v1")
-
-	cmd := exec.Command("make", "-C", dir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Run(), "failed to build plugin in %q", dir)
-
-	return pluginRaw{
-		Metadata: *m,
-		Dir:      dir,
-	}
-}
-
 func TestRuntimeConfigExtismV1Validate(t *testing.T) {
 	rc := RuntimeConfigExtismV1{}
 	err := rc.Validate()
@@ -66,7 +35,7 @@ func TestRuntimeConfigExtismV1Validate(t *testing.T) {
 func TestRuntimeExtismV1InvokePlugin(t *testing.T) {
 	r := RuntimeExtismV1{}
 
-	pr := buildLoadExtismPlugin(t, "testdata/src/extismv1-test")
+	pr := BuildLoadExtismPlugin(t, "testdata/src/extismv1-test")
 	require.Equal(t, "test/v1", pr.Metadata.Type)
 
 	p, err := r.CreatePlugin(pr.Dir, &pr.Metadata)

--- a/internal/plugin/runtime_extismv1_test_helpers.go
+++ b/internal/plugin/runtime_extismv1_test_helpers.go
@@ -1,0 +1,53 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type RawPlugin struct {
+	Metadata Metadata
+	Dir      string
+}
+
+func BuildLoadExtismPlugin(t *testing.T, dir string) RawPlugin {
+	t.Helper()
+
+	pluginFile := filepath.Join(dir, PluginFileName)
+
+	metadataData, err := os.ReadFile(pluginFile)
+	require.NoError(t, err)
+
+	m, err := loadMetadata(metadataData)
+	require.NoError(t, err)
+	require.Equal(t, "extism/v1", m.Runtime, "expected plugin runtime to be extism/v1")
+
+	cmd := exec.Command("make", "-C", dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run(), "failed to build plugin in %q", dir)
+
+	return RawPlugin{
+		Metadata: *m,
+		Dir:      dir,
+	}
+}

--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -255,7 +255,7 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 
 	go func() {
 		defer stdin.Close()
-		io.Copy(stdin, msg.Manifests)
+		io.Copy(stdin, bytes.NewBufferString(msg.Manifests))
 	}()
 
 	postRendered := &bytes.Buffer{}
@@ -272,7 +272,7 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 
 	return &Output{
 		Message: schema.OutputMessagePostRendererV1{
-			Manifests: postRendered,
+			Manifests: postRendered.String(),
 		},
 	}, nil
 }

--- a/internal/plugin/schema/postrenderer.go
+++ b/internal/plugin/schema/postrenderer.go
@@ -16,19 +16,15 @@ limitations under the License.
 
 package schema
 
-import (
-	"bytes"
-)
-
 // InputMessagePostRendererV1 implements Input.Message
 type InputMessagePostRendererV1 struct {
-	Manifests *bytes.Buffer `json:"manifests"`
+	Manifests string `json:"manifests"`
 	// from CLI --post-renderer-args
 	ExtraArgs []string `json:"extraArgs"`
 }
 
 type OutputMessagePostRendererV1 struct {
-	Manifests *bytes.Buffer `json:"manifests"`
+	Manifests string `json:"manifests"`
 }
 
 type ConfigPostRendererV1 struct{}

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/.gitignore
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/.gitignore
@@ -1,0 +1,1 @@
+plugin.wasm

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/Makefile
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/Makefile
@@ -1,0 +1,11 @@
+.DEFAULT: build
+.PHONY: build test vet
+
+.PHONY: plugin.wasm
+plugin.wasm:
+	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o plugin.wasm .
+
+build: plugin.wasm
+
+vet:
+	GOOS=wasip1 GOARCH=wasm go vet ./...

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/go.mod
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/go.mod
@@ -1,0 +1,10 @@
+module helm.sh/helm/v4/pkg/postrenderer/testdata/plugins/postrenderer-v1-extism
+
+go 1.25.0
+
+require (
+	github.com/extism/go-pdk v1.1.3
+	helm.sh/helm/v4 v4.0.0
+)
+
+replace helm.sh/helm/v4 => ../../../../..

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/go.sum
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/go.sum
@@ -1,0 +1,2 @@
+github.com/extism/go-pdk v1.1.3 h1:hfViMPWrqjN6u67cIYRALZTZLk/enSPpNKa+rZ9X2SQ=
+github.com/extism/go-pdk v1.1.3/go.mod h1:Gz+LIU/YCKnKXhgge8yo5Yu1F/lbv7KtKFkiCSzW/P4=

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/main.go
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	pdk "github.com/extism/go-pdk"
+
+	"helm.sh/helm/v4/internal/plugin/schema"
+)
+
+func RunPlugin() error {
+	var input schema.InputMessagePostRendererV1
+
+	if err := pdk.InputJSON(&input); err != nil {
+		return fmt.Errorf("failed to parse input json: %w", err)
+	}
+
+	replacement := "BARTEST"
+
+	if len(input.ExtraArgs) > 0 {
+		replacement = strings.Join(input.ExtraArgs, " ")
+	}
+
+	updatedManifests := strings.ReplaceAll(input.Manifests, "FOOTEST", replacement)
+
+	result := schema.OutputMessagePostRendererV1{
+		Manifests: updatedManifests,
+	}
+
+	if err := pdk.OutputJSON(&result); err != nil {
+		return fmt.Errorf("failed to write output json: %w", err)
+	}
+
+	return nil
+}
+
+//go:wasmexport helm_plugin_main
+func HelmChartRenderer() uint64 {
+	pdk.Log(pdk.LogDebug, "running postrenderer-v1-extism plugin")
+
+	if err := RunPlugin(); err != nil {
+		pdk.Log(pdk.LogError, err.Error())
+		pdk.SetError(err)
+		return 1
+	}
+
+	return 0
+}
+
+func main() {}

--- a/pkg/postrenderer/testdata/plugins/extismv1-str-replace/plugin.yaml
+++ b/pkg/postrenderer/testdata/plugins/extismv1-str-replace/plugin.yaml
@@ -1,0 +1,5 @@
+name: extismv1-str-replace
+version: 1.2.3
+type: postrenderer/v1
+apiVersion: v1
+runtime: extism/v1


### PR DESCRIPTION
**What this PR does / why we need it**:

Post-renderer plugins with the extism runtime were not working. The reason for that is that manifests were passed as buffer; therefore, they were marshaled as `"manifests": {}` for both plugin input and output. Type changed `*bytes.Buffer` -> `string` to avoid this issue. Also, tests were written to confirm that the code is working

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
