### PR TITLE
fix: add debug logging to HTTP getter for helm pull

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sync"
@@ -87,11 +88,13 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 		return nil, err
 	}
 
+	slog.Debug("fetching", "url", href)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	slog.Debug("fetch complete", "url", href, "status", resp.Status, "content-length", resp.ContentLength)
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}


### PR DESCRIPTION
## What this PR does

When running `helm pull --debug`, no debug output was printed. The `--debug` flag enables `slog.Debug` level logging globally via `SetupLogging`, but the HTTP getter in `pkg/getter/httpgetter.go` did not emit any debug-level log messages.

This PR adds `slog.Debug` calls to the HTTP getter's `get` method to log:
- The URL being fetched (before the request)
- The response status and content length (after the request completes)

This brings `helm pull` in line with user expectations that `--debug` would show HTTP-level debug information such as URLs called and response statuses.

## How to test

```bash
helm repo add strimzi https://strimzi.io/charts
helm pull strimzi/strimzi-kafka-operator --version 0.46.1 --debug
```

**Before this fix:** no output.
**After this fix:** debug lines showing the URL fetched and response status.

Fixes #31098