### PR TITLE
fix(action): normalize glued YAML doc separators before post-render parsing

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -62,6 +63,7 @@ import (
 var Timestamper = time.Now
 
 var (
+	compactDocSeparatorPattern = regexp.MustCompile(`(?m)^---(?=\S)`)
 	// errMissingChart indicates that a chart was not provided.
 	errMissingChart = errors.New("no chart provided")
 	// errMissingRelease indicates that a release (name) was not provided.
@@ -159,7 +161,9 @@ func annotateAndMerge(files map[string]string) (string, error) {
 			continue
 		}
 
-		manifests, err := kio.ParseAll(content)
+		// Go template whitespace trimming can produce lines like `---apiVersion: ...`.
+		// Normalize those into valid document separators before YAML parsing.
+		manifests, err := kio.ParseAll(normalizeDocSeparators(content))
 		if err != nil {
 			return "", fmt.Errorf("parsing %s: %w", fname, err)
 		}
@@ -176,6 +180,10 @@ func annotateAndMerge(files map[string]string) (string, error) {
 		return "", fmt.Errorf("writing merged docs: %w", err)
 	}
 	return merged, nil
+}
+
+func normalizeDocSeparators(content string) string {
+	return compactDocSeparatorPattern.ReplaceAllString(content, "---\n")
 }
 
 // splitAndDeannotate reconstructs individual files from a merged YAML stream,

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -507,6 +507,61 @@ data:
 `,
 		},
 		{
+			name: "normalizes glued document separator at file start",
+			files: map[string]string{
+				"templates/glued.yaml": `---apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+data:
+  key: value`,
+			},
+			expected: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/glued.yaml'
+data:
+  key: value
+`,
+		},
+		{
+			name: "normalizes glued document separator between manifests",
+			files: map[string]string{
+				"templates/glued-multi.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+data:
+  key: value
+---apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+data:
+  password: dGVzdA==`,
+			},
+			expected: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/glued-multi.yaml'
+data:
+  key: value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/glued-multi.yaml'
+data:
+  password: dGVzdA==
+`,
+		},
+		{
 			name: "partials and empty files are removed",
 			files: map[string]string{
 				"templates/cm.yaml": `apiVersion: v1


### PR DESCRIPTION
## Summary
- normalize compact YAML document separators in `annotateAndMerge()` before calling `kio.ParseAll()`
- handle rendered content like `---apiVersion: ...` (produced by `---` followed by `{{- include ... }}` in templates)
- add regression coverage for both file-start and between-document glued separator cases

## Problem
In Helm v4 post-render flow, `annotateAndMerge()` parses rendered file content with `kio.ParseAll()`. When template whitespace trimming glues content to a document marker (for example `---apiVersion: v1`), YAML parsing treats it as a regular key and rewrites the manifest incorrectly.

## Fix
Before parsing, normalize line-start `---` markers that are immediately followed by non-whitespace into `---\n...`. This preserves intended document boundaries and avoids manifest corruption in post-render paths.

## Tests
Added `TestAnnotateAndMerge` cases:
- `normalizes glued document separator at file start`
- `normalizes glued document separator between manifests`

Fixes #31867
