### PR TITLE
Ensure `--create-namespace` does not modify existing namespaces

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -447,11 +447,22 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 			return nil, err
 		}
 
-		if _, err := i.cfg.KubeClient.Create(
-			resourceList,
-			kube.ClientCreateOptionServerSideApply(i.ServerSideApply, false)); err != nil && !apierrors.IsAlreadyExists(err) {
+		namespaceExist := false
+		_, err = i.cfg.KubeClient.Get(resourceList, false)
+		if err == nil {
+			namespaceExist = true
+		} else if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
+
+		if !namespaceExist {
+			if _, err := i.cfg.KubeClient.Create(
+				resourceList,
+				kube.ClientCreateOptionServerSideApply(i.ServerSideApply, false)); err != nil && !apierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
+		}
+
 	}
 
 	// If Replace is true, we need to supersede the last release.

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -459,7 +459,6 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 				return nil, err
 			}
 		}
-
 	}
 
 	// If Replace is true, we need to supersede the last release.

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -447,15 +447,12 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 			return nil, err
 		}
 
-		namespaceExist := false
-		_, err = i.cfg.KubeClient.Get(resourceList, false)
-		if err == nil {
-			namespaceExist = true
-		} else if !apierrors.IsNotFound(err) {
+		exists, err := namespaceExists(resourceList)
+		if err != nil {
 			return nil, err
 		}
 
-		if !namespaceExist {
+		if !exists {
 			if _, err := i.cfg.KubeClient.Create(
 				resourceList,
 				kube.ClientCreateOptionServerSideApply(i.ServerSideApply, false)); err != nil && !apierrors.IsAlreadyExists(err) {
@@ -485,6 +482,29 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 		rel, err = i.failRelease(rel, err)
 	}
 	return rel, err
+}
+
+func namespaceExists(resourceList kube.ResourceList) (bool, error) {
+	exists := false
+
+	err := resourceList.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+
+		_, err = resource.NewHelper(info.Client, info.Mapping).Get(info.Namespace, info.Name)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		exists = true
+		return nil
+	})
+
+	return exists, err
 }
 
 func (i *Install) performInstallCtx(ctx context.Context, rel *release.Release, toBeAdopted kube.ResourceList, resources kube.ResourceList) (*release.Release, error) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1320,7 +1320,7 @@ func fakeNamespaceResourceList(name string, statusCode int) kube.ResourceList {
 	restClient := &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: "v1"},
 		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		Client: fake.CreateHTTPClient(func(_ *http.Request) (*http.Response, error) {
 			return newNamespaceResponse(statusCode, body), nil
 		}),
 	}
@@ -1369,7 +1369,7 @@ type namespaceInstallKubeClient struct {
 	namespaceCreateCalled bool
 }
 
-func (c *namespaceInstallKubeClient) Build(reader io.Reader, validate bool) (kube.ResourceList, error) {
+func (c *namespaceInstallKubeClient) Build(reader io.Reader, _ bool) (kube.ResourceList, error) {
 	b, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
@@ -1382,7 +1382,7 @@ func (c *namespaceInstallKubeClient) Build(reader io.Reader, validate bool) (kub
 	return kube.ResourceList{}, nil
 }
 
-func (c *namespaceInstallKubeClient) Create(resources kube.ResourceList, options ...kube.ClientCreateOption) (*kube.Result, error) {
+func (c *namespaceInstallKubeClient) Create(resources kube.ResourceList, _ ...kube.ClientCreateOption) (*kube.Result, error) {
 	for _, info := range resources {
 		if info.Name == "spaced" && info.Mapping != nil && info.Mapping.GroupVersionKind.Kind == "Namespace" {
 			c.namespaceCreateCalled = true

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1294,3 +1294,41 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	// Verify that WaitOptions were passed to GetWaiter
 	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
 }
+
+func TestInstall_CreateNamespaceAlreadyExists(t *testing.T) {
+	is := assert.New(t)
+
+	// Namespace already exists in cluster
+	config := actionConfigFixtureWithDummyResources(t, createDummyResourceList(true))
+
+	instAction := installActionWithConfig(config)
+	instAction.CreateNamespace = true
+	instAction.Namespace = "spaced"
+
+	resi, err := instAction.Run(buildChart(), nil)
+	is.NoError(err)
+
+	res, err := releaserToV1Release(resi)
+	is.NoError(err)
+	is.Equal("spaced", res.Namespace)
+	is.Equal("Install complete", res.Info.Description)
+}
+
+func TestInstall_CreateNamespaceNotExists(t *testing.T) {
+	is := assert.New(t)
+
+	// Empty cluster state, thats mean namespace not present
+	config := actionConfigFixture(t)
+
+	instAction := installActionWithConfig(config)
+	instAction.CreateNamespace = true
+	instAction.Namespace = "spaced"
+
+	resi, err := instAction.Run(buildChart(), nil)
+	is.NoError(err)
+
+	res, err := releaserToV1Release(resi)
+	is.NoError(err)
+	is.Equal("spaced", res.Namespace)
+	is.Equal("Install complete", res.Info.Description)
+}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1295,34 +1296,118 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
 }
 
-func TestInstall_CreateNamespaceAlreadyExists(t *testing.T) {
-	is := assert.New(t)
+func fakeNamespaceResourceList(name string, statusCode int) kube.ResourceList {
+	body := kuberuntime.Object(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"custom-label": "keep-me",
+			},
+			Annotations: map[string]string{
+				"custom-annotation": "keep-me",
+			},
+		},
+	})
 
-	// Namespace already exists in cluster
-	config := actionConfigFixtureWithDummyResources(t, createDummyResourceList(true))
+	if statusCode == http.StatusNotFound {
+		body = &metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: metav1.StatusReasonNotFound,
+			Code:   http.StatusNotFound,
+		}
+	}
 
-	instAction := installActionWithConfig(config)
-	instAction.CreateNamespace = true
-	instAction.Namespace = "spaced"
+	restClient := &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Version: "v1"},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			return newNamespaceResponse(statusCode, body), nil
+		}),
+	}
 
