### PR TITLE
`helm history` respect `TZ` now.

### DIFF
--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -50,6 +50,10 @@ func init() {
 func runTestCmd(t *testing.T, tests []cmdTestCase) {
 	t.Helper()
 	t.Setenv("TZ", "UTC")
+	prevLocal := time.Local
+	t.Cleanup(func() {
+		time.Local = prevLocal
+	})
 	time.Local = time.UTC
 	for _, tt := range tests {
 		for i := 0; i <= tt.repeat; i++ {

--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -49,6 +49,8 @@ func init() {
 
 func runTestCmd(t *testing.T, tests []cmdTestCase) {
 	t.Helper()
+	t.Setenv("TZ", "UTC")
+	time.Local = time.UTC
 	for _, tt := range tests {
 		for i := 0; i <= tt.repeat; i++ {
 			t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/history.go
+++ b/pkg/cmd/history.go
@@ -194,7 +194,7 @@ func (r releaseHistory) WriteTable(out io.Writer) error {
 	tbl := uitable.New()
 	tbl.AddRow("REVISION", "UPDATED", "STATUS", "CHART", "APP VERSION", "DESCRIPTION")
 	for _, item := range r {
-		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.In(time.Local).Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }

--- a/pkg/cmd/history.go
+++ b/pkg/cmd/history.go
@@ -218,7 +218,7 @@ func (r releaseHistoryWithRollback) WriteTable(out io.Writer) error {
 		if item.RollbackRevision > 0 {
 			rollback = strconv.Itoa(item.RollbackRevision)
 		}
-		tbl.AddRow(item.Revision, item.Updated.Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, rollback, item.Description)
+		tbl.AddRow(item.Revision, item.Updated.In(time.Local).Format(time.ANSIC), item.Status, item.Chart, item.AppVersion, rollback, item.Description)
 	}
 	return output.EncodeTable(out, tbl)
 }

--- a/pkg/cmd/history_test.go
+++ b/pkg/cmd/history_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+
+	"helm.sh/helm/v4/internal/test"
 	"helm.sh/helm/v4/pkg/release/common"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
@@ -146,6 +148,93 @@ func TestHistoryWithRollback(t *testing.T) {
 		golden: "output/history-with-rollback.yaml",
 	}}
 	runTestCmd(t, tests)
+}
+
+func TestHistoryCmdRespectsTimezone(t *testing.T) {
+	location := time.FixedZone("UTC-4", -4*60*60)
+
+	prevLocal := time.Local
+	time.Local = location
+	t.Cleanup(func() {
+		time.Local = prevLocal
+	})
+
+	date := time.Unix(242085845, 0).UTC()
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "foo",
+			Version:    "0.1.0-beta.1",
+			AppVersion: "1.0",
+		},
+	}
+
+	releases := []*release.Release{
+		{
+			Name:    "angry-bird",
+			Version: 1,
+			Info: &release.Info{
+				FirstDeployed: date,
+				LastDeployed:  date,
+				Status:        common.StatusSuperseded,
+				Description:   "Install complete",
+			},
+			Chart: ch,
+		},
+		{
+			Name:    "angry-bird",
+			Version: 2,
+			Info: &release.Info{
+				FirstDeployed: date,
+				LastDeployed:  date,
+				Status:        common.StatusSuperseded,
+				Description:   "Upgrade complete",
+			},
+			Chart: ch,
+		},
+		{
+			Name:    "angry-bird",
+			Version: 3,
+			Info: &release.Info{
+				FirstDeployed:    date,
+				LastDeployed:     date,
+				Status:           common.StatusDeployed,
+				RollbackRevision: 1,
+				Description:      "Rollback to 1",
+			},
+			Chart: ch,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		golden  string
+	}{
+		{
+			name:    "default table",
+			command: "history angry-bird",
+			golden:  "output/history-timezone.txt",
+		},
+		{
+			name:    "rollback revision table",
+			command: "history angry-bird --show-rollback-revision",
+			golden:  "output/history-timezone-with-rollback.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := storageFixture()
+			for _, rel := range releases {
+				require.NoError(t, storage.Create(rel))
+			}
+
+			_, out, err := executeActionCommandC(storage, tt.command)
+			require.NoError(t, err)
+
+			test.AssertGoldenString(t, out, tt.golden)
+		})
+	}
 }
 
 func TestHistoryOutputCompletion(t *testing.T) {

--- a/pkg/cmd/testdata/output/history-timezone-with-rollback.txt
+++ b/pkg/cmd/testdata/output/history-timezone-with-rollback.txt
@@ -1,0 +1,4 @@
+REVISION	UPDATED                 	STATUS    	CHART           	APP VERSION	ROLLBACK	DESCRIPTION     
+1       	Fri Sep  2 18:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	        	Install complete
+2       	Fri Sep  2 18:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	        	Upgrade complete
+3       	Fri Sep  2 18:04:05 1977	deployed  	foo-0.1.0-beta.1	1.0        	1       	Rollback to 1   

--- a/pkg/cmd/testdata/output/history-timezone.txt
+++ b/pkg/cmd/testdata/output/history-timezone.txt
@@ -1,0 +1,4 @@
+REVISION	UPDATED                 	STATUS    	CHART           	APP VERSION	DESCRIPTION     
+1       	Fri Sep  2 18:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	Install complete
+2       	Fri Sep  2 18:04:05 1977	superseded	foo-0.1.0-beta.1	1.0        	Upgrade complete
+3       	Fri Sep  2 18:04:05 1977	deployed  	foo-0.1.0-beta.1	1.0        	Rollback to 1   


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**: This PR fixes a timezone display issue in Helm where `helm history` ignores the `TZ` environment variable when printing timestamps (UPDATED). The change converts the stored timestamp to `time.Local` before formatting so allowing the CLi output to respect the users timezone.

closes: #31902

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
