### PR TITLE
pkg/kube: remove legacy import comments from test files

### DIFF
--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"context"

--- a/pkg/kube/resource_test.go
+++ b/pkg/kube/resource_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"testing"

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube // import "helm.sh/helm/v4/pkg/kube"
+package kube
 
 import (
 	"context"


### PR DESCRIPTION
## What

Remove pre-Go modules import path comments from `pkg/kube` test files:
- `pkg/kube/ready_test.go`
- `pkg/kube/resource_test.go`
- `pkg/kube/statuswait_test.go`

## Why

Follow-up to #31931 which addressed the non-test files. As noted in [this Copilot review comment](https://github.com/helm/helm/pull/31931#discussion_r2922418643), the `*_test.go` files in `pkg/kube` still had legacy import path comments. Since Go 1.11 (modules), these comments are redundant — the `go.mod` file is authoritative. Removing them from test files ensures consistency across the entire package.

Addresses: https://github.com/helm/helm/pull/31931#discussion_r2922418643