### PR TITLE
[cherry-pick]  add support for custom template funcs for v3

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -97,6 +98,9 @@ type Configuration struct {
 
 	Log func(string, ...interface{})
 
+	// CustomTemplateFuncs is defined by users to provide custom template funcs
+	CustomTemplateFuncs template.FuncMap
+
 	// HookOutputFunc called with container name and returns and expects writer that will receive the log output.
 	HookOutputFunc func(namespace, pod, container string) io.Writer
 }
@@ -135,10 +139,14 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Valu
 		}
 		e := engine.New(restConfig)
 		e.EnableDNS = enableDNS
+		e.CustomTemplateFuncs = cfg.CustomTemplateFuncs
+
 		files, err2 = e.Render(ch, values)
 	} else {
 		var e engine.Engine
 		e.EnableDNS = enableDNS
+		e.CustomTemplateFuncs = cfg.CustomTemplateFuncs
+
 		files, err2 = e.Render(ch, values)
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -44,6 +44,8 @@ type Engine struct {
 	clientProvider *ClientProvider
 	// EnableDNS tells the engine to allow DNS lookups when rendering templates
 	EnableDNS bool
+	// CustomTemplateFuncs is defined by users to provide custom template funcs
+	CustomTemplateFuncs template.FuncMap
 }
 
 // New creates a new instance of Engine using the passed in rest config.
@@ -242,6 +244,11 @@ func (e Engine) initFunMap(t *template.Template) {
 		funcMap["getHostByName"] = func(_ string) string {
 			return ""
 		}
+	}
+
+	// Set custom template funcs
+	for k, v := range e.CustomTemplateFuncs {
+		funcMap[k] = v
 	}
 
 	t.Funcs(funcMap)


### PR DESCRIPTION
The current PR only syncs the [custom template feature](https://github.com/helm/helm/pull/30734) from the main branch to the v3 branch.
