### PR TITLE
feat(logging): re-introduce logging API

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -21,6 +21,8 @@ import (
 	"log/slog"
 	"os"
 	"sync/atomic"
+
+	api "helm.sh/helm/v4/pkg/logging"
 )
 
 // DebugEnabledFunc is a function type that determines if debug logging is enabled
@@ -90,14 +92,6 @@ func NewLogger(debugEnabled DebugEnabledFunc) *slog.Logger {
 	return slog.New(dynamicHandler)
 }
 
-// LoggerSetterGetter is an interface that can set and get a logger
-type LoggerSetterGetter interface {
-	// SetLogger sets a new slog.Handler
-	SetLogger(newHandler slog.Handler)
-	// Logger returns the slog.Logger created from the slog.Handler
-	Logger() *slog.Logger
-}
-
 type LogHolder struct {
 	// logger is an atomic.Pointer[slog.Logger] to store the slog.Logger
 	// We use atomic.Pointer for thread safety
@@ -122,4 +116,4 @@ func (l *LogHolder) SetLogger(newHandler slog.Handler) {
 }
 
 // Ensure LogHolder implements LoggerSetterGetter
-var _ LoggerSetterGetter = &LogHolder{}
+var _ api.LoggerSetterGetter = &LogHolder{}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	api "helm.sh/helm/v4/pkg/logging"
 )
 
 func TestLogHolder_Logger(t *testing.T) {
@@ -99,11 +101,11 @@ func TestLogHolder_SetLogger(t *testing.T) {
 
 func TestLogHolder_InterfaceCompliance(t *testing.T) {
 	t.Run("implements LoggerSetterGetter interface", func(_ *testing.T) {
-		var _ LoggerSetterGetter = &LogHolder{}
+		var _ api.LoggerSetterGetter = &LogHolder{}
 	})
 
 	t.Run("interface methods work correctly", func(t *testing.T) {
-		var holder LoggerSetterGetter = &LogHolder{}
+		var holder api.LoggerSetterGetter = &LogHolder{}
 
 		buf := &bytes.Buffer{}
 		handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import "log/slog"
+
+// LoggerSetterGetter is an interface that can set and get a logger
+type LoggerSetterGetter interface {
+	// SetLogger sets a new slog.Handler
+	SetLogger(newHandler slog.Handler)
+	// Logger returns the slog.Logger created from the slog.Handler
+	Logger() *slog.Logger
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/internal/logging"
+	loggingapi "helm.sh/helm/v4/pkg/logging"
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
 	rspb "helm.sh/helm/v4/pkg/release/v1"
@@ -340,7 +341,7 @@ func Init(d driver.Driver) *Storage {
 	}
 
 	// Get logger from driver if it implements the LoggerSetterGetter interface
-	if ls, ok := d.(logging.LoggerSetterGetter); ok {
+	if ls, ok := d.(loggingapi.LoggerSetterGetter); ok {
 		ls.SetLogger(s.Logger().Handler())
 	} else {
 		// If the driver does not implement the LoggerSetterGetter interface, set the default logger


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes the interface SDK users can use to pass logger implementations to various parts of the SDK (only storage uses this at the moment).

**Special notes for your reviewer**:

@banjoh Follow up to https://github.com/helm/helm/pull/31411/files#r2683864962

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
