### PR TITLE
fix: implement AND logic for tag and condition in dependencies

### DIFF
--- a/internal/chart/v3/util/dependencies.go
+++ b/internal/chart/v3/util/dependencies.go
@@ -47,7 +47,8 @@ func processDependencyConditions(reqs []*chart.Dependency, cvals common.Values, 
 				if err == nil {
 					// if not bool, warn
 					if bv, ok := vv.(bool); ok {
-						r.Enabled = bv
+						// Use AND logic: both tags and condition must be true
+						r.Enabled = r.Enabled && bv
 						break
 					}
 					slog.Warn("returned non-bool value", "path", c, "chart", r.Name)

--- a/internal/chart/v3/util/dependencies_test.go
+++ b/internal/chart/v3/util/dependencies_test.go
@@ -91,7 +91,7 @@ func TestDependencyEnabled(t *testing.T) {
 	}, {
 		"conditions enabling the parent charts, but back-end (b, c) is still disabled via values.yaml",
 		M{"subchart1": M{"enabled": true}, "subchart2": M{"enabled": true}},
-		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb", "parentchart.subchart2"},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb"},
 	}, {
 		"conditions disabling the parent charts, effectively disabling children",
 		M{"subchart1": M{"enabled": false}, "subchart2": M{"enabled": false}},
@@ -111,7 +111,15 @@ func TestDependencyEnabled(t *testing.T) {
 	}, {
 		"subcharts with alias also respect conditions",
 		M{"subchart1": M{"enabled": false}, "subchart2alias": M{"enabled": true, "subchartb": M{"enabled": true}}},
-		[]string{"parentchart", "parentchart.subchart2alias", "parentchart.subchart2alias.subchartb"},
+		[]string{"parentchart", "parentchart.subchart2alias"},
+	}, {
+		"tags disable chart even when condition is true (AND logic)",
+		M{"tags": M{"front-end": false}, "subchart1": M{"enabled": true}},
+		[]string{"parentchart"},
+	}, {
+		"tags disable child charts even when their conditions are true (AND logic)",
+		M{"tags": M{"front-end": false, "subcharta": false}, "subchart1": M{"enabled": true, "subcharta": M{"enabled": true}}},
+		[]string{"parentchart"},
 	}}
 
 	for _, tc := range tests {

--- a/pkg/chart/v2/util/dependencies.go
+++ b/pkg/chart/v2/util/dependencies.go
@@ -47,7 +47,8 @@ func processDependencyConditions(reqs []*chart.Dependency, cvals common.Values, 
 				if err == nil {
 					// if not bool, warn
 					if bv, ok := vv.(bool); ok {
-						r.Enabled = bv
+						// Use AND logic: both tags and condition must be true
+						r.Enabled = r.Enabled && bv
 						break
 					}
 					slog.Warn("returned non-bool value", "path", c, "chart", r.Name)

--- a/pkg/chart/v2/util/dependencies_test.go
+++ b/pkg/chart/v2/util/dependencies_test.go
@@ -91,7 +91,7 @@ func TestDependencyEnabled(t *testing.T) {
 	}, {
 		"conditions enabling the parent charts, but back-end (b, c) is still disabled via values.yaml",
 		M{"subchart1": M{"enabled": true}, "subchart2": M{"enabled": true}},
-		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb", "parentchart.subchart2"},
+		[]string{"parentchart", "parentchart.subchart1", "parentchart.subchart1.subcharta", "parentchart.subchart1.subchartb"},
 	}, {
 		"conditions disabling the parent charts, effectively disabling children",
 		M{"subchart1": M{"enabled": false}, "subchart2": M{"enabled": false}},
@@ -111,7 +111,15 @@ func TestDependencyEnabled(t *testing.T) {
 	}, {
 		"subcharts with alias also respect conditions",
 		M{"subchart1": M{"enabled": false}, "subchart2alias": M{"enabled": true, "subchartb": M{"enabled": true}}},
-		[]string{"parentchart", "parentchart.subchart2alias", "parentchart.subchart2alias.subchartb"},
+		[]string{"parentchart", "parentchart.subchart2alias"},
+	}, {
+		"tags disable chart even when condition is true (AND logic)",
+		M{"tags": M{"front-end": false}, "subchart1": M{"enabled": true}},
+		[]string{"parentchart"},
+	}, {
+		"tags disable child charts even when their conditions are true (AND logic)",
+		M{"tags": M{"front-end": false, "subcharta": false}, "subchart1": M{"enabled": true, "subcharta": M{"enabled": true}}},
+		[]string{"parentchart"},
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Changes dependency evaluation to use AND logic instead of OR logic when both tags and conditions are specified for a chart dependency.

Previously, a chart would be installed if either the tag was true OR the condition was true. Now, both the tag AND condition must be true for the chart to be installed.

This allows users to disable entire groups of charts using tags, regardless of individual chart conditions, which is the expected behavior described in issue #31604.

Breaking change: Charts that relied on conditions overriding tags will now need both the tag and condition to be true.

Changes:
- Modified processDependencyConditions() to use AND logic (r.Enabled && bv)
- Added test cases for AND logic behavior
- Updated existing test expectations to match new behavior

Fixes #31604