### PR TITLE
fix(copystructure): handle nil elements in slice copying

### DIFF
--- a/internal/copystructure/copystructure.go
+++ b/internal/copystructure/copystructure.go
@@ -89,7 +89,15 @@ func copyValue(original reflect.Value) (any, error) {
 		}
 		copied := reflect.MakeSlice(original.Type(), original.Len(), original.Cap())
 		for i := 0; i < original.Len(); i++ {
-			val, err := copyValue(original.Index(i))
+			elem := original.Index(i)
+
+			// Handle nil values in slices (e.g., interface{} elements that are nil)
+			if elem.Kind() == reflect.Interface && elem.IsNil() {
+				copied.Index(i).Set(elem)
+				continue
+			}
+
+			val, err := copyValue(elem)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/copystructure/copystructure_test.go
+++ b/internal/copystructure/copystructure_test.go
@@ -113,6 +113,21 @@ func TestCopy_Slice(t *testing.T) {
 		input[0]["key1"] = "modified"
 		assert.Equal(t, "value1", resultSlice[0]["key1"])
 	})
+
+	t.Run("slice with nil elements", func(t *testing.T) {
+		input := []any{
+			"value1",
+			nil,
+			"value2",
+		}
+		result, err := Copy(input)
+		require.NoError(t, err)
+
+		resultSlice, ok := result.([]any)
+		require.True(t, ok)
+		assert.Equal(t, input, resultSlice)
+		assert.Nil(t, resultSlice[1])
+	})
 }
 
 func TestCopy_Map(t *testing.T) {


### PR DESCRIPTION
Closes #31750

When copying slices containing nil interface{} elements, the copyValue function would panic with `reflect: call of reflect.Value.Set on zero Value`. 

This issue was introduced in v4.1.0 when replacing mitchellh/copystructure with an internal implementation. The fix mirrors the existing nil handling logic used for map values.

Added test case to verify slice elements with nil values are properly handled during deep copy operations.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
