### PR TITLE
refactor(downloader): use constructor in loadChartRepositories

### DIFF
--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -835,10 +835,11 @@ func (m *Manager) loadChartRepositories() (map[string]*repo.ChartRepository, err
 		}
 
 		// TODO: use constructor
-		cr := &repo.ChartRepository{
-			Config:    re,
-			IndexFile: index,
+		cr, err := repo.NewChartRepository(re, m.Getters)
+		if err != nil {
+			return indices, err
 		}
+		cr.IndexFile = index
 		indices[lname] = cr
 	}
 	return indices, nil

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -31,6 +31,7 @@ import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
+	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/repo/v1"
 	"helm.sh/helm/v4/pkg/repo/v1/repotest"
@@ -61,6 +62,7 @@ func TestFindChartURL(t *testing.T) {
 		Out:              &b,
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
+		Getters:          getter.All(cli.New()),
 	}
 	repos, err := m.loadChartRepositories()
 	if err != nil {
@@ -235,6 +237,7 @@ func TestDownloadAll(t *testing.T) {
 		RepositoryConfig: repoConfig,
 		RepositoryCache:  repoCache,
 		ChartPath:        chartPath,
+		Getters:          getter.All(cli.New()),
 	}
 	signtest, err := loader.LoadDir(filepath.Join("testdata", "signtest"))
 	if err != nil {


### PR DESCRIPTION
### Description
Resolves a TODO in `pkg/downloader/manager.go` by replacing manual struct initialization with `repo.NewChartRepository`.

This ensures that the `ChartRepository` is always initialized with the correct getters and HTTP client configuration, preventing potential nil pointer issues with missing clients.

### Changes
- **pkg/downloader**: Replaced `&repo.ChartRepository{}` with `repo.NewChartRepository`.
- **pkg/downloader/test**: Updated `TestFindChartURL` and `TestDownloadAll` to properly initialize the `Manager` with `getter.All(cli.New())`. The previous tests were passing an empty Getters list, which caused the new safer logic to correctly fail.

### Testing
- Ran `make build` (Success)
- Ran `go test -v ./pkg/downloader` (All Pass)