### PR TITLE
`--all`/`-a` flag added to `helm list` command

### DIFF
--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -300,11 +300,6 @@ func (l *List) filterSelector(releases []*release.Release, selector labels.Selec
 
 // SetStateMask calculates the state mask based on parameters.
 func (l *List) SetStateMask() {
-	if l.All {
-		l.StateMask = ListAll
-		return
-	}
-
 	state := ListStates(0)
 	if l.Deployed {
 		state |= ListDeployed

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -134,10 +134,9 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVar(&client.Offset, "offset", 0, "next release index in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
 	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Works only for secret(default) and configmap storage backends.")
-	f.BoolVarP(&client.All, "all", "a", false, "show all releases without any filter applied")
+	f.BoolVarP(&client.All, "all", "a", true, "show all releases without any filter applied")
 	bindOutputFlag(cmd, &outfmt)
-
-	f.MarkDeprecated("all", "this flag is no longer needed; 'helm list' shows all releases by default and it will be removed in a future release")
+	f.MarkHidden("all")
 
 	return cmd
 }

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -134,7 +134,10 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.IntVar(&client.Offset, "offset", 0, "next release index in the list, used to offset from start value")
 	f.StringVarP(&client.Filter, "filter", "f", "", "a regular expression (Perl compatible). Any releases that match the expression will be included in the results")
 	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Works only for secret(default) and configmap storage backends.")
+	f.BoolVarP(&client.All, "all", "a", false, "show all releases without any filter applied")
 	bindOutputFlag(cmd, &outfmt)
+
+	f.MarkDeprecated("all", "this flag is no longer needed; 'helm list' shows all releases by default and it will be removed in a future release")
 
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR has re-added `--all`/`-a` flag to `helm list` command.  In v4, helm list was changed to show all releases by default, making the --all/-a CLI flag obsolete. But removal of the flag was a breaking change that was not called out in the release notes. 

**Special notes for your reviewer**:
Backwards compatibility has been taken care.

closes #31784 
**If applicable**:
- [x] this PR has been tested for backwards compatibility
