### PR TITLE
chore(internal): fix perfsprint linter issues part 3

### DIFF
--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -112,7 +112,7 @@ func NewTLSConfig(options ...TLSConfigOption) (*tls.Config, error) {
 	if len(to.caPEMBlock) > 0 {
 		cp := x509.NewCertPool()
 		if !cp.AppendCertsFromPEM(to.caPEMBlock) {
-			return nil, fmt.Errorf("failed to append certificates from pem block")
+			return nil, errors.New("failed to append certificates from pem block")
 		}
 
 		config.RootCAs = cp


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in internal part 3

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
