### PR TITLE
fix(action): normalize EOF newline before kyaml parse in post-render pipeline

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -150,6 +150,19 @@ const (
 // "---apiVersion: v1" which is not a valid YAML document separator.
 // This function inserts a newline after any "---" at the start of a line
 // that is immediately followed by non-whitespace content.
+// ensureTrailingNewlineForYAML appends a final newline when the input omits one.
+// kyaml's reader does not add a trailing newline to the last YAML document when
+// splitting streams (see kio.ByteReader.Read); parsing and re-serializing then
+// rewrites literal block scalars from "|" to "|-" (strip chomping). A trailing
+// newline at EOF avoids that round-trip change so post-renderer merge/split
+// matches direct template output. See https://github.com/helm/helm/issues/31948
+func ensureTrailingNewlineForYAML(content string) string {
+	if content == "" || strings.HasSuffix(content, "\n") {
+		return content
+	}
+	return content + "\n"
+}
+
 func fixDocSeparators(content string) string {
 	var b strings.Builder
 	remaining := content
@@ -198,6 +211,7 @@ func annotateAndMerge(files map[string]string) (string, error) {
 		// separator. Insert the missing newline so kio.ParseAll can
 		// parse the content correctly.
 		content = fixDocSeparators(content)
+		content = ensureTrailingNewlineForYAML(content)
 
 		manifests, err := kio.ParseAll(content)
 		if err != nil {
@@ -221,6 +235,7 @@ func annotateAndMerge(files map[string]string) (string, error) {
 // splitAndDeannotate reconstructs individual files from a merged YAML stream,
 // removing filename annotations and grouping documents by their original filenames.
 func splitAndDeannotate(postrendered string) (map[string]string, error) {
+	postrendered = ensureTrailingNewlineForYAML(postrendered)
 	manifests, err := kio.ParseAll(postrendered)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing YAML: %w", err)

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -728,11 +728,20 @@ data:
 	assert.Contains(t, merged, "value: |")
 	assert.NotContains(t, merged, "value: |-")
 
+	// Original behavior: splitAndDeannotate on the merged stream as produced.
 	reconstructed, err := splitAndDeannotate(merged)
 	require.NoError(t, err)
 	out := reconstructed["templates/cm.yaml"]
 	assert.Contains(t, out, "value: |")
 	assert.NotContains(t, out, "value: |-")
+
+	// New regression coverage: simulate a post-renderer output stream lacking a trailing newline.
+	mergedNoEOF := strings.TrimSuffix(merged, "\n")
+	reconstructedNoEOF, err := splitAndDeannotate(mergedNoEOF)
+	require.NoError(t, err)
+	outNoEOF := reconstructedNoEOF["templates/cm.yaml"]
+	assert.Contains(t, outNoEOF, "value: |")
+	assert.NotContains(t, outNoEOF, "value: |-")
 }
 
 func TestSplitAndDeannotate(t *testing.T) {

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -710,6 +710,31 @@ metadata:
 	}
 }
 
+// Regression: https://github.com/helm/helm/issues/31948 — kyaml parse/serialize
+// without a trailing newline rewrites "|" block scalars to "|-" unless we normalize EOF.
+func TestAnnotateAndMerge_PreservesLiteralBlockScalarWithoutEOFNewline(t *testing.T) {
+	files := map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  value: |
+    my value
+    with multiple lines`,
+	}
+	merged, err := annotateAndMerge(files)
+	require.NoError(t, err)
+	assert.Contains(t, merged, "value: |")
+	assert.NotContains(t, merged, "value: |-")
+
+	reconstructed, err := splitAndDeannotate(merged)
+	require.NoError(t, err)
+	out := reconstructed["templates/cm.yaml"]
+	assert.Contains(t, out, "value: |")
+	assert.NotContains(t, out, "value: |-")
+}
+
 func TestSplitAndDeannotate(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION


Resolves: https://github.com/helm/helm/issues/31948

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When --post-renderer is used, Helm merges rendered manifests and splits them again after post-rendering by parsing and re-serializing YAML with kustomize/kyaml (kio.ParseAll / kio.StringAll). If a template file ends without a trailing newline at EOF, that round-trip can rewrite literal block scalars from keep style (|) to strip style (|-), which differs from output without a post-renderer and from Helm 3.

This change introduces **ensureTrailingNewlineForYAML**, which appends a single newline when the input is non-empty and does not already end with one. It is applied in annotateAndMerge (after fixDocSeparators, before parsing) and at the start of **splitAndDeannotate** (before parsing post-renderer output), so kyaml’s reader sees a consistent EOF and literal block scalar formatting is preserved through the post-renderer path.

**Special notes for your reviewer**:
The behavior is limited to adding a trailing newline when missing; inputs that already end with \n are unchanged.
Regression coverage is added in TestAnnotateAndMerge_PreservesLiteralBlockScalarWithoutEOFNewline.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
