### PR TITLE
Validate Host URL on Login

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -227,28 +227,36 @@ type (
 	}
 )
 
-// hostRegex is a pretty naive regex for validating host urls. The goal of it is not to ultimately validate all possible valid hosts,
-// but to catch common user errors such as including a scheme or path in the host string.
-var hostRegex = regexp.MustCompile(`^(?P<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?(?P<host>[a-zA-Z0-9\-._:\[\]]+)(?P<path>\/.*)?$`)
+// schemeRegex is used to check if a schema is present within the host - we have to do so, to determine if we need
+// to prepend a "dummy://" schema for url.Parse to not accidentally interpret the host as just a path
+var schemeRegex = regexp.MustCompile(`^(?P<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/).*$`)
 
-// validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme or path.
+// validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme, query or path.
 // While ORAS will also validate some of these things, the current errors are a bit opaque.
 // By validating these things upfront, we can provide clearer error messages to users when they attempt to login with an invalid host string.
 func validateHost(host string) error {
-	matches := hostRegex.FindStringSubmatch(host)
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("host cannot be empty")
+	}
+
+	matches := schemeRegex.FindStringSubmatch(host)
 	if len(matches) == 0 {
-		return fmt.Errorf("invalid host: %q", host)
+		host = "dummy://" + host
 	}
 
-	scheme := matches[hostRegex.SubexpIndex("scheme")]
-	path := matches[hostRegex.SubexpIndex("path")]
-
-	if scheme != "" {
-		return fmt.Errorf("host should not contain a scheme (e.g. http://), found %q", scheme)
+	url, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid host %q: %w", host, err)
 	}
 
