### PR TITLE
chore(pkg): fix perfsprint linter issues part 2

### DIFF
--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -19,6 +19,7 @@ package action
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -173,7 +174,7 @@ func runInstallForHooksWithSuccess(t *testing.T, manifest, expectedNamespace str
 	t.Helper()
 	var expectedOutput string
 	if shouldOutput {
-		expectedOutput = fmt.Sprintf("attempted to output logs for namespace: %s", expectedNamespace)
+		expectedOutput = "attempted to output logs for namespace: " + expectedNamespace
 	}
 	is := assert.New(t)
 	instAction := installAction(t)
@@ -200,13 +201,13 @@ func runInstallForHooksWithFailure(t *testing.T, manifest, expectedNamespace str
 	t.Helper()
 	var expectedOutput string
 	if shouldOutput {
-		expectedOutput = fmt.Sprintf("attempted to output logs for namespace: %s", expectedNamespace)
+		expectedOutput = "attempted to output logs for namespace: " + expectedNamespace
 	}
 	is := assert.New(t)
 	instAction := installAction(t)
 	instAction.ReleaseName = "failed-hooks"
 	failingClient := instAction.cfg.KubeClient.(*kubefake.FailingKubeClient)
-	failingClient.WatchUntilReadyError = fmt.Errorf("failed watch")
+	failingClient.WatchUntilReadyError = errors.New("failed watch")
 	instAction.cfg.KubeClient = failingClient
 	outBuffer := &bytes.Buffer{}
 	failingClient.PrintingKubeClient = kubefake.PrintingKubeClient{Out: io.Discard, LogOutput: outBuffer}

--- a/pkg/cmd/create_test.go
+++ b/pkg/cmd/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -139,11 +138,11 @@ func TestCreateStarterCmd(t *testing.T) {
 			if tt.useAbsolutePath {
 				starterArg = filepath.Join(starterchart, "starterchart")
 			}
-			cmd := fmt.Sprintf("create --starter=%s", starterArg)
+			cmd := "create --starter=" + starterArg
 			if tt.chartAPIVersion == "v3" {
-				cmd += fmt.Sprintf(" --chart-api-version=%s", chartv3.APIVersionV3)
+				cmd += " --chart-api-version=" + chartv3.APIVersionV3
 			} else {
-				cmd += fmt.Sprintf(" --chart-api-version=%s", chartv2.APIVersionV2)
+				cmd += " --chart-api-version=" + chartv2.APIVersionV2
 			}
 			cmd += " " + cname
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -119,7 +120,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
 // value to the given format pointer
 func bindOutputFlag(cmd *cobra.Command, varRef *output.Format) {
 	cmd.Flags().VarP(newOutputValue(output.Table, varRef), outputFlag, "o",
-		fmt.Sprintf("prints the output in the specified format. Allowed values: %s", strings.Join(output.Formats(), ", ")))
+		"prints the output in the specified format. Allowed values: "+strings.Join(output.Formats(), ", "))
 
 	err := cmd.RegisterFlagCompletionFunc(outputFlag, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		var formatNames []string
@@ -195,7 +196,7 @@ func (p *postRendererString) Set(val string) error {
 		return nil
 	}
 	if p.options.pluginName != "" {
-		return fmt.Errorf("cannot specify --post-renderer flag more than once")
+		return errors.New("cannot specify --post-renderer flag more than once")
 	}
 	p.options.pluginName = val
 	pr, err := postrenderer.NewPostRendererPlugin(p.options.settings, p.options.pluginName, p.options.args...)

--- a/pkg/cmd/plugin_install.go
+++ b/pkg/cmd/plugin_install.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -102,7 +103,7 @@ func (o *pluginInstallOptions) complete(args []string) error {
 
 func (o *pluginInstallOptions) newInstallerForSource() (installer.Installer, error) {
 	// Check if source is an OCI registry reference
-	if strings.HasPrefix(o.source, fmt.Sprintf("%s://", registry.OCIScheme)) {
+	if strings.HasPrefix(o.source, registry.OCIScheme+"://") {
 		// Build getter options for OCI
 		options := []getter.Option{
 			getter.WithTLSClientConfig(o.certFile, o.keyFile, o.caFile),
@@ -135,7 +136,7 @@ func (o *pluginInstallOptions) run(out io.Writer) error {
 	} else if shouldVerify {
 		// For remote installations, check if verification is supported
 		if verifier, ok := i.(installer.Verifier); !ok || !verifier.SupportsVerification() {
-			return fmt.Errorf("plugin source does not support verification. Use --verify=false to skip verification")
+			return errors.New("plugin source does not support verification. Use --verify=false to skip verification")
 		}
 	} else {
 		// User explicitly disabled verification

--- a/pkg/cmd/repo_remove_test.go
+++ b/pkg/cmd/repo_remove_test.go
@@ -196,15 +196,15 @@ func TestRepoRemoveCompletion(t *testing.T) {
 	// and that port changes each time we run the test.
 	tests := []cmdTestCase{{
 		name:   "completion for repo remove",
-		cmd:    fmt.Sprintf("%s __completeNoDesc repo remove ''", repoSetup),
+		cmd:    repoSetup + " __completeNoDesc repo remove ''",
 		golden: "output/repo_list_comp.txt",
 	}, {
 		name:   "completion for repo remove, no filter",
-		cmd:    fmt.Sprintf("%s __completeNoDesc repo remove fo", repoSetup),
+		cmd:    repoSetup + " __completeNoDesc repo remove fo",
 		golden: "output/repo_list_comp.txt",
 	}, {
 		name:   "completion for repo remove repetition",
-		cmd:    fmt.Sprintf("%s __completeNoDesc repo remove foo ''", repoSetup),
+		cmd:    repoSetup + " __completeNoDesc repo remove foo ''",
 		golden: "output/repo_repeat_comp.txt",
 	}}
 	for _, test := range tests {

--- a/pkg/cmd/search_hub.go
+++ b/pkg/cmd/search_hub.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -136,7 +137,7 @@ func (h *hubSearchWriter) WriteTable(out io.Writer) error {
 	if len(h.elements) == 0 {
 		// Fail if no results found and --fail-on-no-result is enabled
 		if h.failOnNoResult {
-			return fmt.Errorf("no results found")
+			return errors.New("no results found")
 		}
 
 		_, err := out.Write([]byte("No results found\n"))
@@ -175,7 +176,7 @@ func (h *hubSearchWriter) WriteYAML(out io.Writer) error {
 func (h *hubSearchWriter) encodeByFormat(out io.Writer, format output.Format) error {
 	// Fail if no results found and --fail-on-no-result is enabled
 	if len(h.elements) == 0 && h.failOnNoResult {
-		return fmt.Errorf("no results found")
+		return errors.New("no results found")
 	}
 
 	// Initialize the array so no results returns an empty array instead of null

--- a/pkg/cmd/search_repo.go
+++ b/pkg/cmd/search_repo.go
@@ -216,7 +216,7 @@ func (r *repoSearchWriter) WriteTable(out io.Writer) error {
 	if len(r.results) == 0 {
 		// Fail if no results found and --fail-on-no-result is enabled
 		if r.failOnNoResult {
-			return fmt.Errorf("no results found")
+			return errors.New("no results found")
 		}
 
 		_, err := out.Write([]byte("No results found\n"))
@@ -245,7 +245,7 @@ func (r *repoSearchWriter) WriteYAML(out io.Writer) error {
 func (r *repoSearchWriter) encodeByFormat(out io.Writer, format output.Format) error {
 	// Fail if no results found and --fail-on-no-result is enabled
 	if len(r.results) == 0 && r.failOnNoResult {
-		return fmt.Errorf("no results found")
+		return errors.New("no results found")
 	}
 
 	// Initialize the array so no results returns an empty array instead of null
@@ -307,7 +307,7 @@ func compListChartsOfRepo(repoName string, prefix string) []string {
 // Provide dynamic auto-completion for commands that operate on charts (e.g., helm show)
 // When true, the includeFiles argument indicates that completion should include local files (e.g., local charts)
 func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.ShellCompDirective) {
-	cobra.CompDebugln(fmt.Sprintf("compListCharts with toComplete %s", toComplete), settings.Debug)
+	cobra.CompDebugln("compListCharts with toComplete "+toComplete, settings.Debug)
 
 	noSpace := false
 	noFile := false
@@ -323,7 +323,7 @@ func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.Shell
 		if len(repoInfo) > 1 {
 			repoDesc = repoInfo[1]
 		}
-		repoWithSlash := fmt.Sprintf("%s/", repo)
+		repoWithSlash := repo + "/"
 		if strings.HasPrefix(toComplete, repoWithSlash) {
 			// Must complete with charts within the specified repo.
 			// Don't filter on toComplete to allow for shell fuzzy matching

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -417,7 +418,7 @@ func TestRenderWithClientProvider_error(t *testing.T) {
 		t: t,
 		scheme: map[string]kindProps{
 			"v1/Error": {
-				shouldErr: fmt.Errorf("kaboom"),
+				shouldErr: errors.New("kaboom"),
 			},
 		},
 	}
@@ -1059,9 +1060,11 @@ func TestRenderRecursionLimit(t *testing.T) {
 	}
 
 	var expect string
+	var expectSb1062 strings.Builder
 	for range times {
-		expect += phrase + "\n"
+		expectSb1062.WriteString(phrase + "\n")
 	}
+	expect += expectSb1062.String()
 	if got := out["overlook/templates/quote"]; got != expect {
 		t.Errorf("Expected %q, got %q (%v)", expect, got, out)
 	}

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -18,7 +18,6 @@ package registry
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 
@@ -65,7 +64,7 @@ func (suite *HTTPRegistryClientTestSuite) Test_3_Tags() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
-	ref := fmt.Sprintf("%s/testrepo/supposedlysafechart:9.9.9", suite.CompromisedRegistryHost)
+	ref := suite.CompromisedRegistryHost + "/testrepo/supposedlysafechart:9.9.9"
 
 	// returns content that does not match the expected digest
 	_, err := suite.RegistryClient.Pull(ref)
@@ -74,7 +73,7 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_5_ImageIndex() {
-	ref := fmt.Sprintf("%s/testrepo/image-index:0.1.0", suite.FakeRegistryHost)
+	ref := suite.FakeRegistryHost + "/testrepo/image-index:0.1.0"
 
 	_, err := suite.RegistryClient.Pull(ref)
 	suite.Nil(err)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -209,7 +209,7 @@ func initCompromisedRegistryTestServer() string {
 	}))
 
 	u, _ := url.Parse(s.URL)
-	return fmt.Sprintf("localhost:%s", u.Port())
+	return "localhost:" + u.Port()
 }
 
 func initFakeRegistryTestServer() string {
@@ -376,7 +376,7 @@ func initFakeRegistryTestServer() string {
 	}))
 
 	u, _ := url.Parse(s.URL)
-	return fmt.Sprintf("localhost:%s", u.Port())
+	return "localhost:" + u.Port()
 }
 
 func testPush(suite *TestRegistry) {
@@ -384,7 +384,7 @@ func testPush(suite *TestRegistry) {
 	testingChartCreationTime := "1977-09-02T22:04:05Z"
 
 	// Bad bytes
-	ref := fmt.Sprintf("%s/testrepo/testchart:1.2.3", suite.DockerRegistryHost)
+	ref := suite.DockerRegistryHost + "/testrepo/testchart:1.2.3"
 	_, err := suite.RegistryClient.Push([]byte("hello"), ref, PushOptCreationTime(testingChartCreationTime))
 	suite.NotNil(err, "error pushing non-chart bytes")
 
@@ -468,7 +468,7 @@ func testPush(suite *TestRegistry) {
 
 func testPull(suite *TestRegistry) {
 	// bad/missing ref
-	ref := fmt.Sprintf("%s/testrepo/no-existy:1.2.3", suite.DockerRegistryHost)
+	ref := suite.DockerRegistryHost + "/testrepo/no-existy:1.2.3"
 	_, err := suite.RegistryClient.Pull(ref)
 	suite.NotNil(err, "error on bad/missing ref")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in pkg part 2

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
