### PR TITLE
fix(engine): handle error when accessing dependency charts

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -563,8 +563,11 @@ func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Val
 	}
 
 	for _, child := range accessor.Dependencies() {
-		// TODO: Handle error
-		sub, _ := ci.NewAccessor(child)
+		sub, err := ci.NewAccessor(child)
+		if err != nil {
+			slog.Error("error accessing dependency chart", slog.Any("error", err))
+			continue
+		}
 		subCharts[sub.Name()] = recAllTpls(child, templates, next)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR fixes a potential nil pointer panic in the template engine when processing chart dependencies.

In pkg/engine/engine.go, the recAllTpls function had a // TODO: Handle error comment where the error from ci.NewAccessor(child) was being silently ignored. If NewAccessor fails (e.g., for an unsupported chart type), it returns nil, and the subsequent call to sub.Name() would panic.

This change adds proper error handling consistent with the pattern already used earlier in the same function (lines 541-544), logging the error and skipping the problematic dependency instead of crashing.

**Special notes for your reviewer**:
This addresses an explicit TODO comment in the codebase
The error handling pattern matches the existing code style in the same function
No behavioral change for the happy path; only affects error cases

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
