### PR TITLE
fix(defaults): server-side apply SDK defaults should always match the CLI defaults

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -159,7 +159,7 @@ type ChartPathOptions struct {
 func NewInstall(cfg *Configuration) *Install {
 	in := &Install{
 		cfg:             cfg,
-		ServerSideApply: true,
+		ServerSideApply: true, // Must always match the CLI default.
 		DryRunStrategy:  DryRunNone,
 	}
 	in.registryClient = cfg.RegistryClient

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -64,8 +64,9 @@ type Rollback struct {
 // NewRollback creates a new Rollback object with the given configuration.
 func NewRollback(cfg *Configuration) *Rollback {
 	return &Rollback{
-		cfg:            cfg,
-		DryRunStrategy: DryRunNone,
+		cfg:             cfg,
+		ServerSideApply: "auto", // Must always match the CLI default.
+		DryRunStrategy:  DryRunNone,
 	}
 }
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -142,7 +142,7 @@ type resultMessage struct {
 func NewUpgrade(cfg *Configuration) *Upgrade {
 	up := &Upgrade{
 		cfg:             cfg,
-		ServerSideApply: "auto",
+		ServerSideApply: "auto", // Must always match the CLI default.
 		DryRunStrategy:  DryRunNone,
 	}
 	up.registryClient = cfg.RegistryClient


### PR DESCRIPTION
**What this PR does / why we need it**:

The SDK server-side apply defaults must always match the CLI defaults.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
