### PR TITLE
chore(pkg): fix perfsprint linter issues part 4

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -257,9 +257,9 @@ func (cfg *Configuration) outputLogsByPolicy(h *release.Hook, releaseNamespace s
 	}
 	switch h.Kind {
 	case "Job":
-		return cfg.outputContainerLogsForListOptions(namespace, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s", h.Name)})
+		return cfg.outputContainerLogsForListOptions(namespace, metav1.ListOptions{LabelSelector: "job-name=" + h.Name})
 	case "Pod":
-		return cfg.outputContainerLogsForListOptions(namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", h.Name)})
+		return cfg.outputContainerLogsForListOptions(namespace, metav1.ListOptions{FieldSelector: "metadata.name=" + h.Name})
 	default:
 		return nil
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 
@@ -226,7 +227,7 @@ func validateNameAndGenerateName(info *resource.Info) (bool, error) {
 	}
 
 	if info.Name != "" && accessor.GetGenerateName() != "" {
-		return true, fmt.Errorf("metadata.name and metadata.generateName cannot both be set")
+		return true, errors.New("metadata.name and metadata.generateName cannot both be set")
 	}
 
 	return false, nil

--- a/pkg/chart/common.go
+++ b/pkg/chart/common.go
@@ -17,7 +17,6 @@ package chart
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -192,7 +191,7 @@ func structToMap(obj any) (map[string]any, error) {
 
 	// Check if the input is a struct
 	if objValue.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("input must be a struct or a pointer to a struct")
+		return nil, errors.New("input must be a struct or a pointer to a struct")
 	}
 
 	result := make(map[string]any)

--- a/pkg/cli/output/output.go
+++ b/pkg/cli/output/output.go
@@ -18,6 +18,7 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -50,7 +51,7 @@ func FormatsWithDesc() map[string]string {
 }
 
 // ErrInvalidFormatType is returned when an unsupported format type is used
-var ErrInvalidFormatType = fmt.Errorf("invalid format type")
+var ErrInvalidFormatType = errors.New("invalid format type")
 
 // String returns the string representation of the Format
 func (o Format) String() string {

--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -19,7 +19,6 @@ package values
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -265,7 +264,7 @@ func TestReadFileErrorMessages(t *testing.T) {
 		{
 			name:      "getter error with message",
 			filePath:  "http://example.com/file",
-			providers: getter.Providers{mockProvider([]string{"http"}, nil, fmt.Errorf("connection refused"))},
+			providers: getter.Providers{mockProvider([]string{"http"}, nil, errors.New("connection refused"))},
 			wantErr:   "connection refused",
 		},
 	}

--- a/pkg/cmd/require/args_test.go
+++ b/pkg/cmd/require/args_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 package require
 
 import (
-	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -65,7 +65,7 @@ type testCase struct {
 func runTestCases(t *testing.T, testCases []testCase) {
 	t.Helper()
 	for i, tc := range testCases {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			cmd := &cobra.Command{
 				Use:  "root",
 				Run:  func(*cobra.Command, []string) {},

--- a/pkg/downloader/cache.go
+++ b/pkg/downloader/cache.go
@@ -17,6 +17,7 @@ package downloader
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -85,5 +86,5 @@ func (c *DiskCache) Put(key [sha256.Size]byte, data io.Reader, cacheType string)
 // fileName generates the filename in a structured manner where the first part is the
 // directory and the full hash is the filename.
 func (c *DiskCache) fileName(id [sha256.Size]byte, cacheType string) string {
-	return filepath.Join(c.Root, fmt.Sprintf("%02x", id[0]), fmt.Sprintf("%x", id)+cacheType)
+	return filepath.Join(c.Root, fmt.Sprintf("%02x", id[0]), hex.EncodeToString(id[:])+cacheType)
 }

--- a/pkg/provenance/sign_test.go
+++ b/pkg/provenance/sign_test.go
@@ -17,7 +17,7 @@ package provenance
 
 import (
 	"crypto"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -330,7 +330,7 @@ func (s failSigner) Public() crypto.PublicKey {
 }
 
 func (s failSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
-	return nil, fmt.Errorf("always fails")
+	return nil, errors.New("always fails")
 }
 
 func TestClearSignError(t *testing.T) {

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -76,7 +76,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 	}
 
 	var pushOpts []registry.PushOption
-	provRef := fmt.Sprintf("%s.prov", chartRef)
+	provRef := chartRef + ".prov"
 	if _, err := os.Stat(provRef); err == nil {
 		provBytes, err := os.ReadFile(provRef)
 		if err != nil {
@@ -86,7 +86,7 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 	}
 
 	ref := fmt.Sprintf("%s:%s",
-		path.Join(strings.TrimPrefix(href, fmt.Sprintf("%s://", registry.OCIScheme)), meta.Metadata.Name),
+		path.Join(strings.TrimPrefix(href, registry.OCIScheme+"://"), meta.Metadata.Name),
 		meta.Metadata.Version)
 
 	// The time the chart was "created" is semantically the time the chart archive file was last written(modified)

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -611,7 +610,7 @@ func TestIgnoreSkippableChartValidationError(t *testing.T) {
 			Input: nil,
 		},
 		"generic_error": {
-			Input: fmt.Errorf("foo"),
+			Input: errors.New("foo"),
 		},
 		"non_skipped_validation_error": {
 			Input: chart.ValidationError("chart.metadata.type must be application or library"),


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in pkg part 4

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
