### PR TITLE
fix: #31665 add default cases to switch statements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,9 @@ linters:
               recommendations:
                 - github.com/evanphx/json-patch/v5
 
+    exhaustive:
+      default-signifies-exhaustive: true
+
 run:
   timeout: 10m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - unused
     - usestdlibvars
     - usetesting
+    - exhaustive
 
   exclusions:
   

--- a/internal/statusreaders/pod_status_reader.go
+++ b/internal/statusreaders/pod_status_reader.go
@@ -86,19 +86,19 @@ func podConditions(u *unstructured.Unstructured) (*status.Result, error) {
 				},
 			},
 		}, nil
-	}
-
-	message := "Pod in progress"
-	return &status.Result{
-		Status:  status.InProgressStatus,
-		Message: message,
-		Conditions: []status.Condition{
-			{
-				Type:    status.ConditionReconciling,
-				Status:  corev1.ConditionTrue,
-				Reason:  "PodInProgress",
-				Message: message,
+	default:
+		message := "Pod in progress"
+		return &status.Result{
+			Status:  status.InProgressStatus,
+			Message: message,
+			Conditions: []status.Condition{
+				{
+					Type:    status.ConditionReconciling,
+					Status:  corev1.ConditionTrue,
+					Reason:  "PodInProgress",
+					Message: message,
+				},
 			},
-		},
-	}, nil
+		}, nil
+	}
 }

--- a/pkg/cmd/repo_list.go
+++ b/pkg/cmd/repo_list.go
@@ -103,11 +103,11 @@ func (r *repoListWriter) encodeByFormat(out io.Writer, format output.Format) err
 		return output.EncodeJSON(out, repolist)
 	case output.YAML:
 		return output.EncodeYAML(out, repolist)
+	default:
+		// Because this is a non-exported function and only called internally by
+		// WriteJSON and WriteYAML, we shouldn't get invalid types
+		return nil
 	}
-
-	// Because this is a non-exported function and only called internally by
-	// WriteJSON and WriteYAML, we shouldn't get invalid types
-	return nil
 }
 
 // Returns all repos from repos, except those with names matching ignoredRepoNames

--- a/pkg/cmd/search_hub.go
+++ b/pkg/cmd/search_hub.go
@@ -190,9 +190,10 @@ func (h *hubSearchWriter) encodeByFormat(out io.Writer, format output.Format) er
 		return output.EncodeJSON(out, chartList)
 	case output.YAML:
 		return output.EncodeYAML(out, chartList)
+	default:
+		// Because this is a non-exported function and only called internally by
+		// WriteJSON and WriteYAML, we shouldn't get invalid types
+		return nil
 	}
 
-	// Because this is a non-exported function and only called internally by
-	// WriteJSON and WriteYAML, we shouldn't get invalid types
-	return nil
 }

--- a/pkg/cmd/search_repo.go
+++ b/pkg/cmd/search_repo.go
@@ -260,11 +260,11 @@ func (r *repoSearchWriter) encodeByFormat(out io.Writer, format output.Format) e
 		return output.EncodeJSON(out, chartList)
 	case output.YAML:
 		return output.EncodeYAML(out, chartList)
+	default:
+		// Because this is a non-exported function and only called internally by
+		// WriteJSON and WriteYAML, we shouldn't get invalid types
+		return nil
 	}
-
-	// Because this is a non-exported function and only called internally by
-	// WriteJSON and WriteYAML, we shouldn't get invalid types
-	return nil
 }
 
 // Provides the list of charts that are part of the specified repo, and that starts with 'prefix'.

--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -354,6 +354,8 @@ func (c *ReadyChecker) crdBetaReady(crd apiextv1beta1.CustomResourceDefinition) 
 				// continue.
 				return true
 			}
+		default:
+			// intentionally left empty
 		}
 	}
 	return false
@@ -374,6 +376,8 @@ func (c *ReadyChecker) crdReady(crd apiextv1.CustomResourceDefinition) bool {
 				// continue.
 				return true
 			}
+		default:
+			// intentionally left empty
 		}
 	}
 	return false

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -333,6 +333,8 @@ func (hw *legacyWaiter) waitForPodSuccess(obj runtime.Object, name string) (bool
 		slog.Debug("pod pending", "pod", o.Name)
 	case corev1.PodRunning:
 		slog.Debug("pod running", "pod", o.Name)
+	case corev1.PodUnknown:
+		slog.Debug("pod unknown", "pod", o.Name)
 	}
 
 	return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
closes: #31665 

The exhaustive linter will fail some switch statements because they don't have a `default` branch. This fix just moves some code around to include a default branch or adds a default branch with the comment `// intentionally left empty` for the cases where the intended behavior is to do nothing.

**Special notes for your reviewer**:
The default (no pun intended) behavior of the exhaustive linter requires covering all enum branches, without allowing a backup the default branch. I changed the [default-signifies-exhaustive](https://golangci-lint.run/docs/linters/configuration/#exhaustive) setting to true in `.golangci.yml` so it'll pass switch statements that have a default branch, since that's a more sensible default in my opinion.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
