### PR TITLE
fix(postrenderer): correctly serialize manifests for WASM plugins

### DIFF
--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -255,7 +255,7 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 
 	go func() {
 		defer stdin.Close()
-		io.Copy(stdin, msg.Manifests)
+		io.Copy(stdin, bytes.NewBufferString(msg.Manifests))
 	}()
 
 	postRendered := &bytes.Buffer{}
@@ -272,7 +272,7 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 
 	return &Output{
 		Message: schema.OutputMessagePostRendererV1{
-			Manifests: postRendered,
+			Manifests: postRendered.String(),
 		},
 	}, nil
 }

--- a/internal/plugin/schema/postrenderer.go
+++ b/internal/plugin/schema/postrenderer.go
@@ -16,19 +16,15 @@ limitations under the License.
 
 package schema
 
-import (
-	"bytes"
-)
-
 // InputMessagePostRendererV1 implements Input.Message
 type InputMessagePostRendererV1 struct {
-	Manifests *bytes.Buffer `json:"manifests"`
+	Manifests string   `json:"manifests"`
 	// from CLI --post-renderer-args
 	ExtraArgs []string `json:"extraArgs"`
 }
 
 type OutputMessagePostRendererV1 struct {
-	Manifests *bytes.Buffer `json:"manifests"`
+	Manifests string   `json:"manifests"`
 }
 
 type ConfigPostRendererV1 struct{}

--- a/pkg/postrenderer/postrenderer.go
+++ b/pkg/postrenderer/postrenderer.go
@@ -64,7 +64,7 @@ func (r *postRendererPlugin) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer
 	input := &plugin.Input{
 		Message: schema.InputMessagePostRendererV1{
 			ExtraArgs: r.args,
-			Manifests: renderedManifests,
+			Manifests: renderedManifests.String(),
 		},
 	}
 	output, err := r.plugin.Invoke(context.Background(), input)
@@ -76,9 +76,9 @@ func (r *postRendererPlugin) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer
 
 	// If the binary returned almost nothing, it's likely that it didn't
 	// successfully render anything
-	if len(bytes.TrimSpace(outputMessage.Manifests.Bytes())) == 0 {
+	if len(bytes.TrimSpace([]byte(outputMessage.Manifests))) == 0 {
 		return nil, fmt.Errorf("post-renderer %q produced empty output", r.plugin.Metadata().Name)
 	}
 
-	return outputMessage.Manifests, nil
+	return bytes.NewBufferString(outputMessage.Manifests), nil
 }


### PR DESCRIPTION
closes #31832

WASM post-renderer plugins were receiving empty manifests because bytes.Buffer does not serialize its contents when encoded to JSON.

This change updates the schema to use string for manifests and performs conversion between string and bytes.Buffer at the runtime boundaries so manifests are correctly passed to and returned from WASM post-renderer plugins.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**What this PR does / why we need it**:
Fixes an issue where WASM post-renderer plugins receive empty manifests due to incorrect JSON serialization of bytes.Buffer.

The manifests field was defined as *bytes.Buffer in the plugin schema. Since bytes.Buffer does not serialize its contents when encoded to JSON, it resulted in an empty object ({}) being passed to the WASM plugin instead of the rendered manifests.

This PR updates the schema to use string for manifests and performs conversion between string and bytes.Buffer at the runtime boundaries. This ensures manifests are correctly passed to and returned from WASM post-renderer plugins.

Reproduction using a minimal WASM echo post-renderer plugin:
Before fix (debug output):
`plugin input: {"manifests":{},"extraArgs":[]}`

This resulted in:
`post-renderer "echo-postrender" produced empty output`

After fix:
`plugin input: {"manifests":"apiVersion: apps/v1\nkind: Deployment\n...","extraArgs":[]}`
The plugin now correctly receives manifests and Helm renders output successfully.


**Special notes for your reviewer**:
This change only affects serialization at the plugin runtime boundary and preserves Helm’s internal use of bytes.Buffer. The fix was verified locally by reproducing the issue using a minimal WASM post-renderer plugin and confirming manifests are correctly passed and returned.



**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility