### PR TITLE
chore(pkg): fix perfsprint linter issues part 6

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -377,7 +377,7 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	}
 	// Check error from render
 	if err != nil {
-		rel.SetStatus(rcommon.StatusFailed, fmt.Sprintf("failed to render resource: %s", err.Error()))
+		rel.SetStatus(rcommon.StatusFailed, "failed to render resource: "+err.Error())
 		// Return a release with partial data so that the client can show debugging information.
 		return rel, err
 	}

--- a/pkg/cmd/history.go
+++ b/pkg/cmd/history.go
@@ -260,7 +260,7 @@ func compListRevisions(_ string, cfg *action.Configuration, releaseName string) 
 			return nil, cobra.ShellCompDirectiveError
 		}
 		for _, version := range hist {
-			appVersion := fmt.Sprintf("App: %s", version.Chart.Metadata.AppVersion)
+			appVersion := "App: " + version.Chart.Metadata.AppVersion
 			chartDesc := fmt.Sprintf("Chart: %s-%s", version.Chart.Metadata.Name, version.Chart.Metadata.Version)
 			revisions = append(revisions, fmt.Sprintf("%s\t%s, %s", strconv.Itoa(version.Version), appVersion, chartDesc))
 		}

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -254,7 +254,7 @@ func filterReleases(releases []*release.Release, ignoredReleaseNames []string) [
 
 // Provide dynamic auto-completion for release names
 func compListReleases(toComplete string, ignoredReleaseNames []string, cfg *action.Configuration) ([]string, cobra.ShellCompDirective) {
-	cobra.CompDebugln(fmt.Sprintf("compListReleases with toComplete %s", toComplete), settings.Debug)
+	cobra.CompDebugln("compListReleases with toComplete "+toComplete, settings.Debug)
 
 	client := action.NewList(cfg)
 	client.All = true

--- a/pkg/cmd/package.go
+++ b/pkg/cmd/package.go
@@ -57,7 +57,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 		Long:  packageDesc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return fmt.Errorf("need at least one argument, the path to the chart")
+				return errors.New("need at least one argument, the path to the chart")
 			}
 			if client.Sign {
 				if client.Key == "" {

--- a/pkg/cmd/plugin_package.go
+++ b/pkg/cmd/plugin_package.go
@@ -81,7 +81,7 @@ func (o *pluginPackageOptions) run(out io.Writer) error {
 		return err
 	}
 	if !fi.IsDir() {
-		return fmt.Errorf("plugin package only supports directories, not tarballs")
+		return errors.New("plugin package only supports directories, not tarballs")
 	}
 
 	// Load and validate plugin metadata

--- a/pkg/cmd/plugin_test.go
+++ b/pkg/cmd/plugin_test.go
@@ -100,7 +100,7 @@ func TestLoadCLIPlugins(t *testing.T) {
 		"HELM_PLUGINS=testdata/helmhome/helm/plugins",
 		"HELM_REPOSITORY_CONFIG=testdata/helmhome/helm/repositories.yaml",
 		"HELM_REPOSITORY_CACHE=testdata/helmhome/helm/repository",
-		fmt.Sprintf("HELM_BIN=%s", os.Args[0]),
+		"HELM_BIN=" + os.Args[0],
 	}, "\n") + "\n"
 
 	// Test that the YAML file was correctly converted to a command.

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -53,7 +53,7 @@ type ErrRepoNotFound struct {
 
 // Error implements the error interface.
 func (e ErrRepoNotFound) Error() string {
-	return fmt.Sprintf("no repository definition for %s", strings.Join(e.Repos, ", "))
+	return "no repository definition for " + strings.Join(e.Repos, ", ")
 }
 
 // Manager handles the lifecycle of fetching, resolving, and storing dependencies.

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -403,7 +403,7 @@ func TestDownloadTLSWithRedirect(t *testing.T) {
 		// request URL for every request (including redirects). Setting `tls.Config.ServerName` on the
 		// client just overrides the remote endpoint's hostname.
 		// See https://github.com/golang/go/blob/3979fb9/src/net/http/transport.go#L1505-L1513.
-		u.Host = fmt.Sprintf("localhost:%s", u.Port())
+		u.Host = "localhost:" + u.Port()
 
 		http.Redirect(rw, r, u.String(), http.StatusTemporaryRedirect)
 	}))

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -882,7 +882,7 @@ func (c *Client) ValidateReference(ref, version string, u *url.URL) (string, *ur
 		tag = version
 	} else {
 		// Retrieve list of repository tags
-		tags, err := c.Tags(strings.TrimPrefix(ref, fmt.Sprintf("%s://", OCIScheme)))
+		tags, err := c.Tags(strings.TrimPrefix(ref, OCIScheme+"://"))
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/repo/v1/repotest/server.go
+++ b/pkg/repo/v1/repotest/server.go
@@ -249,7 +249,7 @@ func (srv *OCIServer) RunWithReturn(t *testing.T, opts ...OCIServerOpt) *OCIServ
 		t.Fatalf("error logging into registry with good credentials: %v", err)
 	}
 
-	ref := fmt.Sprintf("%s/u/ocitestuser/oci-dependent-chart:0.1.0", srv.RegistryURL)
+	ref := srv.RegistryURL + "/u/ocitestuser/oci-dependent-chart:0.1.0"
 
 	err = chartutil.ExpandFile(srv.Dir, filepath.Join(srv.Dir, "oci-dependent-chart-0.1.0.tgz"))
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in pkg part 6

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
