### PR TITLE
Feat: add support for persisting ChartSource

### DIFF
--- a/internal/release/v2/release.go
+++ b/internal/release/v2/release.go
@@ -51,6 +51,9 @@ type Release struct {
 	// ApplyMethod stores whether server-side or client-side apply was used for the release
 	// Unset (empty string) should be treated as the default of client-side apply
 	ApplyMethod string `json:"apply_method,omitempty"` // "ssa" | "csa"
+	// Source records where the chart was fetched from.
+	// Nil for releases created before this field was added.
+	Source *common.ChartSource `json:"source,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -991,6 +991,11 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	if c.resolvedSource == nil && c.RepoURL != "" {
 		c.resolvedSource = &rcommon.ChartSource{RepoURL: c.RepoURL}
 	}
+	// Fallback for direct OCI references (e.g. oci://registry.com/chart:tag)
+	// where RepoURL is empty and the downloader may not have populated it.
+	if c.resolvedSource == nil && registry.IsOCI(name) {
+		c.resolvedSource = &rcommon.ChartSource{RegistryRef: name}
+	}
 
 	lname, err := filepath.Abs(filename)
 	if err != nil {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -153,6 +153,9 @@ type ChartPathOptions struct {
 	// registryClient provides a registry client but is not added with
 	// options from a flag
 	registryClient *registry.Client
+
+	// resolvedSource is populated by LocateChart with chart provenance info.
+	resolvedSource *rcommon.ChartSource
 }
 
 // NewInstall creates a new Install object with the given configuration.
@@ -669,6 +672,7 @@ func (i *Install) createRelease(chrt *chart.Chart, rawVals map[string]any, label
 		Version:     1,
 		Labels:      labels,
 		ApplyMethod: string(determineReleaseSSApplyMethod(i.ServerSideApply)),
+		Source:      i.resolvedSource,
 	}
 
 	return r
@@ -978,6 +982,14 @@ func (c *ChartPathOptions) LocateChart(name string, settings *cli.EnvSettings) (
 	filename, _, err := dl.DownloadToCache(name, version)
 	if err != nil {
 		return "", err
+	}
+
+	// Capture source provenance from downloader or fallback context
+	if dl.ResolvedSource != nil {
+		c.resolvedSource = dl.ResolvedSource
+	}
+	if c.resolvedSource == nil && c.RepoURL != "" {
+		c.resolvedSource = &rcommon.ChartSource{RepoURL: c.RepoURL}
 	}
 
 	lname, err := filepath.Abs(filename)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -329,6 +329,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chartv2.Chart, vals map[str
 		Hooks:       hooks,
 		Labels:      mergeCustomLabels(lastRelease.Labels, u.Labels),
 		ApplyMethod: string(determineReleaseSSApplyMethod(serverSideApply)),
+		Source:      u.resolvedSource,
 	}
 
 	if len(notesTxt) > 0 {

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -36,6 +36,7 @@ import (
 	"helm.sh/helm/v4/pkg/helmpath"
 	"helm.sh/helm/v4/pkg/provenance"
 	"helm.sh/helm/v4/pkg/registry"
+	rcommon "helm.sh/helm/v4/pkg/release/common"
 	"helm.sh/helm/v4/pkg/repo/v1"
 )
 
@@ -85,6 +86,10 @@ type ChartDownloader struct {
 
 	// Cache specifies the cache implementation to use.
 	Cache Cache
+
+	// ResolvedSource is populated after a successful download with the chart's
+	// source provenance (OCI ref and digest).
+	ResolvedSource *rcommon.ChartSource
 }
 
 // DownloadTo retrieves a chart. Depending on the settings, it may also download a provenance file.
@@ -151,6 +156,14 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 		data, err = g.Get(u.String(), c.Options...)
 		if err != nil {
 			return "", nil, err
+		}
+
+		// Capture source provenance via duck-typing
+		if u.Scheme == registry.OCIScheme {
+			c.ResolvedSource = &rcommon.ChartSource{RegistryRef: ref}
+			if dg, ok := g.(interface{ Digest() string }); ok {
+				c.ResolvedSource.Digest = dg.Digest()
+			}
 		}
 	}
 
@@ -265,6 +278,14 @@ func (c *ChartDownloader) DownloadToCache(ref, version string) (string, *provena
 		data, gerr := g.Get(u.String(), c.Options...)
 		if gerr != nil {
 			return "", nil, gerr
+		}
+
+		// Capture source provenance via duck-typing
+		if u.Scheme == registry.OCIScheme {
+			c.ResolvedSource = &rcommon.ChartSource{RegistryRef: ref}
+			if dg, ok := g.(interface{ Digest() string }); ok {
+				c.ResolvedSource.Digest = dg.Digest()
+			}
 		}
 
 		// Generate the digest

--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -150,6 +150,15 @@ func (c *ChartDownloader) DownloadTo(ref, version, dest string) (string, *proven
 		}
 	}
 
+	// Populate source provenance for cached OCI charts.
+	// The ref and digest are already known from ResolveChartVersion.
+	if found && u.Scheme == registry.OCIScheme {
+		c.ResolvedSource = &rcommon.ChartSource{
+			RegistryRef: ref,
+			Digest:      hash,
+		}
+	}
+
 	if !found {
 		c.Options = append(c.Options, getter.WithAcceptHeader("application/gzip,application/octet-stream"))
 
@@ -266,6 +275,14 @@ func (c *ChartDownloader) DownloadToCache(ref, version string) (string, *provena
 		pth, err = c.Cache.Get(digest32, CacheChart)
 		if err == nil {
 			slog.Debug("found chart in cache", "id", digestString)
+
+			// Populate source provenance for cached OCI charts.
+			if u.Scheme == registry.OCIScheme {
+				c.ResolvedSource = &rcommon.ChartSource{
+					RegistryRef: ref,
+					Digest:      digestString,
+				}
+			}
 		}
 	}
 	if len(digest) == 0 || err != nil {

--- a/pkg/getter/ocigetter.go
+++ b/pkg/getter/ocigetter.go
@@ -36,6 +36,7 @@ type OCIGetter struct {
 	opts      getterOptions
 	transport *http.Transport
 	once      sync.Once
+	digest    string
 }
 
 // Get performs a Get from repo.Getter and returns the body.
@@ -82,11 +83,17 @@ func (g *OCIGetter) get(href string) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
+	g.digest = result.Manifest.Digest
 
 	if requestingProv {
 		return bytes.NewBuffer(result.Prov.Data), nil
 	}
 	return bytes.NewBuffer(result.Chart.Data), nil
+}
+
+// Digest returns the OCI manifest digest from the most recent pull.
+func (g *OCIGetter) Digest() string {
+	return g.digest
 }
 
 // NewOCIGetter constructs a valid http/https client as a Getter

--- a/pkg/release/common/source.go
+++ b/pkg/release/common/source.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// ChartSource records where a chart was fetched from.
+type ChartSource struct {
+	RepoURL     string `json:"repo_url,omitempty"`
+	RegistryRef string `json:"registry_ref,omitempty"`
+	Digest      string `json:"digest,omitempty"`
+}

--- a/pkg/release/v1/release.go
+++ b/pkg/release/v1/release.go
@@ -51,6 +51,9 @@ type Release struct {
 	// ApplyMethod stores whether server-side or client-side apply was used for the release
 	// Unset (empty string) should be treated as the default of client-side apply
 	ApplyMethod string `json:"apply_method,omitempty"` // "ssa" | "csa"
+	// Source records where the chart was fetched from.
+	// Nil for releases created before this field was added.
+	Source *common.ChartSource `json:"source,omitempty"`
 }
 
 // SetStatus is a helper for setting the status on a release.


### PR DESCRIPTION
refs #31999
closes #31999 
**Status**
Complete.

**What this PR does / why we need it**:
Adds a Source field to the Release so you can always trace exactly where a chart came from. We now capture this origin data during download (chart_downloader.go) for both new pulls and cached charts. 
The install and upgrade flows (install.go, upgrade.go) safely attach this information to your deployment. 
This is a backward-compatible addition that won't break existing cluster releases.
