### PR TITLE
fix(action): return correct error variable in prepareUpgrade

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -253,7 +253,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chartv2.Chart, vals map[str
 		var cerr error
 		currentRelease, cerr = releaserToV1Release(currentReleasei)
 		if cerr != nil {
-			return nil, nil, false, err
+			return nil, nil, false, cerr
 		}
 		if err != nil {
 			if errors.Is(err, driver.ErrNoDeployedReleases) &&


### PR DESCRIPTION
Closes #32007

**What this PR does / why we need it**:

During an upgrade, if the last release is not in a deployed state, Helm fetches the currently deployed release and converts it. If that conversion fails, the wrong error variable is returned — the error from the fetch (which is nil on success) rather than the actual conversion error. This silently swallows the failure, returning nil across the board, which could cause a nil pointer panic further down the call chain.

This PR fixes the single-line variable mix-up so the correct error is propagated.

**Special notes for your reviewer**:

All existing upgrade tests pass locally. A dedicated regression test for this path is not straightforward to add because the storage layer is a concrete type rather than an interface, so the conversion failure cannot be triggered with the current test infrastructure. Happy to discuss a follow-up if maintainers would like that addressed separately.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility