### PR TITLE
fix: treat nil vals map as empty map to avoid panic

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"maps"
 
 	"helm.sh/helm/v4/internal/copystructure"
@@ -73,6 +74,13 @@ func MergeValues(chrt chart.Charter, vals map[string]any) (common.Values, error)
 }
 
 func copyValues(vals map[string]any) (common.Values, error) {
+	// handle case where vals is nil to avoid panics or misuse of an uninitialized values map
+	if vals == nil {
+		slog.Warn("copyValues called with nil vals; returning nil values map")
+		// ensure we always return a non-nil map to callers
+		return make(map[string]any), nil
+	}
+
 	v, err := copystructure.Copy(vals)
 	if err != nil {
 		return vals, err


### PR DESCRIPTION


**What this PR does / why we need it**:
In dependencies.go, the processImportValues ​​method might pass nil to CoalesceValues ​​when the chart contains imported values ​​but no user values. In copyValues, a nil protection is added before calling Copy.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
