### PR TITLE
fix: regression when pulling charts from OCI indices

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -566,6 +566,7 @@ func (c *Client) Pull(ref string, options ...PullOption) (*PullResult, error) {
 
 	// Build allowed media types for chart pull
 	allowedMediaTypes := []string{
+		ocispec.MediaTypeImageIndex,
 		ocispec.MediaTypeImageManifest,
 		ConfigMediaType,
 	}

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -73,6 +73,13 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 	suite.True(errors.Is(err, content.ErrMismatchedDigest))
 }
 
+func (suite *HTTPRegistryClientTestSuite) Test_5_ImageIndex() {
+	ref := fmt.Sprintf("%s/testrepo/image-index:0.1.0", suite.FakeRegistryHost)
+
+	_, err := suite.RegistryClient.Pull(ref)
+	suite.Nil(err)
+}
+
 func TestHTTPRegistryClientTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRegistryClientTestSuite))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add `ocispec.MediaTypeImageIndex` to the allowed media types for chart pull, fixing a regression introduced in Helm v3.18.0 that prevents pulling charts from OCI tags referencing an image index. See more details in the issue linked below.

**Special notes for your reviewer**:
I would like to have this backported to Helm v3.

Closes #31775

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
