### PR TITLE
Add ShellCheck Github Action for bash scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # pin@v4.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # pin@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,8 +17,8 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout source code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # pin@v4.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,28 @@
+name: ShellCheck
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+        with:
+          scandir: scripts
+          severity: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,14 +1,14 @@
-name: ShellCheck
+name: Lint Bash Scripts
 
 on:
-  workflow_dispatch:
   pull_request:
+    paths:
+      - 'scripts/**.sh'
   push:
     branches:
       - main
     paths:
-      - '**.sh'
-      - '.github/workflows/shellcheck.yml'
+      - 'scripts/**.sh'
 
 permissions:
   contents: read
@@ -17,12 +17,10 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-
-        with:
-          scandir: scripts
-          severity: error
+        run: shellcheck ./scripts/**/*.sh


### PR DESCRIPTION
This PR adds a github actions workflow to run ShellCheck on Helm’s scripts directory.
It enforces shell linting in CI while allowing existing warnings to be addressed
incrementally in follow-up PRs.