### PR TITLE
Use modernize to use newer Golang features.

### DIFF
--- a/pkg/action/package_test.go
+++ b/pkg/action/package_test.go
@@ -93,7 +93,7 @@ func TestPassphraseFileFetcher_WithStdinAndMultipleFetches(t *testing.T) {
 		w.Write([]byte(passphrase + "\n"))
 	}()
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		fetcher, err := testPkg.passphraseFileFetcher("-", stdin)
 		if err != nil {
 			t.Errorf("Expected passphraseFileFetcher to not return an error, but got %v", err)

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,9 +41,7 @@ func createChartArchive(t *testing.T, chartName, apiVersion string, extraFiles m
 	tw := tar.NewWriter(gw)
 
 	files := make(map[string][]byte)
-	for k, v := range extraFiles {
-		files[k] = v
-	}
+	maps.Copy(files, extraFiles)
 
 	if createChartYaml {
 		chartYAMLContent := fmt.Sprintf(`apiVersion: %s

--- a/pkg/cmd/package.go
+++ b/pkg/cmd/package.go
@@ -81,7 +81,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 				return fmt.Errorf("missing registry client: %w", err)
 			}
 
-			for i := 0; i < len(args); i++ {
+			for i := range args {
 				path, err := filepath.Abs(args[i])
 				if err != nil {
 					return err

--- a/pkg/cmd/plugin_test.go
+++ b/pkg/cmd/plugin_test.go
@@ -199,7 +199,7 @@ func TestLoadPluginsWithSpace(t *testing.T) {
 		t.Fatalf("Expected %d plugins, got %d", len(tests), len(plugins))
 	}
 
-	for i := 0; i < len(plugins); i++ {
+	for i := range plugins {
 		out.Reset()
 		tt := tests[i]
 		pp := plugins[i]

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -72,7 +72,7 @@ func newPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			}
 			client.SetRegistryClient(registryClient)
 
-			for i := 0; i < len(args); i++ {
+			for i := range args {
 				output, err := client.Run(args[i])
 				if err != nil {
 					return err

--- a/pkg/cmd/repo_add_test.go
+++ b/pkg/cmd/repo_add_test.go
@@ -200,7 +200,7 @@ func repoAddConcurrent(t *testing.T, testName, repoFile string) {
 
 	var wg sync.WaitGroup
 	wg.Add(3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		go func(name string) {
 			defer wg.Done()
 			o := &repoAddOptions{
@@ -227,7 +227,7 @@ func repoAddConcurrent(t *testing.T, testName, repoFile string) {
 	}
 
 	var name string
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		name = fmt.Sprintf("%s-%d", testName, i)
 		if !f.Has(name) {
 			t.Errorf("%s was not successfully inserted into %s: %s", name, repoFile, f.Repositories[0])

--- a/pkg/cmd/search/search_test.go
+++ b/pkg/cmd/search/search_test.go
@@ -39,13 +39,13 @@ func TestSortScore(t *testing.T) {
 	SortScore(in)
 
 	// Test Score
-	for i := 0; i < len(expectScore); i++ {
+	for i := range expectScore {
 		if expectScore[i] != in[i].Score {
 			t.Errorf("Sort error on index %d: expected %d, got %d", i, expectScore[i], in[i].Score)
 		}
 	}
 	// Test Name
-	for i := 0; i < len(expect); i++ {
+	for i := range expect {
 		if expect[i] != in[i].Name {
 			t.Errorf("Sort error: expected %s, got %s", expect[i], in[i].Name)
 		}

--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -55,7 +55,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if validationErr != nil {
 				return validationErr
 			}
-			for i := 0; i < len(args); i++ {
+			for i := range args {
 
 				res, err := client.Run(args[i])
 				if err != nil {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -169,7 +169,7 @@ func TestRenderRefsOrdering(t *testing.T) {
 		"parent/templates/test.yaml": "parent value",
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		out, err := Render(parentChart, common.Values{})
 		if err != nil {
 			t.Fatalf("Failed to render templates: %s", err)
@@ -431,7 +431,7 @@ func TestParallelRenderInternals(t *testing.T) {
 	// Make sure that we can use one Engine to run parallel template renders.
 	e := new(Engine)
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		wg.Add(1)
 		go func(i int) {
 			tt := fmt.Sprintf("expect-%d", i)
@@ -1041,7 +1041,7 @@ func TestRenderRecursionLimit(t *testing.T) {
 	phrase := "All work and no play makes Jack a dull boy"
 	printFunc := `{{define "overlook"}}{{printf "` + phrase + `\n"}}{{end}}`
 	var repeatedIncl strings.Builder
-	for i := 0; i < times; i++ {
+	for range times {
 		repeatedIncl.WriteString(`{{include "overlook" . }}`)
 	}
 
@@ -1059,7 +1059,7 @@ func TestRenderRecursionLimit(t *testing.T) {
 	}
 
 	var expect string
-	for i := 0; i < times; i++ {
+	for range times {
 		expect += phrase + "\n"
 	}
 	if got := out["overlook/templates/quote"]; got != expect {

--- a/pkg/registry/generic.go
+++ b/pkg/registry/generic.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"sync"
 
@@ -124,10 +125,8 @@ func (c *GenericClient) PullGeneric(ref string, options GenericPullOptions) (*Ge
 				mediaType := desc.MediaType
 
 				// Skip media types if specified
-				for _, skipType := range options.SkipMediaTypes {
-					if mediaType == skipType {
-						return oras.SkipNode
-					}
+				if slices.Contains(options.SkipMediaTypes, mediaType) {
+					return oras.SkipNode
 				}
 
 				// Filter by allowed media types if specified

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -120,7 +120,7 @@ func TestSQLList(t *testing.T) {
 
 	sqlDriver, mock := newTestFixtureSQL(t)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		query := fmt.Sprintf(
 			"SELECT %s, %s, %s FROM %s WHERE %s = $1 AND %s = $2",
 			sqlReleaseTableKeyColumn,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

[modernize](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) has several suggestions for newer GoLang features to use.  I don't see any value in the `efaceany` suggestion as it would change too many things, without any benefit.

* The `rangeint` suggestion is faster.
* The `mapsloop` and `slicescontains` are just syntactic sugar.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
