### PR TITLE
Fix kube client logging

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -179,6 +179,16 @@ func newRootCmdWithConfig(actionConfig *action.Configuration, out io.Writer, arg
 
 	logSetup(settings.Debug)
 
+	// newRootCmdWithConfig is only called from NewRootCmd. NewRootCmd sets up
+	// NewConfiguration without a custom logger. So, the slog default is used. logSetup
+	// can change the default logger to the one in the logger package. This happens for
+	// the Helm client. This means the actionConfig logger is different from the slog
+	// default logger. If they are different we sync the actionConfig logger to the slog
+	// current default one.
+	if actionConfig.Logger() != slog.Default() {
+		actionConfig.SetLogger(slog.Default().Handler())
+	}
+
 	// Validate color mode setting
 	switch settings.ColorMode {
 	case "never", "auto", "always":

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"helm.sh/helm/v4/internal/test/ensure"
+	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/helmpath"
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
 )
@@ -129,3 +132,20 @@ func TestUnknownSubCmd(t *testing.T) {
 // func TestRootFileCompletion(t *testing.T) {
 // 	checkFileCompletion(t, "", false)
 // }
+
+func TestRootCmdLogger(t *testing.T) {
+	args := []string{}
+	buf := new(bytes.Buffer)
+	actionConfig := action.NewConfiguration()
+	_, err := newRootCmdWithConfig(actionConfig, buf, args, SetupLogging)
+	if err != nil {
+		t.Errorf("expected no error, got: '%v'", err)
+	}
+
+	l1 := actionConfig.Logger()
+	l2 := slog.Default()
+
+	if l1.Handler() != l2.Handler() {
+		t.Error("expected actionConfig logger to be the slog default logger")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: The kube client logging is based on the actionConfig logging. This is setup to use slog.Default() before the logging flags are parsed and logging is setup.

newRootCmdWithConfig changes the logging but it wasn't picked up for actionConfig or the kube client. This change updates the logging to include any changes.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
