### PR TITLE
fix: allow null values from --values to override parent chart values

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -302,28 +302,20 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 	if dst == nil {
 		return src
 	}
-	// Track original non-nil src keys before modifying src
-	// This lets us distinguish between user nullifying a chart default vs
-	// user setting nil for a key not in chart defaults.
-	srcOriginalNonNil := make(map[string]bool)
-	for key, val := range src {
-		if val != nil {
-			srcOriginalNonNil[key] = true
-		}
-	}
 	for key, val := range dst {
 		if val == nil {
-			src[key] = nil
+			if _, inSrc := src[key]; inSrc {
+				src[key] = nil
+			}
 		}
 	}
 	// Because dest has higher precedence than src, dest values override src
 	// values.
 	for key, val := range src {
 		fullkey := concatPrefix(prefix, key)
-		if dv, ok := dst[key]; ok && !merge && dv == nil && srcOriginalNonNil[key] {
-			// When coalescing (not merging), if dst has nil and src has a non-nil
-			// value, the user is nullifying a chart default - remove the key.
-			// But if src also has nil (or key not in src), preserve the nil
+		if dv, ok := dst[key]; ok && !merge && dv == nil {
+			// When coalescing (not merging), if dst has nil, remove the key.
+			// This allows null from --values to override and remove parent chart defaults.
 			delete(dst, key)
 		} else if !ok {
 			// key not in user values, preserve src value (including nil)

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -765,3 +765,30 @@ func TestCoalesceValuesEmptyMapWithNils(t *testing.T) {
 	is.True(ok, "Expected data.baz key to be present but it was removed")
 	is.Nil(data["baz"], "Expected data.baz key to be nil but it is not")
 }
+
+
+// TestCoalesceTablesNullNullRegression tests regression #31919: when lower-precedence map has key with nil
+// and override also sets it to null, the key should be removed from coalesced values.
+func TestCoalesceTablesNullNullRegression(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      map[string]any
+		src      map[string]any
+		expected map[string]any
+	}{
+		{
+			name:     "null values merge regression #31919",
+			dst:      map[string]any{"key": nil},
+			src:      map[string]any{"key": nil},
+			expected: map[string]any{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make(map[string]any)
+			maps.Copy(dst, tt.dst)
+			CoalesceTables(dst, tt.src)
+			assert.Equal(t, tt.expected, dst)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix values merge to allow explicit null from `--values` to override parent chart values
- Restores Helm 3.17.0 behavior where null in override files removes parent defaults

## Root Cause
The coalesce logic only copied dst's nil keys to src when the key existed in src. When both chart and user had null, the delete condition required srcOriginalNonNil (chart had non-nil). Now we delete when dst has nil and the key exists in src, and we only copy nils to src for keys that already exist there (preserving user-only null keys like in TestCoalesceValuesEmptyMapWithNils).

## Testing
- Verified null override correctly removes parent values (reproducer from #31919)
- Existing test suite passes

Fixes #31919

Made with [Cursor](https://cursor.com)