### PR TITLE
Fix more errorlint warnings. Use `errors.As` and `errors.Is` for error handling.

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -502,7 +502,7 @@ func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.Resource
 	var err error
 	// pre-install hooks
 	if !i.DisableHooks {
-		if err := i.cfg.execHook(rel, release.HookPreInstall, i.WaitStrategy, i.WaitOptions, i.Timeout, i.ServerSideApply); err != nil {
+		if err := i.cfg.execHook(rel, release.HookPreInstall, i.WaitStrategy, i.Timeout, i.ServerSideApply); err != nil {
 			return rel, fmt.Errorf("failed pre-install: %w", err)
 		}
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -454,7 +454,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 	// pre-upgrade hooks
 
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.WaitStrategy, u.WaitOptions, u.Timeout, serverSideApply); err != nil {
+		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.WaitStrategy, u.Timeout, serverSideApply); err != nil {
 			u.reportToPerformUpgrade(c, upgradedRelease, kube.ResourceList{}, fmt.Errorf("pre-upgrade hooks failed: %w", err))
 			return
 		}
@@ -502,7 +502,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 
 	// post-upgrade hooks
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(upgradedRelease, release.HookPostUpgrade, u.WaitStrategy, u.WaitOptions, u.Timeout, serverSideApply); err != nil {
+		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.WaitStrategy, u.WaitOptions, u.Timeout, serverSideApply); err != nil {
 			u.reportToPerformUpgrade(c, upgradedRelease, results.Created, fmt.Errorf("post-upgrade hooks failed: %w", err))
 			return
 		}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -502,7 +502,7 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 
 	// post-upgrade hooks
 	if !u.DisableHooks {
-		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.WaitStrategy, u.WaitOptions, u.Timeout, serverSideApply); err != nil {
+		if err := u.cfg.execHook(upgradedRelease, release.HookPostUpgrade, u.WaitStrategy, u.WaitOptions, u.Timeout, serverSideApply); err != nil {
 			u.reportToPerformUpgrade(c, upgradedRelease, results.Created, fmt.Errorf("post-upgrade hooks failed: %w", err))
 			return
 		}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -92,7 +92,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 
 		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
 		if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
-			return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
+			return fmt.Errorf("%s exists and cannot be imported into the current release: %w", resourceString(info), err)
 		}
 
 		infoCopy := *info
@@ -115,13 +115,13 @@ func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) er
 
 	var errs []error
 	if err := requireValue(lbls, appManagedByLabel, appManagedByHelm); err != nil {
-		errs = append(errs, fmt.Errorf("label validation error: %s", err))
+		errs = append(errs, fmt.Errorf("label validation error: %w", err))
 	}
 	if err := requireValue(annos, helmReleaseNameAnnotation, releaseName); err != nil {
-		errs = append(errs, fmt.Errorf("annotation validation error: %s", err))
+		errs = append(errs, fmt.Errorf("annotation validation error: %w", err))
 	}
 	if err := requireValue(annos, helmReleaseNamespaceAnnotation, releaseNamespace); err != nil {
-		errs = append(errs, fmt.Errorf("annotation validation error: %s", err))
+		errs = append(errs, fmt.Errorf("annotation validation error: %w", err))
 	}
 
 	if len(errs) > 0 {
@@ -153,7 +153,7 @@ func setMetadataVisitor(releaseName, releaseNamespace string, forceOwnership boo
 
 		if !forceOwnership {
 			if err := checkOwnership(info.Object, releaseName, releaseNamespace); err != nil {
-				return fmt.Errorf("%s cannot be owned: %s", resourceString(info), err)
+				return fmt.Errorf("%s cannot be owned: %w", resourceString(info), err)
 			}
 		}
 
@@ -161,7 +161,7 @@ func setMetadataVisitor(releaseName, releaseNamespace string, forceOwnership boo
 			appManagedByLabel: appManagedByHelm,
 		}); err != nil {
 			return fmt.Errorf(
-				"%s labels could not be updated: %s",
+				"%s labels could not be updated: %w",
 				resourceString(info), err,
 			)
 		}
@@ -171,7 +171,7 @@ func setMetadataVisitor(releaseName, releaseNamespace string, forceOwnership boo
 			helmReleaseNamespaceAnnotation: releaseNamespace,
 		}); err != nil {
 			return fmt.Errorf(
-				"%s annotations could not be updated: %s",
+				"%s annotations could not be updated: %w",
 				resourceString(info), err,
 			)
 		}

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -171,7 +171,7 @@ func EnsureArchive(name string, raw *os.File) error {
 	// Check the file format to give us a chance to provide the user with more actionable feedback.
 	buffer := make([]byte, 512)
 	_, err := raw.Read(buffer)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("file '%s' cannot be read: %w", name, err)
 	}
 

