### PR TITLE
fix: skip waiting for Jobs with TTL in status watcher

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -33,6 +33,7 @@ import (
 	"github.com/fluxcd/cli-utils/pkg/kstatus/watcher"
 	"github.com/fluxcd/cli-utils/pkg/object"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -177,6 +178,10 @@ func (w *statusWaiter) wait(ctx context.Context, resourceList ResourceList, sw w
 		switch value := AsVersioned(resource).(type) {
 		case *appsv1.Deployment:
 			if value.Spec.Paused {
+				continue
+			}
+		case *batchv1.Job:
+			if value.Spec.TTLSecondsAfterFinished != nil {
 				continue
 			}
 		}

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -123,6 +123,23 @@ status:
     message: "Job has reached the specified backoff limit"
 `
 
+var jobWithTTLManifest = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-with-ttl
+  namespace: default
+  generation: 1
+spec:
+  ttlSecondsAfterFinished: 0
+status:
+  succeeded: 1
+  active: 0
+  conditions:
+  - type: Complete
+    status: "True"
+`
+
 var podCompleteManifest = `
 apiVersion: v1
 kind: Pod
@@ -412,6 +429,10 @@ func TestStatusWait(t *testing.T) {
 			name:         "paused deployment passes",
 			objManifests: []string{pausedDeploymentManifest},
 		},
+		{
+			name:         "job with TTL is skipped",
+			objManifests: []string{jobWithTTLManifest},
+		},
 	}
 
 	for _, tt := range tests {
@@ -470,6 +491,10 @@ func TestWaitForJobComplete(t *testing.T) {
 			name:          "Job is ready but not complete",
 			objManifests:  []string{jobReadyManifest},
 			expectErrStrs: []string{"resource Job/default/ready-not-complete not ready. status: InProgress", "context deadline exceeded"},
+		},
+		{
+			name:         "job with TTL is skipped",
+			objManifests: []string{jobWithTTLManifest},
 		},
 	}
 
@@ -531,6 +556,10 @@ func TestWatchForReady(t *testing.T) {
 			name:          "Fails if pod is not complete",
 			objManifests:  []string{podCurrentManifest},
 			expectErrStrs: []string{"resource Pod/ns/current-pod not ready. status: InProgress", "context deadline exceeded"},
+		},
+		{
+			name:         "job with TTL is skipped",
+			objManifests: []string{jobWithTTLManifest},
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a regression where the kstatus watcher in Helm 4 would get stuck waiting for Jobs that have `ttlSecondsAfterFinished` set. These Jobs are automatically deleted by the TTL controller after completion, causing the watcher to see `NotFound` status and timeout.

## Changes

- Added a case in the `wait` function to skip waiting for Jobs that have `TTLSecondsAfterFinished` set
- Added unit tests for `Wait`, `WaitWithJobs`, and `WatchUntilReady` methods to verify Jobs with TTL are properly skipped

## Technical Details

Jobs with `.spec.ttlSecondsAfterFinished` get deleted by the TTL controller after they finish. The kstatus watcher would wait for these Jobs to reach "Current" status, but after the TTL controller deletes them, the status becomes "NotFound", causing the wait to timeout.

The fix follows the same pattern used for paused Deployments - simply skip adding these resources to the watch list. This matches the behavior from the legacy Helm 3 waiter which ignored deleted hooks.

## Testing

- Added test cases for Jobs with TTL in:
  - `TestStatusWait`
  - `TestWaitForJobComplete`
  - `TestWatchForReady`
- All existing tests pass

Fixes #31786