### PR TITLE
pkg/kube: remove legacy import comments

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"bytes"

--- a/pkg/kube/converter.go
+++ b/pkg/kube/converter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"sync"

--- a/pkg/kube/factory.go
+++ b/pkg/kube/factory.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"k8s.io/cli-runtime/pkg/resource"

--- a/pkg/kube/ready.go
+++ b/pkg/kube/ready.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"context"

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import "k8s.io/cli-runtime/pkg/resource"
 

--- a/pkg/kube/resource_policy.go
+++ b/pkg/kube/resource_policy.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 // ResourcePolicyAnno is the annotation name for a resource policy
 const ResourcePolicyAnno = "helm.sh/resource-policy"

--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"context"

--- a/pkg/kube/wait.go
+++ b/pkg/kube/wait.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"context"


### PR DESCRIPTION
## What

Import path comments (e.g. `// import "helm.sh/helm/v4/pkg/kube"`) are a pre-Go modules convention that is no longer needed in module-aware builds. Some files in `pkg/kube/` had these comments while others did not, causing inconsistency that triggered downstream Kythe indexing errors.

Affected files:
- `pkg/kube/client.go`
- `pkg/kube/statuswait.go`
- `pkg/kube/ready.go`
- `pkg/kube/wait.go`
- `pkg/kube/resource.go`
- `pkg/kube/converter.go`
- `pkg/kube/factory.go`
- `pkg/kube/resource_policy.go`

## Why

Since Go 1.11 (modules), import path comments are redundant — the `go.mod` file is the authoritative source for the module path. Having them in some files but not others within the same package causes inconsistency and breaks downstream static analysis tools like Kythe.

Fixes #31846