--- a/pkg/cmd/dependency_build.go
+++ b/pkg/cmd/dependency_build.go
@@ -79,7 +79,7 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 			err = man.Build()
 			var e downloader.ErrRepoNotFound
 			if errors.As(err, &e) {
-				return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", e.Error())
+				return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", repoNotFoundError.Error())
 			}
 			return err
 		},

--- a/pkg/cmd/dependency_build.go
+++ b/pkg/cmd/dependency_build.go
@@ -79,7 +79,7 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 			err = man.Build()
 			var e downloader.ErrRepoNotFound
 			if errors.As(err, &e) {
-				return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", repoNotFoundError.Error())
+				return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", e.Error())
 			}
 			return err
 		},

--- a/pkg/cmd/lint.go
+++ b/pkg/cmd/lint.go
@@ -59,7 +59,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			if kubeVersion != "" {
 				parsedKubeVersion, err := common.ParseKubeVersion(kubeVersion)
 				if err != nil {
-					return fmt.Errorf("invalid kube version '%s': %s", kubeVersion, err)
+					return fmt.Errorf("invalid kube version '%s': %w", kubeVersion, err)
 				}
 				client.KubeVersion = parsedKubeVersion
 			}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -261,7 +261,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			return err
 		}
 	} else {
-		return fmt.Errorf("unable to retrieve file info for '%s': %v", destPath, err)
+		return fmt.Errorf("unable to retrieve file info for '%s': %w", destPath, err)
 	}
 
 	// Prepare tmpPath
