### PR TITLE
fix(pull): honor --debug flag in helm pull command

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sync"
@@ -87,11 +88,17 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 		return nil, err
 	}
 
+	slog.Debug("fetching chart", "url", href)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.Request != nil && resp.Request.URL != nil {
+		slog.Debug("chart fetch response", "url", resp.Request.URL.String(), "status", resp.Status)
+	} else {
+		slog.Debug("chart fetch response", "status", resp.Status)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}

--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -88,13 +88,17 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 		return nil, err
 	}
 
-	slog.Debug("fetching", "url", href)
+	slog.Debug("fetching chart", "url", href)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	slog.Debug("fetch complete", "url", href, "status", resp.Status, "content-length", resp.ContentLength)
+	if resp.Request != nil && resp.Request.URL != nil {
+		slog.Debug("chart fetch response", "url", resp.Request.URL.String(), "status", resp.Status, "content-length", resp.ContentLength)
+	} else {
+		slog.Debug("chart fetch response", "status", resp.Status, "content-length", resp.ContentLength)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}


### PR DESCRIPTION
Fixes #31098

**What changed:**
Added `slog.Debug` calls to `pkg/getter/httpgetter.go` to log the HTTP request URL before fetching, and the status/response URL after the fetch completes.

**Why:**
Currently, when a user passes `--debug` to `helm pull`, they see no HTTP output because the `HTTPGetter` downloader acts silently. Other commands successfully output debug information. This change ensures that `helm pull` and any other action relying on the `HTTPGetter` outputs debug logs if `slog` has a Debug log level.

**Testing:**
Ran `helm pull bitnami/nginx --version 18.2.0 --debug` locally. Verified that it logs the fetching chart URL and chart fetch response status correctly.