### PR TITLE
fix(getter): pass settings environment variables

### DIFF
--- a/internal/plugin/runtime.go
+++ b/internal/plugin/runtime.go
@@ -53,13 +53,13 @@ func remarshalRuntimeConfig[T RuntimeConfig](runtimeData map[string]any) (Runtim
 	return config, nil
 }
 
-// parseEnv takes a list of "KEY=value" environment variable strings
+// ParseEnv takes a list of "KEY=value" environment variable strings
 // and transforms the result into a map[KEY]=value
 //
 // - empty input strings are ignored
 // - input strings with no value are stored as empty strings
 // - duplicate keys overwrite earlier values
-func parseEnv(env []string) map[string]string {
+func ParseEnv(env []string) map[string]string {
 	result := make(map[string]string, len(env))
 	for _, envVar := range env {
 		parts := strings.SplitN(envVar, "=", 2)
@@ -75,7 +75,9 @@ func parseEnv(env []string) map[string]string {
 	return result
 }
 
-func formatEnv(env map[string]string) []string {
+// FormatEnv takes a map[KEY]=value and transforms it into
+// a list of "KEY=value" environment variable strings
+func FormatEnv(env map[string]string) []string {
 	result := make([]string, 0, len(env))
 	for key, value := range env {
 		result = append(result, fmt.Sprintf("%s=%s", key, value))

--- a/internal/plugin/runtime_extismv1.go
+++ b/internal/plugin/runtime_extismv1.go
@@ -259,7 +259,7 @@ func buildPluginConfig(input *Input, r *RuntimeExtismV1) extism.PluginConfig {
 		mc = mc.WithStderr(input.Stderr)
 	}
 	if len(input.Env) > 0 {
-		env := parseEnv(input.Env)
+		env := ParseEnv(input.Env)
 		for k, v := range env {
 			mc = mc.WithEnv(k, v)
 		}

--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -139,7 +139,7 @@ func (r *SubprocessPluginRuntime) InvokeHook(event string) error {
 		return nil
 	}
 
-	env := parseEnv(os.Environ())
+	env := ParseEnv(os.Environ())
 	maps.Insert(env, maps.All(r.EnvVars))
 	env["HELM_PLUGIN_NAME"] = r.metadata.Name
 	env["HELM_PLUGIN_DIR"] = r.pluginDir
@@ -150,7 +150,7 @@ func (r *SubprocessPluginRuntime) InvokeHook(event string) error {
 	}
 
 	cmd := exec.Command(main, argv...)
-	cmd.Env = formatEnv(env)
+	cmd.Env = FormatEnv(env)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -198,9 +198,9 @@ func (r *SubprocessPluginRuntime) runCLI(input *Input) (*Output, error) {
 
 	cmds := r.RuntimeConfig.PlatformCommand
 
-	env := parseEnv(os.Environ())
+	env := ParseEnv(os.Environ())
 	maps.Insert(env, maps.All(r.EnvVars))
-	maps.Insert(env, maps.All(parseEnv(input.Env)))
+	maps.Insert(env, maps.All(ParseEnv(input.Env)))
 	env["HELM_PLUGIN_NAME"] = r.metadata.Name
 	env["HELM_PLUGIN_DIR"] = r.pluginDir
 
@@ -210,7 +210,7 @@ func (r *SubprocessPluginRuntime) runCLI(input *Input) (*Output, error) {
 	}
 
 	cmd := exec.Command(command, args...)
-	cmd.Env = formatEnv(env)
+	cmd.Env = FormatEnv(env)
 
 	cmd.Stdin = input.Stdin
 	cmd.Stdout = input.Stdout
@@ -231,9 +231,9 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 		return nil, fmt.Errorf("plugin %q input message does not implement InputMessagePostRendererV1", r.metadata.Name)
 	}
 
-	env := parseEnv(os.Environ())
+	env := ParseEnv(os.Environ())
 	maps.Insert(env, maps.All(r.EnvVars))
-	maps.Insert(env, maps.All(parseEnv(input.Env)))
+	maps.Insert(env, maps.All(ParseEnv(input.Env)))
 	env["HELM_PLUGIN_NAME"] = r.metadata.Name
 	env["HELM_PLUGIN_DIR"] = r.pluginDir
 
@@ -261,7 +261,7 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 	postRendered := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	cmd.Env = formatEnv(env)
+	cmd.Env = FormatEnv(env)
 	cmd.Stdout = postRendered
 	cmd.Stderr = stderr
 

--- a/internal/plugin/runtime_subprocess_getter.go
+++ b/internal/plugin/runtime_subprocess_getter.go
@@ -56,9 +56,9 @@ func (r *SubprocessPluginRuntime) runGetter(input *Input) (*Output, error) {
 		return nil, fmt.Errorf("no downloader found for protocol %q", msg.Protocol)
 	}
 
-	env := parseEnv(os.Environ())
+	env := ParseEnv(os.Environ())
 	maps.Insert(env, maps.All(r.EnvVars))
-	maps.Insert(env, maps.All(parseEnv(input.Env)))
+	maps.Insert(env, maps.All(ParseEnv(input.Env)))
 	env["HELM_PLUGIN_NAME"] = r.metadata.Name
 	env["HELM_PLUGIN_DIR"] = r.pluginDir
 	env["HELM_PLUGIN_USERNAME"] = msg.Options.Username
@@ -83,7 +83,7 @@ func (r *SubprocessPluginRuntime) runGetter(input *Input) (*Output, error) {
 	cmd := exec.Command(
 		pluginCommand,
 		args...)
-	cmd.Env = formatEnv(env)
+	cmd.Env = FormatEnv(env)
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr
 

--- a/internal/plugin/runtime_test.go
+++ b/internal/plugin/runtime_test.go
@@ -56,7 +56,7 @@ func TestParseEnv(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result := parseEnv(tc.env)
+			result := ParseEnv(tc.env)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -93,7 +93,7 @@ func TestFormatEnv(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result := formatEnv(tc.env)
+			result := FormatEnv(tc.env)
 			assert.ElementsMatch(t, tc.expected, result)
 		})
 	}

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -274,8 +274,10 @@ func (s *EnvSettings) EnvVars() map[string]string {
 
 // Namespace gets the namespace from the configuration
 func (s *EnvSettings) Namespace() string {
-	if ns, _, err := s.config.ToRawKubeConfigLoader().Namespace(); err == nil {
-		return ns
+	if s.config != nil {
+		if ns, _, err := s.config.ToRawKubeConfigLoader().Namespace(); err == nil {
+			return ns
+		}
 	}
 	if s.namespace != "" {
 		return s.namespace

--- a/pkg/getter/plugingetter.go
+++ b/pkg/getter/plugingetter.go
@@ -38,12 +38,14 @@ func collectGetterPlugins(settings *cli.EnvSettings) (Providers, error) {
 	if err != nil {
 		return nil, err
 	}
+	env := plugin.FormatEnv(settings.EnvVars())
 	pluginConstructorBuilder := func(plg plugin.Plugin) Constructor {
 		return func(option ...Option) (Getter, error) {
 
 			return &getterPlugin{
 				options: append([]Option{}, option...),
 				plg:     plg,
+				env:     env,
 			}, nil
 		}
 	}
@@ -91,6 +93,7 @@ func convertOptions(globalOptions, options []Option) schema.GetterOptionsV1 {
 type getterPlugin struct {
 	options []Option
 	plg     plugin.Plugin
+	env     []string
 }
 
 func (g *getterPlugin) Get(href string, options ...Option) (*bytes.Buffer, error) {
@@ -108,6 +111,7 @@ func (g *getterPlugin) Get(href string, options ...Option) (*bytes.Buffer, error
 			Options:  opts,
 			Protocol: u.Scheme,
 		},
+		Env: g.env,
 		// TODO should we pass Stdin, Stdout, and Stderr through Input here to getter plugins?
 		// Stdout: os.Stdout,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR restores Helm settings environment variables for getter plugins.

**Commits:**
1. **Pass environment variables from CLI settings to getter plugins** - Calls `settings.EnvVars()` in `collectGetterPlugins()` to pass Helm environment to plugins
2. **Fix nil pointer dereference in `EnvSettings.Namespace()`** - Pre-existing bug triggered when `EnvVars()` is called on uninitialized `EnvSettings` (e.g., `&cli.EnvSettings{}` instead of `cli.New()`)

Fixes #31612 
Closes #31611 

**Special notes for your reviewer**:
The nil check fix addresses a pre-existing bug in `main` - calling `EnvVars()` on `&cli.EnvSettings{}` panics because `s.config` is nil. Existing tests using `&cli.EnvSettings{}` didn't trigger this because they never entered a code path that called `EnvVars()`.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

