### PR TITLE
bugfix(logging): fix storage not getting logger from driver

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -339,12 +339,14 @@ func Init(d driver.Driver) *Storage {
 		Driver: d,
 	}
 
+	var h slog.Handler
 	// Get logger from driver if it implements the LoggerSetterGetter interface
 	if ls, ok := d.(logging.LoggerSetterGetter); ok {
-		ls.SetLogger(s.Logger().Handler())
+		h = ls.Logger().Handler()
 	} else {
 		// If the driver does not implement the LoggerSetterGetter interface, set the default logger
-		s.SetLogger(slog.Default().Handler())
+		h = slog.Default().Handler()
 	}
+	s.SetLogger(h)
 	return s
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the storage not getting the logger from the driver.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
