### PR TITLE
fix: handle properly conditions with multilevel aliases; fixes 31187

### DIFF
--- a/pkg/chartutil/dependencies.go
+++ b/pkg/chartutil/dependencies.go
@@ -187,7 +187,7 @@ Loop:
 	copy(cd, c.Dependencies()[:0])
 	for _, n := range c.Dependencies() {
 		if _, ok := rm[n.Metadata.Name]; !ok {
-			cd = append(cd, n)
+			cd = append(cd, deepCopyMetadataDependencies(n))
 		}
 	}
 	// don't keep disabled charts in metadata
@@ -212,6 +212,25 @@ Loop:
 	c.SetDependencies(cd...)
 
 	return nil
+}
+
+func deepCopyMetadataDependencies(c *chart.Chart) *chart.Chart {
+	if c == nil || c.Metadata == nil {
+		return c
+	}
+	cCopy := *c
+	metadataCopy := *c.Metadata
+	metadataCopy.Dependencies = nil
+	for _, d := range c.Metadata.Dependencies {
+		if d == nil {
+			metadataCopy.Dependencies = append(metadataCopy.Dependencies, d)
+		} else {
+			depCopy := *d
+			metadataCopy.Dependencies = append(metadataCopy.Dependencies, &depCopy)
+		}
+	}
+	cCopy.Metadata = &metadataCopy
+	return &cCopy
 }
 
 // pathToMap creates a nested map given a YAML path in dot notation.

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -111,6 +111,22 @@ func TestDependencyEnabled(t *testing.T) {
 		"subcharts with alias also respect conditions",
 		M{"subchart1": M{"enabled": false}, "subchart2alias": M{"enabled": true, "subchartb": M{"enabled": true}}},
 		[]string{"parentchart", "parentchart.subchart2alias", "parentchart.subchart2alias.subchartb"},
+	}, {
+		"subcharts with multilevel aliases are not added when disabled",
+		M{
+			"subchart1":      M{"enabled": false},
+			"subchart2":      M{"enabled": true, "subchartbalias": M{"enabled": false}},
+			"subchart2alias": M{"enabled": true, "subchartbalias": M{"enabled": false}},
+		},
+		[]string{"parentchart", "parentchart.subchart2", "parentchart.subchart2alias"},
+	}, {
+		"subchart with multilevel aliases is added when enabled",
+		M{
+			"subchart1":      M{"enabled": false},
+			"subchart2":      M{"enabled": true, "subchartbalias": M{"enabled": true}},
+			"subchart2alias": M{"enabled": true, "subchartbalias": M{"enabled": false}},
+		},
+		[]string{"parentchart", "parentchart.subchart2", "parentchart.subchart2.subchartbalias", "parentchart.subchart2alias"},
 	}}
 
 	for _, tc := range tests {

--- a/pkg/chartutil/testdata/subpop/charts/subchart2/Chart.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart2/Chart.yaml
@@ -17,3 +17,8 @@ dependencies:
     tags:
       - back-end
       - subchartc
+  - name: subchartb
+    alias: subchartbalias
+    repository: http://localhost:10191
+    version: 0.1.0
+    condition: subchartbalias.enabled

--- a/pkg/chartutil/testdata/subpop/charts/subchart2/values.yaml
+++ b/pkg/chartutil/testdata/subpop/charts/subchart2/values.yaml
@@ -19,3 +19,5 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+subchartbalias:
+  enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

closes #31187

**Special notes for your reviewer**:

The issue was in the `processDependencyEnabled` function.
The chart dependencies are only copied with a shallow copy. When there are two versions of the same chart with aliases, then the metadata objects of their dependencies are the same.
This causes an issue if when a dependency has also an alias: its metadata name is mutated to the metadata alias (`line 161 of dependencies.go`) and as the copy is shallow, all metadatas of the copies of this chart are then changed and this cause an issue for the next copied dependencies processed in the `getAliasDependency (line 112)` function: there is a mismatch between the chart name and the dependency name, causing the condition to not be applied.


**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
