### PR TITLE
fix: include version test for dependency-update flag

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -79,7 +79,7 @@ func compare(actual []byte, filename string, templates map[string]string) error 
 	}
 	expected = normalize(expected)
 
-	if templates != nil && len(templates) > 0 {
+	if len(templates) > 0 {
 		expected, err = templateString(expected, templates)
 		if err != nil {
 			return fmt.Errorf("unable to template testdata %s: %w", filename, err)

--- a/pkg/action/dependency_test.go
+++ b/pkg/action/dependency_test.go
@@ -59,7 +59,7 @@ func TestList(t *testing.T) {
 		if err := NewDependency().List(tcase.chart, &buf); err != nil {
 			t.Fatal(err)
 		}
-		test.AssertGoldenString(t, buf.String(), tcase.golden)
+		test.AssertGoldenString(t, buf.String(), tcase.golden, map[string]string{})
 	}
 }
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -840,7 +840,7 @@ OUTER:
 			if err != nil {
 				return err
 			}
-			if dac.Name() == rac.Name() {
+			if dac.Name() == rac.Name() && dac.Version() == rac.Version() {
 				continue OUTER
 			}
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -840,7 +840,7 @@ OUTER:
 			if err != nil {
 				return err
 			}
-			if dac.Name() == rac.Name() && dac.Version() == rac.Version() {
+			if dac.Name() == rac.Name() && chartutil.IsCompatibleRange(rac.Version(), dac.Version()) {
 				continue OUTER
 			}
 		}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1224,7 +1224,7 @@ func TestInstallCRDs_WaiterError(t *testing.T) {
 }
 
 func TestCheckDependencies(t *testing.T) {
-	dependency := chart.Dependency{Name: "hello"}
+	dependency := chart.Dependency{Name: "hello", Version: "0.1.0"}
 	mockChart := buildChart(withDependency())
 
 	assert.Nil(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}))

--- a/pkg/chart/common.go
+++ b/pkg/chart/common.go
@@ -51,6 +51,10 @@ func (r *v2Accessor) Name() string {
 	return r.chrt.Metadata.Name
 }
 
+func (r *v2Accessor) Version() string {
+	return r.chrt.Metadata.Version
+}
+
 func (r *v2Accessor) IsRoot() bool {
 	return r.chrt.IsRoot()
 }
@@ -118,6 +122,10 @@ type v3Accessor struct {
 
 func (r *v3Accessor) Name() string {
 	return r.chrt.Metadata.Name
+}
+
+func (r *v3Accessor) Version() string {
+	return r.chrt.Metadata.Version
 }
 
 func (r *v3Accessor) IsRoot() bool {

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -47,6 +47,10 @@ func (r *v2DependencyAccessor) Name() string {
 	return r.dep.Name
 }
 
+func (r *v2DependencyAccessor) Version() string {
+	return r.dep.Version
+}
+
 func (r *v2DependencyAccessor) Alias() string {
 	return r.dep.Alias
 }
@@ -57,6 +61,10 @@ type v3DependencyAccessor struct {
 
 func (r *v3DependencyAccessor) Name() string {
 	return r.dep.Name
+}
+
+func (r *v3DependencyAccessor) Version() string {
+	return r.dep.Version
 }
 
 func (r *v3DependencyAccessor) Alias() string {

--- a/pkg/chart/interfaces.go
+++ b/pkg/chart/interfaces.go
@@ -25,6 +25,7 @@ type Dependency any
 
 type Accessor interface {
 	Name() string
+	Version() string
 	IsRoot() bool
 	MetadataAsMap() map[string]any
 	Files() []*common.File
@@ -40,5 +41,6 @@ type Accessor interface {
 
 type DependencyAccessor interface {
 	Name() string
+	Version() string
 	Alias() string
 }

--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -69,7 +69,7 @@ func runTestCmd(t *testing.T, tests []cmdTestCase) {
 					t.Errorf("expected no error, got: '%v'", err)
 				}
 				if tt.golden != "" {
-					test.AssertGoldenString(t, out, tt.golden)
+					test.AssertGoldenString(t, out, tt.golden, tt.goldenArgs)
 				}
 			})
 		}
@@ -129,10 +129,11 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 
 // cmdTestCase describes a test case that works with releases.
 type cmdTestCase struct {
-	name      string
-	cmd       string
-	golden    string
-	wantError bool
+	name       string
+	cmd        string
+	golden     string
+	goldenArgs map[string]string
+	wantError  bool
 	// Rels are the available releases at the start of the test.
 	rels []*release.Release
 	// Number of repeats (in case a feature was previously flaky and the test checks

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -153,6 +153,15 @@ func TestInstall(t *testing.T) {
 			cmd:    "install --dependency-update updeps testdata/testcharts/chart-with-subchart-update",
 			golden: "output/chart-with-subchart-update.txt",
 		},
+		// Install chart with update-dependency
+		{
+			name:   "install chart with outdated dependencies",
+			cmd:    fmt.Sprintf("install --dependency-update --repository-cache %s --repository-config %s updeps testdata/testcharts/chart-with-outdated-dependency --username username --password password", srv.Root(), repoFile),
+			golden: "output/install-with-outdated-deps.txt",
+			goldenArgs: map[string]string{
+				"repoUrl": srv.URL(),
+			},
+		},
 		// Install, chart with bad dependencies in Chart.yaml in /charts
 		{
 			name:      "install chart with bad dependencies in Chart.yaml",

--- a/pkg/cmd/testdata/output/install-with-outdated-deps.txt
+++ b/pkg/cmd/testdata/output/install-with-outdated-deps.txt
@@ -1,0 +1,12 @@
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "test" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Saving 1 charts
+Downloading oci-dependent-chart from repo {{ .repoUrl }}
+Deleting outdated charts
+NAME: updeps
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete

--- a/pkg/cmd/testdata/output/install-with-outdated-deps.txt
+++ b/pkg/cmd/testdata/output/install-with-outdated-deps.txt
@@ -1,9 +1,3 @@
-Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "test" chart repository
-Update Complete. ⎈Happy Helming!⎈
-Saving 1 charts
-Downloading oci-dependent-chart from repo {{ .repoUrl }}
-Deleting outdated charts
 NAME: updeps
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.gitignore
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.gitignore
@@ -1,0 +1,1 @@
+requirements.lock

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.helmignore
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: chart-with-outdated-dependency
+version: 0.1.0
+dependencies:
+  - name: oci-dependent-chart
+    version: 0.1.0
+    repository: "@test"

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/.helmignore
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/Chart.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: oci-dependent-chart
+type: application
+version: 0.0.1

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/NOTES.txt
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oci-dependent-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "oci-dependent-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oci-dependent-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oci-dependent-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/tests/test-connection.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "oci-dependent-chart.fullname" . }}-test-connection"
+  labels:
+    {{- include "oci-dependent-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "oci-dependent-chart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/values.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/charts/oci-dependent-chart/values.yaml
@@ -1,0 +1,3 @@
+# Default values for oci-dependent-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/values.yaml
+++ b/pkg/cmd/testdata/testcharts/chart-with-outdated-dependency/values.yaml
@@ -1,0 +1,4 @@
+# Default values for reqtest.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value

--- a/pkg/kube/fake/failing_kube_client.go
+++ b/pkg/kube/fake/failing_kube_client.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,7 @@ type FailingKubeClient struct {
 	WaitDuration           time.Duration
 	// RecordedWaitOptions stores the WaitOptions passed to GetWaiter for testing
 	RecordedWaitOptions []kube.WaitOption
+	mu                  sync.Mutex
 }
 
 var _ kube.Interface = &FailingKubeClient{}
@@ -160,7 +162,9 @@ func (f *FailingKubeClient) GetWaiter(ws kube.WaitStrategy) (kube.Waiter, error)
 
 func (f *FailingKubeClient) GetWaiterWithOptions(ws kube.WaitStrategy, opts ...kube.WaitOption) (kube.Waiter, error) {
 	// Record the WaitOptions for testing
+	f.mu.Lock()
 	f.RecordedWaitOptions = append(f.RecordedWaitOptions, opts...)
+	f.mu.Unlock()
 	waiter, _ := f.PrintingKubeClient.GetWaiterWithOptions(ws, opts...)
 	printingKubeWaiter, _ := waiter.(*PrintingKubeWaiter)
 	return &FailingKubeWaiter{


### PR DESCRIPTION
Closes https://github.com/helm/helm/issues/31455

**What this PR does / why we need it**:
When using --dependency-update, helm does not update dependencies if an outdated version exists in charts/.
This PR includes a version check when attempting to match Chart.yaml deps to the ones in charts/

**Special notes for your reviewer**:

This is a PR based on the work of @Hathoute in #31517 with fixed tests.

**If applicable**:

- [ ]     this PR contains user facing changes (the docs needed label should be applied if so)
- [x]     this PR contains unit tests
- [ ]     this PR has been tested for backwards compatibility

> this PR has been tested for backwards compatibility

The behavior changes with this PR, helm template now fails if the version constraint is not respected whereas before the template would be run with an incorrect version:
```shell
❯ ls -l charts/
total 400
-rw-r--r--@ 1 user  group  201066 Apr 16 12:50 argo-cd-9.0.0.tgz

❯ cat Chart.yaml
apiVersion: v1
description: A Helm chart for Kubernetes
name: argo-cd
version: 0.1.0
dependencies:
  - name: argo-cd
    version: =>9.1.0
    repository: https://argoproj.github.io/argo-helm

❯ helm template . | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.0.0

❯ ../../../../../bin/helm template . | grep helm.sh/chart: | head -n1
Error: an error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: argo-cd

❯ ../../../../../bin/helm template . --dependency-update | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.5.1
```

Before/after:

```shell
❯ helm version --short
v4.1.4+g05fa379

❯ cat Chart.yaml
apiVersion: v1
description: A Helm chart for Kubernetes
name: argo-cd
version: 0.1.0
dependencies:
  - name: argo-cd
    version: 9.0.0
    repository: https://argoproj.github.io/argo-helm

❯ helm template . --dependency-update | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.0.0

❯ cat Chart.yaml
apiVersion: v1
description: A Helm chart for Kubernetes
name: argo-cd
version: 0.1.0
dependencies:
  - name: argo-cd
    version: 9.1.0
    repository: https://argoproj.github.io/argo-helm

❯ helm template . --dependency-update | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.0.0
```

```shell
❯ ../../../../../bin/helm version --short
v4.1+unreleased+g919cbfa

❯ cat Chart.yaml
apiVersion: v1
description: A Helm chart for Kubernetes
name: argo-cd
version: 0.1.0
dependencies:
  - name: argo-cd
    version: 9.0.0
    repository: https://argoproj.github.io/argo-helm

❯ ../../../../../bin/helm template . --dependency-update | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.0.0

❯ cat Chart.yaml
apiVersion: v1
description: A Helm chart for Kubernetes
name: argo-cd
version: 0.1.0
dependencies:
  - name: argo-cd
    version: 9.1.0
    repository: https://argoproj.github.io/argo-helm

❯ ../../../../../bin/helm template . --dependency-update | grep helm.sh/chart: | head -n1
    helm.sh/chart: argo-cd-9.1.0
```
