### PR TITLE
docs: document uninstall using cascade foreground flag

### DIFF
--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -35,6 +35,9 @@ as well as the release history, freeing it up for future use.
 
 Use the '--dry-run' flag to see which releases will be uninstalled without actually
 uninstalling them.
+
+Use '--cascade foreground' with '--wait' to ensure resources with finalizers
+are fully deleted before the command returns.
 `
 
 func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
@@ -76,7 +79,7 @@ func newUninstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&client.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation")
 	f.BoolVar(&client.IgnoreNotFound, "ignore-not-found", false, `Treat "release not found" as a successful uninstall`)
 	f.BoolVar(&client.KeepHistory, "keep-history", false, "remove all associated resources and mark the release as deleted, but retain the release history")
-	f.StringVar(&client.DeletionPropagation, "cascade", "background", "Must be \"background\", \"orphan\", or \"foreground\". Selects the deletion cascading strategy for the dependents. Defaults to background.")
+	f.StringVar(&client.DeletionPropagation, "cascade", "background", "Must be \"background\", \"orphan\", or \"foreground\". Selects the deletion cascading strategy for the dependents. Defaults to background. Use \"foreground\" with --wait to ensure resources with finalizers are fully deleted before returning.")
 	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	AddWaitFlag(cmd, &client.WaitStrategy)


### PR DESCRIPTION
**What this PR does / why we need it**:

Some users want to wait for all resources to be deleted when uninstalling a chart. This PR documents how they can use `helm uninstall <release> --wait --cascade foreground` to achieve this

Closes: https://github.com/helm/helm/issues/31651

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
