### PR TITLE
fix: pin codeql-action/upload-sarif to commit SHA

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -64,6 +64,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pin the one remaining unpinned GitHub Action (`github/codeql-action/upload-sarif@v4`) to its commit SHA in `scorecards.yml`
- All other actions across the repo's 7 workflow files were already correctly SHA-pinned
- Uses the same codeql-action SHA (`e296a935590eb16afc0c0108289f68c87e2a89a5`, v4.30.7) already used in `codeql-analysis.yml` for consistency
- Aligns with the [Kubernetes GitHub Actions security policy](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md)

## Test plan
- [ ] Verify scorecards workflow YAML is valid
- [ ] Confirm the scorecards workflow triggers and runs successfully