### PR TITLE
fix(doc): Update default wait strategy

### DIFF
--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,7 +59,7 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"if specified, wait until resources are ready (up to --timeout). Values: 'watcher' (default), 'hookOnly', and 'legacy'.",
+		"if specified, wait until resources are ready (up to --timeout). Values: 'hookOnly' (default), 'watcher', and 'legacy'.",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,7 +59,7 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"if specified, wait until resources are ready (up to --timeout). Values: 'hookOnly' (default), 'watcher', and 'legacy'.",
+		"if specified, wait until resources are ready (up to --timeout). Values: 'watcher', 'hookOnly', and 'legacy'.",
 	)
 	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)


### PR DESCRIPTION
Closes: #31652

**What this PR does / why we need it**:
Default wait strategy is hookOnly, so updated the docs to reflect the same

**Special notes for your reviewer**:
I reordered the values list, please let me know if you think otherwise.

**If applicable**:
- [X] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
