### PR TITLE
fix: handle JSON decode error in monocular search

### DIFF
--- a/internal/monocular/search.go
+++ b/internal/monocular/search.go
@@ -135,7 +135,9 @@ func (c *Client) Search(term string) ([]SearchResult, error) {
 
 	result := &searchResponse{}
 
-	json.NewDecoder(res.Body).Decode(result)
+	if err := json.NewDecoder(res.Body).Decode(result); err != nil {
+		return nil, fmt.Errorf("failed to decode response from %s: %w", p.String(), err)
+	}
 
 	return result.Data, nil
 }


### PR DESCRIPTION
`internal/monocular/search.go` discards the error from `json.NewDecoder().Decode()`. If the response body can't be decoded (malformed JSON, unexpected EOF, wrong types, etc.), `helm search hub` silently returns empty results instead of an error.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
