### PR TITLE
fix: use kube logger with status waiter

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -166,7 +166,8 @@ func (c *Client) newStatusWatcher(opts ...WaitOption) (*statusWaiter, error) {
 	if waitContext == nil {
 		waitContext = c.WaitContext
 	}
-	return &statusWaiter{
+
+	sw := &statusWaiter{
 		restMapper:         restMapper,
 		client:             dynamicClient,
 		ctx:                waitContext,
@@ -175,7 +176,9 @@ func (c *Client) newStatusWatcher(opts ...WaitOption) (*statusWaiter, error) {
 		waitWithJobsCtx:    o.waitWithJobsCtx,
 		waitForDeleteCtx:   o.waitForDeleteCtx,
 		readers:            o.statusReaders,
-	}, nil
+	}
+	sw.SetLogger(c.Logger().Handler())
+	return sw, nil
 }
 
 func (c *Client) GetWaiter(ws WaitStrategy) (Waiter, error) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -166,7 +166,6 @@ func (c *Client) newStatusWatcher(opts ...WaitOption) (*statusWaiter, error) {
 	if waitContext == nil {
 		waitContext = c.WaitContext
 	}
-
 	sw := &statusWaiter{
 		restMapper:         restMapper,
 		client:             dynamicClient,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Currently unless the global slogger is set, SDK users will not receive any logs at all from the waiter. This is critical as several minutes can go by without any feedback to users. Relates to #31585

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
