### PR TITLE
fix(sdk): Include status message in watcher wait debug logging

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -266,7 +266,7 @@ func statusObserver(cancel context.CancelFunc, desired status.Status, logger *sl
 				return nonDesiredResources[i].Identifier.Name < nonDesiredResources[j].Identifier.Name
 			})
 			first := nonDesiredResources[0]
-			logger.Debug("waiting for resource", "namespace", first.Identifier.Namespace, "name", first.Identifier.Name, "kind", first.Identifier.GroupKind.Kind, "expectedStatus", desired, "actualStatus", first.Status)
+			logger.Debug("waiting for resource", "namespace", first.Identifier.Namespace, "name", first.Identifier.Name, "kind", first.Identifier.GroupKind.Kind, "expectedStatus", desired, "actualStatus", first.Status, "message", first.Message)
 		}
 	}
 }


### PR DESCRIPTION
The status watcher emits debug logs when waiting for resources, but the message field from the kstatus library was missing. This makes SDK debugging harder since users only see status codes like "InProgress" without context.

This adds the Message field to the debug log output so SDK consumers configuring slog with debug level get the detailed resource status information (like "Replicas: 1/2" or "Ready: 0/2").

## Change

Added `"message", first.Message` to the debug log call in `statusObserver`:

```go
slog.Debug("waiting for resource", ..., "actualStatus", first.Status, "message", first.Message)
```

## Verification

**Environment:** Darwin (arm64)  
**Runtime:** go1.25.5

All tests pass:
```
go test -v ./pkg/kube/...
--- PASS: TestStatusWait (0.00s)
    --- PASS: TestStatusWait/Job_is_ready_but_not_complete (0.01s)
    --- PASS: TestStatusWait/Pod_is_ready (0.01s)
    --- PASS: TestStatusWait/paused_deployment_passes (0.01s)
    --- PASS: TestStatusWait/Job_is_not_complete (3.01s)
    --- PASS: TestStatusWait/one_of_the_pods_never_becomes_ready (3.01s)
PASS
ok  helm.sh/helm/v4/pkg/kube (cached)
```

Fixes #31585