### PR TITLE
Refactor duplicate template code

### DIFF
--- a/pkg/action/filewriter.go
+++ b/pkg/action/filewriter.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const defaultDirectoryPermission = 0755
+
+// WriteManifestToFile writes the manifest data to a file in the output directory.
+// If appendData is true, the data will be appended to an existing file; otherwise, a new file is created.
+func WriteManifestToFile(outputDir string, name string, data string, appendData bool) error {
+	outfileName := strings.Join([]string{outputDir, name}, string(filepath.Separator))
+
+	err := ensureDirectoryForFile(outfileName)
+	if err != nil {
+		return err
+	}
+
+	f, err := createOrOpenFile(outfileName, appendData)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", name, data)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("wrote %s\n", outfileName)
+	return nil
+}
+
+// createOrOpenFile creates a new file or opens an existing file for appending.
+func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
+	if appendData {
+		return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
+	}
+	return os.Create(filename)
+}
+
+// ensureDirectoryForFile checks if the directory exists to create file. Creates it if it doesn't exist.
+func ensureDirectoryForFile(file string) error {
+	baseDir := filepath.Dir(file)
+	_, err := os.Stat(baseDir)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	return os.MkdirAll(baseDir, defaultDirectoryPermission)
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
@@ -67,8 +66,6 @@ import (
 // wants to see this file after rendering in the status command. However, it must be a suffix
 // since there can be filepath in front of it.
 const notesFileSuffix = "NOTES.txt"
-
-const defaultDirectoryPermission = 0755
 
 // Install performs an installation operation.
 type Install struct {
@@ -694,50 +691,6 @@ func (i *Install) replaceRelease(rel *release.Release) error {
 	// For any other status, mark it as superseded and store the old record
 	last.SetStatus(rcommon.StatusSuperseded, "superseded by new release")
 	return i.recordRelease(last)
-}
-
-// write the <data> to <output-dir>/<name>. <appendData> controls if the file is created or content will be appended
-func writeToFile(outputDir string, name string, data string, appendData bool) error {
-	outfileName := strings.Join([]string{outputDir, name}, string(filepath.Separator))
-
-	err := ensureDirectoryForFile(outfileName)
-	if err != nil {
-		return err
-	}
-
-	f, err := createOrOpenFile(outfileName, appendData)
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	_, err = fmt.Fprintf(f, "---\n# Source: %s\n%s\n", name, data)
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("wrote %s\n", outfileName)
-	return nil
-}
-
-func createOrOpenFile(filename string, appendData bool) (*os.File, error) {
-	if appendData {
-		return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
-	}
-	return os.Create(filename)
-}
-
-// check if the directory exists to create file. creates if doesn't exist
-func ensureDirectoryForFile(file string) error {
-	baseDir := filepath.Dir(file)
-	_, err := os.Stat(baseDir)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
-	return os.MkdirAll(baseDir, defaultDirectoryPermission)
 }
 
 // NameAndChart returns the name and chart that should be used.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
---
Signed-off-by: Krish Srivastava [krish22092003@gmail.com](mailto:krish22092003@gmail.com)

**What this PR does / why we need it**:

This PR refactors the `renderResources` method in `pkg/action/action.go` and eliminates duplicate file I/O code to improve code organization and maintainability by:

1. **Breaking down the monolithic `renderResources` function**: Split the 159-line function into smaller, focused helper methods:
   - `renderTemplates()` - Handles template rendering with appropriate engine setup
   - `extractNotes()` - Extracts NOTES.txt files from rendered templates
   - `applyPostRenderer()` - Applies post-renderer transformations
   - `writeRenderedOutput()` - Writes manifests and CRDs to buffer or files

2. **Consolidating duplicate file I/O code**: Created `pkg/action/filewriter.go` with shared file writing utilities:
   - `WriteManifestToFile()` - Public API for writing manifest files
   - Removed duplicate implementations from `pkg/action/install.go` and `pkg/cmd/template.go`

4. **Resolving technical debt**: Addresses the TODO comments in `action.go` that called for refactoring and removal of duplicate code

These changes improve code readability, reduce duplication (DRY principle), and make the codebase more maintainable without altering any external behavior or APIs.

---

**Special notes for your reviewer**:

- The refactoring maintains 100% backward compatibility - no user-facing changes
- All existing tests pass without modification (202+ tests in pkg/action)
- The public API of `renderResources` remains unchanged - all existing callers work without modification
- This addresses long-standing TODO comments requesting this refactoring
- Each extracted function now has a single, clear responsibility (Single Responsibility Principle)

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so) - **No user-facing changes**
- [x] this PR contains unit tests - **Yes, existing comprehensive tests verify the refactoring**
- [x] this PR has been tested for backwards compatibility - **Yes, all 202+ existing tests pass**

---