### PR TITLE
fix: --dry-run=server now respect generateName

### DIFF
--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -46,6 +46,10 @@ func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
 			return err
 		}
 
+		if info.Name == "" {
+			return nil
+		}
+
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		_, err = helper.Get(info.Namespace, info.Name)
 		if err != nil {
@@ -68,6 +72,10 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 	err := resources.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if info.Name == "" {
+			return nil
 		}
 
 		helper := resource.NewHelper(info.Client, info.Mapping)

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -47,7 +47,7 @@ func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
 		}
 
 		isGenerateName, err := validateNameAndgenerateName(info)
-		if isGenerateName {
+		if isGenerateName || err != nil {
 			return err
 		}
 
@@ -76,7 +76,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 		}
 
 		isGenerateName, err := validateNameAndgenerateName(info)
-		if isGenerateName {
+		if isGenerateName || err != nil {
 			return err
 		}
 
@@ -216,7 +216,7 @@ func mergeStrStrMaps(current, desired map[string]string) map[string]string {
 func validateNameAndgenerateName(info *resource.Info) (bool, error) {
 	accessor, err := meta.Accessor(info.Object)
 	if err != nil {
-		return true, err
+		return false, err
 	}
 
 	if info.Name == "" && accessor.GetGenerateName() != "" {

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -45,9 +45,11 @@ func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
 		if err != nil {
 			return err
 		}
-
-		if info.Name == "" {
+		accessor, _ := meta.Accessor(info.Object)
+		if info.Name == "" && accessor.GetGenerateName() != "" {
 			return nil
+		} else if info.Name != "" && accessor.GetGenerateName() != "" {
+			return fmt.Errorf("metadata.name and metadata.generateName cannot both be set")
 		}
 
 		helper := resource.NewHelper(info.Client, info.Mapping)
@@ -74,8 +76,11 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return err
 		}
 
-		if info.Name == "" {
+		accessor, _ := meta.Accessor(info.Object)
+		if info.Name == "" && accessor.GetGenerateName() != "" {
 			return nil
+		} else if info.Name != "" && accessor.GetGenerateName() != "" {
+			return fmt.Errorf("metadata.name and metadata.generateName cannot both be set")
 		}
 
 		helper := resource.NewHelper(info.Client, info.Mapping)

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -46,7 +46,7 @@ func requireAdoption(resources kube.ResourceList) (kube.ResourceList, error) {
 			return err
 		}
 
-		isGenerateName, err := validateNameAndgenerateName(info)
+		isGenerateName, err := validateNameAndGenerateName(info)
 		if isGenerateName || err != nil {
 			return err
 		}
@@ -75,7 +75,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return err
 		}
 
-		isGenerateName, err := validateNameAndgenerateName(info)
+		isGenerateName, err := validateNameAndGenerateName(info)
 		if isGenerateName || err != nil {
 			return err
 		}
@@ -210,10 +210,10 @@ func mergeStrStrMaps(current, desired map[string]string) map[string]string {
 	return result
 }
 
-// validateNameAndgenerateName validates that an object only has either `Name` or `GenerateName` set (and not both)
+// validateNameAndGenerateName validates that an object only has either `Name` or `GenerateName` set (and not both)
 // If `GenerateName` is set, true is returned
 // If an invalid combination of `Name` and `GenerateName` are set, an error is returned
-func validateNameAndgenerateName(info *resource.Info) (bool, error) {
+func validateNameAndGenerateName(info *resource.Info) (bool, error) {
 	accessor, err := meta.Accessor(info.Object)
 	if err != nil {
 		return false, err

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 )
 
-func newDeploymentResource(name, namespace string) *resource.Info {
+func newDeploymentResource(name, namespace, generateName string) *resource.Info {
 	return &resource.Info{
 		Name: name,
 		Mapping: &meta.RESTMapping{
@@ -45,8 +45,9 @@ func newDeploymentResource(name, namespace string) *resource.Info {
 		},
 		Object: &appsv1.Deployment{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
+				Name:         name,
+				Namespace:    namespace,
+				GenerateName: generateName,
 			},
 		},
 	}
@@ -164,7 +165,7 @@ func TestExistingResourceConflict(t *testing.T) {
 }
 
 func TestCheckOwnership(t *testing.T) {
-	deployFoo := newDeploymentResource("foo", "ns-a")
+	deployFoo := newDeploymentResource("foo", "ns-a", "")
 
 	// Verify that a resource that lacks labels/annotations is not owned
 	err := checkOwnership(deployFoo.Object, "rel-a", "ns-a")
@@ -211,8 +212,8 @@ func TestCheckOwnership(t *testing.T) {
 func TestSetMetadataVisitor(t *testing.T) {
 	var (
 		err       error
-		deployFoo = newDeploymentResource("foo", "ns-a")
-		deployBar = newDeploymentResource("bar", "ns-a-system")
+		deployFoo = newDeploymentResource("foo", "ns-a", "")
+		deployBar = newDeploymentResource("bar", "ns-a-system", "")
 		resources = kube.ResourceList{deployFoo, deployBar}
 	)
 
@@ -233,8 +234,54 @@ func TestSetMetadataVisitor(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add a new resource that is missing ownership metadata and verify error
-	resources.Append(newDeploymentResource("baz", "default"))
+	resources.Append(newDeploymentResource("baz", "default", ""))
 	err = resources.Visit(setMetadataVisitor("rel-b", "ns-a", false))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `Deployment "baz" in namespace "" cannot be owned`)
+}
+
+func TestValidateNameAndGenerateName(t *testing.T) {
+	tests := []struct {
+		name        string
+		info        *resource.Info
+		wantSkip    bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "both name and generateName present",
+			info:        newDeploymentResource("job-a", "foo", "job-a-"),
+			wantSkip:    true,
+			wantErr:     true,
+			errContains: "metadata.name and metadata.generateName cannot both be set",
+		},
+		{
+			name:     "only generateName present",
+			info:     newDeploymentResource("", "foo", "job-a-"),
+			wantSkip: true,
+			wantErr:  false,
+		},
+		{
+			name:     "only name present",
+			info:     newDeploymentResource("job-a", "foo", ""),
+			wantSkip: false,
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			skip, err := validateNameAndgenerateName(tc.info)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.wantSkip, skip)
+		})
+	}
 }

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -272,7 +272,7 @@ func TestValidateNameAndGenerateName(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			skip, err := validateNameAndgenerateName(tc.info)
+			skip, err := validateNameAndGenerateName(tc.info)
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -29,6 +29,9 @@ func (r *ResourceList) Append(val *resource.Info) {
 // Visit implements resource.Visitor. The visitor stops if fn returns an error.
 func (r ResourceList) Visit(fn resource.VisitorFunc) error {
 	for _, i := range r {
+		if i.Name == "" {
+			continue
+		}
 		if err := fn(i, nil); err != nil {
 			return err
 		}

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -29,9 +29,6 @@ func (r *ResourceList) Append(val *resource.Info) {
 // Visit implements resource.Visitor. The visitor stops if fn returns an error.
 func (r ResourceList) Visit(fn resource.VisitorFunc) error {
 	for _, i := range r {
-		if i.Name == "" {
-			continue
-		}
 		if err := fn(i, nil); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm4 was facing problem with `--dry-run=server` as it was not respecting the `generateName`. The actual behavior is `generateName` is considered only in CREATE client method, not GET. A simple change is made, if `Name == ""`, this will be skipped to avoid error mentioned in issue #31509.

**Special notes for your reviewer**:
Other changes could also be possible, ex: we could `return` at the very first `Name == ""` instead of `continue`. This PR preferred continue because it is intended. 

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

closes #31509 
