### PR TITLE
fix: align toToml error behavior with toYaml and toJson

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -83,7 +83,7 @@ func TestFuncMap(t *testing.T) {
 	}
 
 	// Test for Engine-specific template functions.
-	expect := []string{"include", "required", "tpl", "toYaml", "fromYaml", "toToml", "fromToml", "toJson", "fromJson", "lookup"}
+	expect := []string{"include", "required", "tpl", "toYaml", "fromYaml", "toToml", "mustToToml", "fromToml", "toJson", "fromJson", "lookup"}
 	for _, f := range expect {
 		if _, ok := fns[f]; !ok {
 			t.Errorf("Expected add-on function %q", f)

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -50,6 +50,7 @@ func funcMap() template.FuncMap {
 	// Add some extra functionality
 	extra := template.FuncMap{
 		"toToml":        toTOML,
+		"mustToToml":    mustToTOML,
 		"fromToml":      fromTOML,
 		"toYaml":        toYAML,
 		"mustToYaml":    mustToYAML,
@@ -157,7 +158,23 @@ func toTOML(v any) string {
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
 	if err != nil {
-		return err.Error()
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return b.String()
+}
+
+// mustToTOML takes an interface, marshals it to toml, and returns a string.
+// It will panic if there is an error.
+//
+// This is designed to be called from a template when need to ensure that the
+// output TOML is valid.
+func mustToTOML(v any) string {
+	b := bytes.NewBuffer(nil)
+	e := toml.NewEncoder(b)
+	err := e.Encode(v)
+	if err != nil {
+		panic(err)
 	}
 	return b.String()
 }

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -152,11 +152,18 @@ keyInElement1 = "valueInElement1"`,
 		tpl:  `{{ mustToJson . }}`,
 		vars: loopMap,
 	}, {
+		tpl:  `{{ mustToToml . }}`,
+		vars: loopMap,
+	}, {
 		tpl:    `{{ toYaml . }}`,
 		expect: "", // should return empty string and swallow error
 		vars:   loopMap,
 	}, {
 		tpl:    `{{ toJson . }}`,
+		expect: "", // should return empty string and swallow error
+		vars:   loopMap,
+	}, {
+		tpl:    `{{ toToml . }}`,
 		expect: "", // should return empty string and swallow error
 		vars:   loopMap,
 	},


### PR DESCRIPTION
## Problem

`toToml` returns `err.Error()` on marshal failure, while `toYaml` and `toJson` return empty string.

This causes the raw error message to be rendered into templates, inconsistent with the other serialization functions.

## Fix

- `toTOML` now returns "" on error, consistent with `toYAML` and `toJSON`
- Added `mustToTOML` which panics on error (mirrors `mustToYAML`/`mustToJSON`)
- Registered `mustToToml` in funcMap
- Added test cases for both behaviors

## Testing

go test ./pkg/engine/... -run TestFunctions

Closes #31430