### PR TITLE
fix(template): deprecate unused --hide-notes and --render-subchart-notes flags

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -209,6 +209,26 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in install output. Does not affect presence in chart metadata")
 	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for helm annotations and take ownership of the existing resources")
+
+	// For `helm template`, these notes flags are legacy, unused, and should not show in help, but
+	// must remain accepted for backwards compatibility in Helm 4. Deprecate and hide them for now
+	// TODO remove these from template command in Helm 5
+	if cmd.Name() == "template" {
+		if err := cmd.Flags().MarkDeprecated("hide-notes", "this flag has no effect for 'helm template' and will be removed in Helm 5"); err != nil {
+			log.Fatal(err)
+		}
+		if err := cmd.Flags().MarkHidden("hide-notes"); err != nil {
+			log.Fatal(err)
+		}
+
+		if err := cmd.Flags().MarkDeprecated("render-subchart-notes", "this flag has no effect for 'helm template' and will be removed in Helm 5"); err != nil {
+			log.Fatal(err)
+		}
+		if err := cmd.Flags().MarkHidden("render-subchart-notes"); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	AddWaitFlag(cmd, &client.WaitStrategy)


### PR DESCRIPTION
The --hide-notes and --render-subchart-notes flags have no effect for `helm template` since template output never includes notes. Mark these flags as deprecated and hide them from help output.

The flags are preserved for backwards compatibility in Helm 4 and will be removed in Helm 5.

Fixes #31752

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
