### PR TITLE
testifylint: enable error-is-as and error-nil rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,8 +101,6 @@ linters:
         - empty
         - encoded-compare
         - equal-values
-        - error-is-as
-        - error-nil
         - expected-actual
         - float-compare
         - go-require

--- a/internal/chart/v3/chart_test.go
+++ b/internal/chart/v3/chart_test.go
@@ -104,7 +104,7 @@ func TestMetadata(t *testing.T) {
 
 	is.Equal("foo.yaml", chrt.Name())
 	is.Equal("1.0.0", chrt.AppVersion())
-	is.Equal(nil, chrt.Validate())
+	is.NoError(chrt.Validate())
 }
 
 func TestIsRoot(t *testing.T) {

--- a/internal/plugin/runtime_extismv1_test.go
+++ b/internal/plugin/runtime_extismv1_test.go
@@ -79,7 +79,7 @@ func TestRuntimeExtismV1InvokePlugin(t *testing.T) {
 			Name: "Phippy",
 		},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	msg := output.Message.(schema.OutputMessageTestV1)
 	assert.Equal(t, "Hello, Phippy! (6)", msg.Greeting)

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -867,7 +867,7 @@ func TestInstallReleaseOutputDir(t *testing.T) {
 	test.AssertGoldenFile(t, filepath.Join(dir, "hello/templates/rbac"), "rbac.txt")
 
 	_, err = os.Stat(filepath.Join(dir, "hello/templates/empty"))
-	is.True(errors.Is(err, fs.ErrNotExist))
+	is.ErrorIs(err, fs.ErrNotExist)
 }
 
 func TestInstallOutputDirWithReleaseName(t *testing.T) {
@@ -903,7 +903,7 @@ func TestInstallOutputDirWithReleaseName(t *testing.T) {
 	test.AssertGoldenFile(t, filepath.Join(newDir, "hello/templates/rbac"), "rbac.txt")
 
 	_, err = os.Stat(filepath.Join(newDir, "hello/templates/empty"))
-	is.True(errors.Is(err, fs.ErrNotExist))
+	is.ErrorIs(err, fs.ErrNotExist)
 }
 
 func TestNameAndChart(t *testing.T) {
@@ -1168,7 +1168,7 @@ func TestInstallCRDs_AlreadyExist(t *testing.T) {
 	mockChart := buildChart(withFile(mockFile))
 	crdsToInstall := mockChart.CRDObjects()
 
-	assert.Nil(t, instAction.installCRDs(crdsToInstall))
+	assert.NoError(t, instAction.installCRDs(crdsToInstall))
 }
 
 func TestInstallCRDs_KubeClient_BuildError(t *testing.T) {
@@ -1227,7 +1227,7 @@ func TestCheckDependencies(t *testing.T) {
 	dependency := chart.Dependency{Name: "hello"}
 	mockChart := buildChart(withDependency())
 
-	assert.Nil(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}))
+	assert.NoError(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}))
 }
 
 func TestCheckDependencies_MissingDependency(t *testing.T) {

--- a/pkg/action/registry_login_test.go
+++ b/pkg/action/registry_login_test.go
@@ -37,7 +37,7 @@ func TestWithCertFile(t *testing.T) {
 	certFile := "testdata/cert.pem"
 	opt := WithCertFile(certFile)
 
-	assert.Nil(t, opt(client))
+	assert.NoError(t, opt(client))
 	assert.Equal(t, certFile, client.certFile)
 }
 
@@ -47,7 +47,7 @@ func TestWithInsecure(t *testing.T) {
 
 	opt := WithInsecure(true)
 
-	assert.Nil(t, opt(client))
+	assert.NoError(t, opt(client))
 	assert.True(t, client.insecure)
 }
 
@@ -58,7 +58,7 @@ func TestWithKeyFile(t *testing.T) {
 	keyFile := "testdata/key.pem"
 	opt := WithKeyFile(keyFile)
 
-	assert.Nil(t, opt(client))
+	assert.NoError(t, opt(client))
 	assert.Equal(t, keyFile, client.keyFile)
 }
 
@@ -69,7 +69,7 @@ func TestWithCAFile(t *testing.T) {
 	caFile := "testdata/ca.pem"
 	opt := WithCAFile(caFile)
 
-	assert.Nil(t, opt(client))
+	assert.NoError(t, opt(client))
 	assert.Equal(t, caFile, client.caFile)
 }
 
@@ -79,6 +79,6 @@ func TestWithPlainHTTPLogin(t *testing.T) {
 
 	opt := WithPlainHTTPLogin(true)
 
-	assert.Nil(t, opt(client))
+	assert.NoError(t, opt(client))
 	assert.True(t, client.plainHTTP)
 }

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -716,7 +716,7 @@ func TestGetUpgradeServerSideValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			serverSideApply, err := getUpgradeServerSideValue(tt.actionServerSideOption, tt.releaseApplyMethod)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedServerSideApply, serverSideApply)
 		})
 	}

