### PR TITLE
fix: clarify coalesce warnings about maps vs non-maps

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: Not a map/object.", subPrefix, key)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true
@@ -347,10 +347,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: destination for %s is a non-map value (type: %T). Ignoring map/object value (%v)", fullkey, dv, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a map/object. Ignoring non-map value (%v)", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -720,9 +720,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a map/object.")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a map/object. Ignoring non-map value (true)")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.sail is a non-map value (type: bool). Ignoring map/object value (map[cotton:true])")
 }
 
 func TestConcatPrefix(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #11118

This PR improves the clarity of coalesce warning messages by replacing the ambiguous terms "table/non-table" with clearer and more accurate terminology "map/object" and "non-map value".

The previous wording could be confusing to users unfamiliar with Helm's internal terminology. Since Helm operates on YAML structures, using "map/object" better reflects the actual data type and improves the user experience when troubleshooting configuration issues.

This PR also updates the corresponding unit tests to match the revised warning messages.

No functional behavior has been changed. This is strictly a user-facing message clarity improvement.

**Special notes for your reviewer**:

- Only warning message strings and unit test expectations were updated.
- No functional or logic changes were made.
- All tests pass locally using `go test ./...`.

**If applicable**:

- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility