### PR TITLE
fix: panic in lint when CRD file is empty

### DIFF
--- a/pkg/chart/v2/lint/rules/crds.go
+++ b/pkg/chart/v2/lint/rules/crds.go
@@ -80,6 +80,11 @@ func Crds(linter *support.Linter) {
 				return
 			}
 
+			// Skip validation if yamlStruct is nil (empty document or only comments/whitespace)
+			if yamlStruct == nil {
+				continue
+			}
+
 			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdAPIVersion(yamlStruct))
 			linter.RunLinterRule(support.ErrorSev, fpath, validateCrdKind(yamlStruct))
 		}

--- a/pkg/chart/v2/lint/rules/crds_test.go
+++ b/pkg/chart/v2/lint/rules/crds_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 const invalidCrdsDir = "./testdata/invalidcrdsdir"
+const emptyCrdDir = "./testdata/emptycrd"
 
 func TestInvalidCrdsDir(t *testing.T) {
 	linter := support.Linter{ChartDir: invalidCrdsDir}
@@ -33,4 +34,16 @@ func TestInvalidCrdsDir(t *testing.T) {
 
 	assert.Len(t, res, 1)
 	assert.ErrorContains(t, res[0].Err, "not a directory")
+}
+
+// TestEmptyCrd tests that empty CRD files (containing only comments/whitespace)
+// don't cause a panic when the YAML decoder returns nil.
+// This is a regression test for issue #31571.
+func TestEmptyCrd(t *testing.T) {
+	linter := support.Linter{ChartDir: emptyCrdDir}
+	Crds(&linter)
+	res := linter.Messages
+
+	// Should not panic and should have no errors
+	assert.Len(t, res, 0)
 }

--- a/pkg/chart/v2/lint/rules/testdata/emptycrd/Chart.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/emptycrd/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: emptycrd
+description: A Helm chart with empty CRD file
+version: 0.1.0

--- a/pkg/chart/v2/lint/rules/testdata/emptycrd/crds/empty.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/emptycrd/crds/empty.yaml
@@ -1,0 +1,3 @@
+# This file contains only comments and whitespace
+# It will decode to nil in the YAML decoder
+

--- a/pkg/chart/v2/lint/rules/testdata/emptycrd/values.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/emptycrd/values.yaml
@@ -1,0 +1,1 @@
+# Empty values file


### PR DESCRIPTION


**What this PR does / why we need it**:
The YAML decoder can return nil when a CRD file contains only comments or whitespace. Added nil check to skip validation in these cases. This fixes a panic in the CRD linting rule.

Fixes #31571

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