-	if path != "" {
-		return fmt.Errorf("host should not contain a path, found %q", path)
+	// we check that no schema and query is present
+	if url.Scheme != "dummy" || url.RawQuery != "" {
+		return fmt.Errorf("host should not contain a scheme, query or fragement")
+	}
+
+	// currently, paths are also not supported
+	if url.Path != "" && url.Path != "/" {
+		return fmt.Errorf("host should not contain a path, found %q", url.Path)
 	}
 
 	return nil

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -229,7 +229,7 @@ type (
 
 // hostRegex is a pretty naive regex for validating host urls. The goal of it is not to ultimately validate all possible valid hosts,
 // but to catch common user errors such as including a scheme or path in the host string.
-var hostRegex = regexp.MustCompile(`^(?P<scheme>[a-z]*:\/\/)?(?P<host>[a-zA-Z0-9-\.\:]+)(?P<path>\/.*)?$`)
+var hostRegex = regexp.MustCompile(`^(?P<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?(?P<host>[a-zA-Z0-9\-._:\[\]]+)(?P<path>\/.*)?$`)
 
 // validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme or path.
 // While ORAS will also validate some of these things, the current errors are a bit opaque.
@@ -240,8 +240,8 @@ func validateHost(host string) error {
 		return fmt.Errorf("invalid host: %q", host)
 	}
 
-	scheme := matches[1]
-	path := matches[3]
+	scheme := matches[hostRegex.SubexpIndex("scheme")]
+	path := matches[hostRegex.SubexpIndex("path")]
 
 	if scheme != "" {
 		return fmt.Errorf("host should not contain a scheme (e.g. http://), found %q", scheme)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -24,10 +24,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -227,15 +227,29 @@ type (
 	}
 )
 
-// warnIfHostHasPath checks if the host contains a repository path and logs a warning if it does.
-// Returns true if the host contains a path component (i.e., contains a '/').
-func warnIfHostHasPath(host string) bool {
-	if strings.Contains(host, "/") {
-		registryHost := strings.Split(host, "/")[0]
-		slog.Warn("registry login currently only supports registry hostname, not a repository path", "host", host, "suggested", registryHost)
-		return true
+var hostRegex = regexp.MustCompile(`^(?P<scheme>[a-z]*:\/\/)?(?P<host>[a-zA-Z0-9-\.\:]+)(?P<path>\/.*)?$`)
+
+// validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme or path.
+// While ORAS will also validate some of these things, the current errors are a bit opaque.
+// By validating these things upfront, we can provide clearer error messages to users when they attempt to login with an invalid host string.
+func validateHost(host string) error {
+	matches := hostRegex.FindStringSubmatch(host)
+	if len(matches) == 0 {
+		return fmt.Errorf("invalid host: %q", host)
 	}
-	return false
+
+	scheme := matches[1]
+	path := matches[3]
+
+	if scheme != "" {
+		return fmt.Errorf("host should not contain a scheme (e.g. http://), found %q", scheme)
+	}
+
+	if path != "" {
+		return fmt.Errorf("host should not contain a path, found %q", path)
+	}
+
+	return nil
 }
 
 // Login authenticates the client with a remote OCI registry using the provided host and options.
@@ -244,7 +258,9 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 		option(&loginOperation{host, c})
 	}
 
-	warnIfHostHasPath(host)
+	if err := validateHost(host); err != nil {
+		return err
+	}
 
 	reg, err := remote.NewRegistry(host)
 	if err != nil {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -229,34 +229,41 @@ type (
 
 // schemeRegex is used to check if a schema is present within the host - we have to do so, to determine if we need
 // to prepend a "dummy://" schema for url.Parse to not accidentally interpret the host as just a path
-var schemeRegex = regexp.MustCompile(`^(?P<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/).*$`)
+var schemeRegex = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/).*$`)
 
 // validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme, query or path.
 // While ORAS will also validate some of these things, the current errors are a bit opaque.
 // By validating these things upfront, we can provide clearer error messages to users when they attempt to login with an invalid host string.
 func validateHost(host string) error {
-	if strings.TrimSpace(host) == "" {
+	host = strings.TrimSpace(host)
+	if host == "" {
 		return fmt.Errorf("host cannot be empty")
 	}
 
+	// we pre-validate the scheme part here to make sure that we can prepend a dummy scheme for url.Parse without accidentally
+	// accepting invalid hosts that would be parsed with the scheme as just a path. By not just blindly prepending the scheme,
+	// we can produce a clearer error message for users who still include a scheme in the host string, which is a common thing.
 	matches := schemeRegex.FindStringSubmatch(host)
-	if len(matches) == 0 {
-		host = "dummy://" + host
+	if len(matches) != 0 {
+		return fmt.Errorf("host should not contain a scheme, found %q", host)
 	}
 
-	url, err := url.Parse(host)
+	// keep the original host for potential error messages
+	originalHost := host
+
+	// we have to prepend the dummy scheme here to make it an absolute url
+	parsed, err := url.Parse("dummy://" + host)
 	if err != nil {
-		return fmt.Errorf("invalid host %q: %w", host, err)
+		return fmt.Errorf("invalid host %q: %w", originalHost, err)
 	}
 
-	// we check that no schema and query is present
-	if url.Scheme != "dummy" || url.RawQuery != "" {
-		return fmt.Errorf("host should not contain a scheme, query or fragement")
+	if parsed.RawQuery != "" || parsed.RawFragment != "" {
+		return fmt.Errorf("host should not contain a query or fragment, found %q", originalHost)
 	}
 
 	// currently, paths are also not supported
-	if url.Path != "" && url.Path != "/" {
-		return fmt.Errorf("host should not contain a path, found %q", url.Path)
+	if parsed.Path != "" {
+		return fmt.Errorf("host should not contain a path, found %q", originalHost)
 	}
 
 	return nil

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -227,6 +227,8 @@ type (
 	}
 )
 
+// hostRegex is a pretty naive regex for validating host urls. The goal of it is not to ultimately validate all possible valid hosts,
+// but to catch common user errors such as including a scheme or path in the host string.
 var hostRegex = regexp.MustCompile(`^(?P<scheme>[a-z]*:\/\/)?(?P<host>[a-zA-Z0-9-\.\:]+)(?P<path>\/.*)?$`)
 
 // validateHost checks that the host matches some required pre-checks e.g. does not contain a scheme or path.

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -235,7 +235,6 @@ var schemeRegex = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/).*$`)
 // While ORAS will also validate some of these things, the current errors are a bit opaque.
 // By validating these things upfront, we can provide clearer error messages to users when they attempt to login with an invalid host string.
 func validateHost(host string) error {
-	host = strings.TrimSpace(host)
 	if host == "" {
 		return errors.New("host cannot be empty")
 	}
@@ -243,8 +242,7 @@ func validateHost(host string) error {
 	// we pre-validate the scheme part here to make sure that we can prepend a dummy scheme for url.Parse without accidentally
 	// accepting invalid hosts that would be parsed with the scheme as just a path. By not just blindly prepending the scheme,
 	// we can produce a clearer error message for users who still include a scheme in the host string, which is a common thing.
-	matches := schemeRegex.FindStringSubmatch(host)
-	if len(matches) != 0 {
+	if schemeRegex.MatchString(host) {
 		return fmt.Errorf("host should not contain a scheme, found %q", host)
 	}
 
@@ -257,7 +255,7 @@ func validateHost(host string) error {
 		return fmt.Errorf("invalid host %q: %w", originalHost, err)
 	}
 
-	if parsed.RawQuery != "" || parsed.RawFragment != "" {
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return fmt.Errorf("host should not contain a query or fragment, found %q", originalHost)
 	}
 
@@ -275,6 +273,7 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 		option(&loginOperation{host, c})
 	}
 
+	host = strings.TrimSpace(host)
 	if err := validateHost(host); err != nil {
 		return err
 	}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -237,7 +237,7 @@ var schemeRegex = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/).*$`)
 func validateHost(host string) error {
 	host = strings.TrimSpace(host)
 	if host == "" {
-		return fmt.Errorf("host cannot be empty")
+		return errors.New("host cannot be empty")
 	}
 
 	// we pre-validate the scheme part here to make sure that we can prepend a dummy scheme for url.Parse without accidentally

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -121,47 +121,61 @@ func TestLogin_ResetsForceAttemptOAuth2_OnFailure(t *testing.T) {
 	}
 }
 
-// TestWarnIfHostHasPath verifies that warnIfHostHasPath correctly detects path components.
-func TestWarnIfHostHasPath(t *testing.T) {
+func TestValidateHost(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		host     string
-		wantWarn bool
+		name    string
+		host    string
+		wantErr bool
 	}{
 		{
-			name:     "domain only",
-			host:     "ghcr.io",
-			wantWarn: false,
+			name:    "domain only",
+			host:    "ghcr.io",
+			wantErr: false,
 		},
 		{
-			name:     "domain with port",
-			host:     "localhost:8000",
-			wantWarn: false,
+			name:    "domain with port",
+			host:    "localhost:8000",
+			wantErr: false,
 		},
 		{
-			name:     "domain with repository path",
-			host:     "ghcr.io/terryhowe",
-			wantWarn: true,
+			name:    "domain with repository path",
+			host:    "ghcr.io/terryhowe",
+			wantErr: true,
 		},
 		{
-			name:     "domain with nested path",
-			host:     "ghcr.io/terryhowe/myrepo",
-			wantWarn: true,
+			name:    "domain with nested path",
+			host:    "ghcr.io/terryhowe/myrepo",
+			wantErr: true,
 		},
 		{
-			name:     "localhost with port and path",
-			host:     "localhost:8000/myrepo",
-			wantWarn: true,
+			name:    "localhost with port and path",
+			host:    "localhost:8000/myrepo",
+			wantErr: true,
+		},
+		{
+			name:    "domain with http protocol",
+			host:    "http://ghcr.io",
+			wantErr: true,
+		},
+		{
+			name:    "domain with https protocol",
+			host:    "https://ghcr.io",
+			wantErr: true,
+		},
+		{
+			name:    "domain with oci protocol",
+			host:    "oci://ghcr.io",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := warnIfHostHasPath(tt.host)
-			if got != tt.wantWarn {
-				t.Errorf("warnIfHostHasPath(%q) = %v, want %v", tt.host, got, tt.wantWarn)
+			err := validateHost(tt.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateHost(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -214,6 +214,11 @@ func TestValidateHost(t *testing.T) {
 			host:    "",
 			wantErr: true,
 		},
+		{
+			name:    "url with query parameters",
+			host:    "ghcr.io?param=value",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -169,6 +169,51 @@ func TestValidateHost(t *testing.T) {
 			host:    "oci://ghcr.io",
 			wantErr: true,
 		},
+		{
+			name:    "domain with uppercase scheme",
+			host:    "HTTPS://ghcr.io",
+			wantErr: true,
+		},
+		{
+			name:    "scheme with plus sign",
+			host:    "coap+tcp://ghcr.io",
+			wantErr: true,
+		},
+		{
+			name:    "scheme with dot and hyphen",
+			host:    "my.custom-scheme://ghcr.io",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 loopback with port",
+			host:    "[::1]:5000",
+			wantErr: false,
+		},
+		{
+			name:    "IPv6 full address with port",
+			host:    "[2001:db8::1]:443",
+			wantErr: false,
+		},
+		{
+			name:    "IPv4 address with port",
+			host:    "192.168.1.1:5000",
+			wantErr: false,
+		},
+		{
+			name:    "host with underscore",
+			host:    "my_registry.local",
+			wantErr: false,
+		},
+		{
+			name:    "scheme with path",
+			host:    "https://ghcr.io/myrepo",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			host:    "",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -210,6 +210,11 @@ func TestValidateHost(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "trailing slash",
+			host:    "ghcr.io/",
+			wantErr: true,
+		},
+		{
 			name:    "empty string",
 			host:    "",
 			wantErr: true,

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -224,6 +224,11 @@ func TestValidateHost(t *testing.T) {
 			host:    "ghcr.io?param=value",
 			wantErr: true,
 		},
+		{
+			name:    "url with fragment",
+			host:    "ghcr.io#fragment",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds host validation on login to check if a scheme or path is present. If yes, the login is cancelled with a dedicated error message, informing the user what went wrong.

The context of this PR is the issue #31962, where we discussed the handling of the URL scheme in Helm v4 and the change from v3 (also refer to #30873). Currently, providing a scheme does raise a non-specific error, therefore the goal of this change is to provide clearer error messages and halt execution early (even if ORAS would technically also catch these errors later down the line). Providing a path did already produce a warning, however I decided to remove the warning and integrate the check into the new validation.

Validation is implemented using a naive regex to check if any scheme or path is present, as built-in things like `url.Parse` don't behave well when no scheme is present, interpreting the entire host as a path.

Closes #31962

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
