### PR TITLE
Lint sync-repo.sh with ShellCheck

### DIFF
--- a/scripts/sync-repo.sh
+++ b/scripts/sync-repo.sh
@@ -44,7 +44,8 @@ verify_prereqs() {
 }
 
 confirm() {
-  case $confirm in
+  # shellcheck disable=SC2154
+  case $response in
     [yY][eE][sS]|[yY])
       true
       ;;

--- a/scripts/sync-repo.sh
+++ b/scripts/sync-repo.sh
@@ -44,7 +44,7 @@ verify_prereqs() {
 }
 
 confirm() {
-  case $response in
+  case $confirm in
     [yY][eE][sS]|[yY])
       true
       ;;
@@ -66,11 +66,11 @@ main() {
   verify_prereqs
 
   # dry run of the command
-  gsutil rsync -d -n $1 gs://$2
+  gsutil rsync -d -n "$1" gs://"$2"
 
-  read -p "Are you sure you would like to continue with these changes? [y/N]} " confirm
+  read -r -p "Are you sure you would like to continue with these changes? [y/N] " confirm
   if [[ $confirm =~ [yY](es)* ]]; then
-    gsutil rsync -d $1 gs://$2
+    gsutil rsync -d "$1" gs://"$2"
   else
     error_exit "Discontinuing sync process."
   fi


### PR DESCRIPTION
This PR fixes ShellCheck warnings in scripts/sync-repo.sh by:
- Quoting variables to prevent word splitting
- Using read -r for safer input handling
- Correcting variable usage in case statement

No functional behavior is changed.

Related issue: #31689

