### PR TITLE
chore: enable nolinlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - nolintlint
     - revive
     - sloglint
     - staticcheck
@@ -67,6 +68,9 @@ linters:
     dupl:
       threshold: 400
 
+    exhaustive:
+      default-signifies-exhaustive: true
+
     gomodguard:
       blocked:
         modules:
@@ -74,8 +78,8 @@ linters:
               recommendations:
                 - github.com/evanphx/json-patch/v5
 
-    exhaustive:
-      default-signifies-exhaustive: true
+    nolintlint:
+      require-specific: true
 
 run:
   timeout: 10m

--- a/internal/chart/v3/util/chartfile_test.go
+++ b/internal/chart/v3/util/chartfile_test.go
@@ -35,7 +35,7 @@ func TestLoadChartfile(t *testing.T) {
 
 func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	t.Helper()
-	if f == nil { //nolint:staticcheck
+	if f == nil {
 		t.Fatal("Failed verifyChartfile because f is nil")
 	}
 

--- a/internal/plugin/signing_info.go
+++ b/internal/plugin/signing_info.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ProtonMail/go-crypto/openpgp/clearsign" //nolint
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 
 	"helm.sh/helm/v4/pkg/helmpath"
 )

--- a/pkg/chart/v2/util/chartfile_test.go
+++ b/pkg/chart/v2/util/chartfile_test.go
@@ -35,11 +35,11 @@ func TestLoadChartfile(t *testing.T) {
 
 func verifyChartfile(t *testing.T, f *chart.Metadata, name string) {
 	t.Helper()
-	if f == nil { //nolint:staticcheck
+	if f == nil {
 		t.Fatal("Failed verifyChartfile because f is nil")
 	}
 
-	if f.APIVersion != chart.APIVersionV1 { //nolint:staticcheck
+	if f.APIVersion != chart.APIVersionV1 {
 		t.Errorf("Expected API Version %q, got %q", chart.APIVersionV1, f.APIVersion)
 	}
 

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -583,10 +583,10 @@ func verifyInsecureSkipVerify(t *testing.T, g *HTTPGetter, caseName string, expe
 		t.Fatal(err)
 	}
 
-	if returnVal == nil { //nolint:staticcheck
+	if returnVal == nil {
 		t.Fatalf("Expected non nil value for http client")
 	}
-	transport := (returnVal.Transport).(*http.Transport) //nolint:staticcheck
+	transport := (returnVal.Transport).(*http.Transport)
 	gotValue := false
 	if transport.TLSClientConfig != nil {
 		gotValue = transport.TLSClientConfig.InsecureSkipVerify
@@ -607,11 +607,11 @@ func TestDefaultHTTPTransportReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if httpClient1 == nil { //nolint:staticcheck
+	if httpClient1 == nil {
 		t.Fatalf("Expected non nil value for http client")
 	}
 
-	transport1 := (httpClient1.Transport).(*http.Transport) //nolint:staticcheck
+	transport1 := (httpClient1.Transport).(*http.Transport)
 
 	httpClient2, err := g.httpClient(g.opts)
 
@@ -619,11 +619,11 @@ func TestDefaultHTTPTransportReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if httpClient2 == nil { //nolint:staticcheck
+	if httpClient2 == nil {
 		t.Fatalf("Expected non nil value for http client")
 	}
 
-	transport2 := (httpClient2.Transport).(*http.Transport) //nolint:staticcheck
+	transport2 := (httpClient2.Transport).(*http.Transport)
 
 	if transport1 != transport2 {
 		t.Fatalf("Expected default transport to be reused")
@@ -641,11 +641,11 @@ func TestHTTPTransportOption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if httpClient1 == nil { //nolint:staticcheck
+	if httpClient1 == nil {
 		t.Fatalf("Expected non nil value for http client")
 	}
 
-	transport1 := (httpClient1.Transport).(*http.Transport) //nolint:staticcheck
+	transport1 := (httpClient1.Transport).(*http.Transport)
 
 	if transport1 != transport {
 		t.Fatalf("Expected transport option to be applied")
@@ -657,11 +657,11 @@ func TestHTTPTransportOption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if httpClient2 == nil { //nolint:staticcheck
+	if httpClient2 == nil {
 		t.Fatalf("Expected non nil value for http client")
 	}
 
-	transport2 := (httpClient2.Transport).(*http.Transport) //nolint:staticcheck
+	transport2 := (httpClient2.Transport).(*http.Transport)
 
 	if transport1 != transport2 {
 		t.Fatalf("Expected applied transport to be reused")

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -25,9 +25,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ProtonMail/go-crypto/openpgp"           //nolint
-	"github.com/ProtonMail/go-crypto/openpgp/clearsign" //nolint
-	"github.com/ProtonMail/go-crypto/openpgp/packet"    //nolint
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/provenance/sign_test.go
+++ b/pkg/provenance/sign_test.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"testing"
 
-	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors" //nolint
-	"github.com/ProtonMail/go-crypto/openpgp/packet"           //nolint
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"

--- a/pkg/repo/v1/repo_test.go
+++ b/pkg/repo/v1/repo_test.go
@@ -114,11 +114,11 @@ func TestRepoFile_Get(t *testing.T) {
 	name := "second"
 
 	entry := repo.Get(name)
-	if entry == nil { //nolint:staticcheck
+	if entry == nil {
 		t.Fatalf("Expected repo entry %q to be found", name)
 	}
 
-	if entry.URL != "https://example.com/second" { //nolint:staticcheck
+	if entry.URL != "https://example.com/second" {
 		t.Errorf("Expected repo URL to be %q but got %q", "https://example.com/second", entry.URL)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable [nolinlint](https://golangci-lint.run/docs/linters/configuration/#nolintlint) linter to identify and fix ill-formed or insufficient nolint directives.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
