### PR TITLE
fix: route registry client output to stdout instead of stderr

### DIFF
--- a/pkg/cmd/dependency_build.go
+++ b/pkg/cmd/dependency_build.go
@@ -55,7 +55,7 @@ func newDependencyBuildCmd(out io.Writer) *cobra.Command {
 			if len(args) > 0 {
 				chartpath = filepath.Clean(args[0])
 			}
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/dependency_update.go
+++ b/pkg/cmd/dependency_update.go
@@ -58,7 +58,7 @@ func newDependencyUpdateCmd(_ *action.Configuration, out io.Writer) *cobra.Comma
 			if len(args) > 0 {
 				chartpath = filepath.Clean(args[0])
 			}
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -143,7 +143,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return compInstall(args, toComplete, client)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/package.go
+++ b/pkg/cmd/package.go
@@ -75,7 +75,7 @@ func newPackageCmd(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -65,7 +65,7 @@ func newPullCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.Version = ">0.0.0-0"
 			}
 
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -71,7 +71,7 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			registryClient, err := newRegistryClient(
-				o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSVerify, o.plainHTTP, o.username, o.password,
+				out, o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSVerify, o.plainHTTP, o.username, o.password,
 			)
 
 			if err != nil {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -257,7 +257,7 @@ func newRootCmdWithConfig(actionConfig *action.Configuration, out io.Writer, arg
 		log.Fatal(err)
 	}
 
-	registryClient, err := newDefaultRegistryClient(false, "", "")
+	registryClient, err := newDefaultRegistryClient(out, false, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -403,27 +403,27 @@ func checkForExpiredRepos(repofile string) {
 }
 
 func newRegistryClient(
-	certFile, keyFile, caFile string, insecureSkipTLSVerify, plainHTTP bool, username, password string,
+	out io.Writer, certFile, keyFile, caFile string, insecureSkipTLSVerify, plainHTTP bool, username, password string,
 ) (*registry.Client, error) {
 	if certFile != "" && keyFile != "" || caFile != "" || insecureSkipTLSVerify {
-		registryClient, err := newRegistryClientWithTLS(certFile, keyFile, caFile, insecureSkipTLSVerify, username, password)
+		registryClient, err := newRegistryClientWithTLS(out, certFile, keyFile, caFile, insecureSkipTLSVerify, username, password)
 		if err != nil {
 			return nil, err
 		}
 		return registryClient, nil
 	}
-	registryClient, err := newDefaultRegistryClient(plainHTTP, username, password)
+	registryClient, err := newDefaultRegistryClient(out, plainHTTP, username, password)
 	if err != nil {
 		return nil, err
 	}
 	return registryClient, nil
 }
 
-func newDefaultRegistryClient(plainHTTP bool, username, password string) (*registry.Client, error) {
+func newDefaultRegistryClient(out io.Writer, plainHTTP bool, username, password string) (*registry.Client, error) {
 	opts := []registry.ClientOption{
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
-		registry.ClientOptWriter(os.Stderr),
+		registry.ClientOptWriter(out),
 		registry.ClientOptCredentialsFile(settings.RegistryConfig),
 		registry.ClientOptBasicAuth(username, password),
 	}
@@ -440,7 +440,7 @@ func newDefaultRegistryClient(plainHTTP bool, username, password string) (*regis
 }
 
 func newRegistryClientWithTLS(
-	certFile, keyFile, caFile string, insecureSkipTLSVerify bool, username, password string,
+	out io.Writer, certFile, keyFile, caFile string, insecureSkipTLSVerify bool, username, password string,
 ) (*registry.Client, error) {
 	tlsConf, err := tlsutil.NewTLSConfig(
 		tlsutil.WithInsecureSkipVerify(insecureSkipTLSVerify),
@@ -456,7 +456,7 @@ func newRegistryClientWithTLS(
 	registryClient, err := registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
-		registry.ClientOptWriter(os.Stderr),
+		registry.ClientOptWriter(out),
 		registry.ClientOptCredentialsFile(settings.RegistryConfig),
 		registry.ClientOptHTTPClient(&http.Client{
 			Transport: &http.Transport{

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -84,7 +84,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowAll
-			err := addRegistryClient(client)
+			err := addRegistryClient(out, client)
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowValues
-			err := addRegistryClient(client)
+			err := addRegistryClient(out, client)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowChart
-			err := addRegistryClient(client)
+			err := addRegistryClient(out, client)
 			if err != nil {
 				return err
 			}
@@ -147,7 +147,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowReadme
-			err := addRegistryClient(client)
+			err := addRegistryClient(out, client)
 			if err != nil {
 				return err
 			}
@@ -168,7 +168,7 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(_ *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowCRDs
-			err := addRegistryClient(client)
+			err := addRegistryClient(out, client)
 			if err != nil {
 				return err
 			}
@@ -225,8 +225,8 @@ func runShow(args []string, client *action.Show) (string, error) {
 	return client.Run(cp)
 }
 
-func addRegistryClient(client *action.Show) error {
-	registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+func addRegistryClient(out io.Writer, client *action.Show) error {
+	registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 		client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 	if err != nil {
 		return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -85,7 +85,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -105,7 +105,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.Namespace = settings.Namespace()
 
-			registryClient, err := newRegistryClient(client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)


### PR DESCRIPTION
## Summary

- Commands like `helm registry login`, `helm push`, and `helm pull` were writing success messages (`Login Succeeded`, `Pushed:`, `Pulled:`, `Digest:`) to stderr instead of stdout
- Root cause: `newDefaultRegistryClient` and `newRegistryClientWithTLS` in `pkg/cmd/root.go` hard-coded `os.Stderr` as the registry client writer, ignoring the `out io.Writer` (`os.Stdout`) passed from `main()`
- Fix: thread `out io.Writer` through the three registry client factory functions and update all call sites in `pkg/cmd/`

Debug/warning output via `slog` remains on stderr. Only user-facing success messages move to stdout.

## Test plan

- [ ] `helm registry login <host> -u user -p pass > stdout.log 2> stderr.log` — verify `Login Succeeded` appears in `stdout.log`
- [ ] `helm push chart.tgz oci://... > stdout.log 2> stderr.log` — verify `Pushed:` and `Digest:` appear in `stdout.log`
- [ ] `helm pull oci://... > stdout.log 2> stderr.log` — verify `Pulled:` and `Digest:` appear in `stdout.log`
- [ ] Existing unit tests: `go test ./pkg/cmd/...`

Closes: https://github.com/helm/helm/issues/13464

🤖 Generated with [Claude Code](https://claude.com/claude-code)