### PR TITLE
Use errors.Is to check for io.EOF and gzip.ErrHeader

### DIFF
--- a/internal/chart/v3/lint/rules/crds.go
+++ b/internal/chart/v3/lint/rules/crds.go
@@ -70,7 +70,7 @@ func Crds(linter *support.Linter) {
 			var yamlStruct *k8sYamlStruct
 
 			err := decoder.Decode(&yamlStruct)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 

--- a/internal/chart/v3/lint/rules/template.go
+++ b/internal/chart/v3/lint/rules/template.go
@@ -150,7 +150,7 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 				var yamlStruct *k8sYamlStruct
 
 				err := decoder.Decode(&yamlStruct)
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 

--- a/internal/chart/v3/loader/archive.go
+++ b/internal/chart/v3/loader/archive.go
@@ -56,7 +56,7 @@ func LoadFile(name string) (*chart.Chart, error) {
 
 	c, err := LoadArchive(raw)
 	if err != nil {
-		if err == gzip.ErrHeader {
+		if errors.Is(err, gzip.ErrHeader) {
 			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", name, err)
 		}
 	}

--- a/internal/chart/v3/loader/load.go
+++ b/internal/chart/v3/loader/load.go
@@ -189,7 +189,7 @@ func LoadValues(data io.Reader) (map[string]interface{}, error) {
 		currentMap := map[string]interface{}{}
 		raw, err := reader.Read()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, fmt.Errorf("error reading yaml document: %w", err)

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -116,7 +117,7 @@ func TestBomTestData(t *testing.T) {
 		tr := tar.NewReader(unzipped)
 		for {
 			file, err := tr.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -201,7 +202,7 @@ func retrieveAllHeadersFromTar(path string) ([]*tar.Header, error) {
 	headers := []*tar.Header{}
 	for {
 		hd, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/internal/plugin/installer/extractor.go
+++ b/internal/plugin/installer/extractor.go
@@ -140,7 +140,7 @@ func (g *TarGzExtractor) Extract(buffer *bytes.Buffer, targetDir string) error {
 	tarReader := tar.NewReader(uncompressedStream)
 	for {
 		header, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -19,6 +19,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -214,7 +215,7 @@ func extractTar(r io.Reader, targetDir string) error {
 
 	for {
 		header, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/plugin/sign.go
+++ b/internal/plugin/sign.go
@@ -63,7 +63,7 @@ func ExtractTgzPluginMetadata(r io.Reader) (*Metadata, error) {
 	tr := tar.NewReader(gzr)
 	for {
 		header, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -68,7 +68,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 	for {
 		b := bytes.NewBuffer(nil)
 		hd, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/chart/loader/load.go
+++ b/pkg/chart/loader/load.go
@@ -131,8 +131,8 @@ func LoadFile(name string) (chart.Charter, error) {
 
 	files, err := archive.LoadArchiveFiles(raw)
 	if err != nil {
-		if err == gzip.ErrHeader {
-			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", name, err)
+		if errors.Is(err, gzip.ErrHeader) {
+			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %w)", name, err)
 		}
 		return nil, errors.New("unable to load chart archive")
 	}
@@ -163,7 +163,7 @@ func LoadArchive(in io.Reader) (chart.Charter, error) {
 
 	files, err := archive.LoadArchiveFiles(in)
 	if err != nil {
-		if err == gzip.ErrHeader {
+		if errors.Is(err, gzip.ErrHeader) {
 			return nil, fmt.Errorf("stream does not appear to be a valid chart file (details: %w)", err)
 		}
 		return nil, fmt.Errorf("unable to load chart archive: %w", err)

--- a/pkg/chart/v2/lint/rules/crds.go
+++ b/pkg/chart/v2/lint/rules/crds.go
@@ -70,7 +70,7 @@ func Crds(linter *support.Linter) {
 			var yamlStruct *k8sYamlStruct
 
 			err := decoder.Decode(&yamlStruct)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 

--- a/pkg/chart/v2/lint/rules/template.go
+++ b/pkg/chart/v2/lint/rules/template.go
@@ -180,7 +180,7 @@ func (t *templateLinter) Lint() {
 				var yamlStruct *k8sYamlStruct
 
 				err := decoder.Decode(&yamlStruct)
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 

--- a/pkg/chart/v2/loader/archive.go
+++ b/pkg/chart/v2/loader/archive.go
@@ -56,8 +56,8 @@ func LoadFile(name string) (*chart.Chart, error) {
 
 	c, err := LoadArchive(raw)
 	if err != nil {
-		if err == gzip.ErrHeader {
-			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", name, err)
+		if errors.Is(err, gzip.ErrHeader) {
+			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %w)", name, err)
 		}
 	}
 	return c, err

--- a/pkg/chart/v2/loader/load.go
+++ b/pkg/chart/v2/loader/load.go
@@ -216,7 +216,7 @@ func LoadValues(data io.Reader) (map[string]interface{}, error) {
 		currentMap := map[string]interface{}{}
 		raw, err := reader.Read()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, fmt.Errorf("error reading yaml document: %w", err)

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -116,7 +117,7 @@ func TestBomTestData(t *testing.T) {
 		tr := tar.NewReader(unzipped)
 		for {
 			file, err := tr.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -205,7 +206,7 @@ func retrieveAllHeadersFromTar(path string) ([]*tar.Header, error) {
 	headers := []*tar.Header{}
 	for {
 		hd, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/pkg/strvals/literal_parser.go
+++ b/pkg/strvals/literal_parser.go
@@ -17,6 +17,7 @@ package strvals
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -66,7 +67,7 @@ func (t *literalParser) parse() error {
 		if err == nil {
 			continue
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		return err
@@ -183,7 +184,7 @@ func (t *literalParser) listItem(list []interface{}, i, nestedNameLevel int) ([]
 
 	case lastRune == '=':
 		value, err := t.val()
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return list, err
 		}
 		return setIndex(list, i, string(value))

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -161,7 +161,7 @@ func (t *parser) parse() error {
 		if err == nil {
 			continue
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

In GoLang, using the `==` operator to check for a certain error will not unwrap the error chain, and therefore may hide the problem.

These are recommendations from [errorlint](https://codeberg.org/polyfloyd/go-errorlint) It is somehow also how I have been taught to check for errors in GoLang. Note that changes to enable `errorlint` would be a little too overwhelming. Perhaps it's by design that `errors.Is` is not used to check for the affected instances.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility