### PR TITLE
Minor fix (docs.go): fix import instructions to comply with canonical import paths

### DIFF
--- a/internal/chart/v3/util/doc.go
+++ b/internal/chart/v3/util/doc.go
@@ -42,4 +42,4 @@ into a Chart.
 When creating charts in memory, use the 'helm.sh/helm/pkg/chart'
 package directly.
 */
-package util // import chartutil "helm.sh/helm/v4/internal/chart/v3/util"
+package util // import "helm.sh/helm/v4/internal/chart/v3/util"

--- a/pkg/chart/v2/util/doc.go
+++ b/pkg/chart/v2/util/doc.go
@@ -42,4 +42,4 @@ into a Chart.
 When creating charts in memory, use the 'helm.sh/helm/pkg/chart'
 package directly.
 */
-package util // import chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
+package util // import "helm.sh/helm/v4/pkg/chart/v2/util"


### PR DESCRIPTION
**What this PR does / why we need it**:
In response to https://github.com/helm/helm/issues/32011

The current comments include an alias in the canonical import declaration:
```
package util // import chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
```
[Canonical import comments](https://go.dev/doc/go1.4#canonicalimports) in `Go` must follow the format:
```
package <name> // import "<path>"
```
- strict Go parsers (for example `go/build.ImportDir` with `ImportComment` enabled, or code indexing tools such as `Kythe`) fail with:

```
cannot parse import comment