### PR TITLE
chore: Replace deprecated `NewSimpleClientset`

### DIFF
--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -923,7 +923,7 @@ func TestGetPodList(t *testing.T) {
 		responsePodList.Items = append(responsePodList.Items, newPodWithStatus(name, v1.PodStatus{}, namespace))
 	}
 
-	kubeClient := k8sfake.NewSimpleClientset(&responsePodList)
+	kubeClient := k8sfake.NewClientset(&responsePodList)
 	c := Client{Namespace: namespace, kubeClient: kubeClient}
 
 	podList, err := c.GetPodList(namespace, metav1.ListOptions{})
@@ -936,7 +936,7 @@ func TestOutputContainerLogsForPodList(t *testing.T) {
 	namespace := "some-namespace"
 	somePodList := newPodList("jimmy", "three", "structs")
 
-	kubeClient := k8sfake.NewSimpleClientset(&somePodList)
+	kubeClient := k8sfake.NewClientset(&somePodList)
 	c := Client{Namespace: namespace, kubeClient: kubeClient}
 	outBuffer := &bytes.Buffer{}
 	outBufferFunc := func(_, _, _ string) io.Writer { return outBuffer }
@@ -1314,7 +1314,7 @@ func TestIsReachable(t *testing.T) {
 			setupClient: func(t *testing.T) *Client {
 				t.Helper()
 				client := newTestClient(t)
-				client.kubeClient = k8sfake.NewSimpleClientset()
+				client.kubeClient = k8sfake.NewClientset()
 				return client
 			},
 			expectError: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Deprecated in Kubernetes client-go `v1.35`

```
  Error: pkg/kube/client_test.go:926:16: SA1019: k8sfake.NewSimpleClientset is deprecated: NewClientset replaces this with support for field management, which significantly improves server side apply testing. NewClientset is only available when apply configurations are generated (e.g. via --with-applyconfig). (staticcheck)
  	kubeClient := k8sfake.NewSimpleClientset(&responsePodList)
```

https://github.com/helm/helm/actions/runs/20510962724

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
