### PR TITLE
[v3 backport] fix(action): guard nil RESTClientGetter in CRD install path

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -186,32 +186,34 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 			return err
 		}
 
-		// If we have already gathered the capabilities, we need to invalidate
-		// the cache so that the new CRDs are recognized. This should only be
-		// the case when an action configuration is reused for multiple actions,
-		// as otherwise it is later loaded by ourselves when getCapabilities
-		// is called later on in the installation process.
-		if i.cfg.Capabilities != nil {
-			discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient()
+		if i.cfg.RESTClientGetter != nil {
+			// If we have already gathered the capabilities, we need to invalidate
+			// the cache so that the new CRDs are recognized. This should only be
+			// the case when an action configuration is reused for multiple actions,
+			// as otherwise it is later loaded by ourselves when getCapabilities
+			// is called later on in the installation process.
+			if i.cfg.Capabilities != nil {
+				discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient()
+				if err != nil {
+					return err
+				}
+				if discoveryClient != nil {
+					i.cfg.Log("Clearing discovery cache")
+					discoveryClient.Invalidate()
+					_, _ = discoveryClient.ServerGroups()
+				}
+			}
+
+			// Invalidate the REST mapper, since it will not have the new CRDs
+			// present.
+			restMapper, err := i.cfg.RESTClientGetter.ToRESTMapper()
 			if err != nil {
 				return err
 			}
-
-			i.cfg.Log("Clearing discovery cache")
-			discoveryClient.Invalidate()
-
-			_, _ = discoveryClient.ServerGroups()
-		}
-
-		// Invalidate the REST mapper, since it will not have the new CRDs
-		// present.
-		restMapper, err := i.cfg.RESTClientGetter.ToRESTMapper()
-		if err != nil {
-			return err
-		}
-		if resettable, ok := restMapper.(meta.ResettableRESTMapper); ok {
-			i.cfg.Log("Clearing REST mapper cache")
-			resettable.Reset()
+			if resettable, ok := restMapper.(meta.ResettableRESTMapper); ok {
+				i.cfg.Log("Clearing REST mapper cache")
+				resettable.Reset()
+			}
 		}
 	}
 	return nil

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -894,6 +894,28 @@ func TestNameAndChartGenerateName(t *testing.T) {
 	}
 }
 
+func TestInstallCRDsWithNilRESTClientGetter(t *testing.T) {
+	config := actionConfigFixture(t)
+	failingKubeClient := kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}, BuildDummy: true}
+	config.KubeClient = &failingKubeClient
+	config.RESTClientGetter = nil
+	instAction := NewInstall(config)
+
+	crds := []chart.CRD{{
+		Name: "test-crd",
+		File: &chart.File{
+			Name: "crds/test-crd.yaml",
+			Data: []byte("kind: CustomResourceDefinition"),
+		},
+	}}
+
+	var err error
+	require.NotPanics(t, func() {
+		err = instAction.installCRDs(crds)
+	})
+	require.NoError(t, err)
+}
+
 func TestInstallWithLabels(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)


### PR DESCRIPTION
## What this PR does / why we need it

Backports the `helm template` panic fix in #31578 to `dev-v3` for issue #31552.

When CRDs are present, `installCRDs` always dereferenced `i.cfg.RESTClientGetter` to invalidate discovery/REST mapper caches. In `ClientOnly` flows this getter can be nil, which caused a nil pointer panic instead of returning a template error.

This PR:
- guards CRD cache invalidation behind `i.cfg.RESTClientGetter != nil`
- keeps cache invalidation behavior unchanged when a getter is available
- adds a regression test (`TestInstallCRDsWithNilRESTClientGetter`) to ensure no panic when CRDs exist and `RESTClientGetter` is nil

Fixes #31552

## Validation

- `go test ./pkg/action -run "TestInstallCRDsWithNilRESTClientGetter|TestInstallRelease$" -count=1`
