### PR TITLE
fix(sdk): correct import comment in statuswait.go from v3 to v4

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v3/pkg/kube"
+package kube // import "helm.sh/helm/v4/pkg/kube"
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the Go import comment in `pkg/kube/statuswait.go` from `helm.sh/helm/v3/pkg/kube` to `helm.sh/helm/v4/pkg/kube`, matching every other file in the package. The stale v3 comment causes downstream tooling errors (e.g. kythe) when the module is vendored, since two conflicting import comments exist in the same package directory.

Fixes #31846

**Special notes for your reviewer**:

Single-line change — only the import path comment is updated.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility