### PR TITLE
feat: move TerryHowe triage to maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,9 +7,9 @@ maintainers:
   - sabre1041
   - scottrigby
   - technosophos
+  - TerryHowe
 triage:
   - banjoh
-  - TerryHowe
   - yxxhero
   - zonggen
   - z4ce


### PR DESCRIPTION
**What this PR does / why we need it**:
Move TerryHowe from triage to maintainers

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
