### PR TITLE
Use latest patch release of Go in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # pin@6.1.0
         with:
           go-version: '${{ env.GOLANG_VERSION }}'
+          check-latest: true
       - name: Run unit tests
         run: make test-coverage
       - name: Build Helm Binaries


### PR DESCRIPTION
GitHub Actions has a cache of tools, like Go, and it does not update this cache when a new version comes out. It can take more than a week for a new version to be available.

This change forces the action to check if a newer version is available than is in the cache.

Closes #31634

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
