### PR TITLE
feat(create): add --chart-api-version flag (when HELM_EXPERIMENTAL_CHART_V3 env var is set)

### DIFF
--- a/internal/gates/doc.go
+++ b/internal/gates/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package gates contains internal feature gates that can be used to enable or disable experimental features.
+// This is a separate internal package instead of using the pkg/gates package to avoid circular dependencies.
+package gates

--- a/internal/gates/gates.go
+++ b/internal/gates/gates.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gates
+
+import "helm.sh/helm/v4/pkg/gates"
+
+// ChartV3 is the feature gate for chart API version v3.
+const ChartV3 gates.Gate = "HELM_EXPERIMENTAL_CHART_V3"

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	chartv3 "helm.sh/helm/v4/internal/chart/v3"
+	chartutilv3 "helm.sh/helm/v4/internal/chart/v3/util"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/cmd/require"
@@ -51,9 +53,10 @@ will be overwritten, but other files will be left alone.
 `
 
 type createOptions struct {
-	starter    string // --starter
-	name       string
-	starterDir string
+	starter         string // --starter
+	name            string
+	starterDir      string
+	chartAPIVersion string // --chart-api-version
 }
 
 func newCreateCmd(out io.Writer) *cobra.Command {
@@ -81,12 +84,25 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
+	cmd.Flags().StringVar(&o.chartAPIVersion, "chart-api-version", chart.APIVersionV2, "chart API version to use (v2 or v3)")
+
 	return cmd
 }
 
 func (o *createOptions) run(out io.Writer) error {
 	fmt.Fprintf(out, "Creating %s\n", o.name)
 
+	switch o.chartAPIVersion {
+	case chart.APIVersionV2, "":
+		return o.createV2Chart(out)
+	case chartv3.APIVersionV3:
+		return o.createV3Chart(out)
+	default:
+		return fmt.Errorf("unsupported chart API version: %s (supported: v2, v3)", o.chartAPIVersion)
+	}
+}
+
+func (o *createOptions) createV2Chart(out io.Writer) error {
 	chartname := filepath.Base(o.name)
 	cfile := &chart.Metadata{
 		Name:        chartname,
@@ -109,5 +125,31 @@ func (o *createOptions) run(out io.Writer) error {
 
 	chartutil.Stderr = out
 	_, err := chartutil.Create(chartname, filepath.Dir(o.name))
+	return err
+}
+
+func (o *createOptions) createV3Chart(out io.Writer) error {
+	chartname := filepath.Base(o.name)
+	cfile := &chartv3.Metadata{
+		Name:        chartname,
+		Description: "A Helm chart for Kubernetes",
+		Type:        "application",
+		Version:     "0.1.0",
+		AppVersion:  "0.1.0",
+		APIVersion:  chartv3.APIVersionV3,
+	}
+
+	if o.starter != "" {
+		// Create from the starter
+		lstarter := filepath.Join(o.starterDir, o.starter)
+		// If path is absolute, we don't want to prefix it with helm starters folder
+		if filepath.IsAbs(o.starter) {
+			lstarter = o.starter
+		}
+		return chartutilv3.CreateFrom(cfile, filepath.Dir(o.name), lstarter)
+	}
+
+	chartutilv3.Stderr = out
+	_, err := chartutilv3.Create(chartname, filepath.Dir(o.name))
 	return err
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -28,6 +28,7 @@ import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/cmd/require"
+	"helm.sh/helm/v4/pkg/gates"
 	"helm.sh/helm/v4/pkg/helmpath"
 )
 
@@ -96,6 +97,9 @@ func (o *createOptions) run(out io.Writer) error {
 	case chart.APIVersionV2, "":
 		return o.createV2Chart(out)
 	case chartv3.APIVersionV3:
+		if !gates.ChartV3.IsEnabled() {
+			return gates.ChartV3.Error()
+		}
 		return o.createV3Chart(out)
 	default:
 		return fmt.Errorf("unsupported chart API version: %s (supported: v2, v3)", o.chartAPIVersion)

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -89,6 +89,8 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
 	cmd.Flags().StringVar(&o.chartAPIVersion, "chart-api-version", chart.APIVersionV2, "chart API version to use (v2 or v3)")
+	// Hide the flag until chart v3 is officially released
+	cmd.Flags().MarkHidden("chart-api-version")
 
 	return cmd
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -89,8 +89,10 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
 	cmd.Flags().StringVar(&o.chartAPIVersion, "chart-api-version", chart.APIVersionV2, "chart API version to use (v2 or v3)")
-	// Hide the flag until chart v3 is officially released
-	cmd.Flags().MarkHidden("chart-api-version")
+
+	if !chartV3.IsEnabled() {
+		cmd.Flags().MarkHidden("chart-api-version")
+	}
 
 	return cmd
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -25,10 +25,10 @@ import (
 
 	chartv3 "helm.sh/helm/v4/internal/chart/v3"
 	chartutilv3 "helm.sh/helm/v4/internal/chart/v3/util"
+	"helm.sh/helm/v4/internal/gates"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/cmd/require"
-	"helm.sh/helm/v4/pkg/gates"
 	"helm.sh/helm/v4/pkg/helmpath"
 )
 
@@ -60,9 +60,6 @@ type createOptions struct {
 	chartAPIVersion string // --chart-api-version
 }
 
-// ChartV3 is the feature gate for chart API version v3.
-const chartV3 gates.Gate = "HELM_EXPERIMENTAL_CHART_V3"
-
 func newCreateCmd(out io.Writer) *cobra.Command {
 	o := &createOptions{}
 
@@ -90,7 +87,7 @@ func newCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&o.starter, "starter", "p", "", "the name or absolute path to Helm starter scaffold")
 	cmd.Flags().StringVar(&o.chartAPIVersion, "chart-api-version", chart.APIVersionV2, "chart API version to use (v2 or v3)")
 
-	if !chartV3.IsEnabled() {
+	if !gates.ChartV3.IsEnabled() {
 		cmd.Flags().MarkHidden("chart-api-version")
 	}
 
@@ -104,8 +101,8 @@ func (o *createOptions) run(out io.Writer) error {
 	case chart.APIVersionV2, "":
 		return o.createV2Chart(out)
 	case chartv3.APIVersionV3:
-		if !chartV3.IsEnabled() {
-			return chartV3.Error()
+		if !gates.ChartV3.IsEnabled() {
+			return gates.ChartV3.Error()
 		}
 		return o.createV3Chart(out)
 	default:

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -60,6 +60,9 @@ type createOptions struct {
 	chartAPIVersion string // --chart-api-version
 }
 
+// ChartV3 is the feature gate for chart API version v3.
+const chartV3 gates.Gate = "HELM_EXPERIMENTAL_CHART_V3"
+
 func newCreateCmd(out io.Writer) *cobra.Command {
 	o := &createOptions{}
 
@@ -97,8 +100,8 @@ func (o *createOptions) run(out io.Writer) error {
 	case chart.APIVersionV2, "":
 		return o.createV2Chart(out)
 	case chartv3.APIVersionV3:
-		if !gates.ChartV3.IsEnabled() {
-			return gates.ChartV3.Error()
+		if !chartV3.IsEnabled() {
+			return chartV3.Error()
 		}
 		return o.createV3Chart(out)
 	default:

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -24,6 +24,7 @@ import (
 
 	chartv3 "helm.sh/helm/v4/internal/chart/v3"
 	chartutilv3 "helm.sh/helm/v4/internal/chart/v3/util"
+	"helm.sh/helm/v4/internal/gates"
 	"helm.sh/helm/v4/internal/test/ensure"
 	chart "helm.sh/helm/v4/pkg/chart"
 	chartloader "helm.sh/helm/v4/pkg/chart/loader"
@@ -107,7 +108,7 @@ func TestCreateStarterCmd(t *testing.T) {
 
 			// Enable feature gate for v3 charts
 			if tt.chartAPIVersion == "v3" {
-				t.Setenv(string(chartV3), "1")
+				t.Setenv(string(gates.ChartV3), "1")
 			}
 
 			cname := "testchart"
@@ -249,7 +250,7 @@ func TestCreateCmdChartAPIVersionV2(t *testing.T) {
 func TestCreateCmdChartAPIVersionV3(t *testing.T) {
 	t.Chdir(t.TempDir())
 	ensure.HelmHome(t)
-	t.Setenv(string(chartV3), "1")
+	t.Setenv(string(gates.ChartV3), "1")
 	cname := "testchart"
 
 	// Run a create with v3

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -29,6 +29,7 @@ import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
+	"helm.sh/helm/v4/pkg/gates"
 	"helm.sh/helm/v4/pkg/helmpath"
 )
 
@@ -94,6 +95,12 @@ func TestCreateStarterCmd(t *testing.T) {
 			t.Chdir(t.TempDir())
 			ensure.HelmHome(t)
 			defer resetEnv()()
+
+			// Enable feature gate for v3 charts
+			if tt.chartAPIVersion == "v3" {
+				t.Setenv(string(gates.ChartV3), "1")
+			}
+
 			cname := "testchart"
 
 			// Create a starter using the appropriate chartutil
@@ -224,6 +231,7 @@ func TestCreateCmdChartAPIVersionV2(t *testing.T) {
 func TestCreateCmdChartAPIVersionV3(t *testing.T) {
 	t.Chdir(t.TempDir())
 	ensure.HelmHome(t)
+	t.Setenv(string(gates.ChartV3), "1")
 	cname := "testchart"
 
 	// Run a create with v3

--- a/pkg/gates/gates.go
+++ b/pkg/gates/gates.go
@@ -36,6 +36,3 @@ func (g Gate) IsEnabled() bool {
 func (g Gate) Error() error {
 	return fmt.Errorf("this feature has been marked as experimental and is not enabled by default. Please set %s=1 in your environment to use this feature", g.String())
 }
-
-// ChartV3 is the feature gate for chart API version v3.
-const ChartV3 Gate = "HELM_EXPERIMENTAL_CHART_V3"

--- a/pkg/gates/gates.go
+++ b/pkg/gates/gates.go
@@ -36,3 +36,6 @@ func (g Gate) IsEnabled() bool {
 func (g Gate) Error() error {
 	return fmt.Errorf("this feature has been marked as experimental and is not enabled by default. Please set %s=1 in your environment to use this feature", g.String())
 }
+
+// ChartV3 is the feature gate for chart API version v3.
+const ChartV3 Gate = "HELM_EXPERIMENTAL_CHART_V3"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `--chart-api-version` flag to helm create command to allow selecting chart API version (v2 or v3) when creating a new chart. It will allow adding Chart v3 specific features to created charts without breaking v2 charts.

- Default is v2 (existing behavior unchanged)
- v3 uses internal/chart/v3 scaffold generator
- Invalid versions return clear error message
- Works with `--starter` flag

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
