### PR TITLE
chore: clarify --wait flag help text

### DIFF
--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -59,9 +59,8 @@ func AddWaitFlag(cmd *cobra.Command, wait *kube.WaitStrategy) {
 	cmd.Flags().Var(
 		newWaitValue(kube.HookOnlyStrategy, wait),
 		"wait",
-		"if specified, wait until resources are ready (up to --timeout). Values: 'watcher', 'hookOnly', and 'legacy'.",
+		"wait until resources are ready (up to --timeout). Use '--wait' alone for 'watcher' strategy, or specify one of: 'watcher', 'hookOnly', 'legacy'. Default when flag is omitted: 'hookOnly'.",
 	)
-	// Sets the strategy to use the watcher strategy if `--wait` is used without an argument
 	cmd.Flags().Lookup("wait").NoOptDefVal = string(kube.StatusWatcherStrategy)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve the description to explain the three usage scenarios:
- --wait alone defaults to 'watcher' strategy
- --wait=<value> uses the specified strategy
- flag omitted defaults to 'hookOnly'

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
