### PR TITLE
fix: restore (deprecated) --atomic flag on install command for backwards compatibility

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -201,6 +201,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.DisableOpenAPIValidation, "disable-openapi-validation", false, "if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema")
 	f.BoolVar(&client.RollbackOnFailure, "rollback-on-failure", false, "if set, Helm will rollback (uninstall) the installation upon failure. The --wait flag will be default to \"watcher\" if --rollback-on-failure is set")
+	f.BoolVar(&client.RollbackOnFailure, "atomic", false, "deprecated")
 	f.MarkDeprecated("atomic", "use --rollback-on-failure instead")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes https://github.com/helm/helm/issues/31900 

In https://github.com/helm/helm/pull/13629 the --atomic flag was marked as deprecated for both the install and upgrade command however in the install command the flag binding was removed so the atomic flag no longer works and returns an error `Error: unknown flag: --atomic` when it should just alert that the flag is deprecated instead of failing the entire install

**Special notes for your reviewer**:
I didn't add any unit tests but if desired I can add some

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