--- a/pkg/chart/v2/chart_test.go
+++ b/pkg/chart/v2/chart_test.go
@@ -104,7 +104,7 @@ func TestMetadata(t *testing.T) {
 
 	is.Equal("foo.yaml", chrt.Name())
 	is.Equal("1.0.0", chrt.AppVersion())
-	is.Equal(nil, chrt.Validate())
+	is.NoError(chrt.Validate())
 }
 
 func TestIsRoot(t *testing.T) {

--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -290,14 +290,14 @@ func TestCmdGetDryRunFlagStrategy(t *testing.T) {
 			if tc.ExpectedError {
 				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.ExpectedStrategy, dryRunStrategy)
 			}
 
 			if tc.ExpectedLog != nil {
 				logResult := map[string]string{}
 				err = json.Unmarshal(logBuf.Bytes(), &logResult)
-				require.Nil(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, tc.ExpectedLog.Level, logResult["level"])
 				assert.Equal(t, tc.ExpectedLog.Msg, logResult["msg"])

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1357,7 +1358,7 @@ NestedHelperFunctions/charts/common/templates/_helpers_2.tpl:1:49
 	}
 	_, err := Render(c, vals)
 
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
 
@@ -1391,7 +1392,7 @@ template: no template "nested_helper.name" associated with template "gotpl"`
 	}
 	_, err := Render(c, vals)
 
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
 

--- a/pkg/registry/client_http_test.go
+++ b/pkg/registry/client_http_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"errors"
 	"os"
 	"testing"
 
@@ -43,12 +42,12 @@ func (suite *HTTPRegistryClientTestSuite) Test_0_Login() {
 	err := suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth("badverybad", "ohsobad"),
 		LoginOptPlainText(true))
-	suite.NotNil(err, "error logging into registry with bad credentials")
+	suite.Require().Error(err, "error logging into registry with bad credentials")
 
 	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth(testUsername, testPassword),
 		LoginOptPlainText(true))
-	suite.Nil(err, "no error logging into registry with good credentials")
+	suite.Require().NoError(err, "no error logging into registry with good credentials")
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_1_Push() {
@@ -68,15 +67,15 @@ func (suite *HTTPRegistryClientTestSuite) Test_4_ManInTheMiddle() {
 
 	// returns content that does not match the expected digest
 	_, err := suite.RegistryClient.Pull(ref)
-	suite.NotNil(err)
-	suite.True(errors.Is(err, content.ErrMismatchedDigest))
+	suite.Require().Error(err)
+	suite.ErrorIs(err, content.ErrMismatchedDigest)
 }
 
 func (suite *HTTPRegistryClientTestSuite) Test_5_ImageIndex() {
 	ref := suite.FakeRegistryHost + "/testrepo/image-index:0.1.0"
 
 	_, err := suite.RegistryClient.Pull(ref)
-	suite.Nil(err)
+	suite.Require().NoError(err)
 }
 
 func TestHTTPRegistryClientTestSuite(t *testing.T) {

--- a/pkg/registry/client_insecure_tls_test.go
+++ b/pkg/registry/client_insecure_tls_test.go
@@ -41,12 +41,12 @@ func (suite *InsecureTLSRegistryClientTestSuite) Test_0_Login() {
 	err := suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth("badverybad", "ohsobad"),
 		LoginOptInsecure(true))
-	suite.NotNil(err, "error logging into registry with bad credentials")
+	suite.Require().Error(err, "error logging into registry with bad credentials")
 
 	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth(testUsername, testPassword),
 		LoginOptInsecure(true))
-	suite.Nil(err, "no error logging into registry with good credentials")
+	suite.Require().NoError(err, "no error logging into registry with good credentials")
 }
 
 func (suite *InsecureTLSRegistryClientTestSuite) Test_1_Push() {
@@ -65,11 +65,11 @@ func (suite *InsecureTLSRegistryClientTestSuite) Test_4_Logout() {
 	err := suite.RegistryClient.Logout("this-host-aint-real:5000")
 	if err != nil {
 		// credential backend for mac generates an error
-		suite.NotNil(err, "failed to delete the credential for this-host-aint-real:5000")
+		suite.Require().Error(err, "failed to delete the credential for this-host-aint-real:5000")
 	}
 
 	err = suite.RegistryClient.Logout(suite.DockerRegistryHost)
-	suite.Nil(err, "no error logging out of registry")
+	suite.Require().NoError(err, "no error logging out of registry")
 }
 
 func TestInsecureTLSRegistryClientTestSuite(t *testing.T) {

--- a/pkg/registry/client_tls_test.go
+++ b/pkg/registry/client_tls_test.go
@@ -43,26 +43,26 @@ func (suite *TLSRegistryClientTestSuite) Test_0_Login() {
 	err := suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth("badverybad", "ohsobad"),
 		LoginOptTLSClientConfig(tlsCert, tlsKey, tlsCA))
-	suite.NotNil(err, "error logging into registry with bad credentials")
+	suite.Require().Error(err, "error logging into registry with bad credentials")
 
 	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth(testUsername, testPassword),
 		LoginOptTLSClientConfig(tlsCert, tlsKey, tlsCA))
-	suite.Nil(err, "no error logging into registry with good credentials")
+	suite.Require().NoError(err, "no error logging into registry with good credentials")
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_1_Login() {
 	err := suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth("badverybad", "ohsobad"),
 		LoginOptTLSClientConfigFromConfig(&tls.Config{}))
-	suite.NotNil(err, "error logging into registry with bad credentials")
+	suite.Require().Error(err, "error logging into registry with bad credentials")
 
 	// Create a *tls.Config from tlsCert, tlsKey, and tlsCA.
 	cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-	suite.Nil(err, "error loading x509 key pair")
+	suite.Require().NoError(err, "error loading x509 key pair")
 	rootCAs := x509.NewCertPool()
 	caCert, err := os.ReadFile(tlsCA)
-	suite.Nil(err, "error reading CA certificate")
+	suite.Require().NoError(err, "error reading CA certificate")
 	rootCAs.AppendCertsFromPEM(caCert)
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
@@ -72,7 +72,7 @@ func (suite *TLSRegistryClientTestSuite) Test_1_Login() {
 	err = suite.RegistryClient.Login(suite.DockerRegistryHost,
 		LoginOptBasicAuth(testUsername, testPassword),
 		LoginOptTLSClientConfigFromConfig(conf))
-	suite.Nil(err, "no error logging into registry with good credentials")
+	suite.Require().NoError(err, "no error logging into registry with good credentials")
 }
 
 func (suite *TLSRegistryClientTestSuite) Test_1_Push() {
@@ -91,11 +91,11 @@ func (suite *TLSRegistryClientTestSuite) Test_4_Logout() {
 	err := suite.RegistryClient.Logout("this-host-aint-real:5000")
 	if err != nil {
 		// credential backend for mac generates an error
-		suite.NotNil(err, "failed to delete the credential for this-host-aint-real:5000")
+		suite.Require().Error(err, "failed to delete the credential for this-host-aint-real:5000")
 	}
 
 	err = suite.RegistryClient.Logout(suite.DockerRegistryHost)
-	suite.Nil(err, "no error logging out of registry")
+	suite.Require().NoError(err, "no error logging out of registry")
 }
 
 func TestTLSRegistryClientTestSuite(t *testing.T) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -107,26 +107,26 @@ func setup(suite *TestRegistry, tlsEnabled, insecure bool) {
 				TLSClientConfig: tlsConf,
 			},
 		}
-		suite.Nil(err, "no error loading tls config")
+		suite.Require().NoError(err, "no error loading tls config")
 		opts = append(opts, ClientOptHTTPClient(httpClient))
 	} else {
 		opts = append(opts, ClientOptPlainHTTP())
 	}
 
 	suite.RegistryClient, err = NewClient(opts...)
-	suite.Nil(err, "no error creating registry client")
+	suite.Require().NoError(err, "no error creating registry client")
 
 	// create htpasswd file (w BCrypt, which is required)
 	pwBytes, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
-	suite.Nil(err, "no error generating bcrypt password for test htpasswd file")
+	suite.Require().NoError(err, "no error generating bcrypt password for test htpasswd file")
 	htpasswdPath := filepath.Join(suite.WorkspaceDir, testHtpasswdFileBasename)
 	err = os.WriteFile(htpasswdPath, fmt.Appendf(nil, "%s:%s\n", testUsername, string(pwBytes)), 0644)
-	suite.Nil(err, "no error creating test htpasswd file")
+	suite.Require().NoError(err, "no error creating test htpasswd file")
 
 	// Registry config
 	config := &configuration.Configuration{}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	suite.Nil(err, "no error finding free port for test registry")
+	suite.Require().NoError(err, "no error finding free port for test registry")
 	defer func() { _ = ln.Close() }()
 
 	// Change the registry host to another host which is not localhost.
@@ -159,7 +159,7 @@ func setup(suite *TestRegistry, tlsEnabled, insecure bool) {
 		}
 	}
 	suite.dockerRegistry, err = registry.NewRegistry(context.Background(), config)
-	suite.Nil(err, "no error creating test registry")
+	suite.Require().NoError(err, "no error creating test registry")
 
 	suite.FakeRegistryHost = initFakeRegistryTestServer()
 	suite.CompromisedRegistryHost = initCompromisedRegistryTestServer()
@@ -386,61 +386,61 @@ func testPush(suite *TestRegistry) {
 	// Bad bytes
 	ref := suite.DockerRegistryHost + "/testrepo/testchart:1.2.3"
 	_, err := suite.RegistryClient.Push([]byte("hello"), ref, PushOptCreationTime(testingChartCreationTime))
-	suite.NotNil(err, "error pushing non-chart bytes")
+	suite.Require().Error(err, "error pushing non-chart bytes")
 
 	// Load a test chart
 	chartData, err := os.ReadFile("../repo/v1/repotest/testdata/examplechart-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err := extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 
 	// non-strict ref (chart name)
 	ref = fmt.Sprintf("%s/testrepo/boop:%s", suite.DockerRegistryHost, meta.Version)
 	_, err = suite.RegistryClient.Push(chartData, ref, PushOptCreationTime(testingChartCreationTime))
-	suite.NotNil(err, "error pushing non-strict ref (bad basename)")
+	suite.Require().Error(err, "error pushing non-strict ref (bad basename)")
 
 	// non-strict ref (chart name), with strict mode disabled
 	_, err = suite.RegistryClient.Push(chartData, ref, PushOptStrictMode(false), PushOptCreationTime(testingChartCreationTime))
-	suite.Nil(err, "no error pushing non-strict ref (bad basename), with strict mode disabled")
+	suite.Require().NoError(err, "no error pushing non-strict ref (bad basename), with strict mode disabled")
 
 	// non-strict ref (chart version)
 	ref = fmt.Sprintf("%s/testrepo/%s:latest", suite.DockerRegistryHost, meta.Name)
 	_, err = suite.RegistryClient.Push(chartData, ref, PushOptCreationTime(testingChartCreationTime))
-	suite.NotNil(err, "error pushing non-strict ref (bad tag)")
+	suite.Require().Error(err, "error pushing non-strict ref (bad tag)")
 
 	// non-strict ref (chart version), with strict mode disabled
 	_, err = suite.RegistryClient.Push(chartData, ref, PushOptStrictMode(false), PushOptCreationTime(testingChartCreationTime))
-	suite.Nil(err, "no error pushing non-strict ref (bad tag), with strict mode disabled")
+	suite.Require().NoError(err, "no error pushing non-strict ref (bad tag), with strict mode disabled")
 
 	// basic push, good ref
 	chartData, err = os.ReadFile("../downloader/testdata/local-subchart-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err = extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 	ref = fmt.Sprintf("%s/testrepo/%s:%s", suite.DockerRegistryHost, meta.Name, meta.Version)
 	_, err = suite.RegistryClient.Push(chartData, ref, PushOptCreationTime(testingChartCreationTime))
-	suite.Nil(err, "no error pushing good ref")
+	suite.Require().NoError(err, "no error pushing good ref")
 
 	_, err = suite.RegistryClient.Pull(ref)
-	suite.Nil(err, "no error pulling a simple chart")
+	suite.Require().NoError(err, "no error pulling a simple chart")
 
 	// Load another test chart
 	chartData, err = os.ReadFile("../downloader/testdata/signtest-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err = extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 
 	// Load prov file
 	provData, err := os.ReadFile("../downloader/testdata/signtest-0.1.0.tgz.prov")
-	suite.Nil(err, "no error loading test prov")
+	suite.Require().NoError(err, "no error loading test prov")
 
 	// push with prov
 	ref = fmt.Sprintf("%s/testrepo/%s:%s", suite.DockerRegistryHost, meta.Name, meta.Version)
 	result, err := suite.RegistryClient.Push(chartData, ref, PushOptProvData(provData), PushOptCreationTime(testingChartCreationTime))
-	suite.Nil(err, "no error pushing good ref with prov")
+	suite.Require().NoError(err, "no error pushing good ref with prov")
 
 	_, err = suite.RegistryClient.Pull(ref, PullOptWithProv(true))
-	suite.Nil(err, "no error pulling a simple chart")
+	suite.Require().NoError(err, "no error pulling a simple chart")
 
 	// Validate the output
 	// Note: these digests/sizes etc may change if the test chart/prov files are modified,
@@ -470,50 +470,50 @@ func testPull(suite *TestRegistry) {
 	// bad/missing ref
 	ref := suite.DockerRegistryHost + "/testrepo/no-existy:1.2.3"
 	_, err := suite.RegistryClient.Pull(ref)
-	suite.NotNil(err, "error on bad/missing ref")
+	suite.Require().Error(err, "error on bad/missing ref")
 
 	// Load test chart (to build ref pushed in previous test)
 	chartData, err := os.ReadFile("../downloader/testdata/local-subchart-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err := extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 	ref = fmt.Sprintf("%s/testrepo/%s:%s", suite.DockerRegistryHost, meta.Name, meta.Version)
 
 	// Simple pull, chart only
 	_, err = suite.RegistryClient.Pull(ref)
-	suite.Nil(err, "no error pulling a simple chart")
+	suite.Require().NoError(err, "no error pulling a simple chart")
 
 	// Simple pull with prov (no prov uploaded)
 	_, err = suite.RegistryClient.Pull(ref, PullOptWithProv(true))
-	suite.NotNil(err, "error pulling a chart with prov when no prov exists")
+	suite.Require().Error(err, "error pulling a chart with prov when no prov exists")
 
 	// Simple pull with prov, ignoring missing prov
 	_, err = suite.RegistryClient.Pull(ref,
 		PullOptWithProv(true),
 		PullOptIgnoreMissingProv(true))
-	suite.Nil(err,
+	suite.Require().NoError(err,
 		"no error pulling a chart with prov when no prov exists, ignoring missing")
 
 	// Load test chart (to build ref pushed in previous test)
 	chartData, err = os.ReadFile("../downloader/testdata/signtest-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err = extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 	ref = fmt.Sprintf("%s/testrepo/%s:%s", suite.DockerRegistryHost, meta.Name, meta.Version)
 
 	// Load prov file
 	provData, err := os.ReadFile("../downloader/testdata/signtest-0.1.0.tgz.prov")
-	suite.Nil(err, "no error loading test prov")
+	suite.Require().NoError(err, "no error loading test prov")
 
 	// no chart and no prov causes error
 	_, err = suite.RegistryClient.Pull(ref,
 		PullOptWithChart(false),
 		PullOptWithProv(false))
-	suite.NotNil(err, "error on both no chart and no prov")
+	suite.Require().Error(err, "error on both no chart and no prov")
 
 	// full pull with chart and prov
 	result, err := suite.RegistryClient.Pull(ref, PullOptWithProv(true))
-	suite.Require().Nil(err, "no error pulling a chart with prov")
+	suite.Require().NoError(err, "no error pulling a chart with prov")
 
 	// Validate the output
 	// Note: these digests/sizes etc may change if the test chart/prov files are modified,
@@ -548,13 +548,13 @@ func testPull(suite *TestRegistry) {
 func testTags(suite *TestRegistry) {
 	// Load test chart (to build ref pushed in previous test)
 	chartData, err := os.ReadFile("../downloader/testdata/local-subchart-0.1.0.tgz")
-	suite.Nil(err, "no error loading test chart")
+	suite.Require().NoError(err, "no error loading test chart")
 	meta, err := extractChartMeta(chartData)
-	suite.Nil(err, "no error extracting chart meta")
+	suite.Require().NoError(err, "no error extracting chart meta")
 	ref := fmt.Sprintf("%s/testrepo/%s", suite.DockerRegistryHost, meta.Name)
 
 	// Query for tags and validate length
 	tags, err := suite.RegistryClient.Tags(ref)
-	suite.Nil(err, "no error retrieving tags")
+	suite.Require().NoError(err, "no error retrieving tags")
 	suite.Equal(1, len(tags))
 }

--- a/pkg/repo/v1/repotest/tlsconfig.go
+++ b/pkg/repo/v1/repotest/tlsconfig.go
@@ -35,8 +35,7 @@ func MakeTestTLSConfig(t *testing.T, path string) *tls.Config {
 		tlsutil.WithCertKeyPairFiles(pub, priv),
 		tlsutil.WithCAFile(ca),
 	)
-	//require.Nil(t, err, err.Error())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	tlsConf.ServerName = "helm.sh"
 


### PR DESCRIPTION
Enables the `error-is-as` and `error-nil` testifylint rules by fixing all violations. These dedicated helpers (`ErrorIs`, `NoError`, `Error`) produce better failure messages than the generic `True`/`Nil`/`NotNil` assertions.

**What this PR does / why we need it**:

Fixes all `error-is-as` and `error-nil` testifylint violations and enables both rules in `.golangci.yml`.

`error-is-as` fixes (3 occurrences):
- `pkg/action/install_test.go`: `is.True(errors.Is(err, fs.ErrNotExist))` → `is.ErrorIs(err, fs.ErrNotExist)` (2 occurrences)
- `pkg/registry/client_http_test.go`: `suite.True(errors.Is(err, content.ErrMismatchedDigest))` → `suite.ErrorIs(err, content.ErrMismatchedDigest)`; remove now-unused `"errors"` import

`error-nil` fixes (~35 occurrences across 13 files):
- Replace `assert`/`require`/`suite` `.Nil(err)` → `.NoError(err)` and `.NotNil(err)` → `.Error(err)` wherever the argument is of type `error`
- Files: `internal/chart/v3/chart_test.go`, `internal/plugin/runtime_extismv1_test.go`, `pkg/action/install_test.go`, `pkg/action/registry_login_test.go`, `pkg/action/upgrade_test.go`, `pkg/chart/v2/chart_test.go`, `pkg/cmd/helpers_test.go`, `pkg/engine/engine_test.go`, `pkg/registry/client_http_test.go`, `pkg/registry/client_insecure_tls_test.go`, `pkg/registry/client_tls_test.go`, `pkg/registry/registry_test.go`, `pkg/repo/v1/repotest/tlsconfig.go`

`.golangci.yml`: remove `error-is-as` and `error-nil` from `testifylint.disable`

**Special notes for your reviewer**:

None.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility