### PR TITLE
fix: Delay test hook deletion until after logs are retrieved with `helm test release --logs`

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -34,6 +34,9 @@ import (
 // execHook executes all of the hooks for the given hook event.
 func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) error {
 	shutdown, err := cfg.execHookWithDelayedShutdown(rl, hook, waitStrategy, timeout, serverSideApply)
+	if shutdown == nil {
+		return nil
+	}
 	if err != nil {
 		if err := shutdown(); err != nil {
 			return err

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -52,7 +52,7 @@ func ShutdownNoOp() error {
 	return nil
 }
 
-// execHook executes all of the hooks for the given hook event and returns a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
+// execHookWithDelayedShutdown executes all of the hooks for the given hook event and returns a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
 func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) (ExecuteShutdownHooks, error) {
 	executingHooks := []*release.Hook{}
 

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -46,14 +46,14 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	return shutdown()
 }
 
-type executeShutdownFunc = func() error
+type ExecuteShutdownFunc = func() error
 
 func shutdownNoOp() error {
 	return nil
 }
 
 // execHookWithDelayedShutdown executes all of the hooks for the given hook event and returns a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
-func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) (executeShutdownFunc, error) {
+func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) (ExecuteShutdownFunc, error) {
 	executingHooks := []*release.Hook{}
 
 	for _, h := range rl.Hooks {

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -129,7 +129,6 @@ func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook 
 				}
 				return err
 			}, err
-
 		}
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -33,6 +33,24 @@ import (
 
 // execHook executes all of the hooks for the given hook event.
 func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) error {
+	shutdown, err := cfg.execHookWithDelayedShutdown(rl, hook, waitStrategy, timeout, serverSideApply)
+	if err != nil {
+		if err := shutdown(); err != nil {
+			return err
+		}
+		return err
+	}
+	return shutdown()
+}
+
+type ExecuteShutdownHooks = func() error
+
+func ShutdownNoOp() error {
+	return nil
+}
+
+// execHook executes all of the hooks for the given hook event and return a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
+func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) (ExecuteShutdownHooks, error) {
 	executingHooks := []*release.Hook{}
 
 	for _, h := range rl.Hooks {
@@ -51,12 +69,12 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 		cfg.hookSetDeletePolicy(h)
 
 		if err := cfg.deleteHookByPolicy(h, release.HookBeforeHookCreation, waitStrategy, timeout); err != nil {
-			return err
+			return ShutdownNoOp, err
 		}
 
 		resources, err := cfg.KubeClient.Build(bytes.NewBufferString(h.Manifest), true)
 		if err != nil {
-			return fmt.Errorf("unable to build kubernetes object for %s hook %s: %w", hook, h.Path, err)
+			return ShutdownNoOp, fmt.Errorf("unable to build kubernetes object for %s hook %s: %w", hook, h.Path, err)
 		}
 
 		// Record the time at which the hook was applied to the cluster
@@ -77,12 +95,12 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			kube.ClientCreateOptionServerSideApply(serverSideApply, false)); err != nil {
 			h.LastRun.CompletedAt = time.Now()
 			h.LastRun.Phase = release.HookPhaseFailed
-			return fmt.Errorf("warning: Hook %s %s failed: %w", hook, h.Path, err)
+			return ShutdownNoOp, fmt.Errorf("warning: Hook %s %s failed: %w", hook, h.Path, err)
 		}
 
 		waiter, err := cfg.KubeClient.GetWaiter(waitStrategy)
 		if err != nil {
-			return fmt.Errorf("unable to get waiter: %w", err)
+			return ShutdownNoOp, fmt.Errorf("unable to get waiter: %w", err)
 		}
 		// Watch hook resources until they have completed
 		err = waiter.WatchUntilReady(resources, timeout)
@@ -98,36 +116,39 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			}
 			// If a hook is failed, check the annotation of the hook to determine whether the hook should be deleted
 			// under failed condition. If so, then clear the corresponding resource object in the hook
-			if errDeleting := cfg.deleteHookByPolicy(h, release.HookFailed, waitStrategy, timeout); errDeleting != nil {
-				// We log the error here as we want to propagate the hook failure upwards to the release object.
-				log.Printf("error deleting the hook resource on hook failure: %v", errDeleting)
-			}
+			return func() error {
+				if errDeleting := cfg.deleteHookByPolicy(h, release.HookFailed, waitStrategy, timeout); errDeleting != nil {
+					// We log the error here as we want to propagate the hook failure upwards to the release object.
+					log.Printf("error deleting the hook resource on hook failure: %v", errDeleting)
+				}
 
-			// If a hook is failed, check the annotation of the previous successful hooks to determine whether the hooks
-			// should be deleted under succeeded condition.
-			if err := cfg.deleteHooksByPolicy(executingHooks[0:i], release.HookSucceeded, waitStrategy, timeout); err != nil {
+				// If a hook is failed, check the annotation of the previous successful hooks to determine whether the hooks
+				// should be deleted under succeeded condition.
+				if err := cfg.deleteHooksByPolicy(executingHooks[0:i], release.HookSucceeded, waitStrategy, timeout); err != nil {
+					return err
+				}
 				return err
-			}
+			}, err
 
