### PR TITLE
fix: make toToml swallow errors consistent with toYaml and toJson

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -150,6 +150,7 @@ func fromYAMLArray(str string) []any {
 
 // toTOML takes an interface, marshals it to toml, and returns a string. It will
 // always return a string, even on marshal error (empty string).
+// Errors are swallowed, consistent with toYAML and toJSON behavior.
 //
 // This is designed to be called from a template.
 func toTOML(v any) string {
@@ -157,7 +158,8 @@ func toTOML(v any) string {
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
 	if err != nil {
-		return err.Error()
+		// Swallow errors inside of a template.
+		return ""
 	}
 	return b.String()
 }

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -123,6 +123,12 @@ keyInElement1 = "valueInElement1"`,
 		expect: `[error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go value of type []interface {}]`,
 		vars:   `hello: world`,
 	}, {
+		// toToml should swallow errors and return "" like toYaml and toJson do.
+		// map[int]string cannot be encoded as TOML (keys must be strings).
+		tpl:    `{{ toToml . }}`,
+		expect: ``,
+		vars:   map[int]string{1: "one"},
+	}, {
 		// This should never result in a network lookup. Regression for #7955
 		tpl:    `{{ lookup "v1" "Namespace" "" "unlikelynamespace99999999" }}`,
 		expect: `map[]`,


### PR DESCRIPTION
## Problem

\`toToml\` returns \`err.Error()\` on failure, which renders the raw error message string directly into the template output. This is inconsistent with \`toYAML\` and \`toJSON\`, both of which swallow errors silently by returning \`""\`.

**Before:**
\`\`\`go
if err != nil {
    return err.Error()  // renders error text into template
}
\`\`\`

**After:**
\`\`\`go
if err != nil {
    // Swallow errors inside of a template.
    return ""  // consistent with toYAML and toJSON
}
\`\`\`

## Solution

Changed \`toTOML\` to return \`""\` on error, matching the behavior of \`toYAML\` and \`toJSON\`.

Fixes #31430