### PR TITLE
feat: New --values-tpl flag with limited template support

### DIFF
--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -26,18 +26,20 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
+	"helm.sh/helm/v4/pkg/engine"
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/strvals"
 )
 
 // Options captures the different ways to specify values
 type Options struct {
-	ValueFiles    []string // -f/--values
-	StringValues  []string // --set-string
-	Values        []string // --set
-	FileValues    []string // --set-file
-	JSONValues    []string // --set-json
-	LiteralValues []string // --set-literal
+	ValueFiles     []string // -f/--values
+	ValueTemplates []string // --values-tpl
+	StringValues   []string // --set-string
+	Values         []string // --set
+	FileValues     []string // --set-file
+	JSONValues     []string // --set-json
+	LiteralValues  []string // --set-literal
 }
 
 // MergeValues merges values from files specified via -f/--values and directly
@@ -112,6 +114,19 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		}
 	}
 
+	// User specified a values template via --values-tpl
+	for _, filePath := range opts.ValueTemplates {
+		raw, err := readFile(filePath, p)
+		if err != nil {
+			return nil, err
+		}
+		rendered, err := LoadValuesTpl(filePath, string(raw), base)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render values template %s: %w", filePath, err)
+		}
+		base = loader.MergeMaps(base, rendered)
+	}
+
 	return base, nil
 }
 
@@ -135,4 +150,32 @@ func readFile(filePath string, p getter.Providers) ([]byte, error) {
 		return nil, err
 	}
 	return data.Bytes(), nil
+}
+
+// LoadValuesTpl renders a values file as a Go template with .Values context
+func LoadValuesTpl(
+	templatePath string,
+	templateData string,
+	currentValues map[string]interface{},
+) (map[string]interface{}, error) {
+	// Create template context with .Values
+	context := map[string]interface{}{
+		"Values": currentValues,
+	}
+
+	// Render using the engine
+	eng := engine.Engine{}
+	rendered, err := eng.RenderString(templatePath, templateData, context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render template %s: %w", templatePath, err)
+	}
+
+	// Parse the rendered YAML output
+	buf := bytes.NewBufferString(rendered)
+	result, err := loader.LoadValues(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse rendered template %s as YAML: %w", templatePath, err)
+	}
+
+	return result, nil
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -48,6 +48,7 @@ const (
 
 func addValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
 	f.StringSliceVarP(&v.ValueFiles, "values", "f", []string{}, "specify values in a YAML file or a URL (can specify multiple)")
+	f.StringSliceVar(&v.ValueTemplates, "values-tpl", []string{}, "specify values in a YAML template file or a URL that will be rendered before merging (can specify multiple)")
 	f.StringArrayVar(&v.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.StringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&v.FileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")


### PR DESCRIPTION
Use --values-tpl to dynamically generate values based on previously merged configuration. Templates have access to .Values with basic template functions.

This is especially useful when you don't have control over upstream chart templates and want to avoid forking just to add tpl support.

## How it works

Templates are rendered after all other value sources (--values, --set) and have access to the merged .Values context:

```bash
# Basic usage
helm install myapp ./chart --values-tpl dynamic.yaml.tpl

# With values from previous sources
helm install myapp ./chart \
  --values base.yaml \
  --set environment=production \
  --values-tpl computed.yaml.tpl
```

```yaml
# base.yaml
region: us-east-1
environment: dev

# computed.yaml.tpl
replicas: {{ if eq .Values.environment "production" }}5{{ else }}1{{ end }}
resourceTier: {{ .Values.environment | upper }}
endpoint: "https://{{ .Values.region }}.example.com"
```

## Value merge order

1. Chart defaults (`values.yaml`)
2. All `--values` files
3. All `--set*` flags
4. All `--values-tpl` files (rendered with access to steps 1-3)

## Real-world use case: Dynamic ECR registry per cluster with ArgoCD

**Problem:** Each cluster is in a different AWS region/account, and you need different ECR registries. You want to:
- Avoid committing per-cluster files (values-prod-us.yaml, values-prod-eu.yaml, etc.)
- Not edit upstream chart templates to add tpl support
- Keep ArgoCD unaware of chart-specific paths (image.registry, etc.)

**Solution:** Single template file in git, cluster-specific values via ArgoCD:

```yaml
# values-custom.yaml.tpl (committed to repo, works for all clusters)
image:
  registry: "{{ .Values.accountId }}.dkr.ecr.{{ .Values.region }}.amazonaws.com"
  repository: myapp
  tag: "1.0.0"

service:
  extraEnvironment:  # Arbitrary path in values
    CLUSTER_NAME: "{{ .Values.clusterName }}"
```

```yaml
# ArgoCD Application for prod-us-east cluster
# Note: Requires ArgoCD support for valueTplFiles (pending PR)
spec:
  helm:
    parameters:
    - name: clusterName
      value: prod-us-east
    - name: region
      value: us-east-1
    - name: accountId
      value: "123456789"
    valueTplFiles:
    - values-custom.yaml.tpl
```

```yaml
# ArgoCD Application for prod-eu-west cluster (same template!)
spec:
  helm:
    parameters:
    - name: clusterName
      value: prod-eu-west
    - name: region
      value: eu-west-1
    - name: accountId
      value: "987654321"
    valueTplFiles:
    - values-custom.yaml.tpl
```

## Supported in templates

- Access to `.Values` from previous merge steps
- Sprig functions: `default`, `upper`, `lower`, `trim`, etc.
- Format functions: `toYaml`, `toJson`, `toToml`, `fromYaml`, `fromJson`, `fromToml`
- Conditionals: `if`/`else`, `range`
- Remote templates: `http://`, `https://`, etc.

## Not supported (chart-only features)

- `include` (requires chart template context)
- `tpl` (requires chart template context)
- `lookup` (requires Kubernetes client)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
