### PR TITLE
fix(chartutil): enable format assertions in JSON schema validation

### DIFF
--- a/pkg/chart/common/util/jsonschema.go
+++ b/pkg/chart/common/util/jsonschema.go
@@ -145,6 +145,7 @@ func ValidateAgainstSingleSchema(values common.Values, schemaJSON []byte) (reter
 	}
 
 	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
 	compiler.UseLoader(loader)
 	err = compiler.AddResource("file:///values.schema.json", schema)
 	if err != nil {

--- a/pkg/chart/common/util/jsonschema_test.go
+++ b/pkg/chart/common/util/jsonschema_test.go
@@ -91,6 +91,44 @@ func TestValidateAgainstSingleSchemaNegative(t *testing.T) {
 	}
 }
 
+func TestValidateAgainstSingleSchemaFormat(t *testing.T) {
+	values, err := common.ReadValuesFile("./testdata/test-values-format.yaml")
+	if err != nil {
+		t.Fatalf("Error reading YAML file: %s", err)
+	}
+	schema, err := os.ReadFile("./testdata/test-values-format.schema.json")
+	if err != nil {
+		t.Fatalf("Error reading JSON file: %s", err)
+	}
+
+	if err := ValidateAgainstSingleSchema(values, schema); err != nil {
+		t.Errorf("Error validating Values against Schema: %s", err)
+	}
+}
+
+func TestValidateAgainstSingleSchemaFormatNegative(t *testing.T) {
+	values, err := common.ReadValuesFile("./testdata/test-values-format-negative.yaml")
+	if err != nil {
+		t.Fatalf("Error reading YAML file: %s", err)
+	}
+	schema, err := os.ReadFile("./testdata/test-values-format.schema.json")
+	if err != nil {
+		t.Fatalf("Error reading JSON file: %s", err)
+	}
+
+	err = ValidateAgainstSingleSchema(values, schema)
+	if err == nil {
+		t.Fatal("Expected an error for invalid format values, but got nil")
+	}
+
+	errString := err.Error()
+	for _, expected := range []string{"ipv4", "ipv6", "email"} {
+		if !strings.Contains(errString, expected) {
+			t.Errorf("Expected error to mention %q, got:\n%s", expected, errString)
+		}
+	}
+}
+
 const subchartSchema = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Values",

--- a/pkg/chart/common/util/testdata/test-values-format-negative.yaml
+++ b/pkg/chart/common/util/testdata/test-values-format-negative.yaml
@@ -1,0 +1,3 @@
+ipAddress4: "invalid-ip"
+ipAddress6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334:11111111"
+email: "invalid-email"

--- a/pkg/chart/common/util/testdata/test-values-format.schema.json
+++ b/pkg/chart/common/util/testdata/test-values-format.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Values",
+  "type": "object",
+  "properties": {
+    "ipAddress4": {
+      "description": "IPv4 address",
+      "type": "string",
+      "format": "ipv4"
+    },
+    "ipAddress6": {
+      "description": "IPv6 address",
+      "type": "string",
+      "format": "ipv6"
+    },
+    "email": {
+      "description": "Email address",
+      "type": "string",
+      "format": "email"
+    }
+  },
+  "required": ["email", "ipAddress4", "ipAddress6"]
+}

--- a/pkg/chart/common/util/testdata/test-values-format.yaml
+++ b/pkg/chart/common/util/testdata/test-values-format.yaml
@@ -1,0 +1,3 @@
+ipAddress4: "192.168.1.1"
+ipAddress6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+email: "user@example.com"


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables format assertions in the JSON schema compiler used by `helm lint` and schema validation. After the switch to `github.com/santhosh-tekuri/jsonschema/v6`, the compiler was not configured to enforce `format` keywords (e.g. `ipv4`, `ipv6`, `email`) defined in `values.schema.json`. This caused `helm lint` to silently accept values that violated format constraints.

The fix calls `compiler.AssertFormat()` so that format keywords are enforced during validation.

Closes #31788

**Special notes for your reviewer**:

The `santhosh-tekuri/jsonschema/v6` library disables format assertions by default for draft 2019-09 and 2020-12 (per JSON Schema spec). Calling `AssertFormat()` enables them unconditionally across all drafts. For draft-07 schemas, format assertions were already enabled by default, so this is a no-op for that draft.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility