### PR TITLE
fix(engine): support hash algorithm selection in htpasswd

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -89,11 +89,11 @@ func funcMap() template.FuncMap {
 // By default it uses bcrypt, matching Sprig's existing behavior.
 // An optional third argument can explicitly select the hash algorithm.
 func htpasswd(username, password string, hashAlgorithms ...string) (string, error) {
-	if strings.Contains(username, ":") {
-		return fmt.Sprintf("invalid username: %s", username), nil
-	}
 	if strings.ContainsAny(username, "\n\r") {
 		return "", fmt.Errorf("invalid username %q: must not contain newline characters", username)
+	}
+	if strings.Contains(username, ":") {
+		return fmt.Sprintf("invalid username: %s", username), nil
 	}
 
 	if len(hashAlgorithms) > 1 {

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -92,6 +92,9 @@ func htpasswd(username, password string, hashAlgorithms ...string) (string, erro
 	if strings.Contains(username, ":") {
 		return fmt.Sprintf("invalid username: %s", username), nil
 	}
+	if strings.ContainsAny(username, "\n\r") {
+		return "", fmt.Errorf("invalid username %q: must not contain newline characters", username)
+	}
 
 	if len(hashAlgorithms) > 1 {
 		return "", fmt.Errorf("wrong number of args for htpasswd: want 2 or 3 got %d", len(hashAlgorithms)+2)
@@ -104,7 +107,7 @@ func htpasswd(username, password string, hashAlgorithms ...string) (string, erro
 
 	switch algorithm {
 	case "bcrypt":
-		return fmt.Sprintf("%s:%s", username, sprigBcrypt(password)), nil
+		return bcryptHtpasswd(username, password)
 	case "sha", "sha1":
 		sum := sha1.Sum([]byte(password))
 		return fmt.Sprintf("%s:{SHA}%s", username, base64.StdEncoding.EncodeToString(sum[:])), nil
@@ -113,13 +116,13 @@ func htpasswd(username, password string, hashAlgorithms ...string) (string, erro
 	}
 }
 
-func sprigBcrypt(input string) string {
-	hash, err := bcrypt.GenerateFromPassword([]byte(input), bcrypt.DefaultCost)
+func bcryptHtpasswd(username, password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return fmt.Sprintf("failed to encrypt string with bcrypt: %s", err)
+		return "", fmt.Errorf("failed to encrypt password with bcrypt: %w", err)
 	}
 
-	return string(hash)
+	return fmt.Sprintf("%s:%s", username, string(hash)), nil
 }
 
 // toYAML takes an interface, marshals it to yaml, and returns a string. It will

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -18,13 +18,17 @@ package engine
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"strings"
 	"text/template"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
+	"golang.org/x/crypto/bcrypt"
 	"sigs.k8s.io/yaml"
 	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
@@ -49,6 +53,7 @@ func funcMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
+		"htpasswd":      htpasswd,
 		"toToml":        toTOML,
 		"mustToToml":    mustToTOML,
 		"fromToml":      fromTOML,
@@ -78,6 +83,43 @@ func funcMap() template.FuncMap {
 	maps.Copy(f, extra)
 
 	return f
+}
+
+// htpasswd takes a username and password and returns an htpasswd entry.
+// By default it uses bcrypt, matching Sprig's existing behavior.
+// An optional third argument can explicitly select the hash algorithm.
+func htpasswd(username, password string, hashAlgorithms ...string) (string, error) {
+	if strings.Contains(username, ":") {
+		return fmt.Sprintf("invalid username: %s", username), nil
+	}
+
+	if len(hashAlgorithms) > 1 {
+		return "", fmt.Errorf("wrong number of args for htpasswd: want 2 or 3 got %d", len(hashAlgorithms)+2)
+	}
+
+	algorithm := "bcrypt"
+	if len(hashAlgorithms) == 1 && hashAlgorithms[0] != "" {
+		algorithm = strings.ToLower(hashAlgorithms[0])
+	}
+
+	switch algorithm {
+	case "bcrypt":
+		return fmt.Sprintf("%s:%s", username, sprigBcrypt(password)), nil
+	case "sha", "sha1":
+		sum := sha1.Sum([]byte(password))
+		return fmt.Sprintf("%s:{SHA}%s", username, base64.StdEncoding.EncodeToString(sum[:])), nil
+	default:
+		return "", fmt.Errorf("unsupported htpasswd hash algorithm %q", hashAlgorithms[0])
+	}
+}
+
+func sprigBcrypt(input string) string {
+	hash, err := bcrypt.GenerateFromPassword([]byte(input), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Sprintf("failed to encrypt string with bcrypt: %s", err)
+	}
+
+	return string(hash)
 }
 
 // toYAML takes an interface, marshals it to yaml, and returns a string. It will

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"text/template"
@@ -224,9 +225,24 @@ func TestHtpasswd(t *testing.T) {
 			expect: `invalid username: bad:user`,
 		},
 		{
+			name:        "rejects username with newline",
+			tpl:         "{{ htpasswd \"bad\\nuser\" \"testpassword\" }}",
+			expectError: `must not contain newline characters`,
+		},
+		{
+			name:        "returns bcrypt errors",
+			tpl:         fmt.Sprintf(`{{ htpasswd "testuser" %q }}`, strings.Repeat("x", 73)),
+			expectError: `password length exceeds 72 bytes`,
+		},
+		{
 			name:        "rejects unsupported algorithms",
 			tpl:         `{{ htpasswd "testuser" "testpassword" "md5" }}`,
 			expectError: `unsupported htpasswd hash algorithm "md5"`,
+		},
+		{
+			name:        "rejects too many hash algorithm args",
+			tpl:         `{{ htpasswd "testuser" "testpassword" "sha" "extra" }}`,
+			expectError: `wrong number of args for htpasswd: want 2 or 3 got 4`,
 		},
 	}
 

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -225,6 +225,11 @@ func TestHtpasswd(t *testing.T) {
 			expect: `invalid username: bad:user`,
 		},
 		{
+			name:        "rejects username with colon and newline",
+			tpl:         "{{ htpasswd \"bad:user\\ninjected\" \"testpassword\" }}",
+			expectError: `must not contain newline characters`,
+		},
+		{
 			name:        "rejects username with newline",
 			tpl:         "{{ htpasswd \"bad\\nuser\" \"testpassword\" }}",
 			expectError: `must not contain newline characters`,

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -22,6 +22,8 @@ import (
 	"text/template"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestFuncs(t *testing.T) {
@@ -178,6 +180,74 @@ keyInElement1 = "valueInElement1"`,
 		} else {
 			assert.Error(t, err)
 		}
+	}
+}
+
+func TestHtpasswd(t *testing.T) {
+	tests := []struct {
+		name        string
+		tpl         string
+		expect      string
+		expectError string
+		validate    func(t *testing.T, rendered string)
+	}{
+		{
+			name: "defaults to bcrypt",
+			tpl:  `{{ htpasswd "testuser" "testpassword" }}`,
+			validate: func(t *testing.T, rendered string) {
+				t.Helper()
+				parts := strings.SplitN(rendered, ":", 2)
+				require.Len(t, parts, 2)
+				assert.Equal(t, "testuser", parts[0])
+				assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(parts[1]), []byte("testpassword")))
+			},
+		},
+		{
+			name: "supports explicit bcrypt algorithm",
+			tpl:  `{{ htpasswd "testuser" "testpassword" "bcrypt" }}`,
+			validate: func(t *testing.T, rendered string) {
+				t.Helper()
+				parts := strings.SplitN(rendered, ":", 2)
+				require.Len(t, parts, 2)
+				assert.Equal(t, "testuser", parts[0])
+				assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(parts[1]), []byte("testpassword")))
+			},
+		},
+		{
+			name:   "supports sha algorithm",
+			tpl:    `{{ htpasswd "testuser" "testpassword" "sha" }}`,
+			expect: `testuser:{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0=`,
+		},
+		{
+			name:   "preserves invalid username behavior",
+			tpl:    `{{ htpasswd "bad:user" "testpassword" }}`,
+			expect: `invalid username: bad:user`,
+		},
+		{
+			name:        "rejects unsupported algorithms",
+			tpl:         `{{ htpasswd "testuser" "testpassword" "md5" }}`,
+			expectError: `unsupported htpasswd hash algorithm "md5"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			err := template.Must(template.New("test").Funcs(funcMap()).Parse(tt.tpl)).Execute(&b, nil)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, b.String())
+				return
+			}
+
+			assert.Equal(t, tt.expect, b.String())
+		})
 	}
 }
 


### PR DESCRIPTION
closes #31924

**What this PR does / why we need it**:

Helm currently inherits Sprig's two-argument `htpasswd` helper, so templates fail with a wrong-arity error when users try to select a hashing algorithm explicitly. This change keeps the existing two-argument bcrypt behavior, and adds an optional third argument so charts can call `htpasswd USER PASS "sha"` or `htpasswd USER PASS "bcrypt"`.

**Special notes for your reviewer**:

The default behavior is unchanged: `htpasswd USER PASS` still emits a bcrypt entry.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility