### PR TITLE
docs: `--api-versions` is undocumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ If you're interested in contributing, please refer to the [Contributing Guide](C
 ### Code of conduct
 
 Participation in the Helm community is governed by the [Code of Conduct](code-of-conduct.md).
+
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Description

`helm template --help` reports the type of `--api-versions` as "strings".  Conceptually though it's a duple of (api, version), or a list of duples.

How do I use it?

## Changes Made

- docs: Added contributing section

Fixes #13198
