### PR TITLE
fix: prevent warning when using version range constraints

### DIFF
--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -178,7 +178,7 @@ func (i IndexFile) SortEntries() {
 // isVersionRange checks if the version string is a range constraint (e.g., "^1", "~1.10")
 // rather than an exact version (e.g., "1.10.0").
 func isVersionRange(version string) bool {
-	return strings.ContainsAny(version, "^~<>=!*xX") || strings.Contains(version, " || ") || strings.Contains(version, " - ")
+	return strings.ContainsAny(version, "^~<>=!*xX") || strings.Contains(version, "||") || strings.Contains(version, " - ")
 }
 
 // Get returns the ChartVersion for the given name.

--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -223,6 +223,8 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 		if constraint.Check(test) {
 			if len(version) != 0 && !isVersionRange(version) {
 				slog.Warn("unable to find exact version requested; falling back to closest available version", "chart", name, "requested", version, "selected", ver.Version)
+			} else if len(version) != 0 && isVersionRange(version) {
+				slog.Debug("selected version matching constraint", "chart", name, "constraint", version, "selected", ver.Version)
 			}
 			return ver, nil
 		}

--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -175,6 +175,12 @@ func (i IndexFile) SortEntries() {
 	}
 }
 
+// isVersionRange checks if the version string is a range constraint (e.g., "^1", "~1.10")
+// rather than an exact version (e.g., "1.10.0").
+func isVersionRange(version string) bool {
+	return strings.ContainsAny(version, "^~<>=!*xX") || strings.Contains(version, " || ") || strings.Contains(version, " - ")
+}
+
 // Get returns the ChartVersion for the given name.
 //
 // If version is empty, this will return the chart with the latest stable version,
@@ -215,7 +221,7 @@ func (i IndexFile) Get(name, version string) (*ChartVersion, error) {
 		}
 
 		if constraint.Check(test) {
-			if len(version) != 0 {
+			if len(version) != 0 && !isVersionRange(version) {
 				slog.Warn("unable to find exact version requested; falling back to closest available version", "chart", name, "requested", version, "selected", ver.Version)
 			}
 			return ver, nil

--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -178,7 +178,14 @@ func (i IndexFile) SortEntries() {
 // isVersionRange checks if the version string is a range constraint (e.g., "^1", "~1.10")
 // rather than an exact version (e.g., "1.10.0").
 func isVersionRange(version string) bool {
-	return strings.ContainsAny(version, "^~<>=!*xX") || strings.Contains(version, "||") || strings.Contains(version, " - ")
+	if strings.ContainsAny(version, "^~<>=!*") || strings.Contains(version, "||") || strings.Contains(version, " - ") {
+		return true
+	}
+	core := version
+	if idx := strings.IndexAny(version, "-+"); idx != -1 {
+		core = version[:idx]
+	}
+	return strings.ContainsAny(core, "xX")
 }
 
 // Get returns the ChartVersion for the given name.

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -718,3 +718,37 @@ func TestLoadIndex_DuplicateChartDeps(t *testing.T) {
 		})
 	}
 }
+
+func TestIsVersionRange(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"1.0.0", false},
+		{"1.0.0+metadata", false},
+		{"^1", true},
+		{"^1.2.3", true},
+		{"~1.10", true},
+		{"~1.10.0", true},
+		{">= 1.0.0", true},
+		{"> 1.0.0", true},
+		{"< 2.0.0", true},
+		{"<= 2.0.0", true},
+		{"!= 1.0.0", true},
+		{"1.*", true},
+		{"1.x", true},
+		{"1.X", true},
+		{"1.0.0 - 2.0.0", true},
+		{"^1.0.0 || ^2.0.0", true},
+		{">=1.0.0 <2.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := isVersionRange(tt.version)
+			if got != tt.expected {
+				t.Errorf("isVersionRange(%q) = %v, want %v", tt.version, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -726,6 +726,8 @@ func TestIsVersionRange(t *testing.T) {
 	}{
 		{"1.0.0", false},
 		{"1.0.0+metadata", false},
+		{"v1.19.2", false},
+		{"v1", false},
 		{"^1", true},
 		{"^1.2.3", true},
 		{"~1.10", true},
@@ -738,6 +740,8 @@ func TestIsVersionRange(t *testing.T) {
 		{"1.*", true},
 		{"1.x", true},
 		{"1.X", true},
+		{"v1.x", true},
+		{"v1.X", true},
 		{"1.0.0 - 2.0.0", true},
 		{"^1.0.0 || ^2.0.0", true},
 		{">=1.0.0 <2.0.0", true},

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -745,6 +745,10 @@ func TestIsVersionRange(t *testing.T) {
 		{"1.0.0 - 2.0.0", true},
 		{"^1.0.0 || ^2.0.0", true},
 		{">=1.0.0 <2.0.0", true},
+		// Exact versions with 'x'/'X' in prerelease or build metadata
+		{"1.0.0-fix", false},
+		{"2.0.0-next", false},
+		{"1.0.0+exp", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When using version ranges like `^1` or `~1.10`, Helm incorrectly showed warnings about falling back to closest version 😬. Only show the warning when an exact version is requested but not found and move to debug for version range.

Fixes: https://github.com/helm/helm/issues/31757

**Special notes for your reviewer**:

I've also tested via the CLI that all unit test value are working properly. For example:

```sh
bin/helm show chart brigade/brigade --version '^1.8.0 || ^1.9.0' | grep -E '(level=|^version:)'
version: 1.10.0
```

Also other scenarios like

```sh
❯ bin/helm show chart jetstack/cert-manager --version 'v1' | head -1
level=WARN msg="unable to find exact version requested; falling back to closest available version" chart=cert-manager requested=v1 selected=v1.19.2
annotations:

❯ bin/helm show chart jetstack/cert-manager --version 'v1.x' | head -1
annotations:

❯ bin/helm show chart jetstack/cert-manager --version 'v1.x' --debug | head -1
level=DEBUG msg="original chart version" version=v1.x
level=DEBUG msg="set up default downloader cache"
level=DEBUG msg="selected version matching constraint" chart=cert-manager constraint=v1.x selected=v1.19.2
level=DEBUG msg="found chart in cache" id=87e2dafa946bd05c56be897b2fe2e171f2bbfad96c9d48409d4b1188d240af6f
annotations:

❯ bin/helm show chart jetstack/cert-manager --version '^v1' | head -1
annotations:

❯ bin/helm show chart brigade/brigade --version '^1' --debug | grep -E '(level=DEBUG.*selected version)'           
level=DEBUG msg="selected version matching constraint" chart=brigade constraint=^1 selected=1.10.0
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
