### PR TITLE
fix(engine): make toToml return empty string on error, add mustToToml

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -167,7 +167,7 @@ func toTOML(v any) string {
 // mustToTOML takes an interface, marshals it to toml, and returns a string.
 // It will panic if there is an error.
 //
-// This is designed to be called from a template when need to ensure that the
+// This is designed to be called from a template when you need to ensure that the
 // output TOML is valid.
 func mustToTOML(v any) string {
 	b := bytes.NewBuffer(nil)

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -50,6 +50,7 @@ func funcMap() template.FuncMap {
 	// Add some extra functionality
 	extra := template.FuncMap{
 		"toToml":        toTOML,
+		"mustToToml":    mustToTOML,
 		"fromToml":      fromTOML,
 		"toYaml":        toYAML,
 		"mustToYaml":    mustToYAML,
@@ -157,7 +158,23 @@ func toTOML(v any) string {
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
 	if err != nil {
-		return err.Error()
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return b.String()
+}
+
+// mustToTOML takes an interface, marshals it to toml, and returns a string.
+// It will panic if there is an error.
+//
+// This is designed to be called from a template when need to ensure that the
+// output TOML is valid.
+func mustToTOML(v any) string {
+	b := bytes.NewBuffer(nil)
+	e := toml.NewEncoder(b)
+	err := e.Encode(v)
+	if err != nil {
+		panic(err)
 	}
 	return b.String()
 }

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -87,6 +87,11 @@ keyInElement1 = "valueInElement1"`,
 		expect: "[mast]\n  sail = \"white\"\n",
 		vars:   map[string]map[string]string{"mast": {"sail": "white"}},
 	}, {
+		// toToml should return empty string on error, not the error message
+		tpl:    `{{ toToml . }}`,
+		expect: "", // should return empty string and swallow error
+		vars:   map[int]string{1: "one"},
+	}, {
 		tpl:    `{{ fromYaml . }}`,
 		expect: "map[Error:error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}]",
 		vars:   "- one\n- two\n",
@@ -159,6 +164,13 @@ keyInElement1 = "valueInElement1"`,
 		tpl:    `{{ toJson . }}`,
 		expect: "", // should return empty string and swallow error
 		vars:   loopMap,
+	}, {
+		tpl:  `{{ mustToToml . }}`,
+		vars: map[int]string{1: "one"}, // non-string key is invalid in TOML
+	}, {
+		tpl:    `{{ mustToToml . }}`,
+		expect: "foo = \"bar\"\n", // should succeed and return TOML string
+		vars:   map[string]string{"foo": "bar"},
 	},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`toToml` was returning `err.Error()` on marshal failure, which is inconsistent with `toYaml` and `toJson` — both of which return an empty string and swallow the error (as they are designed to be safe to use in templates).

This PR:
- Fixes `toToml` to return `""` on error, matching the behavior of `toYaml` and `toJson`
- Adds `mustToToml` that panics on error, consistent with `mustToYaml` / `mustToJson`
- Registers `mustToToml` in the template function map
- Adds tests for both behaviors

Closes #31430

**Special notes for your reviewer**:

The `mustToToml` addition makes the change safe — users who previously relied on the error string being embedded (unlikely, but possible) can migrate to checking `fromToml` output or use `mustToToml` if they want a hard failure.

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility