### PR TITLE
feat(engine): add mustToToml template function

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -50,6 +50,7 @@ func funcMap() template.FuncMap {
 	// Add some extra functionality
 	extra := template.FuncMap{
 		"toToml":        toTOML,
+		"mustToToml":    mustToTOML,
 		"fromToml":      fromTOML,
 		"toYaml":        toYAML,
 		"mustToYaml":    mustToYAML,
@@ -158,6 +159,21 @@ func toTOML(v any) string {
 	err := e.Encode(v)
 	if err != nil {
 		return err.Error()
+	}
+	return b.String()
+}
+
+// mustToTOML takes an interface, marshals it to toml, and returns a string.
+// It will panic if there is an error.
+//
+// This is designed to be called from a template when you need to ensure that the
+// output TOML is valid.
+func mustToTOML(v any) string {
+	b := bytes.NewBuffer(nil)
+	e := toml.NewEncoder(b)
+	err := e.Encode(v)
+	if err != nil {
+		panic(err)
 	}
 	return b.String()
 }

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -149,10 +149,11 @@ func fromYAMLArray(str string) []any {
 	return a
 }
 
-// toTOML takes an interface, marshals it to toml, and returns a string. It will
-// always return a string, even on marshal error (empty string).
+// toTOML takes an interface, marshals it to toml, and returns a string.
+// On marshal error it returns the error string.
 //
-// This is designed to be called from a template.
+// This is designed to be called from a template. Use mustToToml if you need
+// the template to fail hard on marshal errors.
 func toTOML(v any) string {
 	b := bytes.NewBuffer(nil)
 	e := toml.NewEncoder(b)

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -159,6 +159,13 @@ keyInElement1 = "valueInElement1"`,
 		tpl:    `{{ toJson . }}`,
 		expect: "", // should return empty string and swallow error
 		vars:   loopMap,
+	}, {
+		tpl:  `{{ mustToToml . }}`,
+		vars: map[int]string{1: "one"}, // non-string key is invalid in TOML
+	}, {
+		tpl:    `{{ mustToToml . }}`,
+		expect: "foo = \"bar\"\n", // should succeed and return TOML string
+		vars:   map[string]string{"foo": "bar"},
 	},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `mustToToml` — a strict variant of `toToml` that panics on marshal error, consistent with `mustToYaml` and `mustToJson`.

`toToml` behavior is **unchanged** in this PR (still returns `err.Error()` on failure). This is a purely additive change.

This follows the guidance from @gjenkins8 on #31431 to split the two concerns:
- This PR: add `mustToToml` (no risk, no behavior change)
- #31431 / follow-up PR: change `toToml` to swallow errors (separate discussion)

Closes #31430

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Signed-off-by: Ilya Kiselev <kis-ilya-a@yandex.ru>