### PR TITLE
fix: do not treat consecutive groups of 3 dashes in a line as document separators

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -162,8 +162,13 @@ func fixDocSeparators(content string) string {
 		}
 		// "---" must be at the start of a line: either idx==0 or preceded by '\n'.
 		if idx > 0 && remaining[idx-1] != '\n' {
-			b.WriteString(remaining[:idx+3])
-			remaining = remaining[idx+3:]
+			// Skip all remaining dashes in the line, otherwise they'll be considered as at the start of a line
+			nonDashIndex := idx + 3
+			for nonDashIndex < len(remaining) && remaining[nonDashIndex] == '-' {
+				nonDashIndex++
+			}
+			b.WriteString(remaining[:nonDashIndex])
+			remaining = remaining[nonDashIndex:]
 			continue
 		}
 		b.WriteString(remaining[:idx+3])

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -460,6 +460,11 @@ func TestFixDocSeparators(t *testing.T) {
 			expected: "data:\n  key: ---------value\n",
 		},
 		{
+				name:  "block scalar with dashes in quoted string",
+				input: "---\napiVersion: v1\nkind: ConfigMap\ndata:\n  script.sh: |\n    echo \"------------------------------------\"\n",
+				expected: "---\napiVersion: v1\nkind: ConfigMap\ndata:\n  script.sh: |\n    echo \"------------------------------------\"\n",
+		},
+		{
 			name:     "realistic multi-doc template output",
 			input:    "apiVersion: v1\nkind: Deployment\n---\napiVersion: v1\nkind: Ingress\n---apiVersion: v1\nkind: Service\n",
 			expected: "apiVersion: v1\nkind: Deployment\n---\napiVersion: v1\nkind: Ingress\n---\napiVersion: v1\nkind: Service\n",

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -455,6 +455,11 @@ func TestFixDocSeparators(t *testing.T) {
 			expected: "data:\n  key: ---value\n",
 		},
 		{
+			name:     "multiple triple dashes in a value is not a separator",
+			input:    "data:\n  key: ---------value\n",
+			expected: "data:\n  key: ---------value\n",
+		},
+		{
 			name:     "realistic multi-doc template output",
 			input:    "apiVersion: v1\nkind: Deployment\n---\napiVersion: v1\nkind: Ingress\n---apiVersion: v1\nkind: Service\n",
 			expected: "apiVersion: v1\nkind: Deployment\n---\napiVersion: v1\nkind: Ingress\n---\napiVersion: v1\nkind: Service\n",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #31935. We consume all remaining dashes after encountering `---` that is not at the start of a line such that the next iteration does not treat a `---` preceded by another `---` as another document separator because it appears to be at the start of the remaining content.

Note that there conceivably could be contrived scenarios where this logic fails. However, this errs on the side of realistic scenarios, as recovering the original intent from whitespace-trimmed output is generally ambiguous.

The following template demonstrates this ambiguity fully:
```yaml
---
{- if true -}
---key: value
{- end -}
---
another-doc-key: value
```
After whitespace trimming, it would like this:
```yaml
------key: value---another-doc-key: value
```
Both by the current fix logic implemented in #31868 and this new one, this would get reconstructed as follows:
```yaml
---
---
key: value---
another-doc-key: value
```
I am not sure there is a good way to resolve such ambiguities in an elegant way.