### PR TITLE
test(kube): fix flaky WaitForDelete timing in status wait tests

### DIFF
--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -317,7 +317,7 @@ func TestStatusWaitForDelete(t *testing.T) {
 			t.Parallel()
 			c := newTestClient(t)
 			timeout := time.Second
-			timeUntilPodDelete := time.Millisecond * 100
+			timeUntilPodDelete := time.Millisecond * 500
 			fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 			fakeMapper := testutil.NewFakeRESTMapper(
 				v1.SchemeGroupVersion.WithKind("Pod"),
@@ -1680,8 +1680,6 @@ func TestMethodContextOverridesGeneralContext(t *testing.T) {
 	t.Run("method-specific context overrides general context for WaitForDelete", func(t *testing.T) {
 		t.Parallel()
 		c := newTestClient(t)
-		timeout := 5 * time.Second
-		timeUntilPodDelete := time.Millisecond * 100
 		fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 		fakeMapper := testutil.NewFakeRESTMapper(
 			v1.SchemeGroupVersion.WithKind("Pod"),
@@ -1698,27 +1696,14 @@ func TestMethodContextOverridesGeneralContext(t *testing.T) {
 			waitForDeleteCtx: context.Background(), // Not cancelled - should be used
 		}
 
+		// Use a non-existent resource: WaitForDelete should return immediately since
+		// the pod is already in the desired "deleted" state.
+		// This also validates context selection: if generalCtx (cancelled) were
+		// incorrectly used instead of waitForDeleteCtx, the watch context would be
+		// immediately cancelled and the call would return a context error.
 		objs := getRuntimeObjFromManifests(t, []string{podCurrentManifest})
-		for _, obj := range objs {
-			u := obj.(*unstructured.Unstructured)
-			gvr := getGVR(t, fakeMapper, u)
-			err := fakeClient.Tracker().Create(gvr, u, u.GetNamespace())
-			require.NoError(t, err)
-		}
-
-		// Schedule deletion
-		for _, obj := range objs {
-			u := obj.(*unstructured.Unstructured)
-			gvr := getGVR(t, fakeMapper, u)
-			go func(gvr schema.GroupVersionResource, u *unstructured.Unstructured) {
-				time.Sleep(timeUntilPodDelete)
-				err := fakeClient.Tracker().Delete(gvr, u.GetNamespace(), u.GetName())
-				assert.NoError(t, err)
-			}(gvr, u)
-		}
-
 		resourceList := getResourceListFromRuntimeObjs(t, c, objs)
-		err := sw.WaitForDelete(resourceList, timeout)
+		err := sw.WaitForDelete(resourceList, time.Second)
 		// Should succeed because method context is used and it's not cancelled
 		assert.NoError(t, err)
 	})

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -317,7 +317,7 @@ func TestStatusWaitForDelete(t *testing.T) {
 			t.Parallel()
 			c := newTestClient(t)
 			timeout := time.Second
-			timeUntilPodDelete := time.Millisecond * 500
+			timeUntilPodDelete := time.Millisecond * 100
 			fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 			fakeMapper := testutil.NewFakeRESTMapper(
 				v1.SchemeGroupVersion.WithKind("Pod"),
@@ -1680,8 +1680,8 @@ func TestMethodContextOverridesGeneralContext(t *testing.T) {
 	t.Run("method-specific context overrides general context for WaitForDelete", func(t *testing.T) {
 		t.Parallel()
 		c := newTestClient(t)
-		timeout := time.Second
-		timeUntilPodDelete := time.Millisecond * 500
+		timeout := 5 * time.Second
+		timeUntilPodDelete := time.Millisecond * 100
 		fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 		fakeMapper := testutil.NewFakeRESTMapper(
 			v1.SchemeGroupVersion.WithKind("Pod"),


### PR DESCRIPTION
## What this PR does / why we need it

Fixes intermittent test failure in `TestMethodContextOverridesGeneralContext/method-specific_context_overrides_general_context_for_WaitForDelete`.

### Root cause

The previous attempt (larger timeout / smaller deletion delay) did not work because this is **not a timing issue**. The root cause is a race in the fluxcd/cli-utils informer sync protocol:

1. `HasSynced()` returns `true` after the initial list item is *popped* from `DeltaFIFO` — but this is **before** `AddFunc` delivers the `ResourceUpdateEvent(pod=Current)` to the status collector
2. This lets the `SyncEvent` race through the event funnel and arrive at `statusObserver` **before** the pod's `Current` status is recorded
3. When `SyncEvent` wins the race, the observer sees the pod as `Unknown`, skips it (the "already deleted before watch started" optimisation), and `AggregateStatus([], NotFoundStatus) == NotFoundStatus` → premature `cancel()`
4. After `cancel()` the watch context is done, so `DeleteFunc` bails early (`ctx.Err() != nil`) and the pod is never reported as `NotFound`
5. Final check: pod is still `Current` → `"resource Pod/ns/current-pod still exists. status: Current, message: Pod is Ready"`

Increasing the timeout has zero effect because the false cancel fires in microseconds via the `SyncEvent` path, not due to deadline expiry.

### Fix

The test's actual intent is to verify that `waitForDeleteCtx` (not the cancelled `generalCtx`) is used for context selection. A **non-existent resource** is sufficient to validate this:

- With `waitForDeleteCtx = context.Background()` (correct): informer syncs with an empty list → pod stays `Unknown` → observer cancels → final check passes (`Unknown` is treated as success) ✓
- With `generalCtx` (cancelled, wrong): the derived context is immediately done → `ctx.Err()` appended → error returned ✓

Removing the goroutine-based pod creation/deletion eliminates the race while fully preserving the assertion that the correct context is selected. The `TestStatusWaitForDelete` suite already covers the "resource exists and gets deleted" scenario.

## Which issue(s) this PR fixes

Fixes flake observed in:
- https://github.com/helm/helm/actions/runs/24052601628/job/70151590646
- https://github.com/helm/helm/actions/runs/24076695798/job/70226819468

## Special notes for your reviewer

The underlying race in `fluxcd/cli-utils` (`HasSynced()` returning before `AddFunc` delivers its event) can also affect `TestStatusWaitForDelete/wait_for_pod_to_be_deleted` in theory, though it hasn't been observed failing in practice. A proper upstream fix in cli-utils would be to ensure the `SyncEvent` is only emitted after all initial `ResourceUpdateEvent`s have been delivered to the collector — but that requires changes outside this repo.

## Checklist

- [x] No logic changes — test-only fix
- [x] Signed-off-by present (DCO)