### PR TITLE
fix(chart): normalize CRD filenames to use forward slashes on all pla…

### DIFF
--- a/internal/chart/v3/chart.go
+++ b/internal/chart/v3/chart.go
@@ -162,7 +162,7 @@ func (ch *Chart) CRDObjects() []CRD {
 	// Find all resources in the crds/ directory
 	for _, f := range ch.Files {
 		if strings.HasPrefix(f.Name, "crds/") && hasManifestExtension(f.Name) {
-			mycrd := CRD{Name: f.Name, Filename: filepath.Join(ch.ChartFullPath(), f.Name), File: f}
+			mycrd := CRD{Name: f.Name, Filename: filepath.ToSlash(filepath.Join(ch.ChartFullPath(), f.Name)), File: f}
 			crds = append(crds, mycrd)
 		}
 	}


### PR DESCRIPTION
fix(chart): normalize CRD filenames to use forward slashes on all platforms

fix(kube): promote watcher top-level logs to Info for better UX

**What this PR do**:

Closes #31585

This PR contains two fixes:

1. **CRD filename normalization (internal/chart/v3/chart.go)**
   - Changed `CRDObjects()` to normalize CRD `Filename` values using `filepath.ToSlash(filepath.Join(...))` instead of just `filepath.Join(...)`
   - On Windows, `filepath.Join()` produces backslashes (`crds\foo.yaml`), but the test expects forward slashes (`crds/foo.yaml`)
   - Using `filepath.ToSlash()` ensures CRD paths are consistent across all platforms, fixing the `TestCRDObjects` failure on Windows
   - This follows the existing pattern used elsewhere in the Helm codebase for cross-platform path handling

2. **Watcher logging improvements (pkg/kube/statuswait.go)**
   - Promoted top-level watcher breadcrumb logs from Debug to Info in `Wait()`, `WaitWithJobs()`, `WatchUntilReady()`, `WaitForDelete()`, and `statusObserver()`
   - Users now see high-level progress messages like "waiting for resources" and "all resources achieved desired status" without enabling Debug logging
   - Per-resource detail logs remain at Debug level to avoid excessive output
   - This improves UX for CLI and SDK users who need visibility into wait operations without verbose Debug logs
