### PR TITLE
refactor: Replace non-format use of t.Fatalf with t.Fatal

### DIFF
--- a/internal/chart/v3/lint/lint_test.go
+++ b/internal/chart/v3/lint/lint_test.go
@@ -231,7 +231,7 @@ func TestMalformedTemplate(t *testing.T) {
 	}()
 	select {
 	case <-c:
-		t.Fatalf("lint malformed template timeout")
+		t.Fatal("lint malformed template timeout")
 	case <-ch:
 		if len(m) != 1 {
 			t.Fatalf("All didn't fail with expected errors, got %#v", m)

--- a/internal/chart/v3/util/chartfile_test.go
+++ b/internal/chart/v3/util/chartfile_test.go
@@ -64,7 +64,7 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	}
 
 	if len(f.Sources) != 1 {
-		t.Fatalf("Unexpected number of sources")
+		t.Fatal("Unexpected number of sources")
 	}
 
 	if f.Sources[0] != "https://example.com/foo/bar" {
@@ -84,7 +84,7 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	}
 
 	if len(f.Annotations) != 2 {
-		t.Fatalf("Unexpected annotations")
+		t.Fatal("Unexpected annotations")
 	}
 
 	if want, got := "extravalue", f.Annotations["extrakey"]; want != got {

--- a/internal/chart/v3/util/dependencies_test.go
+++ b/internal/chart/v3/util/dependencies_test.go
@@ -385,7 +385,7 @@ func TestGetAliasDependency(t *testing.T) {
 	req := c.Metadata.Dependencies
 
 	if len(req) == 0 {
-		t.Fatalf("there are no dependencies to test")
+		t.Fatal("there are no dependencies to test")
 	}
 
 	// Success case
@@ -403,7 +403,7 @@ func TestGetAliasDependency(t *testing.T) {
 
 	if req[0].Version != "" {
 		if !IsCompatibleRange(req[0].Version, aliasChart.Metadata.Version) {
-			t.Fatalf("dependency chart version is not in the compatible range")
+			t.Fatal("dependency chart version is not in the compatible range")
 		}
 	}
 
@@ -415,7 +415,7 @@ func TestGetAliasDependency(t *testing.T) {
 
 	req[0].Version = "something else which is not in the compatible range"
 	if IsCompatibleRange(req[0].Version, aliasChart.Metadata.Version) {
-		t.Fatalf("dependency chart version which is not in the compatible range should cause a failure other than a success ")
+		t.Fatal("dependency chart version outside the compatible range should not be considered compatible")
 	}
 }
 

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -87,7 +87,7 @@ func TestSave(t *testing.T) {
 				t.Fatalf("Schema data did not match.\nExpected:\n%s\nActual:\n%s", formattedExpected, formattedActual)
 			}
 			if _, err := Save(&chartWithInvalidJSON, dest); err == nil {
-				t.Fatalf("Invalid JSON was not caught while saving chart")
+				t.Fatal("Invalid JSON was not caught while saving chart")
 			}
 
 			c.Metadata.APIVersion = chart.APIVersionV3

--- a/internal/plugin/installer/vcs_installer_test.go
+++ b/internal/plugin/installer/vcs_installer_test.go
@@ -90,14 +90,14 @@ func TestVCSInstaller(t *testing.T) {
 
 	// Install again to test plugin exists error
 	if err := Install(i); err == nil {
-		t.Fatalf("expected error for plugin exists, got none")
+		t.Fatal("expected error for plugin exists, got none")
 	} else if err.Error() != "plugin already exists" {
 		t.Fatalf("expected error for plugin exists, got (%v)", err)
 	}
 
 	// Testing FindSource method, expect error because plugin code is not a cloned repository
 	if _, err := FindSource(i.Path()); err == nil {
-		t.Fatalf("expected error for inability to find plugin source, got none")
+		t.Fatal("expected error for inability to find plugin source, got none")
 	} else if err.Error() != "cannot get information about plugin source" {
 		t.Fatalf("expected error for inability to find plugin source, got (%v)", err)
 	}
@@ -120,7 +120,7 @@ func TestVCSInstallerNonExistentVersion(t *testing.T) {
 	}
 
 	if err := Install(i); err == nil {
-		t.Fatalf("expected error for version does not exists, got none")
+		t.Fatal("expected error for version does not exists, got none")
 	} else if strings.Contains(err.Error(), "Could not resolve host: github.com") {
 		t.Skip("Unable to run test without Internet access")
 	} else if err.Error() != fmt.Sprintf("requested version %q does not exist for plugin %q", version, source) {
@@ -181,7 +181,7 @@ func TestVCSInstallerUpdate(t *testing.T) {
 	}
 	// Testing update for error
 	if err := Update(vcsInstaller); err == nil {
-		t.Fatalf("expected error for plugin modified, got none")
+		t.Fatal("expected error for plugin modified, got none")
 	} else if err.Error() != "plugin repo was modified" {
 		t.Fatalf("expected error for plugin modified, got (%v)", err)
 	}

--- a/internal/plugin/installer/verification_test.go
+++ b/internal/plugin/installer/verification_test.go
@@ -107,7 +107,7 @@ func TestInstallWithOptions_VerifyWithValidProvenance(t *testing.T) {
 
 	// Should fail due to invalid signature (empty keyring) but we test that it gets past the hash check
 	if err == nil {
-		t.Fatalf("Expected installation to fail with empty keyring")
+		t.Fatal("Expected installation to fail with empty keyring")
 	}
 	if !strings.Contains(err.Error(), "plugin verification failed") {
 		t.Errorf("Expected plugin verification failed error, got: %v", err)
@@ -218,7 +218,7 @@ func TestInstallWithOptions_VerifyDirectoryNotSupported(t *testing.T) {
 
 	// Should fail with verification not supported error
 	if err == nil {
-		t.Fatalf("Expected installation to fail with verification not supported error")
+		t.Fatal("Expected installation to fail with verification not supported error")
 	}
 	if !strings.Contains(err.Error(), "--verify is only supported for plugin tarballs") {
 		t.Errorf("Expected verification not supported error, got: %v", err)
@@ -257,7 +257,7 @@ func TestInstallWithOptions_VerifyMismatchedProvenance(t *testing.T) {
 
 	// Should fail with verification error
 	if err == nil {
-		t.Fatalf("Expected installation to fail with hash mismatch")
+		t.Fatal("Expected installation to fail with hash mismatch")
 	}
 	if !strings.Contains(err.Error(), "plugin verification failed") {
 		t.Errorf("Expected plugin verification failed error, got: %v", err)
@@ -298,7 +298,7 @@ func TestInstallWithOptions_VerifyProvenanceAccessError(t *testing.T) {
 
 	// Should fail with access error (either at stat level or during verification)
 	if err == nil {
-		t.Fatalf("Expected installation to fail with provenance file access error")
+		t.Fatal("Expected installation to fail with provenance file access error")
 	}
 	// The error could be either "failed to access provenance file" or "plugin verification failed"
 	// depending on when the permission error occurs

--- a/internal/plugin/subprocess_commands_test.go
+++ b/internal/plugin/subprocess_commands_test.go
@@ -210,7 +210,7 @@ func TestPrepareCommandsNoMatch(t *testing.T) {
 
 	env := map[string]string{}
 	if _, _, err := PrepareCommands(cmds, true, []string{}, env); err == nil {
-		t.Fatalf("Expected error to be returned")
+		t.Fatal("Expected error to be returned")
 	}
 }
 
@@ -219,7 +219,7 @@ func TestPrepareCommandsNoCommands(t *testing.T) {
 
 	env := map[string]string{}
 	if _, _, err := PrepareCommands(cmds, true, []string{}, env); err == nil {
-		t.Fatalf("Expected error to be returned")
+		t.Fatal("Expected error to be returned")
 	}
 }
 

--- a/internal/tlsutil/tls_test.go
+++ b/internal/tlsutil/tls_test.go
@@ -58,10 +58,10 @@ func TestNewTLSConfig(t *testing.T) {
 			t.Fatalf("expecting 1 client certificates, got %d", got)
 		}
 		if cfg.InsecureSkipVerify {
-			t.Fatalf("insecure skip verify mismatch, expecting false")
+			t.Fatal("insecure skip verify mismatch, expecting false")
 		}
 		if cfg.RootCAs == nil {
-			t.Fatalf("mismatch tls RootCAs, expecting non-nil")
+			t.Fatal("mismatch tls RootCAs, expecting non-nil")
 		}
 	}
 	{
@@ -77,10 +77,10 @@ func TestNewTLSConfig(t *testing.T) {
 			t.Fatalf("expecting 0 client certificates, got %d", got)
 		}
 		if cfg.InsecureSkipVerify {
-			t.Fatalf("insecure skip verify mismatch, expecting false")
+			t.Fatal("insecure skip verify mismatch, expecting false")
 		}
 		if cfg.RootCAs == nil {
-			t.Fatalf("mismatch tls RootCAs, expecting non-nil")
+			t.Fatal("mismatch tls RootCAs, expecting non-nil")
 		}
 	}
 
@@ -97,10 +97,10 @@ func TestNewTLSConfig(t *testing.T) {
 			t.Fatalf("expecting 1 client certificates, got %d", got)
 		}
 		if cfg.InsecureSkipVerify {
-			t.Fatalf("insecure skip verify mismatch, expecting false")
+			t.Fatal("insecure skip verify mismatch, expecting false")
 		}
 		if cfg.RootCAs != nil {
-			t.Fatalf("mismatch tls RootCAs, expecting nil")
+			t.Fatal("mismatch tls RootCAs, expecting nil")
 		}
 	}
 }

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -505,7 +505,7 @@ func TestInstallRelease_DryRunHiddenSecret(t *testing.T) {
 	vals = map[string]any{}
 	_, err = instAction.Run(buildChart(withSampleSecret(), withSampleTemplates()), vals)
 	if err == nil {
-		t.Fatalf("Did not get expected an error when dry-run false and hide secret is true")
+		t.Fatal("Did not get the expected error when dry-run is false and hide secret is true")
 	}
 }
 

--- a/pkg/chart/common/util/jsonschema_test.go
+++ b/pkg/chart/common/util/jsonschema_test.go
@@ -54,7 +54,7 @@ func TestValidateAgainstInvalidSingleSchema(t *testing.T) {
 
 	var errString string
 	if err := ValidateAgainstSingleSchema(values, schema); err == nil {
-		t.Fatalf("Expected an error, but got nil")
+		t.Fatal("Expected an error, but got nil")
 	} else {
 		errString = err.Error()
 	}
@@ -78,7 +78,7 @@ func TestValidateAgainstSingleSchemaNegative(t *testing.T) {
 
 	var errString string
 	if err := ValidateAgainstSingleSchema(values, schema); err == nil {
-		t.Fatalf("Expected an error, but got nil")
+		t.Fatal("Expected an error, but got nil")
 	} else {
 		errString = err.Error()
 	}
@@ -172,7 +172,7 @@ func TestValidateAgainstSchemaNegative(t *testing.T) {
 
 	var errString string
 	if err := ValidateAgainstSchema(chrt, vals); err == nil {
-		t.Fatalf("Expected an error, but got nil")
+		t.Fatal("Expected an error, but got nil")
 	} else {
 		errString = err.Error()
 	}
@@ -236,7 +236,7 @@ func TestValidateAgainstSchema2020Negative(t *testing.T) {
 
 	var errString string
 	if err := ValidateAgainstSchema(chrt, vals); err == nil {
-		t.Fatalf("Expected an error, but got nil")
+		t.Fatal("Expected an error, but got nil")
 	} else {
 		errString = err.Error()
 	}
@@ -386,6 +386,6 @@ func TestValidateAgainstSchema_InvalidSubchartValuesType_NoPanic(t *testing.T) {
 
 	// We expect a non-nil error (invalid type), but crucially no panic.
 	if err := ValidateAgainstSchema(chrt, vals); err == nil {
-		t.Fatalf("expected an error when subchart values have invalid type, got nil")
+		t.Fatal("expected an error when subchart values have invalid type, got nil")
 	}
 }

--- a/pkg/chart/v2/lint/lint_test.go
+++ b/pkg/chart/v2/lint/lint_test.go
@@ -235,7 +235,7 @@ func TestMalformedTemplate(t *testing.T) {
 	}()
 	select {
 	case <-c:
-		t.Fatalf("lint malformed template timeout")
+		t.Fatal("lint malformed template timeout")
 	case <-ch:
 		if len(m) != 1 {
 			t.Fatalf("All didn't fail with expected errors, got %#v", m)

--- a/pkg/chart/v2/util/chartfile_test.go
+++ b/pkg/chart/v2/util/chartfile_test.go
@@ -68,7 +68,7 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	}
 
 	if len(f.Sources) != 1 {
-		t.Fatalf("Unexpected number of sources")
+		t.Fatal("Unexpected number of sources")
 	}
 
 	if f.Sources[0] != "https://example.com/foo/bar" {
@@ -88,7 +88,7 @@ func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	}
 
 	if len(f.Annotations) != 2 {
-		t.Fatalf("Unexpected annotations")
+		t.Fatal("Unexpected annotations")
 	}
 
 	if want, got := "extravalue", f.Annotations["extrakey"]; want != got {

--- a/pkg/chart/v2/util/dependencies_test.go
+++ b/pkg/chart/v2/util/dependencies_test.go
@@ -385,7 +385,7 @@ func TestGetAliasDependency(t *testing.T) {
 	req := c.Metadata.Dependencies
 
 	if len(req) == 0 {
-		t.Fatalf("there are no dependencies to test")
+		t.Fatal("there are no dependencies to test")
 	}
 
 	// Success case
@@ -403,7 +403,7 @@ func TestGetAliasDependency(t *testing.T) {
 
 	if req[0].Version != "" {
 		if !IsCompatibleRange(req[0].Version, aliasChart.Metadata.Version) {
-			t.Fatalf("dependency chart version is not in the compatible range")
+			t.Fatal("dependency chart version is not in the compatible range")
 		}
 	}
 
@@ -415,7 +415,7 @@ func TestGetAliasDependency(t *testing.T) {
 
 	req[0].Version = "something else which is not in the compatible range"
 	if IsCompatibleRange(req[0].Version, aliasChart.Metadata.Version) {
-		t.Fatalf("dependency chart version which is not in the compatible range should cause a failure other than a success ")
+		t.Fatal("dependency chart version outside the compatible range should fail, but it succeeded")
 	}
 }
 

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -90,7 +90,7 @@ func TestSave(t *testing.T) {
 				t.Fatalf("Schema data did not match.\nExpected:\n%s\nActual:\n%s", formattedExpected, formattedActual)
 			}
 			if _, err := Save(&chartWithInvalidJSON, dest); err == nil {
-				t.Fatalf("Invalid JSON was not caught while saving chart")
+				t.Fatal("Invalid JSON was not caught while saving chart")
 			}
 
 			c.Metadata.APIVersion = chart.APIVersionV2

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -48,7 +48,7 @@ func TestCreateCmd(t *testing.T) {
 	if fi, err := os.Stat(cname); err != nil {
 		t.Fatalf("no chart directory: %s", err)
 	} else if !fi.IsDir() {
-		t.Fatalf("chart is not directory")
+		t.Fatal("chart is not directory")
 	}
 
 	c, err := chartloader.LoadDir(cname)
@@ -156,7 +156,7 @@ func TestCreateStarterCmd(t *testing.T) {
 			if fi, err := os.Stat(cname); err != nil {
 				t.Fatalf("no chart directory: %s", err)
 			} else if !fi.IsDir() {
-				t.Fatalf("chart is not directory")
+				t.Fatal("chart is not directory")
 			}
 
 			// Load and verify the chart
@@ -216,7 +216,7 @@ func TestCreateCmdChartAPIVersionV2(t *testing.T) {
 	if fi, err := os.Stat(cname); err != nil {
 		t.Fatalf("no chart directory: %s", err)
 	} else if !fi.IsDir() {
-		t.Fatalf("chart is not directory")
+		t.Fatal("chart is not directory")
 	}
 
 	c, err := chartloader.LoadDir(cname)
@@ -257,7 +257,7 @@ func TestCreateCmdChartAPIVersionV3(t *testing.T) {
 	if fi, err := os.Stat(cname); err != nil {
 		t.Fatalf("no chart directory: %s", err)
 	} else if !fi.IsDir() {
-		t.Fatalf("chart is not directory")
+		t.Fatal("chart is not directory")
 	}
 
 	c, err := chartloader.LoadDir(cname)

--- a/pkg/cmd/dependency_update_test.go
+++ b/pkg/cmd/dependency_update_test.go
@@ -208,7 +208,7 @@ func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 	// Make sure tmpcharts-x is deleted
 	tmpPath := filepath.Join(dir(chartname), fmt.Sprintf("tmpcharts-%d", os.Getpid()))
 	if _, err := os.Stat(tmpPath); !errors.Is(err, fs.ErrNotExist) {
-		t.Fatalf("tmpcharts dir still exists")
+		t.Fatal("tmpcharts dir still exists")
 	}
 }
 

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -584,7 +584,7 @@ func verifyInsecureSkipVerify(t *testing.T, g *HTTPGetter, caseName string, expe
 	}
 
 	if returnVal == nil {
-		t.Fatalf("Expected non nil value for http client")
+		t.Fatal("Expected non nil value for http client")
 	}
 	transport := (returnVal.Transport).(*http.Transport)
 	gotValue := false
@@ -608,7 +608,7 @@ func TestDefaultHTTPTransportReuse(t *testing.T) {
 	}
 
 	if httpClient1 == nil {
-		t.Fatalf("Expected non nil value for http client")
+		t.Fatal("Expected non nil value for http client")
 	}
 
 	transport1 := (httpClient1.Transport).(*http.Transport)
@@ -620,13 +620,13 @@ func TestDefaultHTTPTransportReuse(t *testing.T) {
 	}
 
 	if httpClient2 == nil {
-		t.Fatalf("Expected non nil value for http client")
+		t.Fatal("Expected non nil value for http client")
 	}
 
 	transport2 := (httpClient2.Transport).(*http.Transport)
 
 	if transport1 != transport2 {
-		t.Fatalf("Expected default transport to be reused")
+		t.Fatal("Expected default transport to be reused")
 	}
 }
 
@@ -642,13 +642,13 @@ func TestHTTPTransportOption(t *testing.T) {
 	}
 
 	if httpClient1 == nil {
-		t.Fatalf("Expected non nil value for http client")
+		t.Fatal("Expected non nil value for http client")
 	}
 
 	transport1 := (httpClient1.Transport).(*http.Transport)
 
 	if transport1 != transport {
-		t.Fatalf("Expected transport option to be applied")
+		t.Fatal("Expected transport option to be applied")
 	}
 
 	httpClient2, err := g.httpClient(g.opts)
@@ -658,13 +658,13 @@ func TestHTTPTransportOption(t *testing.T) {
 	}
 
 	if httpClient2 == nil {
-		t.Fatalf("Expected non nil value for http client")
+		t.Fatal("Expected non nil value for http client")
 	}
 
 	transport2 := (httpClient2.Transport).(*http.Transport)
 
 	if transport1 != transport2 {
-		t.Fatalf("Expected applied transport to be reused")
+		t.Fatal("Expected applied transport to be reused")
 	}
 
 	g = HTTPGetter{}

--- a/pkg/getter/ocigetter_test.go
+++ b/pkg/getter/ocigetter_test.go
@@ -128,7 +128,7 @@ func TestOCIHTTPTransportReuse(t *testing.T) {
 	}
 
 	if g.transport == nil {
-		t.Fatalf("Expected non nil value for transport")
+		t.Fatal("Expected non nil value for transport")
 	}
 
 	transport1 := g.transport
@@ -140,12 +140,12 @@ func TestOCIHTTPTransportReuse(t *testing.T) {
 	}
 
 	if g.transport == nil {
-		t.Fatalf("Expected non nil value for transport")
+		t.Fatal("Expected non nil value for transport")
 	}
 
 	transport2 := g.transport
 
 	if transport1 != transport2 {
-		t.Fatalf("Expected default transport to be reused")
+		t.Fatal("Expected default transport to be reused")
 	}
 }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -82,7 +82,7 @@ func TestLogin_ResetsForceAttemptOAuth2_OnSuccess(t *testing.T) {
 	}
 
 	if c.authorizer == nil || c.authorizer.ForceAttemptOAuth2 {
-		t.Fatalf("expected ForceAttemptOAuth2 default to be false")
+		t.Fatal("expected ForceAttemptOAuth2 default to be false")
 	}
 
 	// Call Login with plain HTTP against our test server

--- a/pkg/registry/tag_test.go
+++ b/pkg/registry/tag_test.go
@@ -71,7 +71,7 @@ func TestGetTagMatchingVersionOrConstraint_InvalidConstraint(t *testing.T) {
 	tags := []string{"1.0.0"}
 	_, err := GetTagMatchingVersionOrConstraint(tags, ">a1")
 	if err == nil {
-		t.Fatalf("expected error for invalid constraint")
+		t.Fatal("expected error for invalid constraint")
 	}
 }
 
@@ -79,7 +79,7 @@ func TestGetTagMatchingVersionOrConstraint_NoMatches(t *testing.T) {
 	tags := []string{"0.1.0", "0.2.0"}
 	_, err := GetTagMatchingVersionOrConstraint(tags, ">=1.0.0")
 	if err == nil {
-		t.Fatalf("expected error when no tags match")
+		t.Fatal("expected error when no tags match")
 	}
 	if !strings.Contains(err.Error(), ">=1.0.0") {
 		t.Fatalf("expected error to contain version string, got: %v", err)

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -370,7 +370,7 @@ func verifyLocalIndex(t *testing.T, i *IndexFile) {
 
 	nginx, ok := i.Entries["nginx"]
 	if !ok || len(nginx) != 2 {
-		t.Fatalf("Expected 2 nginx entries")
+		t.Fatal("Expected 2 nginx entries")
 	}
 
 	expects := []*ChartVersion{

--- a/pkg/repo/v1/repotest/server.go
+++ b/pkg/repo/v1/repotest/server.go
@@ -175,14 +175,14 @@ func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
 	htpasswdPath := filepath.Join(dir, testHtpasswdFileBasename)
 	err = os.WriteFile(htpasswdPath, fmt.Appendf(nil, "%s:%s\n", testUsername, string(pwBytes)), 0o644)
 	if err != nil {
-		t.Fatalf("error creating test htpasswd file")
+		t.Fatal("error creating test htpasswd file")
 	}
 
 	// Registry config
 	config := &configuration.Configuration{}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("error finding free port for test registry")
+		t.Fatalf("error finding free port for test registry: %v", err)
 	}
 	defer ln.Close()
 
@@ -237,7 +237,7 @@ func (srv *OCIServer) RunWithReturn(t *testing.T, opts ...OCIServerOpt) *OCIServ
 		ociRegistry.ClientOptCredentialsFile(credentialsFile),
 	)
 	if err != nil {
-		t.Fatalf("error creating registry client")
+		t.Fatalf("error creating registry client: %v", err)
 	}
 
 	err = registryClient.Login(

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -208,7 +208,7 @@ func TestStorageDeployed(t *testing.T) {
 
 	switch {
 	case rls == nil:
-		t.Fatalf("Release is nil")
+		t.Fatal("Release is nil")
 	case rel.Name != name:
 		t.Fatalf("Expected release name %q, actual %q\n", name, rel.Name)
 	case rel.Version != vers:
@@ -251,7 +251,7 @@ func TestStorageDeployedWithCorruption(t *testing.T) {
 
 	switch {
 	case rls == nil:
-		t.Fatalf("Release is nil")
+		t.Fatal("Release is nil")
 	case rel.Name != name:
 		t.Fatalf("Expected release name %q, actual %q\n", name, rel.Name)
 	case rel.Version != vers:


### PR DESCRIPTION
**What this PR does / why we need it**:

This somehow already seems to be a standard in the code base. 
[`t.Fatal`](https://pkg.go.dev/testing#T.Fatal) can be used when there are no formatting strings.
I don't know if there is a linter that can be configured to block the use `Fatalf` when there are no `%s` (or whatever).
`semgrep` can easily find it with `- pattern: t.Fatalf("...")`

**Special notes for your reviewer**:

[`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) is supported by GitHub. You may consider adding a file with commit SHAs for such simple changes.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
