### PR TITLE
fix: graceful fallback when debug.BuildInfo is unavailable

### DIFF
--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -33,8 +34,8 @@ import (
 )
 
 const (
-	kubeVersionMajorTesting = 1
-	kubeVersionMinorTesting = 20
+	kubeVersionMajorDefault = 1
+	kubeVersionMinorDefault = 20
 )
 
 var (
@@ -147,14 +148,15 @@ func makeDefaultCapabilities() (*Capabilities, error) {
 	// (And even if they did, we probably want stable capabilities for tests anyway)
 	// Return a default value for test builds
 	if testing.Testing() {
-		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
+		return newCapabilities(kubeVersionMajorDefault, kubeVersionMinorDefault)
 	}
 
 	vstr, err := helmversion.K8sIOClientGoModVersion()
 	if err != nil {
 		// Build info may be unavailable when compiled with toolchains other
 		// than "go build" (e.g. Bazel). Fall back to a safe default.
-		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
+		slog.Warn("failed to retrieve k8s.io/client-go version, falling back to default Kubernetes version", slog.Any("error", err))
+		return newCapabilities(kubeVersionMajorDefault, kubeVersionMinorDefault)
 	}
 
 	v, err := semver.NewVersion(vstr)

--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -152,7 +152,9 @@ func makeDefaultCapabilities() (*Capabilities, error) {
 
 	vstr, err := helmversion.K8sIOClientGoModVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve k8s.io/client-go version: %w", err)
+		// Build info may be unavailable when compiled with toolchains other
+		// than "go build" (e.g. Bazel). Fall back to a safe default.
+		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
 	}
 
 	v, err := semver.NewVersion(vstr)


### PR DESCRIPTION
When Helm is built with toolchains other than `go build` (e.g. Bazel), `debug.ReadBuildInfo()` returns false, causing a panic during DefaultCapabilities initialization. Fall back to the default Kubernetes version (v1.20.0) instead of panicking.

Fixes #31904

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
