### PR TITLE
docs: clarify error message for invalid --set syntax

### DIFF
--- a/pkg/strvals/parser.go
+++ b/pkg/strvals/parser.go
@@ -431,7 +431,7 @@ func (t *parser) listItem(list []interface{}, i, nestedNameLevel int) ([]interfa
 		}
 		return setIndex(list, i, inner)
 	default:
-		return nil, fmt.Errorf("parse error: unexpected token %v", last)
+		return nil, fmt.Errorf("invalid --set syntax: unexpected token %q while parsing list or nested key", last)
 	}
 }
 


### PR DESCRIPTION
This PR improves a vague parse error message in pkg/strvals/parser.go by making it clearer that the failure is due to invalid --set syntax and by explaining what was being parsed. This makes Helm errors more actionable for users.

