### PR TITLE
ci: enable errcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
   enable:
     - depguard
     - dupl
+    - errcheck
     - exhaustive
     - gomodguard
     - govet


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable the `errcheck` linter to detect ignored errors in the codebase.

Ignoring returned errors can lead to silent failures and undefined behavior at runtime. This change strengthens static analysis by ensuring error handling is not accidentally skipped.

**Special notes for your reviewer**:

`errcheck` is widely used and generally low-noise. No additional strict rules are enabled to avoid introducing unnecessary CI friction.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility