### PR TITLE
feat(list): warn on 'helm list' truncation with default --max limit

### DIFF
--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -153,6 +153,8 @@ func (l *List) Run() ([]ri.Releaser, error) {
 		return nil, err
 	}
 
+	l.Truncated = false
+
 	var filter *regexp.Regexp
 	if l.Filter != "" {
 		var err error

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -135,6 +135,8 @@ type List struct {
 	Failed       bool
 	Pending      bool
 	Selector     string
+	// Truncated indicates results were omitted due to Limit
+	Truncated bool
 }
 
 // NewList constructs a new *List
@@ -213,7 +215,7 @@ func (l *List) Run() ([]ri.Releaser, error) {
 	}
 
 	// Calculate the limit and offset, and then truncate results if necessary.
-	limit := len(results)
+	limit := len(rresults)
 	if l.Limit > 0 && l.Limit < limit {
 		limit = l.Limit
 	}
@@ -221,6 +223,8 @@ func (l *List) Run() ([]ri.Releaser, error) {
 	if l := len(rresults); l < last {
 		last = l
 	}
+	l.Truncated = last < len(rresults)
+
 	rresults = rresults[l.Offset:last]
 
 	return releaseV1ListToReleaserList(rresults)

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -209,19 +209,20 @@ func TestList_Truncation(t *testing.T) {
 	is.Len(list, 1)
 	is.True(lister.Truncated, "Expected Truncated to be true when offset + limit < total")
 
-	lister.Limit = 1
-	lister.Offset = 2
-	list, err = lister.Run()
-	is.NoError(err)
-	is.Len(list, 1)
-	is.False(lister.Truncated, "Expected Truncated to be false when offset + limit == total")
-
+	// Early return path should reset Truncated even after a truncated run
 	lister.Limit = 1
 	lister.Offset = 3
 	list, err = lister.Run()
 	is.NoError(err)
 	is.Len(list, 0)
 	is.False(lister.Truncated, "Expected Truncated to be false when offset >= total")
+
+	lister.Limit = 1
+	lister.Offset = 2
+	list, err = lister.Run()
+	is.NoError(err)
+	is.Len(list, 1)
+	is.False(lister.Truncated, "Expected Truncated to be false when offset + limit == total")
 }
 
 func TestList_StateMask(t *testing.T) {

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -113,7 +113,16 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				}
 			}
 
-			return outfmt.Write(out, newReleaseListWriter(results, client.TimeFormat, client.NoHeaders, settings.ShouldDisableColor()))
+			if err := outfmt.Write(out, newReleaseListWriter(results, client.TimeFormat, client.NoHeaders, settings.ShouldDisableColor())); err != nil {
+				return err
+			}
+
+			outputFlag := cmd.Flag("output")
+			if outputFlag.Value.String() == "table" && client.Truncated && !cmd.Flags().Changed("max") {
+				fmt.Fprintln(os.Stderr, "WARNING: results were truncated due to the default --max limit. Use --max to show more releases.")
+			}
+
+			return nil
 		},
 	}
 

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -119,7 +119,7 @@ func newListCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 			outputFlag := cmd.Flag("output")
 			if outputFlag.Value.String() == "table" && client.Truncated && !cmd.Flags().Changed("max") {
-				fmt.Fprintln(os.Stderr, "WARNING: results were truncated due to the default --max limit. Use --max to show more releases.")
+				fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: results were truncated due to the default --max limit. Use --max to show more releases.")
 			}
 
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a warning to `helm list` when results are truncated due to the default `--max` limit (only when the user has not explicitly set `--max`).

Currently, `helm list` silently truncates results (default max=256), which can make it appear as if releases are missing. This change improves clarity by informing users that more results may exist.

The warning:
- is printed to stderr
- only applies to table (default) output
- does not affect JSON/YAML or other machine-readable formats
- is only shown when truncation is caused by the default limit

My intention in printing the warning to stderr and limiting it to table output was to preserve backward compatibility of structured and machine-readable output.

Closes #31617

**Special notes for your reviewer**:

- Implemented via a `Truncated` field in the action `List` struct
- No changes to existing CLI flags or output formats
- Manually tested with large (>256) release sets using `--max` and `--offset`
- Unit tests added to cover truncation scenarios

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