@@ -281,17 +281,17 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 			chartPath := filepath.Join(destPath, dep.Name)
 			ch, err := loader.LoadDir(chartPath)
 			if err != nil {
-				return fmt.Errorf("unable to load chart '%s': %v", chartPath, err)
+				return fmt.Errorf("unable to load chart '%s': %w", chartPath, err)
 			}
 
 			constraint, err := semver.NewConstraint(dep.Version)
 			if err != nil {
-				return fmt.Errorf("dependency %s has an invalid version/constraint format: %s", dep.Name, err)
+				return fmt.Errorf("dependency %s has an invalid version/constraint format: %w", dep.Name, err)
 			}
 
 			v, err := semver.NewVersion(ch.Metadata.Version)
 			if err != nil {
-				return fmt.Errorf("invalid version %s for dependency %s: %s", dep.Version, dep.Name, err)
+				return fmt.Errorf("invalid version %s for dependency %s: %w", dep.Version, dep.Name, err)
 			}
 
 			if !constraint.Check(v) {
@@ -765,7 +765,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 	}
 	url, err = repo.FindChartInRepoURL(repoURL, name, m.Getters, repo.WithChartVersion(version), repo.WithClientTLS(certFile, keyFile, caFile))
 	if err == nil {
-		return url, username, password, false, false, "", "", "", err
+		return url, username, password, false, false, "", "", "", nil
 	}
 	err = fmt.Errorf("chart %s not found in %s: %w", name, repoURL, err)
 	return url, username, password, false, false, "", "", "", err

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -246,7 +246,7 @@ func (c *Client) getKubeClient() (kubernetes.Interface, error) {
 // IsReachable tests connectivity to the cluster.
 func (c *Client) IsReachable() error {
 	client, err := c.getKubeClient()
-	if err == genericclioptions.ErrEmptyConfig {
+	if errors.Is(err, genericclioptions.ErrEmptyConfig) {
 		// re-replace kubernetes ErrEmptyConfig error with a friendly error
 		// moar workarounds for Kubernetes API breaking.
 		return errors.New("kubernetes cluster unreachable")
@@ -944,11 +944,13 @@ func (c *Client) Delete(resources ResourceList, policy metav1.DeletionPropagatio
 func isIncompatibleServerError(err error) bool {
 	// 415: Unsupported media type means we're talking to a server which doesn't
 	// support server-side apply.
-	if _, ok := err.(*apierrors.StatusError); !ok {
+	var statusError *apierrors.StatusError
+	ok := errors.As(err, &statusError)
+	if !ok {
 		// Non-StatusError means the error isn't because the server is incompatible.
 		return false
 	}
-	return err.(*apierrors.StatusError).Status().Code == http.StatusUnsupportedMediaType
+	return statusError.Status().Code == http.StatusUnsupportedMediaType
 }
 
 // getManagedFieldsManager returns the manager string. If one was set it will be returned.
@@ -1234,7 +1236,7 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 	)
 	if err != nil {
 		if isIncompatibleServerError(err) {
-			return fmt.Errorf("server-side apply not available on the server: %v", err)
+			return fmt.Errorf("server-side apply not available on the server: %w", err)
 		}
 
 		if apierrors.IsConflict(err) {
@@ -1251,7 +1253,7 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 func (c *Client) GetPodList(namespace string, listOptions metav1.ListOptions) (*v1.PodList, error) {
 	podList, err := c.kubeClient.CoreV1().Pods(namespace).List(context.Background(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pod list with options: %+v with error: %v", listOptions, err)
+		return nil, fmt.Errorf("failed to get pod list with options: %+v with error: %w", listOptions, err)
 	}
 	return podList, nil
 }

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -108,8 +108,8 @@ func (hw *legacyWaiter) isRetryableError(err error, resource *resource.Info) boo
 		slog.String("resource", resource.Name),
 		slog.Any("error", err),
 	)
-	ev := &apierrors.StatusError{}
-	if errors.As(err, &ev) {
+	var ev *apierrors.StatusError
+	if ok := errors.As(err, &ev); ok {
 		statusCode := ev.Status().Code
 		retryable := hw.isRetryableHTTPStatusCode(statusCode)
 		slog.Debug(

--- a/pkg/registry/transport.go
+++ b/pkg/registry/transport.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -137,7 +138,9 @@ func logResponseBody(resp *http.Response) string {
 		Closer: body,
 	}
 	// read the body up to limit+1 to check if the body exceeds the limit
-	if _, err := io.CopyN(buf, body, payloadSizeLimit+1); err != nil && err != io.EOF {
+	if _, err := io.CopyN(buf, body, payloadSizeLimit+1); err != nil &&
+		!errors.Is(err, io.EOF) &&
+		!errors.Is(err, io.ErrUnexpectedEOF) {
 		return fmt.Sprintf("   Error reading response body: %v", err)
 	}
 

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -485,7 +485,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 	transaction, err := s.db.Beginx()
 	if err != nil {
 		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
-		return fmt.Errorf("error beginning transaction: %v", err)
+		return fmt.Errorf("error beginning transaction: %w", err)
 	}
 
 	insertQuery, args, err := s.statementBuilder.
@@ -623,7 +623,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 	transaction, err := s.db.Beginx()
 	if err != nil {
 		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
-		return nil, fmt.Errorf("error beginning transaction: %v", err)
+		return nil, fmt.Errorf("error beginning transaction: %w", err)
 	}
 
 	selectQuery, args, err := s.statementBuilder.

--- a/pkg/strvals/literal_parser.go
+++ b/pkg/strvals/literal_parser.go
@@ -106,7 +106,7 @@ func (t *literalParser) key(data map[string]any, nestedNameLevel int) (reterr er
 		case lastRune == '=':
 			// found end of key: swallow the '=' and get the value
 			value, err := t.val()
-			if err == nil && !errors.Is(err, io.EOF) {
+			if err != nil && !errors.Is(err, io.EOF) {
 				return err
 			}
 			set(data, string(key), string(value))

--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -240,16 +240,16 @@ func (t *parser) key(data map[string]any, nestedNameLevel int) (reterr error) {
 			// End of key. Consume =, Get value.
 			// FIXME: Get value list first
 			vl, e := t.valList()
-			switch e {
-			case nil:
+			switch {
+			case e == nil:
 				set(data, string(k), vl)
 				return nil
-			case io.EOF:
+			case errors.Is(e, io.EOF):
 				set(data, string(k), "")
 				return e
-			case ErrNotList:
+			case errors.Is(e, ErrNotList):
 				rs, e := t.val()
-				if e != nil && e != io.EOF {
+				if e != nil && !errors.Is(e, io.EOF) {
 					return e
 				}
 				v, e := t.reader(rs)
@@ -380,7 +380,7 @@ func (t *parser) listItem(list []any, i, nestedNameLevel int) ([]any, error) {
 			return setIndex(list, i, "")
 		case ErrNotList:
 			rs, e := t.val()
-			if e != nil && e != io.EOF {
+			if e != nil && !errors.Is(e, io.EOF) {
 				return list, e
 			}
 			v, e := t.reader(rs)
@@ -479,7 +479,7 @@ func (t *parser) valList() ([]any, error) {
 	for {
 		switch rs, last, err := runesUntil(t.sc, stop); {
 		case err != nil:
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = errors.New("list must terminate with '}'")
 			}
 			return list, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Use `errors.As` instead of type-casting, `errors.Is` for comparison and use of `%w` for error formatting in `fmt.Errorf`. The changes do not fully fix all of errorlint. I don't feel comfortable touching files under v1-3 as this may break compatibility with API users.

I have not successfully been able to change the use of `switch` with comparison of the error type. There are a few instances of this:

```
pkg/provenance/sign_test.go:401:9: type switch on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
	switch err.(type) {
	       ^
pkg/strvals/parser.go:247:4: switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors (errorlint)
			case io.EOF:
			^
pkg/strvals/parser.go:379:3: switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors (errorlint)
		case io.EOF:
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
