### PR TITLE
fix(list): reintroduce deprecated --all/-a flag for backward compatibility

### DIFF
--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -136,6 +136,13 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVarP(&client.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Works only for secret(default) and configmap storage backends.")
 	bindOutputFlag(cmd, &outfmt)
 
+	// deprecated flags -- kept for backwards compatibility with helm v3 scripts
+	var all bool
+	f.BoolVarP(&all, "all", "a", false, "show all releases without any filter applied (default behavior in v4)")
+	if err := cmd.Flags().MarkDeprecated("all", "this is now the default behavior in Helm v4 and this flag will be removed in a future release"); err != nil {
+		panic(err)
+	}
+
 	return cmd
 }
 

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -234,6 +234,16 @@ func TestListCmd(t *testing.T) {
 		cmd:    "list -n milano",
 		golden: "output/list-namespace.txt",
 		rels:   releaseFixture,
+	}, {
+		name:   "list with deprecated --all flag produces same output",
+		cmd:    "list --all",
+		golden: "output/list-all-deprecated.txt",
+		rels:   releaseFixture,
+	}, {
+		name:   "list with deprecated -a flag produces same output",
+		cmd:    "list -a",
+		golden: "output/list-all-deprecated.txt",
+		rels:   releaseFixture,
 	}}
 	runTestCmd(t, tests)
 }

--- a/pkg/cmd/testdata/output/list-all-deprecated.txt
+++ b/pkg/cmd/testdata/output/list-all-deprecated.txt
@@ -1,0 +1,10 @@
+Flag --all has been deprecated, this is now the default behavior in Helm v4 and this flag will be removed in a future release
+NAME       	NAMESPACE	REVISION	UPDATED                      	STATUS         	CHART          	APP VERSION
+drax       	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalling   	chickadee-1.0.0	0.0.1      
+gamora     	default  	1       	2016-01-16 00:00:01 +0000 UTC	superseded     	chickadee-1.0.0	0.0.1      
+groot      	default  	1       	2016-01-16 00:00:01 +0000 UTC	uninstalled    	chickadee-1.0.0	0.0.1      
+hummingbird	default  	1       	2016-01-16 00:00:03 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
+iguana     	default  	2       	2016-01-16 00:00:04 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
+rocket     	default  	1       	2016-01-16 00:00:02 +0000 UTC	failed         	chickadee-1.0.0	0.0.1      
+starlord   	default  	2       	2016-01-16 00:00:01 +0000 UTC	deployed       	chickadee-1.0.0	0.0.1      
+thanos     	default  	1       	2016-01-16 00:00:01 +0000 UTC	pending-install	chickadee-1.0.0	0.0.1      


### PR DESCRIPTION
Reintroduces --all/-a for helm list as a deprecated no-op with a warning. In v4, helm list shows all releases by default, making this flag unnecessary - but removing it broke existing scripts. Follows the same MarkDeprecated pattern used for --force and --atomic.

Fixes #31784