### PR TITLE
Fix missing conflict retry with server-side apply

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -318,20 +318,23 @@ func (c *Client) makeCreateApplyFunc(serverSideApply, forceConflicts, dryRun boo
 			slog.String("fieldValidationDirective", string(fieldValidationDirective)))
 
 		return func(target *resource.Info) error {
-			err := patchResourceServerSide(target, dryRun, forceConflicts, fieldValidationDirective)
-
 			logger := c.Logger().With(
 				slog.String("namespace", target.Namespace),
 				slog.String("name", target.Name),
 				slog.String("gvk", target.Mapping.GroupVersionKind.String()))
-			if err != nil {
-				logger.Debug("Error creating resource via patch", slog.Any("error", err))
-				return err
-			}
 
-			logger.Debug("Created resource via patch")
+			return retry.RetryOnConflict(
+				retry.DefaultRetry,
+				func() error {
+					err := patchResourceServerSide(target, dryRun, forceConflicts, fieldValidationDirective)
+					if err != nil {
+						logger.Debug("Error creating resource via patch", slog.Any("error", err))
+						return err
+					}
 
-			return nil
+					logger.Debug("Created resource via patch")
+					return nil
+				})
 		}
 	}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -325,7 +325,7 @@ func (c *Client) makeCreateApplyFunc(serverSideApply, forceConflicts, dryRun boo
 
 			return retry.OnError(
 				retry.DefaultRetry,
-				isQuotaConflict,
+				isServerSideRetryable,
 				func() error {
 					err := patchResourceServerSide(target, dryRun, forceConflicts, fieldValidationDirective)
 					if err != nil {
@@ -955,10 +955,16 @@ func isIncompatibleServerError(err error) bool {
 	return err.(*apierrors.StatusError).Status().Code == http.StatusUnsupportedMediaType
 }
 
-// isQuotaConflict checks if the error is a conflict error specifically caused by
+// isServerSideRetryable checks if an error encountered during server-side apply
+// should be retried. Currently, only ResourceQuota conflicts are considered retryable.
+func isServerSideRetryable(err error) bool {
+	return isResourceQuotaConflict(err)
+}
+
+// isResourceQuotaConflict checks if the error is a conflict error specifically caused by
 // a ResourceQuota. This is used to determine if a retry should be attempted,
 // since quota conflicts are typically transient and can be resolved by retrying.
-func isQuotaConflict(err error) bool {
+func isResourceQuotaConflict(err error) bool {
 	if !apierrors.IsConflict(err) {
 		return false
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -323,8 +323,9 @@ func (c *Client) makeCreateApplyFunc(serverSideApply, forceConflicts, dryRun boo
 				slog.String("name", target.Name),
 				slog.String("gvk", target.Mapping.GroupVersionKind.String()))
 
-			return retry.RetryOnConflict(
+			return retry.OnError(
 				retry.DefaultRetry,
+				isQuotaConflict,
 				func() error {
 					err := patchResourceServerSide(target, dryRun, forceConflicts, fieldValidationDirective)
 					if err != nil {
@@ -952,6 +953,26 @@ func isIncompatibleServerError(err error) bool {
 		return false
 	}
 	return err.(*apierrors.StatusError).Status().Code == http.StatusUnsupportedMediaType
+}
+
+// isQuotaConflict checks if the error is a conflict error specifically caused by
+// a ResourceQuota. This is used to determine if a retry should be attempted,
+// since quota conflicts are typically transient and can be resolved by retrying.
+func isQuotaConflict(err error) bool {
+	if !apierrors.IsConflict(err) {
+		return false
+	}
+
+	// Check the error message for the specific ResourceQuota conflict pattern.
+	// The error message from the ResourceQuota admission controller contains:
+	// "Operation cannot be fulfilled on resourcequotas" and "the object has been modified"
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "Operation cannot be fulfilled on resourcequotas") &&
+		strings.Contains(errMsg, "the object has been modified") {
+		return true
+	}
+
+	return false
 }
 
 // getManagedFieldsManager returns the manager string. If one was set it will be returned.

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -53,6 +53,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/client-go/util/retry"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
@@ -273,9 +274,13 @@ func TestCreate(t *testing.T) {
 			},
 			ExpectedErrorContains: "Operation cannot be fulfilled on resourcequotas \"quota\": the object has been modified; " +
 				"please apply your changes to the latest version and try again",
-			ExpectedActions: []string{
-				"/namespaces/default/pods/dolphin:PATCH",
-			},
+			ExpectedActions: func() []string { // expect helm to retry on conflict, workaround for: https://github.com/kubernetes/kubernetes/issues/67761
+				actions := make([]string, retry.DefaultRetry.Steps)
+				for i := range actions {
+					actions[i] = "/namespaces/default/pods/dolphin:PATCH"
+				}
+				return actions
+			}(),
 		},
 	}
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -282,6 +282,24 @@ func TestCreate(t *testing.T) {
 				return actions
 			}(),
 		},
+		"Create fail: managed fields conflict (server-side apply)": {
+			Pods:            newPodList("seal"),
+			ServerSideApply: true,
+			Callback: func(t *testing.T, _ testCase, _ []RequestResponseAction, req *http.Request) (*http.Response, error) {
+				t.Helper()
+
+				// Return a generic 409 conflict (not quota-related)
+				// This simulates a managed fields conflict
+				return &http.Response{
+					StatusCode: http.StatusConflict,
+					Request:    req,
+				}, nil
+			},
+			ExpectedErrorContains: "the server reported a conflict",
+			ExpectedActions: []string{
+				"/namespaces/default/pods/seal:PATCH",
+			},
+		},
 	}
 
 	c := newTestClient(t)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Closes: #32087
Relevant issue: #9710

This PR adds retry mechanism for resource creation when using server side apply. The exact same solution is already implemented in client-side apply (via #9713), but was missing from the server-side apply.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
