### PR TITLE
feat: helm performance improvement by deep copying coalesce globals

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"log"
-	"maps"
 
 	"helm.sh/helm/v4/internal/copystructure"
 	chart "helm.sh/helm/v4/pkg/chart"
@@ -160,7 +159,8 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	// tables in globals.
 	for key, val := range sg {
 		if istable(val) {
-			vv := copyMap(val.(map[string]any))
+			valCopy, _ := copystructure.Copy(val)
+			vv := valCopy.(map[string]interface{})
 			if destv, ok := dg[key]; !ok {
 				// Here there is no merge. We're just adding.
 				dg[key] = vv
@@ -189,11 +189,6 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	dest[common.GlobalKey] = dg
 }
 
-func copyMap(src map[string]any) map[string]any {
-	m := make(map[string]any, len(src))
-	maps.Copy(m, src)
-	return m
-}
 
 // coalesceValues builds up a values map for a particular chart.
 //

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -137,8 +137,6 @@ func coalesceDeps(printf printFn, chrt chart.Charter, dest map[string]any, prefi
 }
 
 // coalesceGlobals copies the globals out of src and merges them into dest.
-//
-// For convenience, returns dest.
 func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ bool) error {
 	var dg, sg map[string]any
 

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -121,7 +121,10 @@ func coalesceDeps(printf printFn, chrt chart.Charter, dest map[string]any, prefi
 			dvmap := dv.(map[string]any)
 			subPrefix := concatPrefix(prefix, ch.Name())
 			// Get globals out of dest and merge them into dvmap.
-			coalesceGlobals(printf, dvmap, dest, subPrefix, merge)
+			err = coalesceGlobals(printf, dvmap, dest, subPrefix, merge)
+			if err != nil {
+				return dest, err
+			}
 			// Now coalesce the rest of the values.
 			var err error
 			dest[sub.Name()], err = coalesce(printf, subchart, dvmap, subPrefix, merge)
@@ -136,21 +139,21 @@ func coalesceDeps(printf printFn, chrt chart.Charter, dest map[string]any, prefi
 // coalesceGlobals copies the globals out of src and merges them into dest.
 //
 // For convenience, returns dest.
-func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ bool) {
+func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ bool) error {
 	var dg, sg map[string]any
 
 	if destglob, ok := dest[common.GlobalKey]; !ok {
 		dg = make(map[string]any)
 	} else if dg, ok = destglob.(map[string]any); !ok {
 		printf("warning: skipping globals because destination %s is not a table.", common.GlobalKey)
-		return
+		return nil
 	}
 
 	if srcglob, ok := src[common.GlobalKey]; !ok {
 		sg = make(map[string]any)
 	} else if sg, ok = srcglob.(map[string]any); !ok {
 		printf("warning: skipping globals because source %s is not a table.", common.GlobalKey)
-		return
+		return nil
 	}
 
 	// EXPERIMENTAL: In the past, we have disallowed globals to test tables. This
@@ -159,8 +162,15 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	// tables in globals.
 	for key, val := range sg {
 		if istable(val) {
-			valCopy, _ := copystructure.Copy(val)
-			vv := valCopy.(map[string]interface{})
+			valCopy, err := copystructure.Copy(val)
+			if err != nil {
+				return err
+			}
+			vv, ok := valCopy.(map[string]any)
+			if !ok {
+				printf("warning: unable to convert globals copy to Helm values type")
+				continue
+			}
 			if destv, ok := dg[key]; !ok {
 				// Here there is no merge. We're just adding.
 				dg[key] = vv
@@ -187,6 +197,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 		}
 	}
 	dest[common.GlobalKey] = dg
+	return nil
 }
 
 

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -164,7 +164,8 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 		if istable(val) {
 			valCopy, err := copystructure.Copy(val)
 			if err != nil {
-				return err
+				fullPath := concatPrefix(prefix, key)
+				return fmt.Errorf("copying globals for %s: %w", fullPath, err)
 			}
 			vv, ok := valCopy.(map[string]any)
 			if !ok {

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -199,7 +199,6 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	return nil
 }
 
-
 // coalesceValues builds up a values map for a particular chart.
 //
 // Values in v will override the values in the chart.

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -168,6 +168,10 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 				printf("warning: unable to convert globals copy to Helm values type")
 				continue
 			}
+			// Ensure vv is a non-nil map so that merges into it are not lost.
+			if vv == nil {
+				vv = make(map[string]any)
+			}
 			if destv, ok := dg[key]; !ok {
 				// Here there is no merge. We're just adding.
 				dg[key] = vv

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -121,12 +121,10 @@ func coalesceDeps(printf printFn, chrt chart.Charter, dest map[string]any, prefi
 			dvmap := dv.(map[string]any)
 			subPrefix := concatPrefix(prefix, ch.Name())
 			// Get globals out of dest and merge them into dvmap.
-			err = coalesceGlobals(printf, dvmap, dest, subPrefix, merge)
-			if err != nil {
+			if err := coalesceGlobals(printf, dvmap, dest, subPrefix, merge); err != nil {
 				return dest, err
 			}
 			// Now coalesce the rest of the values.
-			var err error
 			dest[sub.Name()], err = coalesce(printf, subchart, dvmap, subPrefix, merge)
 			if err != nil {
 				return dest, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Resolves : https://github.com/helm/helm/issues/31865

**What this PR does / why we need it**:
This PR uses deep copy in coalesceGlobals instead of shallow copy.

Due to this change, helm command's performance got massive improvement (both in time & memory consumption)

**Special notes for your reviewer**:
This change is being used within my company since a very long time (was being used in helm v3 also), so I suggest to make this change in helm v4 which will be a huge performance improvement.

Moreover, I am below sharing some performance difference while executing helm commands with/without this perf change on big bundles of my company (can not share the bundle).


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

  | helm-package | helm-template | helm-lint | helm-install:dry | helm-install
-- | -- | -- | -- | -- | --
Helm v3 | >35min (Needs very high memory)   | >40min (Needs very high memory)  |   |>40min (Needs very high memory) |  
Helm v3-perf |   | 4min 53sec | 3min 45sec | 5min 51sec | 5min 33sec
Helm v4 |   | 36min 21sec(Needs very high memory) | 31 sec | 34min 21sec |  
Helm v4-perf | 3min (around)  | 1min 44sec | 16sec | 2min 51sec |  

</body>

</html>



**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
