### PR TITLE
chore(internal): fix perfsprint linter issues part 2

### DIFF
--- a/internal/chart/v3/lint/rules/values.go
+++ b/internal/chart/v3/lint/rules/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +48,7 @@ func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]any, 
 func validateValuesFileExistence(valuesPath string) error {
 	_, err := os.Stat(valuesPath)
 	if err != nil {
-		return fmt.Errorf("file does not exist")
+		return errors.New("file does not exist")
 	}
 	return nil
 }

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -353,5 +353,5 @@ func sha256Sum(filePath string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/plugin/installer/http_installer_test.go
+++ b/internal/plugin/installer/http_installer_test.go
@@ -150,7 +150,7 @@ func TestHTTPInstallerNonExistentVersion(t *testing.T) {
 
 	// inject fake http client responding with error
 	httpInstaller.getter = &TestHTTPGetter{
-		MockError: fmt.Errorf("failed to download plugin for some reason"),
+		MockError: errors.New("failed to download plugin for some reason"),
 	}
 
 	// attempt to install the plugin

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -188,7 +188,7 @@ func (i *LocalInstaller) SupportsVerification() bool {
 // GetVerificationData loads plugin and provenance data from local files for verification
 func (i *LocalInstaller) GetVerificationData() (archiveData, provData []byte, filename string, err error) {
 	if !i.SupportsVerification() {
-		return nil, nil, "", fmt.Errorf("verification not supported for directories")
+		return nil, nil, "", errors.New("verification not supported for directories")
 	}
 
 	// Read and cache the plugin archive file

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -130,7 +130,7 @@ func (i *OCIInstaller) Install() error {
 
 	// Check if this is a gzip compressed file
 	if len(i.pluginData) < 2 || i.pluginData[0] != 0x1f || i.pluginData[1] != 0x8b {
-		return fmt.Errorf("plugin data is not a gzip compressed archive")
+		return errors.New("plugin data is not a gzip compressed archive")
 	}
 
 	// Create cache directory

--- a/internal/plugin/installer/oci_installer_test.go
+++ b/internal/plugin/installer/oci_installer_test.go
@@ -82,7 +82,7 @@ command: "$HELM_PLUGIN_DIR/bin/%s"
 	// Add executable
 	execContent := fmt.Sprintf("#!/bin/sh\necho '%s test plugin'", pluginName)
 	execHeader := &tar.Header{
-		Name:     fmt.Sprintf("bin/%s", pluginName),
+		Name:     "bin/" + pluginName,
 		Mode:     0755,
 		Size:     int64(len(execContent)),
 		Typeflag: tar.TypeReg,

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -17,7 +17,6 @@ package plugin
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,7 +70,7 @@ func TestLoadDir(t *testing.T) {
 		}
 		return Metadata{
 			APIVersion: apiVersion,
-			Name:       fmt.Sprintf("hello-%s", apiVersion),
+			Name:       "hello-" + apiVersion,
 			Version:    "0.1.0",
 			Type:       "cli/v1",
 			Runtime:    "subprocess",

--- a/internal/plugin/runtime_subprocess_getter.go
+++ b/internal/plugin/runtime_subprocess_getter.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 
 	"helm.sh/helm/v4/internal/plugin/schema"
 )
@@ -63,7 +64,7 @@ func (r *SubprocessPluginRuntime) runGetter(input *Input) (*Output, error) {
 	env["HELM_PLUGIN_DIR"] = r.pluginDir
 	env["HELM_PLUGIN_USERNAME"] = msg.Options.Username
 	env["HELM_PLUGIN_PASSWORD"] = msg.Options.Password
-	env["HELM_PLUGIN_PASS_CREDENTIALS_ALL"] = fmt.Sprintf("%t", msg.Options.PassCredentialsAll)
+	env["HELM_PLUGIN_PASS_CREDENTIALS_ALL"] = strconv.FormatBool(msg.Options.PassCredentialsAll)
 
 	command, args, err := PrepareCommands(d.PlatformCommand, false, []string{}, env)
 	if err != nil {

--- a/internal/plugin/schema/getter.go
+++ b/internal/plugin/schema/getter.go
@@ -14,6 +14,7 @@
 package schema
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -55,7 +56,7 @@ type ConfigGetterV1 struct {
 
 func (c *ConfigGetterV1) Validate() error {
 	if len(c.Protocols) == 0 {
-		return fmt.Errorf("getter has no protocols")
+		return errors.New("getter has no protocols")
 	}
 	for i, protocol := range c.Protocols {
 		if protocol == "" {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -149,7 +149,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 
 			} else {
 				// Retrieve list of tags for repository
-				ref := fmt.Sprintf("%s/%s", strings.TrimPrefix(d.Repository, fmt.Sprintf("%s://", registry.OCIScheme)), d.Name)
+				ref := fmt.Sprintf("%s/%s", strings.TrimPrefix(d.Repository, registry.OCIScheme+"://"), d.Name)
 				tags, err := r.registryClient.Tags(ref)
 				if err != nil {
 					return nil, fmt.Errorf("could not retrieve list of tags for repository %s: %w", d.Repository, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in internal part 2

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