-			return err
 		}
 		h.LastRun.Phase = release.HookPhaseSucceeded
 	}
 
-	// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
-	// or output should be logged under succeeded condition. If so, then clear the corresponding resource object in each hook
-	for i := len(executingHooks) - 1; i >= 0; i-- {
-		h := executingHooks[i]
-		if err := cfg.outputLogsByPolicy(h, rl.Namespace, release.HookOutputOnSucceeded); err != nil {
-			// We log here as we still want to attempt hook resource deletion even if output logging fails.
-			log.Printf("error outputting logs for hook failure: %v", err)
+	return func() error {
+		// If all hooks are successful, check the annotation of each hook to determine whether the hook should be deleted
+		// or output should be logged under succeeded condition. If so, then clear the corresponding resource object in each hook
+		for i := len(executingHooks) - 1; i >= 0; i-- {
+			h := executingHooks[i]
+			if err := cfg.outputLogsByPolicy(h, rl.Namespace, release.HookOutputOnSucceeded); err != nil {
+				// We log here as we still want to attempt hook resource deletion even if output logging fails.
+				log.Printf("error outputting logs for hook failure: %v", err)
+			}
+			if err := cfg.deleteHookByPolicy(h, release.HookSucceeded, waitStrategy, timeout); err != nil {
+				return err
+			}
 		}
-		if err := cfg.deleteHookByPolicy(h, release.HookSucceeded, waitStrategy, timeout); err != nil {
-			return err
-		}
-	}
-
-	return nil
+		return nil
+	}, nil
 }
 
 // hookByWeight is a sorter for hooks

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -49,7 +49,7 @@ func ShutdownNoOp() error {
 	return nil
 }
 
-// execHook executes all of the hooks for the given hook event and return a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
+// execHook executes all of the hooks for the given hook event and returns a shutdownHook function to trigger deletions after doing other things like e.g. retrieving logs.
 func (cfg *Configuration) execHookWithDelayedShutdown(rl *release.Release, hook release.HookEvent, waitStrategy kube.WaitStrategy, timeout time.Duration, serverSideApply bool) (ExecuteShutdownHooks, error) {
 	executingHooks := []*release.Hook{}
 

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -57,24 +57,24 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 }
 
 // Run executes 'helm test' against the given release.
-func (r *ReleaseTesting) Run(name string) (ri.Releaser, ExecuteShutdownHooks, error) {
+func (r *ReleaseTesting) Run(name string) (ri.Releaser, executeShutdownFunc, error) {
 	if err := r.cfg.KubeClient.IsReachable(); err != nil {
-		return nil, ShutdownNoOp, err
+		return nil, shutdownNoOp, err
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, ShutdownNoOp, fmt.Errorf("releaseTest: Release name is invalid: %s", name)
+		return nil, shutdownNoOp, fmt.Errorf("releaseTest: Release name is invalid: %s", name)
 	}
 
 	// finds the non-deleted release with the given name
 	reli, err := r.cfg.Releases.Last(name)
 	if err != nil {
-		return reli, ShutdownNoOp, err
+		return reli, shutdownNoOp, err
 	}
 
 	rel, err := releaserToV1Release(reli)
 	if err != nil {
-		return reli, ShutdownNoOp, err
+		return reli, shutdownNoOp, err
 	}
 
 	skippedHooks := []*release.Hook{}

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -57,7 +57,7 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 }
 
 // Run executes 'helm test' against the given release.
-func (r *ReleaseTesting) Run(name string) (ri.Releaser, executeShutdownFunc, error) {
+func (r *ReleaseTesting) Run(name string) (ri.Releaser, ExecuteShutdownFunc, error) {
 	if err := r.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, shutdownNoOp, err
 	}

--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -57,24 +57,24 @@ func NewReleaseTesting(cfg *Configuration) *ReleaseTesting {
 }
 
 // Run executes 'helm test' against the given release.
-func (r *ReleaseTesting) Run(name string) (ri.Releaser, error) {
+func (r *ReleaseTesting) Run(name string) (ri.Releaser, ExecuteShutdownHooks, error) {
 	if err := r.cfg.KubeClient.IsReachable(); err != nil {
-		return nil, err
+		return nil, ShutdownNoOp, err
 	}
 
 	if err := chartutil.ValidateReleaseName(name); err != nil {
-		return nil, fmt.Errorf("releaseTest: Release name is invalid: %s", name)
+		return nil, ShutdownNoOp, fmt.Errorf("releaseTest: Release name is invalid: %s", name)
 	}
 
 	// finds the non-deleted release with the given name
 	reli, err := r.cfg.Releases.Last(name)
 	if err != nil {
-		return reli, err
+		return reli, ShutdownNoOp, err
 	}
 
 	rel, err := releaserToV1Release(reli)
 	if err != nil {
-		return rel, err
+		return reli, ShutdownNoOp, err
 	}
 
 	skippedHooks := []*release.Hook{}
@@ -102,14 +102,16 @@ func (r *ReleaseTesting) Run(name string) (ri.Releaser, error) {
 	}
 
 	serverSideApply := rel.ApplyMethod == string(release.ApplyMethodServerSideApply)
-	if err := r.cfg.execHook(rel, release.HookTest, kube.StatusWatcherStrategy, r.Timeout, serverSideApply); err != nil {
+	shutdown, err := r.cfg.execHookWithDelayedShutdown(rel, release.HookTest, kube.StatusWatcherStrategy, r.Timeout, serverSideApply)
+
+	if err != nil {
 		rel.Hooks = append(skippedHooks, rel.Hooks...)
-		r.cfg.Releases.Update(rel)
-		return rel, err
+		r.cfg.Releases.Update(reli)
+		return reli, shutdown, err
 	}
 
 	rel.Hooks = append(skippedHooks, rel.Hooks...)
-	return rel, r.cfg.Releases.Update(rel)
+	return reli, shutdown, r.cfg.Releases.Update(reli)
 }
 
 // GetPodLogs will write the logs for all test pods in the given release into

--- a/pkg/cmd/release_testing.go
+++ b/pkg/cmd/release_testing.go
@@ -75,7 +75,6 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 				}
 			}()
 
-
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs
 			// if requested

--- a/pkg/cmd/release_testing.go
+++ b/pkg/cmd/release_testing.go
@@ -55,7 +55,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 			}
 			return compListReleases(toComplete, args, cfg)
 		},
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) (returnError error) {
 			client.Namespace = settings.Namespace()
 			notName := regexp.MustCompile(`^!\s?name=`)
 			for _, f := range filter {
@@ -65,8 +65,17 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 					client.Filters[action.ExcludeNameFilter] = append(client.Filters[action.ExcludeNameFilter], notName.ReplaceAllLiteralString(f, ""))
 				}
 			}
