### PR TITLE
fix: Add support for SOURCE_DATE_EPOCH in reproducible builds

### DIFF
--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -25,6 +25,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -234,7 +235,9 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
-	if h.ModTime.IsZero() {
+	if epoch, ok := sourceDateEpoch(); ok {
+		h.ModTime = epoch
+	} else if h.ModTime.IsZero() {
 		h.ModTime = time.Now()
 	}
 	if err := out.WriteHeader(h); err != nil {
@@ -242,6 +245,20 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 	}
 	_, err := out.Write(body)
 	return err
+}
+
+// sourceDateEpoch returns the time specified by SOURCE_DATE_EPOCH env var, if set.
+// SOURCE_DATE_EPOCH is a Unix timestamp used to ensure reproducible builds.
+func sourceDateEpoch() (time.Time, bool) {
+	s, ok := os.LookupEnv("SOURCE_DATE_EPOCH")
+	if !ok {
+		return time.Time{}, false
+	}
+	secs, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(secs, 0), true
 }
 
 // If the name has directory name has characters which would change the location

--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -126,6 +126,15 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 		return "", fmt.Errorf("is not a directory: %s", dir)
 	}
 
+	epoch, hasEpoch, err := sourceDateEpoch()
+	if err != nil {
+		return "", err
+	}
+	var epochPtr *time.Time
+	if hasEpoch {
+		epochPtr = &epoch
+	}
+
 	f, err := os.Create(filename)
 	if err != nil {
 		return "", err
@@ -148,14 +157,14 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 		}
 	}()
 
-	if err := writeTarContents(twriter, c, ""); err != nil {
+	if err := writeTarContents(twriter, c, "", epochPtr); err != nil {
 		rollback = true
 		return filename, err
 	}
 	return filename, nil
 }
 
-func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
+func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string, epoch *time.Time) error {
 	err := validateName(c.Name())
 	if err != nil {
 		return err
@@ -167,7 +176,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime, epoch); err != nil {
 		return err
 	}
 
@@ -177,7 +186,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if err != nil {
 			return err
 		}
-		if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated); err != nil {
+		if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated, epoch); err != nil {
 			return err
 		}
 	}
@@ -185,7 +194,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save values.yaml
 	for _, f := range c.Raw {
 		if f.Name == ValuesfileName {
-			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime); err != nil {
+			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime, epoch); err != nil {
 				return err
 			}
 		}
@@ -196,7 +205,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if !json.Valid(c.Schema) {
 			return errors.New("invalid JSON in " + SchemafileName)
 		}
-		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime); err != nil {
+		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime, epoch); err != nil {
 			return err
 		}
 	}
@@ -204,7 +213,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime, epoch); err != nil {
 			return err
 		}
 	}
@@ -212,14 +221,14 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save files
 	for _, f := range c.Files {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime, epoch); err != nil {
 			return err
 		}
 	}
 
 	// Save dependencies
 	for _, dep := range c.Dependencies() {
-		if err := writeTarContents(out, dep, filepath.Join(base, ChartsDir)); err != nil {
+		if err := writeTarContents(out, dep, filepath.Join(base, ChartsDir), epoch); err != nil {
 			return err
 		}
 	}
@@ -227,7 +236,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 }
 
 // writeToTar writes a single file to a tar archive.
