### PR TITLE
chore(pkg): fix perfsprint linter issues part 7

### DIFF
--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -290,7 +290,7 @@ func TestSqlCreateAlreadyExists(t *testing.T) {
 	mock.
 		ExpectExec(regexp.QuoteMeta(insertQuery)).
 		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, recentUnixTimestamp()).
-		WillReturnError(fmt.Errorf("dialect dependent SQL error"))
+		WillReturnError(errors.New("dialect dependent SQL error"))
 
 	selectQuery := fmt.Sprintf(
 		regexp.QuoteMeta("SELECT %s FROM %s WHERE %s = $1 AND %s = $2"),


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter issues in pkg part 7

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
