### PR TITLE
template: honor --create-namespace in `template` output

### DIFF
--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -97,6 +97,11 @@ func TestTemplateCmd(t *testing.T) {
 			golden: "output/template-with-crds.txt",
 		},
 		{
+			name:   "template with create-namespace",
+			cmd:    fmt.Sprintf("template '%s' --create-namespace --namespace create-ns", chartPath),
+			golden: "output/template-create-namespace.txt",
+		},
+		{
 			name:   "template with show-only one",
 			cmd:    fmt.Sprintf("template '%s' --show-only templates/service.yaml", chartPath),
 			golden: "output/template-show-only-one.txt",

--- a/pkg/cmd/testdata/output/template-create-namespace.txt
+++ b/pkg/cmd/testdata/output/template-create-namespace.txt
@@ -1,0 +1,122 @@
+---
+# Source: subchart/templates/helm-create-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: create-ns
+  labels:
+    name: create-ns
+---
+# Source: subchart/templates/subdir/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: subchart-sa
+---
+# Source: subchart/templates/subdir/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: subchart-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list","watch"]
+---
+# Source: subchart/templates/subdir/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: subchart-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: subchart-role
+subjects:
+- kind: ServiceAccount
+  name: subchart-sa
+  namespace: default
+---
+# Source: subchart/charts/subcharta/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subcharta
+  labels:
+    helm.sh/chart: "subcharta-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: apache
+  selector:
+    app.kubernetes.io/name: subcharta
+---
+# Source: subchart/charts/subchartb/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchartb
+  labels:
+    helm.sh/chart: "subchartb-0.1.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchartb
+---
+# Source: subchart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: subchart
+  labels:
+    helm.sh/chart: "subchart-0.1.0"
+    app.kubernetes.io/instance: "release-name"
+    kube-version/major: "1"
+    kube-version/minor: "20"
+    kube-version/version: "v1.20.0"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: nginx
+  selector:
+    app.kubernetes.io/name: subchart
+---
+# Source: subchart/templates/tests/test-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "release-name-testconfig"
+  annotations:
+    "helm.sh/hook": test
+data:
+  message: Hello World
+---
+# Source: subchart/templates/tests/test-nothing.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "release-name-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test
+      image: "alpine:latest"
+      envFrom:
+        - configMapRef:
+            name: "release-name-testconfig"
+      command:
+        - echo
+        - "$message"
+  restartPolicy: Never


### PR DESCRIPTION
**What this PR does / why we need it**:
- renders a Namespace manifest when `--create-namespace` is used with `helm template` (and other dry-run install paths)
- keeps non-dry-run behavior unchanged by only injecting the manifest for dry-run
- adds a golden test for `helm template --create-namespace --namespace create-ns`

Closes #9813

**Special notes for your reviewer**:
- the namespace manifest is injected via a generated `templates/helm-create-namespace.yaml` so it is post-renderer aware
- tests: `go test ./pkg/cmd -run TestTemplateCmd`

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
