### PR TITLE
fix: use length check for MetaDependencies instead of nil comparison

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -103,7 +103,7 @@ func (p *Package) Run(path string, _ map[string]interface{}) (string, error) {
 		ch.Metadata.AppVersion = p.AppVersion
 	}
 
-	if reqs := ac.MetaDependencies(); reqs != nil {
+	if reqs := ac.MetaDependencies(); len(reqs) > 0 {
 		if err := CheckDependencies(ch, reqs); err != nil {
 			return "", err
 		}

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -275,7 +275,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		slog.Warn("this chart is deprecated")
 	}
 
-	if req := ac.MetaDependencies(); req != nil {
+	if req := ac.MetaDependencies(); len(req) > 0 {
 		// If CheckDependencies returns an error, we have unfulfilled dependencies.
 		// As of Helm 2.4.0, this is treated as a stopping condition:
 		// https://github.com/helm/helm/issues/2209

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -200,7 +200,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if req := ac.MetaDependencies(); req != nil {
+			if req := ac.MetaDependencies(); len(req) > 0 {
 				if err := action.CheckDependencies(ch, req); err != nil {
 					err = fmt.Errorf("an error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: %w", err)
 					if client.DependencyUpdate {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The MetaDependencies implementations for `v2Accessor` and `v3Accessor` always return a non-nil slice (using `make`), even when there are no dependencies. This made the `req != nil` condition always true and incorrectly treated empty dependency lists as present.

Update the logic to check `len(r) > 0 `instead of `r != nil` so that empty dependency slices are handled correctly.

**Special notes for your reviewer**:

Please close if this PR is incorrect.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
