### PR TITLE
fix(kstatus): fine-grained context options for waiting

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -167,10 +167,14 @@ func (c *Client) newStatusWatcher(opts ...WaitOption) (*statusWaiter, error) {
 		waitContext = c.WaitContext
 	}
 	return &statusWaiter{
-		restMapper: restMapper,
-		client:     dynamicClient,
-		ctx:        waitContext,
-		readers:    o.statusReaders,
+		restMapper:         restMapper,
+		client:             dynamicClient,
+		ctx:                waitContext,
+		watchUntilReadyCtx: o.watchUntilReadyCtx,
+		waitCtx:            o.waitCtx,
+		waitWithJobsCtx:    o.waitWithJobsCtx,
+		waitForDeleteCtx:   o.waitForDeleteCtx,
+		readers:            o.statusReaders,
 	}, nil
 }
 

--- a/pkg/kube/options.go
+++ b/pkg/kube/options.go
@@ -26,9 +26,42 @@ import (
 type WaitOption func(*waitOptions)
 
 // WithWaitContext sets the context for waiting on resources.
+// If unset, context.Background() will be used.
 func WithWaitContext(ctx context.Context) WaitOption {
 	return func(wo *waitOptions) {
 		wo.ctx = ctx
+	}
+}
+
+// WithWatchUntilReadyMethodContext sets the context specifically for the WatchUntilReady method.
+// If unset, the context set by `WithWaitContext` will be used (falling back to `context.Background()`).
+func WithWatchUntilReadyMethodContext(ctx context.Context) WaitOption {
+	return func(wo *waitOptions) {
+		wo.watchUntilReadyCtx = ctx
+	}
+}
+
+// WithWaitMethodContext sets the context specifically for the Wait method.
+// If unset, the context set by `WithWaitContext` will be used (falling back to `context.Background()`).
+func WithWaitMethodContext(ctx context.Context) WaitOption {
+	return func(wo *waitOptions) {
+		wo.waitCtx = ctx
+	}
+}
+
+// WithWaitWithJobsMethodContext sets the context specifically for the WaitWithJobs method.
+// If unset, the context set by `WithWaitContext` will be used (falling back to `context.Background()`).
+func WithWaitWithJobsMethodContext(ctx context.Context) WaitOption {
+	return func(wo *waitOptions) {
+		wo.waitWithJobsCtx = ctx
+	}
+}
+
+// WithWaitForDeleteMethodContext sets the context specifically for the WaitForDelete method.
+// If unset, the context set by `WithWaitContext` will be used (falling back to `context.Background()`).
+func WithWaitForDeleteMethodContext(ctx context.Context) WaitOption {
+	return func(wo *waitOptions) {
+		wo.waitForDeleteCtx = ctx
 	}
 }
 
@@ -40,6 +73,10 @@ func WithKStatusReaders(readers ...engine.StatusReader) WaitOption {
 }
 
 type waitOptions struct {
-	ctx           context.Context
-	statusReaders []engine.StatusReader
+	ctx                context.Context
+	watchUntilReadyCtx context.Context
+	waitCtx            context.Context
+	waitWithJobsCtx    context.Context
+	waitForDeleteCtx   context.Context
+	statusReaders      []engine.StatusReader
 }


### PR DESCRIPTION
**What this PR does / why we need it** / **Special notes for your reviewer**:

This is a critical fix for the feature previously introduced here:

https://github.com/helm/helm/pull/31435/files (see file `pkg/kube/statuswait.go`)

Basically, Flux cannot pass the custom context to all the waiter methods. Specifically for `WatchUntilReady`, we can never pass the custom context to it because it means cancelling Helm hooks, which can be very bad, as users use hooks to run e.g. database migrations. Please see this issue for more context: https://github.com/fluxcd/helm-controller/issues/1380#issuecomment-3755101398

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