-func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) error {
+func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time, epoch *time.Time) error {
 	// TODO: Do we need to create dummy parent directory names if none exist?
 	h := &tar.Header{
 		Name:    filepath.ToSlash(name),
@@ -235,8 +244,8 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
-	if epoch, ok := sourceDateEpoch(); ok {
-		h.ModTime = epoch
+	if epoch != nil {
+		h.ModTime = *epoch
 	} else if h.ModTime.IsZero() {
 		h.ModTime = time.Now()
 	}
@@ -247,18 +256,19 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 	return err
 }
 
-// sourceDateEpoch returns the time specified by SOURCE_DATE_EPOCH env var, if set.
+// sourceDateEpoch parses the SOURCE_DATE_EPOCH environment variable.
 // SOURCE_DATE_EPOCH is a Unix timestamp used to ensure reproducible builds.
-func sourceDateEpoch() (time.Time, bool) {
+// It returns an error if the variable is set but cannot be parsed.
+func sourceDateEpoch() (time.Time, bool, error) {
 	s, ok := os.LookupEnv("SOURCE_DATE_EPOCH")
 	if !ok {
-		return time.Time{}, false
+		return time.Time{}, false, nil
 	}
 	secs, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return time.Time{}, false
+		return time.Time{}, false, fmt.Errorf("invalid SOURCE_DATE_EPOCH %q: %w", s, err)
 	}
-	return time.Unix(secs, 0), true
+	return time.Unix(secs, 0), true, nil
 }
 
 // If the name has directory name has characters which would change the location

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -269,6 +269,12 @@ func TestSaveDir(t *testing.T) {
 }
 
 func TestRepeatableSave(t *testing.T) {
+	// Guard against SOURCE_DATE_EPOCH being set in the test runner environment,
+	// which would override chart modtimes and invalidate the fixed SHA assertions.
+	if orig, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok {
+		os.Unsetenv("SOURCE_DATE_EPOCH")
+		t.Cleanup(func() { os.Setenv("SOURCE_DATE_EPOCH", orig) })
+	}
 	tmp := t.TempDir()
 	defer os.RemoveAll(tmp)
 	modTime := time.Date(2021, 9, 1, 20, 34, 58, 651387237, time.UTC)

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -410,3 +410,19 @@ func sha256Sum(filePath string) (string, error) {
 
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
+
+func TestSourceDateEpochInvalid(t *testing.T) {
+	t.Setenv("SOURCE_DATE_EPOCH", "not-a-number")
+
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: chart.APIVersionV3,
+			Name:       "ahab",
+			Version:    "1.2.3",
+		},
+	}
+	_, err := Save(c, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid SOURCE_DATE_EPOCH, got nil")
+	}
+}

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -338,6 +339,60 @@ func TestRepeatableSave(t *testing.T) {
 				t.Errorf("FormatName() result = %v, want %v", result, test.want)
 			}
 		})
