### PR TITLE
test(cli): make User-Agent REST config test hermetic

### DIFF
--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -120,7 +120,8 @@ func TestEnvSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer resetEnv()()
+			cleanup := resetEnv()
+			t.Cleanup(cleanup)
 
 			for k, v := range tt.envvars {
 				t.Setenv(k, v)
@@ -219,7 +220,8 @@ func TestEnvOrBool(t *testing.T) {
 }
 
 func TestUserAgentHeaderInK8sRESTClientConfig(t *testing.T) {
-	defer resetEnv()()
+	cleanup := resetEnv()
+	t.Cleanup(cleanup)
 
 	kubeconfigPath := filepath.Join(t.TempDir(), "config")
 	kubeconfig := `apiVersion: v1

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -219,6 +220,30 @@ func TestEnvOrBool(t *testing.T) {
 
 func TestUserAgentHeaderInK8sRESTClientConfig(t *testing.T) {
 	defer resetEnv()()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "config")
+	kubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test-user
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to create test kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", kubeconfigPath)
 
 	settings := New()
 	restConfig, err := settings.RESTClientGetter().ToRESTConfig()

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -242,9 +242,7 @@ users:
   user:
     token: test-token
 `
-	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600); err != nil {
-		t.Fatalf("failed to create test kubeconfig: %v", err)
-	}
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600), "failed to create test kubeconfig")
 	t.Setenv("KUBECONFIG", kubeconfigPath)
 
 	settings := New()


### PR DESCRIPTION
Closes #31470

## Summary
`TestUserAgentHeaderInK8sRESTClientConfig` currently depends on the machine's kubeconfig state. If the host has an invalid `~/.kube/config` (or invalid current context), the test fails for reasons unrelated to what the test is validating.

## What changed
- Updated `pkg/cli/environment_test.go` to create a temporary minimal kubeconfig inside the test.
- Set `KUBECONFIG` to that temporary file before calling `ToRESTConfig()`.

## Result
The test now validates only what it is meant to validate (the User-Agent wiring), and no longer depends on host-specific Kubernetes environment.

## Notes
I could not run local `go test` in this environment because Go is not installed and Docker daemon is unavailable. CI should run the full test suite.
