### PR TITLE
fix: default to foreground cascade when --wait is used in uninstall

### DIFF
--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -290,11 +290,11 @@ func (u *Uninstall) parseCascadingFlag(cascadingFlag string) v1.DeletionPropagat
 	case "background":
 		return v1.DeletePropagationBackground
 	default:
-		// When --wait is used with a non-hookOnly strategy (i.e. watcher or legacy), default to foreground
+		// When --wait is used with watcher or legacy strategy, default to foreground
 		// deletion to ensure dependent resources are cleaned up before returning.
-		// This prevents the issue where helm uninstall --wait returns before
+		// This prevents the issue where uninstallation with wait strategy returns before
 		// all resources (including controller-created dependents) are fully deleted.
-		if u.WaitStrategy != kube.HookOnlyStrategy {
+		if u.WaitStrategy == kube.StatusWatcherStrategy || u.WaitStrategy == kube.LegacyStrategy {
 			slog.Debug("uninstall: defaulting to foreground deletion due to wait strategy", "wait strategy", u.WaitStrategy, "cascading flag", cascadingFlag)
 			return v1.DeletePropagationForeground
 		}

--- a/pkg/kube/fake/capturing_kube_client.go
+++ b/pkg/kube/fake/capturing_kube_client.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"helm.sh/helm/v4/pkg/kube"
+)
+
+// CapturingKubeClient is a fake KubeClient that captures internal flags such as the
+// deletion propagation policy. It extends FailingKubeClient to provide dummy resources.
+type CapturingKubeClient struct {
+	FailingKubeClient
+	// CapturedDeletionPropagation stores the DeletionPropagation value passed to Delete
+	CapturedDeletionPropagation *string
+}
+
+// Delete captures the deletion propagation policy and returns success
+func (c *CapturingKubeClient) Delete(resources kube.ResourceList, policy metav1.DeletionPropagation) (*kube.Result, []error) {
+	if c.CapturedDeletionPropagation != nil {
+		*c.CapturedDeletionPropagation = string(policy)
+	}
+	return &kube.Result{Deleted: resources}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When `helm uninstall --wait` is called, the default deletion propagation is now "foreground" instead of "background". This ensures dependent resources (like Pods, ReplicaSets created by controllers) are fully cleaned up before the command returns.

Previously, with background deletion, parent resources were deleted immediately while garbage collection handled dependents asynchronously. This caused subsequent namespace deletions to hang while waiting for those dependent resources to be cleaned up.

With foreground deletion, Kubernetes waits for all dependents to be deleted before removing the parent resource, ensuring `--wait` truly waits for all cleanup to complete.

Docs on cascading deletion propagation: https://kubernetes.io/docs/concepts/architecture/garbage-collection/?utm_source=chatgpt.com#cascading-deletion

Cascade behavior by command:

| Command                                      | Cascade    |
|----------------------------------------------|------------|
| `helm uninstall release`                     | background |
| `helm uninstall release --wait`              | foreground |
| `helm uninstall release --wait=hookOnly`     | background |
| `helm uninstall release --wait --cascade=background` | background |

Users can still explicitly set `--cascade=background` to restore the previous behavior if needed.

Fixes #31651

### Test results

In this test case, note that logs show helm waiting for dependant resources to get cleaned up

- Without cascading
```sh
helm uninstall --debug -n ingress-nginx ingress-nginx --wait
level=DEBUG msg="uninstall: deleting release" name=ingress-nginx
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx-admission kind=ValidatingWebhookConfiguration
level=DEBUG msg="starting delete resource" namespace="" name=nginx kind=IngressClass
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Service
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller-admission kind=Service
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Deployment
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=RoleBinding
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=Role
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx kind=ClusterRoleBinding
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx kind=ClusterRole
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=ConfigMap
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount
level=DEBUG msg="waiting for resources to be deleted" count=11 timeout=5m0s
level=DEBUG msg="all resources achieved desired status" desiredStatus=NotFound resourceCount=0
level=DEBUG msg="purge requested" release=ingress-nginx
release "ingress-nginx" uninstalled
```

- With cascading
```
helm uninstall --debug -n ingress-nginx ingress-nginx --wait
level=DEBUG msg="uninstall: deleting release" name=ingress-nginx
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx-admission kind=ValidatingWebhookConfiguration
level=DEBUG msg="starting delete resource" namespace="" name=nginx kind=IngressClass
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Service
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller-admission kind=Service
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Deployment
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=RoleBinding
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=Role
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx kind=ClusterRoleBinding
level=DEBUG msg="starting delete resource" namespace="" name=ingress-nginx kind=ClusterRole
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx-controller kind=ConfigMap
level=DEBUG msg="starting delete resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount
level=DEBUG msg="waiting for resources to be deleted" count=11 timeout=5m0s
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx-controller-admission kind=Service expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=Role expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace="" name=ingress-nginx kind=ClusterRoleBinding expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=Role expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=Role expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace="" name=ingress-nginx kind=ClusterRoleBinding expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=Role expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace="" name=ingress-nginx kind=ClusterRoleBinding expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx kind=ServiceAccount expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Deployment expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="waiting for resource" namespace=ingress-nginx name=ingress-nginx-controller kind=Deployment expectedStatus=NotFound actualStatus=Terminating
level=DEBUG msg="all resources achieved desired status" desiredStatus=NotFound resourceCount=7
level=DEBUG msg="purge requested" release=ingress-nginx
release "ingress-nginx" uninstalled
```

**Special notes for your reviewer**:
- Added new fake client to capture states passed to kubeclient API calls

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
