### PR TITLE
fix(upgrade): pass --server-side flag to install when using upgrade --install

### DIFF
--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -153,6 +153,8 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					instClient.EnableDNS = client.EnableDNS
 					instClient.HideSecret = client.HideSecret
 					instClient.TakeOwnership = client.TakeOwnership
+					instClient.ForceConflicts = client.ForceConflicts
+					instClient.ServerSideApply = client.ServerSideApply != "false"
 
 					if isReleaseUninstalled(versions) {
 						instClient.Replace = true


### PR DESCRIPTION
**What this PR does / why we need it**:

When running `helm upgrade --install` on a non-existent release, the --server-side flag was not being passed to the install action. This caused the install to always use server-side apply (the default), ignoring --server-side=false.

Copy ServerSideApply and ForceConflicts from the upgrade client to the install client when falling back to install.

Fixes #31627

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
