### PR TITLE
fix: prevent fixDocSeparators from corrupting long dash sequences in YAML block scalars

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -153,6 +153,7 @@ const (
 func fixDocSeparators(content string) string {
 	var b strings.Builder
 	remaining := content
+	atLineStart := true
 	for {
 		// Find "---" at the start of a line (or start of content).
 		idx := strings.Index(remaining, "---")
@@ -160,10 +161,13 @@ func fixDocSeparators(content string) string {
 			b.WriteString(remaining)
 			break
 		}
-		// "---" must be at the start of a line: either idx==0 or preceded by '\n'.
-		if idx > 0 && remaining[idx-1] != '\n' {
+		// "---" must be at the start of a line: either idx==0 and we are
+		// at a logical line start, or preceded by '\n'.
+		isAtLineStart := (idx == 0 && atLineStart) || (idx > 0 && remaining[idx-1] == '\n')
+		if !isAtLineStart {
 			b.WriteString(remaining[:idx+3])
 			remaining = remaining[idx+3:]
+			atLineStart = false
 			continue
 		}
 		b.WriteString(remaining[:idx+3])
@@ -172,6 +176,9 @@ func fixDocSeparators(content string) string {
 		// insert a newline to make it a proper document separator.
 		if len(remaining) > 0 && remaining[0] != '\n' && remaining[0] != '\r' && remaining[0] != ' ' && remaining[0] != '\t' {
 			b.WriteByte('\n')
+			atLineStart = true
+		} else {
+			atLineStart = false
 		}
 	}
 	return b.String()

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -484,6 +484,26 @@ func TestFixDocSeparators(t *testing.T) {
 			input:    "----more\napiVersion: v1\n",
 			expected: "---\n-more\napiVersion: v1\n",
 		},
+		{
+			name:     "long dash sequence mid-line in block scalar should not be split",
+			input:    "command:\n  - /bin/sh\n  - -c\n  - |\n    echo -------------------\n    echo done\n",
+			expected: "command:\n  - /bin/sh\n  - -c\n  - |\n    echo -------------------\n    echo done\n",
+		},
+		{
+			name:     "multiple long dash sequences in block scalar",
+			input:    "command:\n  - -c\n  - |\n    echo -------------------\n    curl http://localhost\n    echo -------------------\n",
+			expected: "command:\n  - -c\n  - |\n    echo -------------------\n    curl http://localhost\n    echo -------------------\n",
+		},
+		{
+			name:     "indented long dash sequence at start of line in block scalar",
+			input:    "data:\n  script: |\n    -------------------\n    echo done\n",
+			expected: "data:\n  script: |\n    -------------------\n    echo done\n",
+		},
+		{
+			name:     "long dash sequence at start of line",
+			input:    "-------------------\napiVersion: v1\n",
+			expected: "---\n---\n---\n---\n---\n---\n-\napiVersion: v1\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -690,6 +710,33 @@ metadata:
   name: test-svc
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/all.yaml'
+`,
+		},
+		{
+			name: "long dash sequence in block scalar should not corrupt YAML",
+			files: map[string]string{
+				"templates/job.yaml": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: hook-job\nspec:\n  template:\n    spec:\n      restartPolicy: Never\n      containers:\n        - name: c\n          image: example.com/repro:1.0\n          command:\n            - /bin/sh\n            - -c\n            - |\n              echo -------------------\n              resp=$(curl -o /dev/null -s -w \"%{http_code}\\n\" -k -X POST --url http://localhost:8080/api/metadata/workflow -H 'Content-Type: application/json' -d \"@\"$file)\n              echo -------------------\n",
+			},
+			expected: `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hook-job
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/job.yaml'
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: c
+        image: example.com/repro:1.0
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo -------------------
+          resp=$(curl -o /dev/null -s -w "%{http_code}\n" -k -X POST --url http://localhost:8080/api/metadata/workflow -H 'Content-Type: application/json' -d "@"$file)
+          echo -------------------
 `,
 		},
 	}


### PR DESCRIPTION

closes #31977 

**What this PR does / why we need it**:
As mentioned in #31977  the function `fixDocSeparators` that is introduced in #31868 fails for longer dash sequences in a block scalar. This PR introduces the unit tests and the fix for the issue.

The issue was the loop was not checking for line start properly and it would split the document if there is a long dash sequences in the middle of the line. The loop treated idx == 0 in the sliced buffer as "start of line" but after rejecting a mid-line and advancing 3 characters, position 0 of the new slice is still mid-line. This caused it to incorrectly separate the document. The fix adds an atLineStart boolean to track whether index 0 of the sliced buffer is actually at the beginning of a line.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility -> (Checked through unit tests)
