### PR TITLE
fix: Unalignment between toToml and toYaml/toJson

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -157,7 +157,7 @@ func toTOML(v any) string {
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
 	if err != nil {
-		return err.Error()
+		return ""
 	}
 	return b.String()
 }


### PR DESCRIPTION
Fixes #31430

`toTOML` in `pkg/engine/funcs.go` returned the error message string on encoding failure, while the equivalent `toYaml` and `toJson` functions return an empty string. This inconsistency caused templates using `toToml` to silently embed error text into rendered output rather than producing an empty value. Changes `toTOML` to return `""` on error, aligning its behavior with the other serialization functions. Verified by comparing behavior against existing tests for `toYaml` and `toJson`.