### PR TITLE
fix: race condition in FailingKubeClient.GetWaiterWithOptions

### DIFF
--- a/pkg/action/hooks_test.go
+++ b/pkg/action/hooks_test.go
@@ -490,5 +490,5 @@ data:
 	is.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1295,5 +1295,5 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	is.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/action/release_testing_test.go
+++ b/pkg/action/release_testing_test.go
@@ -115,5 +115,5 @@ func TestReleaseTesting_WaitOptionsPassedDownstream(t *testing.T) {
 	is.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/action/rollback_test.go
+++ b/pkg/action/rollback_test.go
@@ -81,5 +81,5 @@ func TestRollback_WaitOptionsPassedDownstream(t *testing.T) {
 	is.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/action/uninstall_test.go
+++ b/pkg/action/uninstall_test.go
@@ -204,5 +204,5 @@ func TestUninstall_WaitOptionsPassedDownstream(t *testing.T) {
 	is.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -800,5 +800,5 @@ func TestUpgradeRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	req.NoError(err)
 
 	// Verify that WaitOptions were passed to GetWaiter
-	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
+	is.NotEmpty(failer.GetRecordedWaitOptions(), "WaitOptions should be passed to GetWaiter")
 }

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,8 +48,9 @@ type FailingKubeClient struct {
 	WaitForDeleteError     error
 	WatchUntilReadyError   error
 	WaitDuration           time.Duration
-	// RecordedWaitOptions stores the WaitOptions passed to GetWaiter for testing
-	RecordedWaitOptions []kube.WaitOption
+	// recordedWaitOptions stores the WaitOptions passed to GetWaiter for testing
+	recordedWaitOptions []kube.WaitOption
+	mu                  sync.Mutex
 }
 
 var _ kube.Interface = &FailingKubeClient{}
@@ -158,9 +160,19 @@ func (f *FailingKubeClient) GetWaiter(ws kube.WaitStrategy) (kube.Waiter, error)
 	return f.GetWaiterWithOptions(ws)
 }
 
+// GetRecordedWaitOptions returns the recorded WaitOptions in a thread-safe manner.
+func (f *FailingKubeClient) GetRecordedWaitOptions() []kube.WaitOption {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	dst := make([]kube.WaitOption, len(f.recordedWaitOptions))
+	copy(dst, f.recordedWaitOptions)
+	return dst
+}
+
 func (f *FailingKubeClient) GetWaiterWithOptions(ws kube.WaitStrategy, opts ...kube.WaitOption) (kube.Waiter, error) {
-	// Record the WaitOptions for testing
-	f.RecordedWaitOptions = append(f.RecordedWaitOptions, opts...)
+	f.mu.Lock()
+	f.recordedWaitOptions = append(f.recordedWaitOptions, opts...)
+	f.mu.Unlock()
 	waiter, _ := f.PrintingKubeClient.GetWaiterWithOptions(ws, opts...)
 	printingKubeWaiter, _ := waiter.(*PrintingKubeWaiter)
 	return &FailingKubeWaiter{


### PR DESCRIPTION
## Summary
- Fixes data race in `FailingKubeClient.GetWaiterWithOptions` where concurrent goroutines append to the `RecordedWaitOptions` slice without synchronization
- Adds a mutex to protect the slice and exposes a thread-safe `GetRecordedWaitOptions()` accessor
- Updates all test callers to use the new accessor

The race is triggered by `TestInstallRelease_RollbackOnFailure_Interrupted` and `TestUpgradeRelease_Interrupted_RollbackOnFailure` when run with `-race` (as `make test` does).

## Test plan
- [x] `make test` passes with zero failures (previously 2 race failures)
- [x] Targeted `-race` tests pass: `TestInstallRelease_RollbackOnFailure_Interrupted`, `TestUpgradeRelease_Interrupted_RollbackOnFailure`