+
 			reli, shutdown, runErr := client.Run(args[0])
-			defer shutdown()
+			defer func() {
+				if shutdownErr := shutdown(); shutdownErr != nil {
+					if returnError == nil {
+						returnError = shutdownErr
+					}
+				}
+			}()
+
+
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs
 			// if requested

--- a/pkg/cmd/release_testing.go
+++ b/pkg/cmd/release_testing.go
@@ -65,7 +65,8 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 					client.Filters[action.ExcludeNameFilter] = append(client.Filters[action.ExcludeNameFilter], notName.ReplaceAllLiteralString(f, ""))
 				}
 			}
-			reli, runErr := client.Run(args[0])
+			reli, shutdown, runErr := client.Run(args[0])
+			defer shutdown()
 			// We only return an error if we weren't even able to get the
 			// release, otherwise we keep going so we can print status and logs
 			// if requested


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is a rebase of #10603

Fixing a [very old issue](https://github.com/helm/helm/pull/10603) with frequent activity from users.

When running `helm test <release-name> --logs`, test pods with `hook-succeeded` delete policy were being deleted before logs could be retrieved, resulting in "pods not found" errors. This PR delays the execution of hook deletion until after logs have been successfully retrieved.

**Special notes for your reviewer**:

Tested with a chart 
1. `helm create test-chart`
2. Modify the `tests/test-connection.yaml` generated file by adding one annotation `"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded`
3. Run test
  ```
  helm test new-chart --logs        
NAME: new-chart
LAST DEPLOYED: Wed Nov 26 17:18:45 2025
NAMESPACE: default
STATUS: deployed
REVISION: 2
DESCRIPTION: Upgrade complete
TEST SUITE:     new-chart-test-connection
Last Started:   Wed Nov 26 17:18:48 2025
Last Completed: Wed Nov 26 17:18:51 2025
Phase:          Succeeded

Error: unable to get pod logs for new-chart-test-connection: pods "new-chart-test-connection" not found
```
4. With this branch
```
bin/helm test new-chart --logs
NAME: new-chart
LAST DEPLOYED: Wed Nov 26 17:18:45 2025
NAMESPACE: default
STATUS: deployed
REVISION: 2
DESCRIPTION: Upgrade complete
TEST SUITE:     new-chart-test-connection
Last Started:   Wed Nov 26 17:20:04 2025
Last Completed: Wed Nov 26 17:20:08 2025
Phase:          Succeeded

POD LOGS: new-chart-test-connection
Connecting to new-chart:80 (192.168.194.168:80)
saving to 'index.html'
index.html           100% |********************************|   612  0:00:00 ETA
'index.html' saved
``` 

Fixes #9098
Closes: #10603

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

