### PR TITLE
dependency update: add untar flags with safe extraction flow

### DIFF
--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -35,6 +35,8 @@ import (
 // It provides the implementation of 'helm dependency' and its respective subcommands.
 type Dependency struct {
 	Verify                bool
+	Untar                 bool
+	UntarDir              string
 	Keyring               string
 	SkipRefresh           bool
 	ColumnWidth           uint
@@ -51,6 +53,7 @@ type Dependency struct {
 func NewDependency() *Dependency {
 	return &Dependency{
 		ColumnWidth: 80,
+		UntarDir:    "charts",
 	}
 }
 

--- a/pkg/cmd/dependency.go
+++ b/pkg/cmd/dependency.go
@@ -134,7 +134,7 @@ func addDependencySubcommandFlags(f *pflag.FlagSet, client *action.Dependency, w
 	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use insecure HTTP connections for the chart download")
 	f.StringVar(&client.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 	if withUntar {
-		f.BoolVar(&client.Untar, "untar", false, "if set to true, will untar the dependency charts after downloading them and remove the chart archives")
+		f.BoolVar(&client.Untar, "untar", false, "if set to true, will untar dependency charts after downloading them; with the default --untardir (charts/), chart archives are removed after extraction")
 		f.StringVar(&client.UntarDir, "untardir", "charts", "if untar is specified, this flag specifies the directory (relative to chart root) into which dependencies are expanded")
 	}
 }

--- a/pkg/cmd/dependency.go
+++ b/pkg/cmd/dependency.go
@@ -122,7 +122,7 @@ func newDependencyListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func addDependencySubcommandFlags(f *pflag.FlagSet, client *action.Dependency) {
+func addDependencySubcommandFlags(f *pflag.FlagSet, client *action.Dependency, withUntar bool) {
 	f.BoolVar(&client.Verify, "verify", false, "verify the packages against signatures")
 	f.StringVar(&client.Keyring, "keyring", defaultKeyring(), "keyring containing public keys")
 	f.BoolVar(&client.SkipRefresh, "skip-refresh", false, "do not refresh the local repository cache")
@@ -133,4 +133,8 @@ func addDependencySubcommandFlags(f *pflag.FlagSet, client *action.Dependency) {
 	f.BoolVar(&client.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
 	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use insecure HTTP connections for the chart download")
 	f.StringVar(&client.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	if withUntar {
+		f.BoolVar(&client.Untar, "untar", false, "if set to true, will untar the dependency charts after downloading them and remove the chart archives")
+		f.StringVar(&client.UntarDir, "untardir", "charts", "if untar is specified, this flag specifies the directory (relative to chart root) into which dependencies are expanded")
+	}
 }

--- a/pkg/cmd/dependency_build.go
+++ b/pkg/cmd/dependency_build.go
@@ -86,7 +86,7 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	addDependencySubcommandFlags(f, client)
+	addDependencySubcommandFlags(f, client, false)
 
 	return cmd
 }

--- a/pkg/cmd/dependency_update.go
+++ b/pkg/cmd/dependency_update.go
@@ -68,6 +68,8 @@ func newDependencyUpdateCmd(_ *action.Configuration, out io.Writer) *cobra.Comma
 				Out:              out,
 				ChartPath:        chartpath,
 				Keyring:          client.Keyring,
+				Untar:            client.Untar,
+				UntarDir:         client.UntarDir,
 				SkipUpdate:       client.SkipRefresh,
 				Getters:          getter.All(settings),
 				RegistryClient:   registryClient,
@@ -84,7 +86,7 @@ func newDependencyUpdateCmd(_ *action.Configuration, out io.Writer) *cobra.Comma
 	}
 
 	f := cmd.Flags()
-	addDependencySubcommandFlags(f, client)
+	addDependencySubcommandFlags(f, client, true)
 
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds unpacked dependency workflow support to `helm dependency update` with safer extraction behavior.

- adds `--untar` and `--untardir` flags to `helm dependency update`
- extracts dependency archives into directories (including alias targets)
- keeps repeated `dependency update --untar` runs idempotent by replacing existing extracted directories
- restricts `--untardir` to remain within chart root, including symlink-escape checks
- limits stale unpacked-chart cleanup to default `charts/` root
- with default `--untardir` (`charts/`), untar flow removes dependency archives after extraction

**Special notes for your reviewer**:

- `helm dependency build` behavior is unchanged (no untar flags added there)
- added targeted tests for untar behavior, cleanup safety, and local-dependency preservation
- local validation included focused tests, race test, full `go test ./...`, and CLI E2E scenarios

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
