### PR TITLE
fix(action): block scalar support for contiguous separators

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -162,8 +162,15 @@ func fixDocSeparators(content string) string {
 		}
 		// "---" must be at the start of a line: either idx==0 or preceded by '\n'.
 		if idx > 0 && remaining[idx-1] != '\n' {
-			b.WriteString(remaining[:idx+3])
-			remaining = remaining[idx+3:]
+			// Skip past all contiguous dashes to avoid re-examining
+			// interior dashes of a long sequence (e.g. "--------------------")
+			// as a new "---" at position 0 of the remaining buffer.
+			end := idx + 3
+			for end < len(remaining) && remaining[end] == '-' {
+				end++
+			}
+			b.WriteString(remaining[:end])
+			remaining = remaining[end:]
 			continue
 		}
 		b.WriteString(remaining[:idx+3])

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -484,6 +484,11 @@ func TestFixDocSeparators(t *testing.T) {
 			input:    "----more\napiVersion: v1\n",
 			expected: "---\n-more\napiVersion: v1\n",
 		},
+		{
+			name:     "long dashes in block scalar are not separators",
+			input:    "apiVersion: v1\nkind: Job\nspec:\n  containers:\n    - command:\n      - |\n        echo --------------------\n        echo done\n",
+			expected: "apiVersion: v1\nkind: Job\nspec:\n  containers:\n    - command:\n      - |\n        echo --------------------\n        echo done\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

closes #31977

**What this PR does / why we need it**:

I believe this is a bit of a regression in behavior given the context of the issue and possibly introduced as part of #31868. I was looking through #31941 which proposes the removal of `fixDocSeparators` and for which the associated test case here may be relevant and otherwise this PR could be closed.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
