### PR TITLE
Improve error message for invalid --set-json input

### DIFF
--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -66,13 +66,13 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 			// If value is JSON object format, parse it as map
 			var jsonMap map[string]interface{}
 			if err := json.Unmarshal([]byte(trimmedValue), &jsonMap); err != nil {
-				return nil, fmt.Errorf("failed parsing --set-json data JSON: %s", value)
+				return nil, fmt.Errorf("failed parsing --set-json data %q: expected valid JSON", value)
 			}
 			base = loader.MergeMaps(base, jsonMap)
 		} else {
 			// Otherwise, parse it as key=value format
 			if err := strvals.ParseJSON(value, base); err != nil {
-				return nil, fmt.Errorf("failed parsing --set-json data %s", value)
+				return nil, fmt.Errorf("failed parsing --set-json data %q: expected valid JSON", value)
 			}
 		}
 	}


### PR DESCRIPTION
### What this PR does
Improves the error message shown when invalid JSON is passed to `--set-json`.

### Why this change is needed
The previous error messages were inconsistent and did not clearly indicate the cause of the failure.
This change:
- Safely quotes the invalid input
- Explicitly mentions that valid JSON is expected
- Keeps error messaging consistent across code paths

No functional behavior is changed.
