### PR TITLE
remove legacy import comments from remaining packages

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main // import "helm.sh/helm/v4/cmd/helm"
+package main
 
 import (
 	"errors"

--- a/internal/chart/v3/lint/lint.go
+++ b/internal/chart/v3/lint/lint.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lint // import "helm.sh/helm/v4/internal/chart/v3/lint"
+package lint
 
 import (
 	"path/filepath"

--- a/internal/chart/v3/lint/rules/chartfile.go
+++ b/internal/chart/v3/lint/rules/chartfile.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/internal/chart/v3/lint/rules"
+package rules
 
 import (
 	"errors"

--- a/internal/chart/v3/lint/rules/dependencies.go
+++ b/internal/chart/v3/lint/rules/dependencies.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/internal/chart/v3/lint/rules"
+package rules
 
 import (
 	"fmt"

--- a/internal/chart/v3/lint/rules/deprecations.go
+++ b/internal/chart/v3/lint/rules/deprecations.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/internal/chart/v3/lint/rules"
+package rules
 
 import (
 	"fmt"

--- a/internal/chart/v3/lint/rules/deprecations_test.go
+++ b/internal/chart/v3/lint/rules/deprecations_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/internal/chart/v3/lint/rules"
+package rules
 
 import "testing"
 

--- a/internal/chart/v3/lint/support/doc.go
+++ b/internal/chart/v3/lint/support/doc.go
@@ -20,4 +20,4 @@ Package support contains tools for linting charts.
 Linting is the process of testing charts for errors or warnings regarding
 formatting, compilation, or standards compliance.
 */
-package support // import "helm.sh/helm/v4/internal/chart/v3/lint/support"
+package support

--- a/internal/plugin/cache/cache.go
+++ b/internal/plugin/cache/cache.go
@@ -14,7 +14,7 @@ limitations under the License.
 */
 
 // Package cache provides a key generator for vcs urls.
-package cache // import "helm.sh/helm/v4/internal/plugin/cache"
+package cache
 
 import (
 	"net/url"

--- a/internal/plugin/installer/base.go
+++ b/internal/plugin/installer/base.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"path/filepath"

--- a/internal/plugin/installer/base_test.go
+++ b/internal/plugin/installer/base_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"testing"

--- a/internal/plugin/installer/doc.go
+++ b/internal/plugin/installer/doc.go
@@ -14,4 +14,4 @@ limitations under the License.
 */
 
 // Package installer provides an interface for installing Helm plugins.
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer

--- a/internal/plugin/installer/extractor.go
+++ b/internal/plugin/installer/extractor.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"archive/tar"

--- a/internal/plugin/installer/http_installer.go
+++ b/internal/plugin/installer/http_installer.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"bytes"

--- a/internal/plugin/installer/http_installer_test.go
+++ b/internal/plugin/installer/http_installer_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"archive/tar"

--- a/internal/plugin/installer/local_installer.go
+++ b/internal/plugin/installer/local_installer.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"bytes"

--- a/internal/plugin/installer/local_installer_test.go
+++ b/internal/plugin/installer/local_installer_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"archive/tar"

--- a/internal/plugin/installer/oci_installer_test.go
+++ b/internal/plugin/installer/oci_installer_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"archive/tar"

--- a/internal/plugin/installer/vcs_installer.go
+++ b/internal/plugin/installer/vcs_installer.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"errors"

--- a/internal/plugin/installer/vcs_installer_test.go
+++ b/internal/plugin/installer/vcs_installer_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package installer // import "helm.sh/helm/v4/internal/plugin/installer"
+package installer
 
 import (
 	"fmt"

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugin // import "helm.sh/helm/v4/internal/plugin"
+package plugin
 
 import (
 	"context"

--- a/internal/plugin/runtime_subprocess_hooks.go
+++ b/internal/plugin/runtime_subprocess_hooks.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugin // import "helm.sh/helm/v4/internal/plugin"
+package plugin
 
 // Types of hooks
 const (

--- a/internal/release/v2/util/filter.go
+++ b/internal/release/v2/util/filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	v2 "helm.sh/helm/v4/internal/release/v2"

--- a/internal/release/v2/util/filter_test.go
+++ b/internal/release/v2/util/filter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"testing"

--- a/internal/release/v2/util/kind_sorter.go
+++ b/internal/release/v2/util/kind_sorter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"sort"

--- a/internal/release/v2/util/kind_sorter_test.go
+++ b/internal/release/v2/util/kind_sorter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"bytes"

--- a/internal/release/v2/util/manifest.go
+++ b/internal/release/v2/util/manifest.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"fmt"

--- a/internal/release/v2/util/manifest_sorter.go
+++ b/internal/release/v2/util/manifest_sorter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"fmt"

--- a/internal/release/v2/util/manifest_sorter_test.go
+++ b/internal/release/v2/util/manifest_sorter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"reflect"

--- a/internal/release/v2/util/manifest_test.go
+++ b/internal/release/v2/util/manifest_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"reflect"

--- a/internal/release/v2/util/sorter.go
+++ b/internal/release/v2/util/sorter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"sort"

--- a/internal/release/v2/util/sorter_test.go
+++ b/internal/release/v2/util/sorter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/internal/release/v2/util"
+package util
 
 import (
 	"testing"

--- a/pkg/chart/v2/lint/lint.go
+++ b/pkg/chart/v2/lint/lint.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lint // import "helm.sh/helm/v4/pkg/chart/v2/lint"
+package lint
 
 import (
 	"path/filepath"

--- a/pkg/chart/v2/lint/rules/chartfile.go
+++ b/pkg/chart/v2/lint/rules/chartfile.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/pkg/chart/v2/lint/rules"
+package rules
 
 import (
 	"errors"

--- a/pkg/chart/v2/lint/rules/dependencies.go
+++ b/pkg/chart/v2/lint/rules/dependencies.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/pkg/chart/v2/lint/rules"
+package rules
 
 import (
 	"fmt"

--- a/pkg/chart/v2/lint/rules/deprecations.go
+++ b/pkg/chart/v2/lint/rules/deprecations.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/pkg/chart/v2/lint/rules"
+package rules
 
 import (
 	"fmt"

--- a/pkg/chart/v2/lint/rules/deprecations_test.go
+++ b/pkg/chart/v2/lint/rules/deprecations_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rules // import "helm.sh/helm/v4/pkg/chart/v2/lint/rules"
+package rules
 
 import "testing"
 

--- a/pkg/chart/v2/lint/support/doc.go
+++ b/pkg/chart/v2/lint/support/doc.go
@@ -20,4 +20,4 @@ Package support contains tools for linting charts.
 Linting is the process of testing charts for errors or warnings regarding
 formatting, compilation, or standards compliance.
 */
-package support // import "helm.sh/helm/v4/pkg/chart/v2/lint/support"
+package support

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd // import "helm.sh/helm/v4/pkg/cmd"
+package cmd
 
 import (
 	"context"

--- a/pkg/engine/doc.go
+++ b/pkg/engine/doc.go
@@ -21,4 +21,4 @@ When Helm renders templates it does so with additional functions and different
 modes (e.g., strict, lint mode). This package handles the helm specific
 implementation.
 */
-package engine // import "helm.sh/helm/v4/pkg/engine"
+package engine

--- a/pkg/ignore/doc.go
+++ b/pkg/ignore/doc.go
@@ -65,4 +65,4 @@ Notable differences from .gitignore:
   - The evaluation of escape sequences has not been tested for compatibility
   - There is no support for '\!' as a special leading sequence.
 */
-package ignore // import "helm.sh/helm/v4/pkg/ignore"
+package ignore

--- a/pkg/provenance/doc.go
+++ b/pkg/provenance/doc.go
@@ -35,4 +35,4 @@ and using `gpg --verify`, `keybase pgp verify`, or similar:
 	gpg: Signature made Mon Jul 25 17:23:44 2016 MDT using RSA key ID 1FC18762
 	gpg: Good signature from "Helm Testing (This key should only be used for testing. DO NOT TRUST.) <helm-testing@helm.sh>" [ultimate]
 */
-package provenance // import "helm.sh/helm/v4/pkg/provenance"
+package provenance

--- a/pkg/registry/chart.go
+++ b/pkg/registry/chart.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry // import "helm.sh/helm/v4/pkg/registry"
+package registry
 
 import (
 	"bytes"

--- a/pkg/registry/chart_test.go
+++ b/pkg/registry/chart_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry // import "helm.sh/helm/v4/pkg/registry"
+package registry
 
 import (
 	"reflect"

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry // import "helm.sh/helm/v4/pkg/registry"
+package registry
 
 import (
 	"context"

--- a/pkg/registry/constants.go
+++ b/pkg/registry/constants.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry // import "helm.sh/helm/v4/pkg/registry"
+package registry
 
 const (
 	// OCIScheme is the URL scheme for OCI-based requests

--- a/pkg/registry/tag.go
+++ b/pkg/registry/tag.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry // import "helm.sh/helm/v4/pkg/registry"
+package registry
 
 import (
 	"fmt"

--- a/pkg/release/v1/util/filter.go
+++ b/pkg/release/v1/util/filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/pkg/release/v1/util"
+package util
 
 import (
 	"helm.sh/helm/v4/pkg/release/common"

--- a/pkg/release/v1/util/filter_test.go
+++ b/pkg/release/v1/util/filter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/pkg/release/v1/util"
+package util
 
 import (
 	"testing"

--- a/pkg/release/v1/util/manifest_test.go
+++ b/pkg/release/v1/util/manifest_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/pkg/release/v1/util"
+package util
 
 import (
 	"reflect"

--- a/pkg/release/v1/util/sorter.go
+++ b/pkg/release/v1/util/sorter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/pkg/release/v1/util"
+package util
 
 import (
 	"sort"

--- a/pkg/release/v1/util/sorter_test.go
+++ b/pkg/release/v1/util/sorter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "helm.sh/helm/v4/pkg/release/v1/util"
+package util
 
 import (
 	"testing"

--- a/pkg/repo/v1/chartrepo.go
+++ b/pkg/repo/v1/chartrepo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package repo // import "helm.sh/helm/v4/pkg/repo/v1"
+package repo
 
 import (
 	"bytes"

--- a/pkg/repo/v1/repo.go
+++ b/pkg/repo/v1/repo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package repo // import "helm.sh/helm/v4/pkg/repo/v1"
+package repo
 
 import (
 	"fmt"

--- a/pkg/storage/driver/cfgmaps.go
+++ b/pkg/storage/driver/cfgmaps.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"context"

--- a/pkg/storage/driver/driver.go
+++ b/pkg/storage/driver/driver.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"errors"

--- a/pkg/storage/driver/labels_test.go
+++ b/pkg/storage/driver/labels_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"testing"

--- a/pkg/storage/driver/mock_test.go
+++ b/pkg/storage/driver/mock_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"context"

--- a/pkg/storage/driver/records.go
+++ b/pkg/storage/driver/records.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"sort"

--- a/pkg/storage/driver/records_test.go
+++ b/pkg/storage/driver/records_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"reflect"

--- a/pkg/storage/driver/secrets.go
+++ b/pkg/storage/driver/secrets.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"context"

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"fmt"

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver // import "helm.sh/helm/v4/pkg/storage/driver"
+package driver
 
 import (
 	"bytes"

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package storage // import "helm.sh/helm/v4/pkg/storage"
+package storage
 
 import (
 	"errors"

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package storage // import "helm.sh/helm/v4/pkg/storage"
+package storage
 
 import (
 	"context"


### PR DESCRIPTION
## Problem

Pre-Go-modules import path comments (e.g. `// import "helm.sh/helm/v4/..."`) are obsolete since Go 1.11 introduced `go.mod` as the authoritative module path source. These stale comments cause downstream tooling issues — specifically breaking **Kythe** indexing (as reported in #31846).

## Solution

Remove the `// import "..."` comments from **64 files** across **20 packages** that were missed in #31931 and #31932:

- `cmd/helm`
- `internal/chart/v3/lint` and sub-packages
- `internal/plugin` and sub-packages
- `internal/release/v2/util`
- `pkg/chart/v2/lint` and sub-packages
- `pkg/cmd`, `pkg/engine`, `pkg/ignore`, `pkg/provenance`
- `pkg/registry`
- `pkg/release/v1/util`
- `pkg/repo/v1`
- `pkg/storage` and `pkg/storage/driver`

## Related

- Fixes #31846
- Follows up on #31931 (which cleaned `pkg/kube` source files)
- Follows up on #31932 (which cleaned `pkg/kube` test files)