### PR TITLE
backport(action): guard empty CRD resources

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -162,10 +162,18 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 	// We do these one file at a time in the order they were read.
 	totalItems := []*resource.Info{}
 	for _, obj := range crds {
+		if obj.File == nil {
+			return fmt.Errorf("failed to install CRD %s: file is empty", obj.Name)
+		}
+
 		// Read in the resources
 		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.File.Data), false)
 		if err != nil {
 			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+		}
+
+		if len(res) == 0 {
+			return fmt.Errorf("failed to install CRD %s: resources are empty", obj.Name)
 		}
 
 		// Send them to Kube

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -923,3 +923,21 @@ func TestInstallWithSystemLabels(t *testing.T) {
 
 	is.Equal(fmt.Errorf("user supplied labels contains system reserved label name. System labels: %+v", driver.GetSystemLabels()), err)
 }
+
+func TestInstallCRDs_NilFile(t *testing.T) {
+	instAction := installAction(t)
+
+	err := instAction.installCRDs([]chart.CRD{{Name: "crds/empty.yaml"}})
+	require.ErrorContains(t, err, "file is empty")
+}
+
+func TestInstallCRDs_EmptyResources(t *testing.T) {
+	config := actionConfigFixtureWithDummyResources(t, kube.ResourceList{})
+	instAction := NewInstall(config)
+
+	mockChart := buildChart()
+	mockChart.Files = append(mockChart.Files, &chart.File{Name: "crds/foo.yaml", Data: []byte("apiVersion: v1\nkind: CustomResourceDefinition\n")})
+
+	err := instAction.installCRDs(mockChart.CRDObjects())
+	require.ErrorContains(t, err, "resources are empty")
+}


### PR DESCRIPTION
## Summary
- guard `installCRDs` against nil CRD files and empty build results
- add regression tests for nil CRD files and empty CRD resource lists

Fixes #31552

## Validation
- /usr/local/bin/go test ./pkg/action -run "TestInstallCRDs|TestInstallWithSystemLabels"
- /usr/local/bin/go test ./pkg/action -run "TestInstallRelease|TestInstallReleaseClientOnly"

## Notes
- Local Go 1.13 was too old for this branch; validation was rerun with Homebrew Go 1.26.2.