### PR TITLE
fix(common): remove testing package import from production code

### DIFF
--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/Masterminds/semver/v3"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -146,7 +145,7 @@ func makeDefaultCapabilities() (*Capabilities, error) {
 	// Test builds don't include debug info / module info
 	// (And even if they did, we probably want stable capabilities for tests anyway)
 	// Return a default value for test builds
-	if testing.Testing() {
+	if isTestBuild {
 		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
 	}
 

--- a/pkg/chart/common/capabilities_prod.go
+++ b/pkg/chart/common/capabilities_prod.go
@@ -1,0 +1,20 @@
+//go:build !test
+
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const isTestBuild = false

--- a/pkg/chart/common/capabilities_testbuild.go
+++ b/pkg/chart/common/capabilities_testbuild.go
@@ -1,0 +1,20 @@
+//go:build test
+
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const isTestBuild = true


### PR DESCRIPTION
Importing the \	esting\ package in \capabilities.go\ causes it to be included in production binaries. This is a dependency pollution issue reported by downstream projects like Istio.

The fix uses build tags instead:
- \capabilities_prod.go\ (\!test\ tag): \isTestBuild = false\
- \capabilities_testbuild.go\ (\	est\ tag): \isTestBuild = true\

The existing \	esting.Testing()\ call is replaced with the \isTestBuild\ constant. Tests that need the fixed capabilities behavior should be run with \-tags test\.

Fixes #32047