### PR TITLE
fix(plugin): install into first path when HELM_PLUGINS has multiple entries

### DIFF
--- a/internal/plugin/installer/base.go
+++ b/internal/plugin/installer/base.go
@@ -32,8 +32,23 @@ func newBase(source string) base {
 	settings := cli.New()
 	return base{
 		Source:           source,
-		PluginsDirectory: settings.PluginsDirectory,
+		PluginsDirectory: pluginInstallDir(settings.PluginsDirectory),
 	}
+}
+
+// pluginInstallDir returns the directory to install a new plugin into.
+// When HELM_PLUGINS contains multiple colon-separated paths, the first
+// path is used as the install destination — consistent with how
+// FindPlugins() loads from all paths and matching git conventions.
+func pluginInstallDir(helmPlugins string) string {
+	if helmPlugins == "" {
+		return helmPlugins
+	}
+	dirs := filepath.SplitList(helmPlugins)
+	if len(dirs) == 0 {
+		return helmPlugins
+	}
+	return dirs[0]
 }
 
 // Path is where the plugin will be installed.

--- a/internal/plugin/installer/base_test.go
+++ b/internal/plugin/installer/base_test.go
@@ -44,3 +44,40 @@ func TestPath(t *testing.T) {
 		}
 	}
 }
+
+func TestPluginInstallDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		helmPlugins string
+		want        string
+	}{
+		{
+			name:        "empty string returns empty string",
+			helmPlugins: "",
+			want:        "",
+		},
+		{
+			name:        "single path returned as-is",
+			helmPlugins: "/tmp/plugins",
+			want:        "/tmp/plugins",
+		},
+		{
+			name:        "two paths returns first",
+			helmPlugins: "/tmp/abc:/tmp/xyz",
+			want:        "/tmp/abc",
+		},
+		{
+			name:        "three paths returns first",
+			helmPlugins: "/tmp/a:/tmp/b:/tmp/c",
+			want:        "/tmp/a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pluginInstallDir(tt.helmPlugins)
+			if got != tt.want {
+				t.Errorf("pluginInstallDir(%q) = %q, want %q", tt.helmPlugins, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

When `HELM_PLUGINS` is set to a colon-separated list of directories (e.g. `HELM_PLUGINS=/tmp/abc:/tmp/xyz`), `helm plugin list` correctly reads from all paths using `filepath.SplitList()`. However, `helm plugin install` was broken — it passed the raw `HELM_PLUGINS` string directly as the install destination, resulting in a literal directory name like `/tmp/abc:/tmp/xyz` instead of installing into the first path.

## Root cause

In `internal/plugin/installer/base.go`, `newBase()` set:

```go
PluginsDirectory: settings.PluginsDirectory,
```

`settings.PluginsDirectory` is the raw value of `HELM_PLUGINS` with no splitting applied.

## Fix

Added `pluginInstallDir()` which uses `filepath.SplitList()` and returns the first path when multiple are present. `newBase()` now calls this instead of using the raw value directly.

This matches how `load_plugins.go` and `plugin_list.go` already handle `HELM_PLUGINS`, and is consistent with how git handles multiple path variables.

## Tests

Added `TestPluginInstallDir` covering empty string, single path, two paths, and three paths.

Fixes #11310