+	}
+}
+
+func TestSourceDateEpoch(t *testing.T) {
+	epoch := int64(1630000000)
+	t.Setenv("SOURCE_DATE_EPOCH", fmt.Sprintf("%d", epoch))
+
+	mkChart := func(modTime time.Time) *chart.Chart {
+		return &chart.Chart{
+			Metadata: &chart.Metadata{
+				APIVersion: chart.APIVersionV3,
+				Name:       "ahab",
+				Version:    "1.2.3",
+			},
+			ModTime: modTime,
+			Files: []*common.File{
+				{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+			},
+		}
+	}
+
+	tmp := t.TempDir()
+
+	where1, err := Save(mkChart(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)), filepath.Join(tmp, "build1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	where2, err := Save(mkChart(time.Date(2023, 6, 15, 12, 0, 0, 0, time.UTC)), filepath.Join(tmp, "build2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum1, err := sha256Sum(where1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum2, err := sha256Sum(where2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sum1 != sum2 {
+		t.Errorf("builds with same SOURCE_DATE_EPOCH should be byte-identical: %s != %s", sum1, sum2)
+	}
+
+	allHeaders, err := retrieveAllHeadersFromTar(where1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTime := time.Unix(epoch, 0)
+	for _, header := range allHeaders {
+		if !header.ModTime.Equal(expectedTime) {
+			t.Errorf("expected timestamp %v, got %v for %s", expectedTime, header.ModTime, header.Name)
+		}
 	}
 }
 

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -126,6 +126,15 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 		return "", fmt.Errorf("is not a directory: %s", dir)
 	}
 
+	epoch, hasEpoch, err := sourceDateEpoch()
+	if err != nil {
+		return "", err
+	}
+	var epochPtr *time.Time
+	if hasEpoch {
+		epochPtr = &epoch
+	}
+
 	f, err := os.Create(filename)
 	if err != nil {
 		return "", err
@@ -148,14 +157,14 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 		}
 	}()
 
-	if err := writeTarContents(twriter, c, ""); err != nil {
+	if err := writeTarContents(twriter, c, "", epochPtr); err != nil {
 		rollback = true
 		return filename, err
 	}
 	return filename, nil
 }
 
-func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
+func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string, epoch *time.Time) error {
 	err := validateName(c.Name())
 	if err != nil {
 		return err
@@ -176,7 +185,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime); err != nil {
+	if err := writeToTar(out, filepath.Join(base, ChartfileName), cdata, c.ModTime, epoch); err != nil {
 		return err
 	}
 
@@ -188,7 +197,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 			if err != nil {
 				return err
 			}
-			if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated); err != nil {
+			if err := writeToTar(out, filepath.Join(base, "Chart.lock"), ldata, c.Lock.Generated, epoch); err != nil {
 				return err
 			}
 		}
@@ -197,7 +206,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save values.yaml
 	for _, f := range c.Raw {
 		if f.Name == ValuesfileName {
-			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime); err != nil {
+			if err := writeToTar(out, filepath.Join(base, ValuesfileName), f.Data, f.ModTime, epoch); err != nil {
 				return err
 			}
 		}
@@ -208,7 +217,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 		if !json.Valid(c.Schema) {
 			return errors.New("invalid JSON in " + SchemafileName)
 		}
-		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime); err != nil {
+		if err := writeToTar(out, filepath.Join(base, SchemafileName), c.Schema, c.SchemaModTime, epoch); err != nil {
 			return err
 		}
 	}
@@ -216,7 +225,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime, epoch); err != nil {
 			return err
 		}
 	}
@@ -224,14 +233,14 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 	// Save files
 	for _, f := range c.Files {
 		n := filepath.Join(base, f.Name)
-		if err := writeToTar(out, n, f.Data, f.ModTime); err != nil {
+		if err := writeToTar(out, n, f.Data, f.ModTime, epoch); err != nil {
 			return err
 		}
 	}
 
 	// Save dependencies
 	for _, dep := range c.Dependencies() {
-		if err := writeTarContents(out, dep, filepath.Join(base, ChartsDir)); err != nil {
+		if err := writeTarContents(out, dep, filepath.Join(base, ChartsDir), epoch); err != nil {
 			return err
 		}
 	}
@@ -239,7 +248,7 @@ func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
 }
 
 // writeToTar writes a single file to a tar archive.
-func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) error {
+func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time, epoch *time.Time) error {
 	// TODO: Do we need to create dummy parent directory names if none exist?
 	h := &tar.Header{
 		Name:    filepath.ToSlash(name),
@@ -247,8 +256,8 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
-	if epoch, ok := sourceDateEpoch(); ok {
-		h.ModTime = epoch
+	if epoch != nil {
+		h.ModTime = *epoch
 	} else if h.ModTime.IsZero() {
 		h.ModTime = time.Now()
 	}
@@ -259,18 +268,19 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 	return err
 }
 
-// sourceDateEpoch returns the time specified by SOURCE_DATE_EPOCH env var, if set.
+// sourceDateEpoch parses the SOURCE_DATE_EPOCH environment variable.
 // SOURCE_DATE_EPOCH is a Unix timestamp used to ensure reproducible builds.
-func sourceDateEpoch() (time.Time, bool) {
+// It returns an error if the variable is set but cannot be parsed.
+func sourceDateEpoch() (time.Time, bool, error) {
 	s, ok := os.LookupEnv("SOURCE_DATE_EPOCH")
 	if !ok {
-		return time.Time{}, false
+		return time.Time{}, false, nil
 	}
 	secs, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return time.Time{}, false
+		return time.Time{}, false, fmt.Errorf("invalid SOURCE_DATE_EPOCH %q: %w", s, err)
 	}
-	return time.Unix(secs, 0), true
+	return time.Unix(secs, 0), true, nil
 }
 
 // If the name has directory name has characters which would change the location

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -25,6 +25,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -246,7 +247,9 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 		Size:    int64(len(body)),
 		ModTime: modTime,
 	}
-	if h.ModTime.IsZero() {
+	if epoch, ok := sourceDateEpoch(); ok {
+		h.ModTime = epoch
+	} else if h.ModTime.IsZero() {
 		h.ModTime = time.Now()
 	}
 	if err := out.WriteHeader(h); err != nil {
@@ -254,6 +257,20 @@ func writeToTar(out *tar.Writer, name string, body []byte, modTime time.Time) er
 	}
 	_, err := out.Write(body)
 	return err
+}
+
+// sourceDateEpoch returns the time specified by SOURCE_DATE_EPOCH env var, if set.
+// SOURCE_DATE_EPOCH is a Unix timestamp used to ensure reproducible builds.
+func sourceDateEpoch() (time.Time, bool) {
+	s, ok := os.LookupEnv("SOURCE_DATE_EPOCH")
+	if !ok {
+		return time.Time{}, false
+	}
+	secs, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(secs, 0), true
 }
 
 // If the name has directory name has characters which would change the location

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -273,6 +273,12 @@ func TestSaveDir(t *testing.T) {
 }
 
 func TestRepeatableSave(t *testing.T) {
+	// Guard against SOURCE_DATE_EPOCH being set in the test runner environment,
+	// which would override chart modtimes and invalidate the fixed SHA assertions.
+	if orig, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok {
+		os.Unsetenv("SOURCE_DATE_EPOCH")
+		t.Cleanup(func() { os.Setenv("SOURCE_DATE_EPOCH", orig) })
+	}
 	tmp := t.TempDir()
 	defer os.RemoveAll(tmp)
 	modTime := time.Date(2021, 9, 1, 20, 34, 58, 651387237, time.UTC)

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -342,6 +343,60 @@ func TestRepeatableSave(t *testing.T) {
 				t.Errorf("FormatName() result = %v, want %v", result, test.want)
 			}
 		})
+	}
+}
+
+func TestSourceDateEpoch(t *testing.T) {
+	epoch := int64(1630000000)
+	t.Setenv("SOURCE_DATE_EPOCH", fmt.Sprintf("%d", epoch))
+
+	mkChart := func(modTime time.Time) *chart.Chart {
+		return &chart.Chart{
+			Metadata: &chart.Metadata{
+				APIVersion: chart.APIVersionV2,
+				Name:       "ahab",
+				Version:    "1.2.3",
+			},
+			ModTime: modTime,
+			Files: []*common.File{
+				{Name: "scheherazade/shahryar.txt", ModTime: modTime, Data: []byte("1,001 Nights")},
+			},
+		}
+	}
+
+	tmp := t.TempDir()
+
+	where1, err := Save(mkChart(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)), filepath.Join(tmp, "build1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	where2, err := Save(mkChart(time.Date(2023, 6, 15, 12, 0, 0, 0, time.UTC)), filepath.Join(tmp, "build2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum1, err := sha256Sum(where1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum2, err := sha256Sum(where2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sum1 != sum2 {
+		t.Errorf("builds with same SOURCE_DATE_EPOCH should be byte-identical: %s != %s", sum1, sum2)
+	}
+
+	allHeaders, err := retrieveAllHeadersFromTar(where1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTime := time.Unix(epoch, 0)
+	for _, header := range allHeaders {
+		if !header.ModTime.Equal(expectedTime) {
+			t.Errorf("expected timestamp %v, got %v for %s", expectedTime, header.ModTime, header.Name)
+		}
 	}
 }
 

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -414,3 +414,19 @@ func sha256Sum(filePath string) (string, error) {
 
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
+
+func TestSourceDateEpochInvalid(t *testing.T) {
+	t.Setenv("SOURCE_DATE_EPOCH", "not-a-number")
+
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: chart.APIVersionV2,
+			Name:       "ahab",
+			Version:    "1.2.3",
+		},
+	}
+	_, err := Save(c, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid SOURCE_DATE_EPOCH, got nil")
+	}
+}


### PR DESCRIPTION
Closes #31439

## What this fixes

Read the SOURCE_DATE_EPOCH environment variable (a Unix timestamp) during helm package/build and use it to set archive timestamps instead of the current time, enabling reproducible chart builds. The change should be in the chart packaging code (pkg/chartutil or cmd/helm/package.go). If SOURCE_DATE_EPOCH is set, parse it and use time.Unix(epoch, 0) as the build timestamp; fall back to time.Now() otherwise. Add a test verifying that two builds with the same SOURCE_DATE_EPOCH produce byte-identical archives.