### PR TITLE
Add new option to define api-versions from file

### DIFF
--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -166,6 +166,17 @@ func TestTemplateCmd(t *testing.T) {
 			cmd:    fmt.Sprintf("template '%s' -f %s/extra_values.yaml", chartPath, chartPath),
 			golden: "output/template-subchart-cm-set-file.txt",
 		},
+		{
+			name:   "template with default-api-versions-file",
+			cmd:    fmt.Sprintf("template '%s' --default-api-versions-file testdata/default-api-versions.txt",
+			"testdata/testcharts/chart-listing-apiversions"),
+			golden: "output/template-default-api-versions-file1.txt",
+		},
+		{
+			name:   "template with default-api-versions-file and api-versions",
+			cmd:    fmt.Sprintf("template '%s' --default-api-versions-file testdata/default-api-versions.txt --api-versions helm.sh/extra1 --api-versions helm.sh/extra2", "testdata/testcharts/chart-listing-apiversions"),
+			golden: "output/template-default-api-versions-file2.txt",
+		},
 	}
 	runTestCmd(t, tests)
 }

--- a/pkg/cmd/testdata/default-api-versions.txt
+++ b/pkg/cmd/testdata/default-api-versions.txt
@@ -1,0 +1,3 @@
+apps/v1/Deployment
+apps/v1/StatefulSet
+networking.k8s.io/v1/NetworkPolicy

--- a/pkg/cmd/testdata/output/template-default-api-versions-file1.txt
+++ b/pkg/cmd/testdata/output/template-default-api-versions-file1.txt
@@ -1,0 +1,8 @@
+---
+# Source: chart-listing-apiversions/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "release-name-chart-listing-apiversions"
+data:
+  apiVersions: [apps/v1/Deployment apps/v1/StatefulSet networking.k8s.io/v1/NetworkPolicy]

--- a/pkg/cmd/testdata/output/template-default-api-versions-file2.txt
+++ b/pkg/cmd/testdata/output/template-default-api-versions-file2.txt
@@ -1,0 +1,8 @@
+---
+# Source: chart-listing-apiversions/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "release-name-chart-listing-apiversions"
+data:
+  apiVersions: [apps/v1/Deployment apps/v1/StatefulSet networking.k8s.io/v1/NetworkPolicy helm.sh/extra1 helm.sh/extra2]

--- a/pkg/cmd/testdata/testcharts/chart-listing-apiversions/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-listing-apiversions/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: Testing .Capabilities.APIVersions
+home: https://helm.sh/helm
+name: chart-listing-apiversions
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+type: application

--- a/pkg/cmd/testdata/testcharts/chart-listing-apiversions/README.md
+++ b/pkg/cmd/testdata/testcharts/chart-listing-apiversions/README.md
@@ -1,0 +1,4 @@
+# Helm Chart to print .Capabilities.APIVersions
+
+Used for testing `helm template . --default-api-versions-file <filepath>`
+option

--- a/pkg/cmd/testdata/testcharts/chart-listing-apiversions/templates/configmap.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-listing-apiversions/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{.Release.Name}}-{{.Chart.Name}}"
+data:
+  apiVersions: {{ .Capabilities.APIVersions }}


### PR DESCRIPTION
To implement compatibility with different K8S versions the Capabilities.APIVersions is used in the helm chart's template yaml or tpl files.

A helm version hardcodes a fixed set of APIVersions from a specific K8S release.

A new option is added to load the full list of APIVersions from files that "mocks" the API list of a given K8S version or distribution, so the default list can be overriden.

This way the compatibility of a helm chart can be tested offline using helm template with different set of K8S API Versions as input.

The output of helm template operation can be input to kubeval or kubeconform to test the schema compatibility.

Example: helm template mychart-1.0.0.tgz --api-versions-file k8s.v1.27.txt

where the k8s.v127.txt can contain the list of API versions. Example

```txt
v1
v1/Binding
v1/ComponentStatus
v1/ConfigMap
v1/Endpoints
v1/Event
v1/LimitRange
v1/Namespace
v1/Node
v1/PersistentVolume
v1/PersistentVolumeClaim
v1/Pod
v1/PodTemplate
v1/ReplicationController
v1/ResourceQuota
v1/Secret
v1/Service
v1/ServiceAccount
apps/v1
apps/v1/ControllerRevision
apps/v1/DaemonSet
apps/v1/Deployment
apps/v1/ReplicaSet
apps/v1/StatefulSet
etc.
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
