### PR TITLE
feat(helm): Add --output flag to version subcommand

### DIFF
--- a/pkg/cmd/testdata/output/version-output-go.txt
+++ b/pkg/cmd/testdata/output/version-output-go.txt
@@ -1,0 +1,1 @@
+version.BuildInfo{Version:"v4.1", GitCommit:"", GitTreeState:"", GoVersion:"", KubeClientVersion:"v1.20"}

--- a/pkg/cmd/testdata/output/version-output-human.txt
+++ b/pkg/cmd/testdata/output/version-output-human.txt
@@ -1,0 +1,5 @@
+Version:             v4.1
+Git Commit:          
+Git Tree State:      
+Go Version:          
+KubeClient Version:  v1.20

--- a/pkg/cmd/testdata/output/version-output-invalid.txt
+++ b/pkg/cmd/testdata/output/version-output-invalid.txt
@@ -1,0 +1,1 @@
+Error: invalid output format: "invalid" (valid formats: "go", "human")

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -32,6 +32,19 @@ func TestVersion(t *testing.T) {
 		name:   "template",
 		cmd:    "version --template='Version: {{.Version}}'",
 		golden: "output/version-template.txt",
+	}, {
+		name:   "output go",
+		cmd:    "version -o go",
+		golden: "output/version-output-go.txt",
+	}, {
+		name:   "output human",
+		cmd:    "version -o human",
+		golden: "output/version-output-human.txt",
+	}, {
+		name:      "invalid output format",
+		cmd:       "version -o invalid",
+		wantError: true,
+		golden:    "output/version-output-invalid.txt",
 	}}
 	runTestCmd(t, tests)
 }


### PR DESCRIPTION
This PR introduces the `--output` flag to the `version` subcommand. This flag allows adding more formats to the `version` output without adding additional flags.

It also adds the `go` and `human` formats to the `--output` flag, for printing the version in a raw Go struct and a human-readable table format, respectively, as well as a proper error message:

```
$ helm version -o go
version.BuildInfo{Version:"v4.1+unreleased", GitCommit:"f05c21b6b6380d923696a7684c80a5e0847fbd7b", GitTreeState:"dirty", GoVersion:"go1.25.4", KubeClientVersion:"v1.34"}

$ helm version -o human
Version:             v4.1+unreleased
Git Commit:          f05c21b6b6380d923696a7684c80a5e0847fbd7b
Git Tree State:      dirty
Go Version:          go1.25.4
KubeClient Version:  v1.34

$ helm version -o asdf
Error: invalid output format: "asdf" (valid formats: "go", "human")
```

**Special notes for your reviewer**:
The current output of `version` has not been changed, for backwards compatibility:
```
$ helm version
version.BuildInfo{Version:"v4.1+unreleased", GitCommit:"f05c21b6b6380d923696a7684c80a5e0847fbd7b", GitTreeState:"dirty", GoVersion:"go1.25.4", KubeClientVersion:"v1.34"}
```
We may switch to the human-readable format as the default output for `version` in the next major release.

As follow-up, I suggest the following improvements:
- Update the help message for the version subcommand.
- Add shell completion for the available flags.
- Add other output formats, such as `yaml` and `json`.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