-	resi, err := instAction.Run(buildChart(), nil)
-	is.NoError(err)
-
-	res, err := releaserToV1Release(resi)
-	is.NoError(err)
-	is.Equal("spaced", res.Namespace)
-	is.Equal("Install complete", res.Info.Description)
+	return kube.ResourceList{
+		&resource.Info{
+			Client: restClient,
+			Mapping: &meta.RESTMapping{
+				Resource: schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "namespaces",
+				},
+				GroupVersionKind: schema.GroupVersionKind{
+					Version: "v1",
+					Kind:    "Namespace",
+				},
+				Scope: meta.RESTScopeRoot,
+			},
+			Name: name,
+			Object: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			},
+		},
+	}
 }
 
-func TestInstall_CreateNamespaceNotExists(t *testing.T) {
+func newNamespaceResponse(code int, obj kuberuntime.Object) *http.Response {
+	body := kuberuntime.EncodeOrDie(
+		scheme.Codecs.LegacyCodec(schema.GroupVersion{Version: "v1"}),
+		obj,
+	)
+
+	return &http.Response{
+		StatusCode: code,
+		Header: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type namespaceInstallKubeClient struct {
+	*kubefake.FailingKubeClient
+
+	namespaceStatusCode   int
+	namespaceCreateCalled bool
+}
+
+func (c *namespaceInstallKubeClient) Build(reader io.Reader, validate bool) (kube.ResourceList, error) {
+	b, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.Contains(string(b), "kind: Namespace") {
+		return fakeNamespaceResourceList("spaced", c.namespaceStatusCode), nil
+	}
+
+	return kube.ResourceList{}, nil
+}
+
+func (c *namespaceInstallKubeClient) Create(resources kube.ResourceList, options ...kube.ClientCreateOption) (*kube.Result, error) {
+	for _, info := range resources {
+		if info.Name == "spaced" && info.Mapping != nil && info.Mapping.GroupVersionKind.Kind == "Namespace" {
+			c.namespaceCreateCalled = true
+		}
+	}
+
+	return &kube.Result{}, nil
+}
+
+func TestInstall_CreateNamespaceAlreadyExistsSkipsCreate(t *testing.T) {
 	is := assert.New(t)
 
-	// Empty cluster state, thats mean namespace not present
 	config := actionConfigFixture(t)
+	client := &namespaceInstallKubeClient{
+		FailingKubeClient: &kubefake.FailingKubeClient{
+			PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
+		},
+		namespaceStatusCode: http.StatusOK,
+	}
+	config.KubeClient = client
 
 	instAction := installActionWithConfig(config)
 	instAction.CreateNamespace = true
 	instAction.Namespace = "spaced"
+	instAction.ServerSideApply = true
 
 	resi, err := instAction.Run(buildChart(), nil)
 	is.NoError(err)
@@ -1331,4 +1416,34 @@ func TestInstall_CreateNamespaceNotExists(t *testing.T) {
 	is.NoError(err)
 	is.Equal("spaced", res.Namespace)
 	is.Equal("Install complete", res.Info.Description)
+
+	is.False(client.namespaceCreateCalled, "existing namespace should not be created/applied again")
+}
+
+func TestInstall_CreateNamespaceNotExistsCreatesNamespace(t *testing.T) {
+	is := assert.New(t)
+
+	config := actionConfigFixture(t)
+	client := &namespaceInstallKubeClient{
+		FailingKubeClient: &kubefake.FailingKubeClient{
+			PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
+		},
+		namespaceStatusCode: http.StatusNotFound,
+	}
+	config.KubeClient = client
+
+	instAction := installActionWithConfig(config)
+	instAction.CreateNamespace = true
+	instAction.Namespace = "spaced"
+	instAction.ServerSideApply = true
+
+	resi, err := instAction.Run(buildChart(), nil)
+	is.NoError(err)
+
+	res, err := releaserToV1Release(resi)
+	is.NoError(err)
+	is.Equal("spaced", res.Namespace)
+	is.Equal("Install complete", res.Info.Description)
+
+	is.True(client.namespaceCreateCalled, "missing namespace should be created")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When using `--create-namespace` with Helm, the chart tries to create the namespace if it doesn’t exist. With server-side apply (--server-side), Helm was previously trying to apply the namespace even if it already existed. This could overwrite or remove existing labels and annotations, which is not expected.

This PR fixes that by first checking if the namespace already exists. If it does, Helm skips creating it. If it doesn’t, Helm creates it (using server-side apply if requested). This makes `--create-namespace` idempotent and ensures existing namespace are left unchange.

closes #31767 
**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
