### PR TITLE
refactor: remove per-file decompression size limit

### DIFF
--- a/internal/chart/v3/loader/directory.go
+++ b/internal/chart/v3/loader/directory.go
@@ -100,10 +100,6 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		if fi.Size() > archive.MaxDecompressedFileSize {
-			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), archive.MaxDecompressedFileSize)
-		}
-
 		data, err := os.ReadFile(name)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)

--- a/internal/chart/v3/loader/directory.go
+++ b/internal/chart/v3/loader/directory.go
@@ -64,6 +64,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 	files := []*archive.BufferedFile{}
 	topdir += string(filepath.Separator)
+	remaining := archive.MaxDecompressedChartSize
 
 	walk := func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
@@ -100,7 +101,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		data, err := os.ReadFile(name)
+		data, err := archive.ReadFileWithBudget(name, fi.Size(), &remaining)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)
 		}

--- a/internal/chart/v3/loader/directory.go
+++ b/internal/chart/v3/loader/directory.go
@@ -43,6 +43,10 @@ func (l DirLoader) Load() (*chart.Chart, error) {
 //
 // This loads charts only from directories.
 func LoadDir(dir string) (*chart.Chart, error) {
+	return loadDir(dir, archive.MaxDecompressedChartSize)
+}
+
+func loadDir(dir string, budget int64) (*chart.Chart, error) {
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -64,7 +68,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 	files := []*archive.BufferedFile{}
 	topdir += string(filepath.Separator)
-	remaining := archive.MaxDecompressedChartSize
+	budgetReader := archive.NewBudgetedReader(budget)
 
 	walk := func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
@@ -101,7 +105,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		data, err := archive.ReadFileWithBudget(name, fi.Size(), &remaining)
+		data, err := budgetReader.ReadFileWithBudget(name, fi.Size())
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)
 		}

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -52,11 +52,7 @@ func TestLoadDir(t *testing.T) {
 }
 
 func TestLoadDirExceedsBudget(t *testing.T) {
-	orig := archive.MaxDecompressedChartSize
-	archive.MaxDecompressedChartSize = 1 // 1 byte budget
-	defer func() { archive.MaxDecompressedChartSize = orig }()
-
-	_, err := LoadDir("testdata/frobnitz")
+	_, err := loadDir("testdata/frobnitz", 1)
 	if err == nil {
 		t.Fatal("expected error when chart directory exceeds budget")
 	}

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -51,6 +51,20 @@ func TestLoadDir(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirExceedsBudget(t *testing.T) {
+	orig := archive.MaxDecompressedChartSize
+	archive.MaxDecompressedChartSize = 1 // 1 byte budget
+	defer func() { archive.MaxDecompressedChartSize = orig }()
+
+	_, err := LoadDir("testdata/frobnitz")
+	if err == nil {
+		t.Fatal("expected error when chart directory exceeds budget")
+	}
+	if !strings.Contains(err.Error(), "chart exceeds maximum decompressed size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadDirWithDevNull(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test only works on unix systems with /dev/null present")

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -37,10 +37,6 @@ import (
 // The default value is 100 MiB.
 var MaxDecompressedChartSize int64 = 100 * 1024 * 1024 // Default 100 MiB
 
-// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
-// The size of the file is the decompressed version of it when it is stored in an archive.
-var MaxDecompressedFileSize int64 = 5 * 1024 * 1024 // Default 5 MiB
-
 var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
 
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}
@@ -126,10 +122,6 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 
 		if hd.Size > remainingSize {
 			return nil, fmt.Errorf("decompressed chart is larger than the maximum size %d", MaxDecompressedChartSize)
-		}
-
-		if hd.Size > MaxDecompressedFileSize {
-			return nil, fmt.Errorf("decompressed chart file %q is larger than the maximum file size %d", hd.Name, MaxDecompressedFileSize)
 		}
 
 		limitedReader := io.LimitReader(tr, remainingSize)

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -37,6 +37,12 @@ import (
 // The default value is 100 MiB.
 var MaxDecompressedChartSize int64 = 100 * 1024 * 1024 // Default 100 MiB
 
+// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
+// The size of the file is the decompressed version of it when it is stored in an archive.
+//
+// Deprecated: This variable is no longer used internally and will be removed in Helm v5.
+var MaxDecompressedFileSize int64 = 5 * 1024 * 1024 // Default 5 MiB
+
 var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
 
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}

--- a/pkg/chart/loader/archive/archive.go
+++ b/pkg/chart/loader/archive/archive.go
@@ -37,10 +37,10 @@ import (
 // The default value is 100 MiB.
 var MaxDecompressedChartSize int64 = 100 * 1024 * 1024 // Default 100 MiB
 
-// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
-// The size of the file is the decompressed version of it when it is stored in an archive.
+// MaxDecompressedFileSize was the per-file size limit enforced during chart loading.
+// It is no longer used internally; aggregate chart size is enforced via MaxDecompressedChartSize.
 //
-// Deprecated: This variable is no longer used internally and will be removed in Helm v5.
+// Deprecated: Retained for backward compatibility with external callers. Will be removed in Helm v5.
 var MaxDecompressedFileSize int64 = 5 * 1024 * 1024 // Default 5 MiB
 
 var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)

--- a/pkg/chart/loader/archive/budget.go
+++ b/pkg/chart/loader/archive/budget.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"fmt"
+	"os"
+)
+
+// ReadFileWithBudget reads a file and decrements remaining by the bytes read.
+// It returns an error if the total would exceed MaxDecompressedChartSize.
+func ReadFileWithBudget(path string, size int64, remaining *int64) ([]byte, error) {
+	if size > *remaining {
+		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-check with actual length: the file may have grown between stat and read.
+	if int64(len(data)) > *remaining {
+		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
+	}
+
+	*remaining -= int64(len(data))
+	return data, nil
+}

--- a/pkg/chart/loader/archive/budget.go
+++ b/pkg/chart/loader/archive/budget.go
@@ -23,26 +23,26 @@ import (
 	"os"
 )
 
-// budgetedReader tracks cumulative file reads against a size limit.
-type budgetedReader struct {
+// BudgetedReader tracks cumulative file reads against a size limit.
+type BudgetedReader struct {
 	max       int64
 	remaining int64
 }
 
-// newBudgetedReader creates a new budgetedReader with the given maximum decompressed chart size.
-// The remaining budget is initialized to the maximum size.
-func NewBudgetedReader(max int64) *budgetedReader {
-	return &budgetedReader{
+// NewBudgetedReader creates a BudgetedReader with the given maximum total size.
+// The remaining budget is initialized to the maximum.
+func NewBudgetedReader(max int64) *BudgetedReader {
+	return &BudgetedReader{
 		max:       max,
 		remaining: max,
 	}
 }
 
-// readFileWithBudget reads a file and decrements remaining by the bytes read.
-// It returns an error if the total would exceed the maximum decompressed chart size.
+// ReadFileWithBudget reads a file and decrements the remaining budget by the bytes read.
+// It returns an error if the total would exceed the configured maximum.
 // The read is capped via io.LimitReader so a file that grows between stat
 // and read cannot cause unbounded memory allocation.
-func (r *budgetedReader) ReadFileWithBudget(path string, size int64) ([]byte, error) {
+func (r *BudgetedReader) ReadFileWithBudget(path string, size int64) ([]byte, error) {
 	if size > r.remaining {
 		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", r.max)
 	}

--- a/pkg/chart/loader/archive/budget.go
+++ b/pkg/chart/loader/archive/budget.go
@@ -17,23 +17,37 @@ limitations under the License.
 package archive
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 )
 
 // ReadFileWithBudget reads a file and decrements remaining by the bytes read.
 // It returns an error if the total would exceed MaxDecompressedChartSize.
+// The read is capped via io.LimitReader so a file that grows between stat
+// and read cannot cause unbounded memory allocation.
 func ReadFileWithBudget(path string, size int64, remaining *int64) ([]byte, error) {
+	if remaining == nil {
+		return nil, errors.New("remaining budget must not be nil")
+	}
 	if size > *remaining {
 		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
 	}
 
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Read at most *remaining+1 bytes so we can detect over-budget without
+	// allocating unbounded memory if the file grew since stat.
+	data, err := io.ReadAll(io.LimitReader(f, *remaining+1))
 	if err != nil {
 		return nil, err
 	}
 
-	// Re-check with actual length: the file may have grown between stat and read.
 	if int64(len(data)) > *remaining {
 		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
 	}

--- a/pkg/chart/loader/archive/budget.go
+++ b/pkg/chart/loader/archive/budget.go
@@ -17,22 +17,34 @@ limitations under the License.
 package archive
 
 import (
-	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
-// ReadFileWithBudget reads a file and decrements remaining by the bytes read.
-// It returns an error if the total would exceed MaxDecompressedChartSize.
+// budgetedReader tracks cumulative file reads against a size limit.
+type budgetedReader struct {
+	max       int64
+	remaining int64
+}
+
+// newBudgetedReader creates a new budgetedReader with the given maximum decompressed chart size.
+// The remaining budget is initialized to the maximum size.
+func NewBudgetedReader(max int64) *budgetedReader {
+	return &budgetedReader{
+		max:       max,
+		remaining: max,
+	}
+}
+
+// readFileWithBudget reads a file and decrements remaining by the bytes read.
+// It returns an error if the total would exceed the maximum decompressed chart size.
 // The read is capped via io.LimitReader so a file that grows between stat
 // and read cannot cause unbounded memory allocation.
-func ReadFileWithBudget(path string, size int64, remaining *int64) ([]byte, error) {
-	if remaining == nil {
-		return nil, errors.New("remaining budget must not be nil")
-	}
-	if size > *remaining {
-		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
+func (r *budgetedReader) ReadFileWithBudget(path string, size int64) ([]byte, error) {
+	if size > r.remaining {
+		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", r.max)
 	}
 
 	f, err := os.Open(path)
@@ -41,17 +53,22 @@ func ReadFileWithBudget(path string, size int64, remaining *int64) ([]byte, erro
 	}
 	defer f.Close()
 
-	// Read at most *remaining+1 bytes so we can detect over-budget without
+	// Read at most r.remaining+1 bytes so we can detect over-budget without
 	// allocating unbounded memory if the file grew since stat.
-	data, err := io.ReadAll(io.LimitReader(f, *remaining+1))
+	// Clamp to avoid int64 overflow when r.remaining is near math.MaxInt64.
+	limit := r.remaining
+	if limit < math.MaxInt64 {
+		limit++
+	}
+	data, err := io.ReadAll(io.LimitReader(f, limit))
 	if err != nil {
 		return nil, err
 	}
 
-	if int64(len(data)) > *remaining {
-		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
+	if int64(len(data)) > r.remaining {
+		return nil, fmt.Errorf("chart exceeds maximum decompressed size of %d bytes", r.max)
 	}
 
-	*remaining -= int64(len(data))
+	r.remaining -= int64(len(data))
 	return data, nil
 }

--- a/pkg/chart/loader/archive/budget.go
+++ b/pkg/chart/loader/archive/budget.go
@@ -31,10 +31,10 @@ type BudgetedReader struct {
 
 // NewBudgetedReader creates a BudgetedReader with the given maximum total size.
 // The remaining budget is initialized to the maximum.
-func NewBudgetedReader(max int64) *BudgetedReader {
+func NewBudgetedReader(limit int64) *BudgetedReader {
 	return &BudgetedReader{
-		max:       max,
-		remaining: max,
+		max:       limit,
+		remaining: limit,
 	}
 }
 

--- a/pkg/chart/loader/archive/budget_test.go
+++ b/pkg/chart/loader/archive/budget_test.go
@@ -46,7 +46,10 @@ func TestReadFileWithBudget(t *testing.T) {
 			check: func(t *testing.T) {
 				t.Helper()
 				p := writeFile(t, "small.txt", 100)
-				fi, _ := os.Stat(p)
+				fi, err := os.Stat(p)
+				if err != nil {
+					t.Fatalf("failed to stat %s: %v", p, err)
+				}
 				remaining := int64(1000)
 
 				data, err := ReadFileWithBudget(p, fi.Size(), &remaining)
@@ -66,10 +69,13 @@ func TestReadFileWithBudget(t *testing.T) {
 			check: func(t *testing.T) {
 				t.Helper()
 				p := writeFile(t, "big.txt", 500)
-				fi, _ := os.Stat(p)
+				fi, err := os.Stat(p)
+				if err != nil {
+					t.Fatalf("failed to stat %s: %v", p, err)
+				}
 				remaining := int64(100)
 
-				_, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				_, err = ReadFileWithBudget(p, fi.Size(), &remaining)
 				if err == nil {
 					t.Fatal("expected error for file exceeding budget")
 				}
@@ -89,7 +95,10 @@ func TestReadFileWithBudget(t *testing.T) {
 
 				for i := range 3 {
 					p := writeFile(t, fmt.Sprintf("f%d.txt", i), 80)
-					fi, _ := os.Stat(p)
+					fi, err := os.Stat(p)
+					if err != nil {
+						t.Fatalf("failed to stat %s: %v", p, err)
+					}
 					if _, err := ReadFileWithBudget(p, fi.Size(), &remaining); err != nil {
 						t.Fatalf("read %d: unexpected error: %v", i, err)
 					}
@@ -99,8 +108,11 @@ func TestReadFileWithBudget(t *testing.T) {
 				}
 
 				p := writeFile(t, "over.txt", 20)
-				fi, _ := os.Stat(p)
-				_, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				fi, err := os.Stat(p)
+				if err != nil {
+					t.Fatalf("failed to stat %s: %v", p, err)
+				}
+				_, err = ReadFileWithBudget(p, fi.Size(), &remaining)
 				if err == nil {
 					t.Fatal("expected error when cumulative reads exceed budget")
 				}

--- a/pkg/chart/loader/archive/budget_test.go
+++ b/pkg/chart/loader/archive/budget_test.go
@@ -35,8 +35,6 @@ func TestReadFileWithBudget(t *testing.T) {
 		return p
 	}
 
-	expectedErr := fmt.Sprintf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
-
 	tcs := []struct {
 		name  string
 		check func(t *testing.T)
@@ -50,17 +48,18 @@ func TestReadFileWithBudget(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to stat %s: %v", p, err)
 				}
-				remaining := int64(1000)
+				max := int64(1000)
 
-				data, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				br := NewBudgetedReader(max)
+				data, err := br.ReadFileWithBudget(p, fi.Size())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 				if len(data) != 100 {
 					t.Fatalf("expected 100 bytes, got %d", len(data))
 				}
-				if remaining != 900 {
-					t.Fatalf("expected remaining=900, got %d", remaining)
+				if br.remaining != 900 {
+					t.Fatalf("expected remaining=900, got %d", br.remaining)
 				}
 			},
 		},
@@ -73,17 +72,19 @@ func TestReadFileWithBudget(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to stat %s: %v", p, err)
 				}
-				remaining := int64(100)
+				max := int64(100)
 
-				_, err = ReadFileWithBudget(p, fi.Size(), &remaining)
+				br := NewBudgetedReader(max)
+				_, err = br.ReadFileWithBudget(p, fi.Size())
 				if err == nil {
 					t.Fatal("expected error for file exceeding budget")
 				}
+				expectedErr := fmt.Sprintf("chart exceeds maximum decompressed size of %d bytes", max)
 				if err.Error() != expectedErr {
 					t.Fatalf("expected %q, got %q", expectedErr, err.Error())
 				}
-				if remaining != 100 {
-					t.Fatalf("budget should not change on rejection, got %d", remaining)
+				if br.remaining != 100 {
+					t.Fatalf("budget should not change on rejection, got %d", br.remaining)
 				}
 			},
 		},
@@ -93,18 +94,19 @@ func TestReadFileWithBudget(t *testing.T) {
 				t.Helper()
 				remaining := int64(250)
 
+				br := NewBudgetedReader(remaining)
 				for i := range 3 {
 					p := writeFile(t, fmt.Sprintf("f%d.txt", i), 80)
 					fi, err := os.Stat(p)
 					if err != nil {
 						t.Fatalf("failed to stat %s: %v", p, err)
 					}
-					if _, err := ReadFileWithBudget(p, fi.Size(), &remaining); err != nil {
+					if _, err := br.ReadFileWithBudget(p, fi.Size()); err != nil {
 						t.Fatalf("read %d: unexpected error: %v", i, err)
 					}
 				}
-				if remaining != 10 {
-					t.Fatalf("expected remaining=10, got %d", remaining)
+				if br.remaining != 10 {
+					t.Fatalf("expected remaining=10, got %d", br.remaining)
 				}
 
 				p := writeFile(t, "over.txt", 20)
@@ -112,7 +114,7 @@ func TestReadFileWithBudget(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to stat %s: %v", p, err)
 				}
-				_, err = ReadFileWithBudget(p, fi.Size(), &remaining)
+				_, err = br.ReadFileWithBudget(p, fi.Size())
 				if err == nil {
 					t.Fatal("expected error when cumulative reads exceed budget")
 				}

--- a/pkg/chart/loader/archive/budget_test.go
+++ b/pkg/chart/loader/archive/budget_test.go
@@ -48,9 +48,9 @@ func TestReadFileWithBudget(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to stat %s: %v", p, err)
 				}
-				max := int64(1000)
+				limit := int64(1000)
 
-				br := NewBudgetedReader(max)
+				br := NewBudgetedReader(limit)
 				data, err := br.ReadFileWithBudget(p, fi.Size())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -72,14 +72,14 @@ func TestReadFileWithBudget(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to stat %s: %v", p, err)
 				}
-				max := int64(100)
+				limit := int64(100)
 
-				br := NewBudgetedReader(max)
+				br := NewBudgetedReader(limit)
 				_, err = br.ReadFileWithBudget(p, fi.Size())
 				if err == nil {
 					t.Fatal("expected error for file exceeding budget")
 				}
-				expectedErr := fmt.Sprintf("chart exceeds maximum decompressed size of %d bytes", max)
+				expectedErr := fmt.Sprintf("chart exceeds maximum decompressed size of %d bytes", limit)
 				if err.Error() != expectedErr {
 					t.Fatalf("expected %q, got %q", expectedErr, err.Error())
 				}

--- a/pkg/chart/loader/archive/budget_test.go
+++ b/pkg/chart/loader/archive/budget_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFileWithBudget(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile := func(t *testing.T, name string, size int) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, make([]byte, size), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	expectedErr := fmt.Sprintf("chart exceeds maximum decompressed size of %d bytes", MaxDecompressedChartSize)
+
+	tcs := []struct {
+		name  string
+		check func(t *testing.T)
+	}{
+		{
+			name: "reads file and decrements budget",
+			check: func(t *testing.T) {
+				t.Helper()
+				p := writeFile(t, "small.txt", 100)
+				fi, _ := os.Stat(p)
+				remaining := int64(1000)
+
+				data, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(data) != 100 {
+					t.Fatalf("expected 100 bytes, got %d", len(data))
+				}
+				if remaining != 900 {
+					t.Fatalf("expected remaining=900, got %d", remaining)
+				}
+			},
+		},
+		{
+			name: "rejects file exceeding budget",
+			check: func(t *testing.T) {
+				t.Helper()
+				p := writeFile(t, "big.txt", 500)
+				fi, _ := os.Stat(p)
+				remaining := int64(100)
+
+				_, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				if err == nil {
+					t.Fatal("expected error for file exceeding budget")
+				}
+				if err.Error() != expectedErr {
+					t.Fatalf("expected %q, got %q", expectedErr, err.Error())
+				}
+				if remaining != 100 {
+					t.Fatalf("budget should not change on rejection, got %d", remaining)
+				}
+			},
+		},
+		{
+			name: "tracks budget across multiple reads",
+			check: func(t *testing.T) {
+				t.Helper()
+				remaining := int64(250)
+
+				for i := range 3 {
+					p := writeFile(t, fmt.Sprintf("f%d.txt", i), 80)
+					fi, _ := os.Stat(p)
+					if _, err := ReadFileWithBudget(p, fi.Size(), &remaining); err != nil {
+						t.Fatalf("read %d: unexpected error: %v", i, err)
+					}
+				}
+				if remaining != 10 {
+					t.Fatalf("expected remaining=10, got %d", remaining)
+				}
+
+				p := writeFile(t, "over.txt", 20)
+				fi, _ := os.Stat(p)
+				_, err := ReadFileWithBudget(p, fi.Size(), &remaining)
+				if err == nil {
+					t.Fatal("expected error when cumulative reads exceed budget")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, tc.check)
+	}
+}

--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -100,10 +100,6 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		if fi.Size() > archive.MaxDecompressedFileSize {
-			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), archive.MaxDecompressedFileSize)
-		}
-
 		data, err := os.ReadFile(name)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)

--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -64,6 +64,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 	files := []*archive.BufferedFile{}
 	topdir += string(filepath.Separator)
+	remaining := archive.MaxDecompressedChartSize
 
 	walk := func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
@@ -100,7 +101,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		data, err := os.ReadFile(name)
+		data, err := archive.ReadFileWithBudget(name, fi.Size(), &remaining)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)
 		}

--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -43,6 +43,10 @@ func (l DirLoader) Load() (*chart.Chart, error) {
 //
 // This loads charts only from directories.
 func LoadDir(dir string) (*chart.Chart, error) {
+	return loadDir(dir, archive.MaxDecompressedChartSize)
+}
+
+func loadDir(dir string, budget int64) (*chart.Chart, error) {
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -64,7 +68,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 
 	files := []*archive.BufferedFile{}
 	topdir += string(filepath.Separator)
-	remaining := archive.MaxDecompressedChartSize
+	budgetReader := archive.NewBudgetedReader(budget)
 
 	walk := func(name string, fi os.FileInfo, err error) error {
 		n := strings.TrimPrefix(name, topdir)
@@ -101,7 +105,7 @@ func LoadDir(dir string) (*chart.Chart, error) {
 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
 		}
 
-		data, err := archive.ReadFileWithBudget(name, fi.Size(), &remaining)
+		data, err := budgetReader.ReadFileWithBudget(name, fi.Size())
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", n, err)
 		}

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -52,11 +52,7 @@ func TestLoadDir(t *testing.T) {
 }
 
 func TestLoadDirExceedsBudget(t *testing.T) {
-	orig := archive.MaxDecompressedChartSize
-	archive.MaxDecompressedChartSize = 1 // 1 byte budget
-	defer func() { archive.MaxDecompressedChartSize = orig }()
-
-	_, err := LoadDir("testdata/frobnitz")
+	_, err := loadDir("testdata/frobnitz", 1)
 	if err == nil {
 		t.Fatal("expected error when chart directory exceeds budget")
 	}

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -51,6 +51,20 @@ func TestLoadDir(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirExceedsBudget(t *testing.T) {
+	orig := archive.MaxDecompressedChartSize
+	archive.MaxDecompressedChartSize = 1 // 1 byte budget
+	defer func() { archive.MaxDecompressedChartSize = orig }()
+
+	_, err := LoadDir("testdata/frobnitz")
+	if err == nil {
+		t.Fatal("expected error when chart directory exceeds budget")
+	}
+	if !strings.Contains(err.Error(), "chart exceeds maximum decompressed size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadDirWithDevNull(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test only works on unix systems with /dev/null present")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #30738

Remove the per-file `MaxDecompressedFileSize` (5 MiB) enforcement. The original limit was added to protect against vulnerabilities in an unmaintained JSON schema library that Helm no longer uses (migrated to `santhosh-tekuri/jsonschema/v6`). The variable itself is deprecated rather than removed for backward compatibility until v5.

Directory-based chart loading (`LoadDir`) previously had no aggregate size protection, unlike archive loading which already enforces `MaxDecompressedChartSize`. This PR adds a shared `ReadFileWithBudget` helper so both v2 and v3 directory loaders track the same 100 MiB total budget, addressing the concern raised in https://github.com/helm/helm/pull/31748#issuecomment-4138927643.

Charts with large individual files (like 8 MB `values.schema.json`) work fine as long as the total stays within `MaxDecompressedChartSize`.

Related:
  - https://github.com/helm/helm/pull/30743

The next step is probably to slightly increase the size limit for archives, as discussed in the Helm Dev Meeting to help users with very big charts to be able to upgrade Helm.

**Special notes for your reviewer**:

1. Do we need to document this?
2. Can you confirm whether we want to backport this change?

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility