### PR TITLE
feat(template): add --skip-chart-dir and --skip-templates-dir flags

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -213,11 +213,11 @@ func splitAndDeannotate(postrendered string) (map[string]string, error) {
 	return reconstructed, nil
 }
 
-// transformManifestPath modifies the manifest path based on the skipChartNameDir and skipTemplatesDir flags.
+// TransformManifestPath modifies the manifest path based on the skipChartNameDir and skipTemplatesDir flags.
 // The input path is typically in the format "chart-name/templates/file.yaml" or "chart-name/charts/subchart/templates/file.yaml"
 // - skipChartNameDir: removes the root chart name directory
 // - skipTemplatesDir: removes all "templates" directories from the path
-func transformManifestPath(name string, skipChartNameDir, skipTemplatesDir bool) string {
+func TransformManifestPath(name string, skipChartNameDir, skipTemplatesDir bool) string {
 	if !skipChartNameDir && !skipTemplatesDir {
 		return name
 	}
@@ -230,6 +230,10 @@ func transformManifestPath(name string, skipChartNameDir, skipTemplatesDir bool)
 	var result []string
 
 	for i, part := range parts {
+		// Skip empty parts (e.g., from leading slash or double slashes)
+		if part == "" {
+			continue
+		}
 		// Skip the first part (chart name) if skipChartNameDir is true
 		if i == 0 && skipChartNameDir {
 			continue
@@ -371,7 +375,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 			if outputDir == "" {
 				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data[:]))
 			} else {
-				transformedName := transformManifestPath(crd.Filename, skipChartNameDir, skipTemplatesDir)
+				transformedName := TransformManifestPath(crd.Filename, skipChartNameDir, skipTemplatesDir)
 				err = writeToFile(outputDir, transformedName, string(crd.File.Data[:]), fileWritten[transformedName])
 				if err != nil {
 					return hs, b, "", err
@@ -397,7 +401,7 @@ func (cfg *Configuration) renderResources(ch *chart.Chart, values common.Values,
 			// output dir is only used by `helm template`. In the next major
 			// release, we should move this logic to template only as it is not
 			// used by install or upgrade
-			transformedName := transformManifestPath(m.Name, skipChartNameDir, skipTemplatesDir)
+			transformedName := TransformManifestPath(m.Name, skipChartNameDir, skipTemplatesDir)
 			err = writeToFile(newDir, transformedName, m.Content, fileWritten[transformedName])
 			if err != nil {
 				return hs, b, "", err

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1064,7 +1064,7 @@ func TestTransformManifestPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := transformManifestPath(tt.input, tt.skipChartNameDir, tt.skipTemplatesDir)
+			result := TransformManifestPath(tt.input, tt.skipChartNameDir, tt.skipTemplatesDir)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -799,7 +799,7 @@ func TestRenderResources_PostRenderer_Success(t *testing.T) {
 
 	hooks, buf, notes, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		mockPR, false, false, false,
+		mockPR, false, false, false, false, false,
 	)
 
 	assert.NoError(t, err)
@@ -842,7 +842,7 @@ func TestRenderResources_PostRenderer_Error(t *testing.T) {
 
 	_, _, _, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		mockPR, false, false, false,
+		mockPR, false, false, false, false, false,
 	)
 
 	assert.Error(t, err)
@@ -870,7 +870,7 @@ func TestRenderResources_PostRenderer_MergeError(t *testing.T) {
 
 	_, _, _, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		mockPR, false, false, false,
+		mockPR, false, false, false, false, false,
 	)
 
 	assert.Error(t, err)
@@ -892,7 +892,7 @@ func TestRenderResources_PostRenderer_SplitError(t *testing.T) {
 
 	_, _, _, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		mockPR, false, false, false,
+		mockPR, false, false, false, false, false,
 	)
 
 	assert.Error(t, err)
@@ -913,7 +913,7 @@ func TestRenderResources_PostRenderer_Integration(t *testing.T) {
 
 	hooks, buf, notes, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		mockPR, false, false, false,
+		mockPR, false, false, false, false, false,
 	)
 
 	assert.NoError(t, err)
@@ -949,7 +949,7 @@ func TestRenderResources_NoPostRenderer(t *testing.T) {
 
 	hooks, buf, notes, err := cfg.renderResources(
 		ch, values, "test-release", "", false, false, false,
-		nil, false, false, false,
+		nil, false, false, false, false, false,
 	)
 
 	assert.NoError(t, err)
@@ -973,4 +973,99 @@ func TestInteractWithServer(t *testing.T) {
 	assert.True(t, interactWithServer(DryRunNone))
 	assert.False(t, interactWithServer(DryRunClient))
 	assert.True(t, interactWithServer(DryRunServer))
+}
+
+func TestTransformManifestPath(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		skipChartNameDir bool
+		skipTemplatesDir bool
+		expected         string
+	}{
+		{
+			name:             "no transformation",
+			input:            "mychart/templates/deployment.yaml",
+			skipChartNameDir: false,
+			skipTemplatesDir: false,
+			expected:         "mychart/templates/deployment.yaml",
+		},
+		{
+			name:             "skip chart name only",
+			input:            "mychart/templates/deployment.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: false,
+			expected:         "templates/deployment.yaml",
+		},
+		{
+			name:             "skip templates dir only",
+			input:            "mychart/templates/deployment.yaml",
+			skipChartNameDir: false,
+			skipTemplatesDir: true,
+			expected:         "mychart/deployment.yaml",
+		},
+		{
+			name:             "skip both chart name and templates dir",
+			input:            "mychart/templates/deployment.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: true,
+			expected:         "deployment.yaml",
+		},
+		{
+			name:             "subchart path - skip chart name",
+			input:            "mychart/charts/subchart/templates/deployment.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: false,
+			expected:         "charts/subchart/templates/deployment.yaml",
+		},
+		{
+			name:             "subchart path - skip templates",
+			input:            "mychart/charts/subchart/templates/deployment.yaml",
+			skipChartNameDir: false,
+			skipTemplatesDir: true,
+			expected:         "mychart/charts/subchart/deployment.yaml",
+		},
+		{
+			name:             "subchart path - skip both",
+			input:            "mychart/charts/subchart/templates/deployment.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: true,
+			expected:         "charts/subchart/deployment.yaml",
+		},
+		{
+			name:             "crds path - skip chart name",
+			input:            "mychart/crds/crd.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: false,
+			expected:         "crds/crd.yaml",
+		},
+		{
+			name:             "crds path - skip templates (no effect)",
+			input:            "mychart/crds/crd.yaml",
+			skipChartNameDir: false,
+			skipTemplatesDir: true,
+			expected:         "mychart/crds/crd.yaml",
+		},
+		{
+			name:             "single filename - skip both returns original",
+			input:            "deployment.yaml",
+			skipChartNameDir: true,
+			skipTemplatesDir: true,
+			expected:         "deployment.yaml",
+		},
+		{
+			name:             "empty string",
+			input:            "",
+			skipChartNameDir: true,
+			skipTemplatesDir: true,
+			expected:         "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transformManifestPath(tt.input, tt.skipChartNameDir, tt.skipTemplatesDir)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -127,6 +127,12 @@ type Install struct {
 	// Used by helm template to add the release as part of OutputDir path
 	// OutputDir/<ReleaseName>
 	UseReleaseName bool
+	// SkipChartNameDir skips adding the chart name directory when writing to OutputDir
+	// When true: OutputDir/templates/file.yaml instead of OutputDir/chart-name/templates/file.yaml
+	SkipChartNameDir bool
+	// SkipTemplatesDir skips adding the "templates" subdirectory when writing to OutputDir
+	// When true: OutputDir/chart-name/file.yaml instead of OutputDir/chart-name/templates/file.yaml
+	SkipTemplatesDir bool
 	// TakeOwnership will ignore the check for helm annotations and take ownership of the resources.
 	TakeOwnership bool
 	PostRenderer  postrenderer.PostRenderer
@@ -355,7 +361,7 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	rel := i.createRelease(chrt, vals, i.Labels)
 
 	var manifestDoc *bytes.Buffer
-	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithServer(i.DryRunStrategy), i.EnableDNS, i.HideSecret)
+	rel.Hooks, manifestDoc, rel.Info.Notes, err = i.cfg.renderResources(chrt, valuesToRender, i.ReleaseName, i.OutputDir, i.SubNotes, i.UseReleaseName, i.IncludeCRDs, i.PostRenderer, interactWithServer(i.DryRunStrategy), i.EnableDNS, i.HideSecret, i.SkipChartNameDir, i.SkipTemplatesDir)
 	// Even for errors, attach this if available
 	if manifestDoc != nil {
 		rel.Manifest = manifestDoc.String()

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -296,7 +296,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chartv2.Chart, vals map[str
 		return nil, nil, false, err
 	}
 
-	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, interactWithServer(u.DryRunStrategy), u.EnableDNS, u.HideSecret)
+	hooks, manifestDoc, notesTxt, err := u.cfg.renderResources(chart, valuesToRender, "", "", u.SubNotes, false, false, u.PostRenderer, interactWithServer(u.DryRunStrategy), u.EnableDNS, u.HideSecret, false, false)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -132,7 +132,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							if client.UseReleaseName {
 								newDir = filepath.Join(client.OutputDir, client.ReleaseName)
 							}
-							transformedPath := transformManifestPath(m.Path, client.SkipChartNameDir, client.SkipTemplatesDir)
+							transformedPath := action.TransformManifestPath(m.Path, client.SkipChartNameDir, client.SkipTemplatesDir)
 							_, err := os.Stat(filepath.Join(newDir, transformedPath))
 							if err == nil {
 								fileWritten[transformedPath] = true
@@ -277,39 +277,4 @@ func ensureDirectoryForFile(file string) error {
 	}
 
 	return os.MkdirAll(baseDir, 0755)
-}
-
-// transformManifestPath modifies the manifest path based on the skipChartNameDir and skipTemplatesDir flags.
-// The input path is typically in the format "chart-name/templates/file.yaml" or "chart-name/charts/subchart/templates/file.yaml"
-// - skipChartNameDir: removes the root chart name directory
-// - skipTemplatesDir: removes all "templates" directories from the path
-func transformManifestPath(name string, skipChartNameDir, skipTemplatesDir bool) string {
-	if !skipChartNameDir && !skipTemplatesDir {
-		return name
-	}
-
-	parts := strings.Split(name, "/")
-	if len(parts) == 0 {
-		return name
-	}
-
-	var result []string
-
-	for i, part := range parts {
-		// Skip the first part (chart name) if skipChartNameDir is true
-		if i == 0 && skipChartNameDir {
-			continue
-		}
-		// Skip "templates" directories if skipTemplatesDir is true
-		if skipTemplatesDir && part == "templates" {
-			continue
-		}
-		result = append(result, part)
-	}
-
-	if len(result) == 0 {
-		return name
-	}
-
-	return strings.Join(result, "/")
 }


### PR DESCRIPTION
## What this PR does / why we need it

Add two new flags to `helm template` to make `--output-dir` fully configurable:

| Flag | Description |
|------|-------------|
| `--skip-chart-dir` | Skips adding the chart name directory |
| `--skip-templates-dir` | Skips adding the `templates` subdirectory |

This allows users to customize the output directory structure for better alignment with GitOps workflows where manifests need to be stored in specific file structures.

### Example
```bash
helm template my-app ./mychart --output-dir gitops/cluster/app \
    --skip-chart-dir --skip-templates-dir
```

### Output paths with different flag combinations

| Flags | Output Path |
|-------|-------------|
| Default (no flags) | `gitops/cluster/app/mychart/templates/deployment.yaml` |
| `--skip-chart-dir` | `gitops/cluster/app/templates/deployment.yaml` |
| `--skip-templates-dir` | `gitops/cluster/app/mychart/deployment.yaml` |
| Both flags | `gitops/cluster/app/deployment.yaml` |

**Fixes #31747**

---

## Special notes for your reviewer

- The `transformManifestPath` helper function handles path transformation
- Works correctly with subcharts — only removes root chart name, preserves `charts/subchart/` structure
- Compatible with existing `--release-name` flag

---

## Checklist

- [x] This PR contains user facing changes
- [x] This PR contains unit tests
- [x] This PR has been tested for backwards compatibility