### PR TITLE
[dev-v3] Replace deprecated `NewSimpleClientset`

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -352,7 +352,7 @@ func TestConfiguration_Init(t *testing.T) {
 }
 
 func TestGetVersionSet(t *testing.T) {
-	client := fakeclientset.NewSimpleClientset()
+	client := fakeclientset.NewClientset()
 
 	vs, err := GetVersionSet(client.Discovery())
 	if err != nil {

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -712,7 +712,7 @@ func TestGetPodList(t *testing.T) {
 		responsePodList.Items = append(responsePodList.Items, newPodWithStatus(name, v1.PodStatus{}, namespace))
 	}
 
-	kubeClient := k8sfake.NewSimpleClientset(&responsePodList)
+	kubeClient := k8sfake.NewClientset(&responsePodList)
 	c := Client{Namespace: namespace, kubeClient: kubeClient}
 
 	podList, err := c.GetPodList(namespace, metav1.ListOptions{})
@@ -726,7 +726,7 @@ func TestOutputContainerLogsForPodList(t *testing.T) {
 	namespace := "some-namespace"
 	somePodList := newPodList("jimmy", "three", "structs")
 
-	kubeClient := k8sfake.NewSimpleClientset(&somePodList)
+	kubeClient := k8sfake.NewClientset(&somePodList)
 	c := Client{Namespace: namespace, kubeClient: kubeClient}
 	outBuffer := &bytes.Buffer{}
 	outBufferFunc := func(_, _, _ string) io.Writer { return outBuffer }

--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -58,7 +58,7 @@ func Test_ReadyChecker_IsReady_Pod(t *testing.T) {
 		{
 			name: "IsReady Pod",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -74,7 +74,7 @@ func Test_ReadyChecker_IsReady_Pod(t *testing.T) {
 		{
 			name: "IsReady Pod returns error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -134,7 +134,7 @@ func Test_ReadyChecker_IsReady_Job(t *testing.T) {
 		{
 			name: "IsReady Job error while getting job",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -150,7 +150,7 @@ func Test_ReadyChecker_IsReady_Job(t *testing.T) {
 		{
 			name: "IsReady Job",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -210,7 +210,7 @@ func Test_ReadyChecker_IsReady_Deployment(t *testing.T) {
 		{
 			name: "IsReady Deployments error while getting current Deployment",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -227,7 +227,7 @@ func Test_ReadyChecker_IsReady_Deployment(t *testing.T) {
 		{
 			name: "IsReady Deployments", //TODO fix this one
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -291,7 +291,7 @@ func Test_ReadyChecker_IsReady_PersistentVolumeClaim(t *testing.T) {
 		{
 			name: "IsReady PersistentVolumeClaim",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -307,7 +307,7 @@ func Test_ReadyChecker_IsReady_PersistentVolumeClaim(t *testing.T) {
 		{
 			name: "IsReady PersistentVolumeClaim with error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -366,7 +366,7 @@ func Test_ReadyChecker_IsReady_Service(t *testing.T) {
 		{
 			name: "IsReady Service",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -382,7 +382,7 @@ func Test_ReadyChecker_IsReady_Service(t *testing.T) {
 		{
 			name: "IsReady Service with error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -441,7 +441,7 @@ func Test_ReadyChecker_IsReady_DaemonSet(t *testing.T) {
 		{
 			name: "IsReady DaemonSet",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -457,7 +457,7 @@ func Test_ReadyChecker_IsReady_DaemonSet(t *testing.T) {
 		{
 			name: "IsReady DaemonSet with error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -516,7 +516,7 @@ func Test_ReadyChecker_IsReady_StatefulSet(t *testing.T) {
 		{
 			name: "IsReady StatefulSet",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -532,7 +532,7 @@ func Test_ReadyChecker_IsReady_StatefulSet(t *testing.T) {
 		{
 			name: "IsReady StatefulSet with error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -591,7 +591,7 @@ func Test_ReadyChecker_IsReady_ReplicationController(t *testing.T) {
 		{
 			name: "IsReady ReplicationController",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -607,7 +607,7 @@ func Test_ReadyChecker_IsReady_ReplicationController(t *testing.T) {
 		{
 			name: "IsReady ReplicationController with error",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -623,7 +623,7 @@ func Test_ReadyChecker_IsReady_ReplicationController(t *testing.T) {
 		{
 			name: "IsReady ReplicationController and pods not ready for object",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -682,7 +682,7 @@ func Test_ReadyChecker_IsReady_ReplicaSet(t *testing.T) {
 		{
 			name: "IsReady ReplicaSet",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -698,7 +698,7 @@ func Test_ReadyChecker_IsReady_ReplicaSet(t *testing.T) {
 		{
 			name: "IsReady ReplicaSet not ready",
 			fields: fields{
-				client:        fake.NewSimpleClientset(),
+				client:        fake.NewClientset(),
 				log:           func(string, ...interface{}) {},
 				checkJobs:     true,
 				pausedAsReady: false,
@@ -793,7 +793,7 @@ func Test_ReadyChecker_deploymentReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.deploymentReady(tt.args.rs, tt.args.dep); got != tt.want {
 				t.Errorf("deploymentReady() = %v, want %v", got, tt.want)
 			}
@@ -827,7 +827,7 @@ func Test_ReadyChecker_replicaSetReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.replicaSetReady(tt.args.rs); got != tt.want {
 				t.Errorf("replicaSetReady() = %v, want %v", got, tt.want)
 			}
@@ -861,7 +861,7 @@ func Test_ReadyChecker_replicationControllerReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.replicationControllerReady(tt.args.rc); got != tt.want {
 				t.Errorf("replicationControllerReady() = %v, want %v", got, tt.want)
 			}
@@ -916,7 +916,7 @@ func Test_ReadyChecker_daemonSetReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.daemonSetReady(tt.args.ds); got != tt.want {
 				t.Errorf("daemonSetReady() = %v, want %v", got, tt.want)
 			}
@@ -992,7 +992,7 @@ func Test_ReadyChecker_statefulSetReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.statefulSetReady(tt.args.sts); got != tt.want {
 				t.Errorf("statefulSetReady() = %v, want %v", got, tt.want)
 			}
@@ -1051,7 +1051,7 @@ func Test_ReadyChecker_podsReadyForObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			for _, pod := range tt.existPods {
 				if _, err := c.client.CoreV1().Pods(defaultNamespace).Create(context.TODO(), &pod, metav1.CreateOptions{}); err != nil {
 					t.Errorf("Failed to create Pod error: %v", err)
@@ -1130,7 +1130,7 @@ func Test_ReadyChecker_jobReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			got, err := c.jobReady(tt.args.job)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("jobReady() error = %v, wantErr %v", err, tt.wantErr)
@@ -1169,7 +1169,7 @@ func Test_ReadyChecker_volumeReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			if got := c.volumeReady(tt.args.v); got != tt.want {
 				t.Errorf("volumeReady() = %v, want %v", got, tt.want)
 			}
@@ -1214,7 +1214,7 @@ func Test_ReadyChecker_serviceReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			got := c.serviceReady(tt.args.service)
 			if got != tt.want {
 				t.Errorf("serviceReady() = %v, want %v", got, tt.want)
@@ -1283,7 +1283,7 @@ func Test_ReadyChecker_crdBetaReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			got := c.crdBetaReady(tt.args.crdBeta)
 			if got != tt.want {
 				t.Errorf("crdBetaReady() = %v, want %v", got, tt.want)
@@ -1352,7 +1352,7 @@ func Test_ReadyChecker_crdReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewReadyChecker(fake.NewSimpleClientset(), nil)
+			c := NewReadyChecker(fake.NewClientset(), nil)
 			got := c.crdReady(tt.args.crdBeta)
 			if got != tt.want {
 				t.Errorf("crdBetaReady() = %v, want %v", got, tt.want)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
`client-go` bump to `v1.35` is failing as `fakeclientset.NewSimpleClientset()` is now deprecated.

https://github.com/helm/helm/pull/31661

```
  Error: pkg/action/action_test.go:355:12: SA1019: fakeclientset.NewSimpleClientset is deprecated: NewClientset replaces this with support for field management, which significantly improves server side apply testing. NewClientset is only available when apply configurations are generated (e.g. via --with-applyconfig). (staticcheck)
  	client := fakeclientset.NewSimpleClientset()
```

Since this is a simple change in test code, fix by replacing usage of the deprecated code.
 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
