### PR TITLE
fix(chart/common): avoid pulling testing into non-test builds

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,9 +20,10 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
-	"testing"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -47,6 +48,11 @@ var (
 const (
 	kubeClientGoVersionTesting = "v1.20"
 )
+
+func isGoTestBinary(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(base, ".test") || strings.HasSuffix(base, ".test.exe")
+}
 
 // BuildInfo describes the compile time information.
 type BuildInfo struct {
@@ -79,10 +85,10 @@ func GetUserAgent() string {
 func Get() BuildInfo {
 
 	makeKubeClientVersionString := func() string {
-		// Test builds don't include debug info / module info
-		// (And even if they did, we probably want a stable version during tests anyway)
-		// Return a default value for test builds
-		if testing.Testing() {
+		// `go test` binaries don't include the module metadata that `K8sIOClientGoModVersion`
+		// relies on, so keep returning the stable test value without importing `testing`
+		// into production dependency graphs.
+		if isGoTestBinary(os.Args[0]) {
 			return kubeClientGoVersionTesting
 		}
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import "testing"
+
+func TestIsGoTestBinary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "go test temp binary", path: "/tmp/go-build1234/b001/version.test", want: true},
+		{name: "go test windows binary", path: `C:\Temp\go-build1234\b001\version.test.exe`, want: true},
+		{name: "regular binary", path: "/usr/local/bin/helm", want: false},
+		{name: "user binary with test in name only", path: "/usr/local/bin/helm-test", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isGoTestBinary(tt.path); got != tt.want {
+				t.Fatalf("isGoTestBinary(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetUsesStableKubeClientVersionInTestBinary(t *testing.T) {
+	t.Parallel()
+
+	if got := Get().KubeClientVersion; got != kubeClientGoVersionTesting {
+		t.Fatalf("Get().KubeClientVersion = %q, want %q", got, kubeClientGoVersionTesting)
+	}
+}

--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/Masterminds/semver/v3"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,11 +29,6 @@ import (
 	k8sversion "k8s.io/apimachinery/pkg/util/version"
 
 	helmversion "helm.sh/helm/v4/internal/version"
-)
-
-const (
-	kubeVersionMajorTesting = 1
-	kubeVersionMinorTesting = 20
 )
 
 var (
@@ -143,24 +137,17 @@ func allKnownVersions() VersionSet {
 }
 
 func makeDefaultCapabilities() (*Capabilities, error) {
-	// Test builds don't include debug info / module info
-	// (And even if they did, we probably want stable capabilities for tests anyway)
-	// Return a default value for test builds
-	if testing.Testing() {
-		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
-	}
-
-	vstr, err := helmversion.K8sIOClientGoModVersion()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve k8s.io/client-go version: %w", err)
+	vstr := helmversion.Get().KubeClientVersion
+	if vstr == "" {
+		return nil, fmt.Errorf("failed to retrieve Kubernetes client version")
 	}
 
 	v, err := semver.NewVersion(vstr)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse k8s.io/client-go version %q: %w", vstr, err)
+		return nil, fmt.Errorf("unable to parse Kubernetes client version %q: %w", vstr, err)
 	}
 
-	kubeVersionMajor := v.Major() + 1
+	kubeVersionMajor := v.Major()
 	kubeVersionMinor := v.Minor()
 
 	return newCapabilities(kubeVersionMajor, kubeVersionMinor)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #32047.

`pkg/chart/common` currently pulls the Go `testing` package into non-test binaries because both `pkg/chart/common` and `internal/version` call `testing.Testing()` while computing default capabilities/build info.

This change removes those runtime imports from production packages by:
- detecting standard `go test` binaries in `internal/version` without importing `testing`
- reusing `version.Get().KubeClientVersion` from `pkg/chart/common` instead of reading `client-go` module metadata separately

That keeps the stable test-only kube client version used by existing tests, while dropping `testing` from the dependency graph of binaries that import `pkg/chart/common` or `pkg/engine`.

**Special notes for your reviewer**:

Validation:
- `go test ./internal/version ./pkg/chart/common ./pkg/cmd`
- built a minimal external module importing `helm.sh/helm/v4/pkg/chart/common` with `replace helm.sh/helm/v4 => /tmp/helm-codex-pr`; `go list -f '{{ join .Deps "\\n" }}' . | grep '^testing'` returned no matches
- built a minimal external module importing `helm.sh/helm/v4/pkg/engine` with the same `replace`; the same dependency check returned no matches

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
