### PR TITLE
fix: protect FailingKubeClient.RecordedWaitOptions from data race

### DIFF
--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,7 @@ type FailingKubeClient struct {
 	WaitDuration           time.Duration
 	// RecordedWaitOptions stores the WaitOptions passed to GetWaiter for testing
 	RecordedWaitOptions []kube.WaitOption
+	mu                  sync.Mutex
 }
 
 var _ kube.Interface = &FailingKubeClient{}
@@ -160,7 +162,9 @@ func (f *FailingKubeClient) GetWaiter(ws kube.WaitStrategy) (kube.Waiter, error)
 
 func (f *FailingKubeClient) GetWaiterWithOptions(ws kube.WaitStrategy, opts ...kube.WaitOption) (kube.Waiter, error) {
 	// Record the WaitOptions for testing
+	f.mu.Lock()
 	f.RecordedWaitOptions = append(f.RecordedWaitOptions, opts...)
+	f.mu.Unlock()
 	waiter, _ := f.PrintingKubeClient.GetWaiterWithOptions(ws, opts...)
 	printingKubeWaiter, _ := waiter.(*PrintingKubeWaiter)
 	return &FailingKubeWaiter{

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -160,11 +160,14 @@ func (f *FailingKubeClient) GetWaiter(ws kube.WaitStrategy) (kube.Waiter, error)
 	return f.GetWaiterWithOptions(ws)
 }
 
-func (f *FailingKubeClient) GetWaiterWithOptions(ws kube.WaitStrategy, opts ...kube.WaitOption) (kube.Waiter, error) {
-	// Record the WaitOptions for testing
+func (f *FailingKubeClient) appendRecordedWaitOptionsLocked(opts ...kube.WaitOption) {
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.RecordedWaitOptions = append(f.RecordedWaitOptions, opts...)
-	f.mu.Unlock()
+}
+
+func (f *FailingKubeClient) GetWaiterWithOptions(ws kube.WaitStrategy, opts ...kube.WaitOption) (kube.Waiter, error) {
+	f.appendRecordedWaitOptionsLocked(opts...)
 	waiter, _ := f.PrintingKubeClient.GetWaiterWithOptions(ws, opts...)
 	printingKubeWaiter, _ := waiter.(*PrintingKubeWaiter)
 	return &FailingKubeWaiter{


### PR DESCRIPTION
## Summary

- Add `sync.Mutex` to `FailingKubeClient` to guard concurrent access to `RecordedWaitOptions` in `GetWaiterWithOptions`
- Fixes data race detected by `-race` flag when concurrent goroutines (upgrade + rollback, install + uninstall) both call `GetWaiterWithOptions` on the same `FailingKubeClient` instance

## Test plan

- [x] `go test -race -run TestUpgradeRelease_Interrupted_RollbackOnFailure ./pkg/action` passes
- [x] `go test -race -run TestInstallRelease_RollbackOnFailure_Interrupted ./pkg/action` passes
- [x] Full `make test-unit` passes