### PR TITLE
chore: enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - modernize
     - nakedret
     - nolintlint
+    - perfsprint
     - revive
     - sloglint
     - staticcheck


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable and fixes [perfsprint](https://golangci-lint.run/docs/linters/configuration/#perfsprint) linter, which checks for faster alternatives to fmt.Sprintf.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
