### PR TITLE
pkg/kube: promote statusWaiter wait-progress messages to Info

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -74,7 +74,7 @@ func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.D
 	}
 	ctx, cancel := w.contextWithTimeout(w.watchUntilReadyCtx, timeout)
 	defer cancel()
-	w.Logger().Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
+	w.Logger().Info("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
 	jobSR := helmStatusReaders.NewCustomJobStatusReader(w.restMapper)
 	podSR := helmStatusReaders.NewCustomPodStatusReader(w.restMapper)
@@ -96,7 +96,7 @@ func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) er
 	}
 	ctx, cancel := w.contextWithTimeout(w.waitCtx, timeout)
 	defer cancel()
-	w.Logger().Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
+	w.Logger().Info("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
 	sw.StatusReader = statusreaders.NewStatusReader(w.restMapper, w.readers...)
 	return w.wait(ctx, resourceList, sw)
@@ -108,7 +108,7 @@ func (w *statusWaiter) WaitWithJobs(resourceList ResourceList, timeout time.Dura
 	}
 	ctx, cancel := w.contextWithTimeout(w.waitWithJobsCtx, timeout)
 	defer cancel()
-	w.Logger().Debug("waiting for resources", "count", len(resourceList), "timeout", timeout)
+	w.Logger().Info("waiting for resources", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
 	newCustomJobStatusReader := helmStatusReaders.NewCustomJobStatusReader(w.restMapper)
 	readers := append([]engine.StatusReader(nil), w.readers...)
@@ -124,7 +124,7 @@ func (w *statusWaiter) WaitForDelete(resourceList ResourceList, timeout time.Dur
 	}
 	ctx, cancel := w.contextWithTimeout(w.waitForDeleteCtx, timeout)
 	defer cancel()
-	w.Logger().Debug("waiting for resources to be deleted", "count", len(resourceList), "timeout", timeout)
+	w.Logger().Info("waiting for resources to be deleted", "count", len(resourceList), "timeout", timeout)
 	sw := watcher.NewDefaultStatusWatcher(w.client, w.restMapper)
 	return w.waitForDelete(ctx, resourceList, sw)
 }
@@ -255,7 +255,7 @@ func statusObserver(cancel context.CancelFunc, desired status.Status, logger *sl
 		}
 
 		if aggregator.AggregateStatus(rss, desired) == desired {
-			logger.Debug("all resources achieved desired status", "desiredStatus", desired, "resourceCount", len(rss))
+			logger.Info("all resources achieved desired status", "desiredStatus", desired, "resourceCount", len(rss))
 			cancel()
 			return
 		}


### PR DESCRIPTION
## Problem

SDK users who do not enable debug logging see no output while the `statusWaiter` (new watcher wait strategy) is running. The legacy waiter printed resource-readiness progress (e.g. "StatefulSet is not ready", "wait for resources succeeded") to stdout. The equivalent messages in the new strategy were all at `slog.Debug` level, invisible unless `--debug` is passed to the CLI or the SDK caller explicitly sets up a debug-level logger.

Relevant comment from the issue:
> I believe the problem here is that all the methods on the statusWaiter object don't accept their own logger, but instead use the default slog functions. Most likely, the statusWaiter object should have a logger Field...

Note: the logger *is* already threaded via `LogHolder` / `sw.SetLogger(c.Logger().Handler())` — the root cause is level, not logger propagation.

## Fix

Promote these five `statuswait.go` calls from `Debug` to `Info`:

- `w.Logger().Debug("waiting for resources", ...)` (×4 — one per wait method)
- `logger.Debug("all resources achieved desired status", ...)`

The per-resource `"waiting for resource"` callback remains at `Debug` — it fires on every poll cycle and would be too noisy at Info.

## Testing

All `pkg/kube` tests pass.

Fixes #31585

Signed-off-by: Ali <alliasgher123@gmail.com>