### PR TITLE
fix(jsonschema): log schema as string instead of byte slice

### DIFF
--- a/pkg/chart/common/util/jsonschema.go
+++ b/pkg/chart/common/util/jsonschema.go
@@ -134,7 +134,7 @@ func ValidateAgainstSingleSchema(values common.Values, schemaJSON []byte) (reter
 	if err != nil {
 		return err
 	}
-	slog.Debug("unmarshalled JSON schema", "schema", schemaJSON)
+	slog.Debug("unmarshalled JSON schema", "schema", string(schemaJSON))
 
 	// Configure compiler with loaders for different URL schemes
 	loader := jsonschema.SchemeURLLoader{


### PR DESCRIPTION
Fixes #32076

## What changed

`slog` logs `[]byte` values as base64 rather than the raw content. `schemaJSON` was being passed directly to `slog.Debug`, so debug output showed an encoded blob instead of the JSON schema text.

Wrapping in `string()` makes the log readable.

```go
// before
slog.Debug("unmarshalled JSON schema", "schema", schemaJSON)

// after
slog.Debug("unmarshalled JSON schema", "schema", string(schemaJSON))
```