### PR TITLE
chore(pkg): fix perfsprint linter issues part 5

### DIFF
--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -92,7 +92,7 @@ func (d *Dependency) dependencyStatus(chartpath string, dep *chart.Dependency, p
 		for _, arc := range archives {
 			// we need to trip the prefix dirs and the extension off.
 			filename = strings.TrimSuffix(filepath.Base(arc), ".tgz")
-			maybeVersion := strings.TrimPrefix(filename, fmt.Sprintf("%s-", dep.Name))
+			maybeVersion := strings.TrimPrefix(filename, dep.Name+"-")
 
 			if _, err := semver.StrictNewVersion(maybeVersion); err == nil {
 				// If the version parsed without an error, it is possibly a valid

--- a/pkg/chart/v2/lint/rules/values.go
+++ b/pkg/chart/v2/lint/rules/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +48,7 @@ func ValuesWithOverrides(linter *support.Linter, valueOverrides map[string]any, 
 func validateValuesFileExistence(valuesPath string) error {
 	_, err := os.Stat(valuesPath)
 	if err != nil {
-		return fmt.Errorf("file does not exist")
+		return errors.New("file does not exist")
 	}
 	return nil
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -24,7 +24,6 @@ These dependencies are expressed as interfaces so that alternate implementations
 package cli
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -246,7 +245,7 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HELM_CACHE_HOME":        helmpath.CachePath(""),
 		"HELM_CONFIG_HOME":       helmpath.ConfigPath(""),
 		"HELM_DATA_HOME":         helmpath.DataPath(""),
-		"HELM_DEBUG":             fmt.Sprint(s.Debug),
+		"HELM_DEBUG":             strconv.FormatBool(s.Debug),
 		"HELM_PLUGINS":           s.PluginsDirectory,
 		"HELM_REGISTRY_CONFIG":   s.RegistryConfig,
 		"HELM_REPOSITORY_CACHE":  s.RepositoryCache,

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -62,7 +62,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				var comps []string
 				for _, p := range providers {
 					for _, scheme := range p.Schemes {
-						comps = append(comps, fmt.Sprintf("%s://", scheme))
+						comps = append(comps, scheme+"://")
 					}
 				}
 				return comps, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace

--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -58,7 +58,7 @@ func (g *OCIGetter) get(href string) (*bytes.Buffer, error) {
 		client = c
 	}
 
-	ref := strings.TrimPrefix(href, fmt.Sprintf("%s://", registry.OCIScheme))
+	ref := strings.TrimPrefix(href, registry.OCIScheme+"://")
 
 	if version := g.opts.version; version != "" && !strings.Contains(path.Base(ref), ":") {
 		ref = fmt.Sprintf("%s:%s", ref, version)

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -1434,7 +1433,7 @@ func TestIsIncompatibleServerError(t *testing.T) {
 			Want: false,
 		},
 		"Generic error": {
-			Err:  fmt.Errorf("some generic error"),
+			Err:  errors.New("some generic error"),
 			Want: false,
 		},
 	}

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fake
 
 import (
-	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -133,7 +132,7 @@ func (p *PrintingKubeClient) GetPodList(_ string, _ metav1.ListOptions) (*v1.Pod
 
 // OutputContainerLogsForPodList implements KubeClient OutputContainerLogsForPodList.
 func (p *PrintingKubeClient) OutputContainerLogsForPodList(_ *v1.PodList, someNamespace string, _ func(namespace, pod, container string) io.Writer) error {
-	_, err := io.Copy(p.LogOutput, strings.NewReader(fmt.Sprintf("attempted to output logs for namespace: %s", someNamespace)))
+	_, err := io.Copy(p.LogOutput, strings.NewReader("attempted to output logs for namespace: "+someNamespace))
 	return err
 }
 

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -246,7 +246,7 @@ func (hw *legacyWaiter) watchUntilReady(timeout time.Duration, info *resource.In
 
 	// Use a selector on the name of the resource. This should be unique for the
 	// given version and kind
-	selector, err := fields.ParseSelector(fmt.Sprintf("metadata.name=%s", info.Name))
+	selector, err := fields.ParseSelector("metadata.name=" + info.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/plugin.go
+++ b/pkg/registry/plugin.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -190,7 +191,7 @@ func GetPluginName(source string) (string, error) {
 	// e.g., "ghcr.io/user/plugin-name:v1.0.0" -> Repository: "user/plugin-name"
 	repository := ref.Repository
 	if repository == "" {
-		return "", fmt.Errorf("invalid OCI reference: missing repository")
+		return "", errors.New("invalid OCI reference: missing repository")
 	}
 
 	// Get the last part of the repository path as the plugin name

--- a/pkg/registry/reference.go
+++ b/pkg/registry/reference.go
@@ -17,7 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"fmt"
 	"strings"
 
 	"oras.land/oras-go/v2/registry"
@@ -80,5 +79,5 @@ func (r *reference) String() string {
 
 // IsOCI determines whether a URL is to be treated as an OCI URL
 func IsOCI(url string) bool {
-	return strings.HasPrefix(url, fmt.Sprintf("%s://", OCIScheme))
+	return strings.HasPrefix(url, OCIScheme+"://")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in pkg part 5

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
