### PR TITLE
fix: clean up temp files after atomic write failures

### DIFF
--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -26,12 +26,17 @@ import (
 
 // AtomicWriteFile atomically (as atomic as os.Rename allows) writes a file to a
 // disk.
-func AtomicWriteFile(filename string, reader io.Reader, mode os.FileMode) error {
+func AtomicWriteFile(filename string, reader io.Reader, mode os.FileMode) (err error) {
 	tempFile, err := os.CreateTemp(filepath.Split(filename))
 	if err != nil {
 		return err
 	}
 	tempName := tempFile.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tempName)
+		}
+	}()
 
 	if _, err := io.Copy(tempFile, reader); err != nil {
 		tempFile.Close() // return value is ignored as we are already on error path

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -120,6 +120,30 @@ func TestAtomicWriteFile_LargeContent(t *testing.T) {
 	}
 }
 
+// TestAtomicWriteFile_CleansUpTempFileOnRenameError verifies that temporary
+// files are removed when the final rename step fails.
+func TestAtomicWriteFile_CleansUpTempFileOnRenameError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "existing-dir")
+	if err := os.Mkdir(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AtomicWriteFile(target, bytes.NewReader([]byte("content")), 0644)
+	if err == nil {
+		t.Fatal("expected rename error, got nil")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) != 1 || entries[0].Name() != "existing-dir" {
+		t.Fatalf("expected only existing-dir to remain, found %v entries", len(entries))
+	}
+}
+
 // TestPlatformAtomicWriteFile_OverwritesExisting verifies that the platform
 // helper replaces existing files instead of silently skipping them.
 func TestPlatformAtomicWriteFile_OverwritesExisting(t *testing.T) {


### PR DESCRIPTION

**Repo:** helm/helm (⭐ 26000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +30/-1

## What
This change updates `internal/fileutil.AtomicWriteFile` to remove its temporary file whenever the write fails before the final rename completes. It also adds a regression test that forces the rename step to fail by targeting an existing directory, then verifies that no stray temp files are left behind.

## Why
Failed atomic writes should not leave garbage files in the destination directory. Before this patch, errors during copy, close, chmod, or rename could leave the temporary file on disk, which is noisy for users and can accumulate over time in directories Helm writes to. Cleaning up on failure keeps the helper's behavior predictable without changing its success path.

## Testing
Ran `GOCACHE=/tmp/go-build-helm-helm go test ./internal/fileutil` locally; it passed. Additional verification is covered by the new regression test for rename failure cleanup.

## Risk
Low / The change only affects error cleanup in a small internal helper and is covered by a focused package test.
