### PR TITLE
Print waiting message when --wait is used for install/upgrade

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -38,6 +38,7 @@ import (
 	"helm.sh/helm/v4/pkg/cmd/require"
 	"helm.sh/helm/v4/pkg/downloader"
 	"helm.sh/helm/v4/pkg/getter"
+	"helm.sh/helm/v4/pkg/kube"
 	release "helm.sh/helm/v4/pkg/release/v1"
 )
 
@@ -324,6 +325,8 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		cancel()
 	}()
 
+	printWaitMessage(out, client.WaitStrategy, client.Timeout)
+
 	ri, err := client.RunWithContext(ctx, chartRequested, vals)
 	rel, rerr := releaserToV1Release(ri)
 	if rerr != nil {
@@ -343,6 +346,13 @@ func checkIfInstallable(ch chart.Accessor) error {
 		return nil
 	}
 	return fmt.Errorf("%s charts are not installable", meta["Type"])
+}
+
+func printWaitMessage(out io.Writer, strategy kube.WaitStrategy, timeout time.Duration) {
+	if strategy == kube.HookOnlyStrategy {
+		return
+	}
+	fmt.Fprintf(out, "Waiting for resources to become ready (timeout: %s)\n", timeout)
 }
 
 // Provide dynamic auto-completion for the install and template commands

--- a/pkg/cmd/testdata/output/install-with-wait-for-jobs.txt
+++ b/pkg/cmd/testdata/output/install-with-wait-for-jobs.txt
@@ -1,3 +1,4 @@
+Waiting for resources to become ready (timeout: 5m0s)
 NAME: apollo
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default

--- a/pkg/cmd/testdata/output/install-with-wait.txt
+++ b/pkg/cmd/testdata/output/install-with-wait.txt
@@ -1,3 +1,4 @@
+Waiting for resources to become ready (timeout: 5m0s)
 NAME: apollo
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default

--- a/pkg/cmd/testdata/output/upgrade-with-wait-for-jobs.txt
+++ b/pkg/cmd/testdata/output/upgrade-with-wait-for-jobs.txt
@@ -1,3 +1,4 @@
+Waiting for resources to become ready (timeout: 5m0s)
 Release "crazy-bunny" has been upgraded. Happy Helming!
 NAME: crazy-bunny
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977

--- a/pkg/cmd/testdata/output/upgrade-with-wait.txt
+++ b/pkg/cmd/testdata/output/upgrade-with-wait.txt
@@ -1,3 +1,4 @@
+Waiting for resources to become ready (timeout: 5m0s)
 Release "crazy-bunny" has been upgraded. Happy Helming!
 NAME: crazy-bunny
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -250,6 +250,10 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				cancel()
 			}()
 
+			if outfmt == output.Table {
+				printWaitMessage(out, client.WaitStrategy, client.Timeout)
+			}
+
 			rel, err := client.RunWithContext(ctx, args[0], ch, vals)
 			if err != nil {
 				return fmt.Errorf("UPGRADE FAILED: %w", err)


### PR DESCRIPTION
Closes #12710

Signed-off-by: John Lin <johnlinp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds a user-facing progress message for `helm install --wait` and `helm upgrade --wait`.

Today, Helm can appear to stall after printing earlier output such as dependency update messages, because there is no explicit indication that it has entered the resource-wait phase. This change prints `Waiting for resources to become ready...` before the blocking wait begins, so users have clearer feedback about what Helm is doing.

**Special notes for your reviewer**:

This intentionally changes the default table output for `install` and `upgrade` when `--wait` is used.

A Helm maintainer previously noted in the issue discussion that the main concern was changing command output that some users may consume from scripts, and that a Helm v4-targeted PR would be welcome:
https://github.com/helm/helm/issues/12710#issuecomment-1896414837

If that is considered too compatibility-sensitive for Helm v4.x, I'm happy to rework this behind a gate or defer it to the next major release.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
