### PR TITLE
Fix: Data Race Bug detected via TestConcurrenyDownloadIndex

### DIFF
--- a/pkg/repo/v1/chartrepo.go
+++ b/pkg/repo/v1/chartrepo.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"helm.sh/helm/v4/internal/fileutil"
 	"helm.sh/helm/v4/pkg/getter"
@@ -54,7 +53,6 @@ type ChartRepository struct {
 	IndexFile *IndexFile
 	Client    getter.Getter
 	CachePath string
-	mutex     sync.RWMutex
 }
 
 // NewChartRepository constructs ChartRepository
@@ -79,8 +77,6 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 
 // DownloadIndexFile fetches the index from a repository.
 func (r *ChartRepository) DownloadIndexFile() (string, error) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
 
 	indexURL, err := ResolveReferenceURL(r.Config.URL, "index.yaml")
 	if err != nil {

--- a/pkg/repo/v1/chartrepo.go
+++ b/pkg/repo/v1/chartrepo.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"helm.sh/helm/v4/internal/fileutil"
 	"helm.sh/helm/v4/pkg/getter"
@@ -53,6 +54,7 @@ type ChartRepository struct {
 	IndexFile *IndexFile
 	Client    getter.Getter
 	CachePath string
+	mutex     sync.RWMutex
 }
 
 // NewChartRepository constructs ChartRepository
@@ -77,6 +79,9 @@ func NewChartRepository(cfg *Entry, getters getter.Providers) (*ChartRepository,
 
 // DownloadIndexFile fetches the index from a repository.
 func (r *ChartRepository) DownloadIndexFile() (string, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	indexURL, err := ResolveReferenceURL(r.Config.URL, "index.yaml")
 	if err != nil {
 		return "", err

--- a/pkg/repo/v1/chartrepo_test.go
+++ b/pkg/repo/v1/chartrepo_test.go
@@ -101,10 +101,13 @@ func TestConcurrenyDownloadIndex(t *testing.T) {
 	}
 	defer srv.Close()
 
-	repo, err := NewChartRepository(&Entry{
+	// set base environment settings
+	baseEntry := &Entry{
 		Name: "nginx",
 		URL:  srv.URL,
-	}, getter.All(&cli.EnvSettings{}))
+	}
+	settings := cli.EnvSettings{}
+	repo, err := NewChartRepository(baseEntry, getter.All(&settings))
 
 	if err != nil {
 		t.Fatalf("Problem loading chart repository from %s: %v", srv.URL, err)
@@ -130,7 +133,14 @@ func TestConcurrenyDownloadIndex(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			idx, err := repo.DownloadIndexFile()
+			localRepo, err := NewChartRepository(baseEntry, getter.All(&settings))
+			if err != nil {
+				t.Errorf("Failed to create chart repository: %v", err)
+				return
+			}
+			localRepo.CachePath = repo.CachePath
+
+			idx, err := localRepo.DownloadIndexFile()
 			if err != nil {
 				t.Errorf("Failed to download index file to %s: %v", idx, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
close #31536 

**Special notes for your reviewer**:
Add a RWMutex in struct ChartRepository, for avoid client get data race within concurrency.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
