### PR TITLE
fix(kube): clarify server-side apply patch errors

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1241,7 +1241,7 @@ func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts 
 			return fmt.Errorf("conflict occurred while applying object %s/%s %s: %w", target.Namespace, target.Name, target.Mapping.GroupVersionKind.String(), err)
 		}
 
-		return err
+		return fmt.Errorf("server-side apply failed for object %s/%s %s: %w", target.Namespace, target.Name, target.Mapping.GroupVersionKind.String(), err)
 	}
 
 	return target.Refresh(obj, true)

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -1802,6 +1802,23 @@ func TestPatchResourceServerSide(t *testing.T) {
 			},
 			ExpectedErrorContains: "the server reported a conflict",
 		},
+		"generic server-side apply error": {
+			Pods:                     newPodList("whale"),
+			DryRun:                   false,
+			ForceConflicts:           false,
+			FieldValidationDirective: FieldValidationDirectiveStrict,
+			Callback: func(t *testing.T, _ testCase, _ []RequestResponseAction, _ *http.Request) (*http.Response, error) {
+				t.Helper()
+
+				return newResponse(http.StatusBadRequest, &metav1.Status{
+					Status:  metav1.StatusFailure,
+					Message: `failed to create typed patch object: .spec.template.spec.containers[name="test"].env: duplicate entries for key [name="SERVER_CONTEXT_PATH"]`,
+					Reason:  metav1.StatusReasonBadRequest,
+					Code:    http.StatusBadRequest,
+				})
+			},
+			ExpectedErrorContains: "server-side apply failed for object default/whale /v1, Kind=Pod: failed to create typed patch object",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## What this PR does / why we need it

Refs #31529

When a generic server-side apply patch fails, Helm currently returns the raw API error without clearly indicating that the failure happened on the server-side apply path.

This change wraps generic server-side apply patch errors with resource context and an explicit `server-side apply failed` prefix, while leaving the existing incompatible-server and conflict-specific messages unchanged.

## What changed

- wrap generic errors returned from `patchResourceServerSide()` with server-side apply context
- add regression coverage for a duplicate-key style typed patch error

## Validation

- `env GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache go test ./pkg/kube -run 'Test(Create|PatchResourceServerSide)' -count=1`