### PR TITLE
fix(plugin): install to first HELM_PLUGINS path entry

### DIFF
--- a/internal/plugin/installer/base.go
+++ b/internal/plugin/installer/base.go
@@ -30,9 +30,17 @@ type base struct {
 
 func newBase(source string) base {
 	settings := cli.New()
+	pluginsDirectory := settings.PluginsDirectory
+	for _, dir := range filepath.SplitList(settings.PluginsDirectory) {
+		if dir != "" {
+			pluginsDirectory = dir
+			break
+		}
+	}
+
 	return base{
 		Source:           source,
-		PluginsDirectory: settings.PluginsDirectory,
+		PluginsDirectory: pluginsDirectory,
 	}
 }
 

--- a/internal/plugin/installer/base_test.go
+++ b/internal/plugin/installer/base_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package installer // import "helm.sh/helm/v4/internal/plugin/installer"
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,10 +29,21 @@ func TestPath(t *testing.T) {
 			source:         "",
 			helmPluginsDir: "/helm/data/plugins",
 			expectPath:     "",
-		}, {
+		},
+		{
 			source:         "https://github.com/jkroepke/helm-secrets",
 			helmPluginsDir: "/helm/data/plugins",
 			expectPath:     "/helm/data/plugins/helm-secrets",
+		},
+		{
+			source:         "https://github.com/jkroepke/helm-secrets",
+			helmPluginsDir: strings.Join([]string{"/helm/data/plugins", "/helm/nfs/plugins"}, string(filepath.ListSeparator)),
+			expectPath:     "/helm/data/plugins/helm-secrets",
+		},
+		{
+			source:         "https://github.com/jkroepke/helm-secrets",
+			helmPluginsDir: strings.Join([]string{"", "/helm/nfs/plugins"}, string(filepath.ListSeparator)),
+			expectPath:     "/helm/nfs/plugins/helm-secrets",
 		},
 	}
 


### PR DESCRIPTION
Closes #11310

## Summary
`plugin install` was treating `HELM_PLUGINS` as a single directory string, even when it was a path list (for example `/tmp/abc:/tmp/xyz`).
That caused install destinations like `/tmp/abc:/tmp/xyz/<plugin>` which are not searched by plugin loading.

## What changed
- Updated `internal/plugin/installer/base.go` to resolve the install target directory from `filepath.SplitList(HELM_PLUGINS)`.
- Installer now uses the first non-empty entry from the path list as the install destination.
- Added regression coverage in `internal/plugin/installer/base_test.go` for:
  - multi-entry plugin path list
  - leading-empty entry path list

## Why this behavior
Helm already resolves plugins from all entries in `HELM_PLUGINS` and gives precedence to the leftmost entry. Installing into the first entry preserves that precedence and avoids writing into a literal path-list string.

## Notes
I could not run `go test` in this environment because the local Go toolchain is unavailable and Docker daemon is not running, so I focused on a narrow, test-backed code change and will rely on CI for full verification.
