### PR TITLE
test(values): cover subchart-default nil cleanup when parent has unrelated user values

### DIFF
--- a/pkg/chart/v2/util/dependencies_test.go
+++ b/pkg/chart/v2/util/dependencies_test.go
@@ -21,7 +21,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"helm.sh/helm/v4/pkg/chart/common"
+	commonutil "helm.sh/helm/v4/pkg/chart/common/util"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 )
@@ -567,4 +571,110 @@ func TestChartWithDependencyAliasedTwiceAndDoublyReferencedSubDependency(t *test
 		t.Fatal("expected two dependencies after processing aliases")
 	}
 	validateDependencyTree(t, c)
+}
+
+// Metadata.Dependencies must be set so processImportValues doesn't early-exit
+// before contaminating parent.Values with subchart nil defaults.
+func newParentWithNilSubchart() *chart.Chart {
+	subchart := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "child"},
+		Values: map[string]any{
+			"keyMapping": map[string]any{
+				"password": nil,
+			},
+			"ingress": map[string]any{
+				"configureCertmanager": nil,
+			},
+		},
+	}
+	parent := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:         "parent",
+			Dependencies: []*chart.Dependency{{Name: "child"}},
+		},
+		Values: map[string]any{},
+	}
+	parent.AddDependency(subchart)
+	return parent
+}
+
+func processAndCoalesce(t *testing.T, parent *chart.Chart, vals common.Values) common.Values {
+	t.Helper()
+	require.NoError(t, ProcessDependencies(parent, vals))
+	coalesced, err := commonutil.CoalesceValues(parent, vals)
+	require.NoError(t, err)
+	return coalesced
+}
+
+// Baseline: with no user subchart values, nil cleanup goes through the
+// !merge else-branch in coalesceValues and works.
+func TestProcessDependenciesNilCleanedNoUserSubchartVals(t *testing.T) {
+	is := assert.New(t)
+	coalesced := processAndCoalesce(t, newParentWithNilSubchart(), common.Values{})
+
+	_, err := common.Values(coalesced).PathValue("child.keyMapping.password")
+	is.ErrorAs(err, &common.ErrNoValue{}, "child.keyMapping.password should be absent")
+
+	_, err = common.Values(coalesced).PathValue("child.ingress.configureCertmanager")
+	is.ErrorAs(err, &common.ErrNoValue{}, "child.ingress.configureCertmanager should be absent")
+}
+
+// Any user value under "child" routes coalescing through merge=true and
+// bypasses cleanNilValues. Covers #31919 and #31971.
+func TestProcessDependenciesNilCleanedWithUnrelatedSubchartVals(t *testing.T) {
+	is := assert.New(t)
+	coalesced := processAndCoalesce(t, newParentWithNilSubchart(), common.Values{
+		"child": map[string]any{
+			"someOtherKey": "someValue",
+		},
+		"global": map[string]any{
+			"ingress": map[string]any{
+				"configureCertmanager": true,
+			},
+		},
+	})
+
+	_, err := common.Values(coalesced).PathValue("child.keyMapping.password")
+	is.ErrorAs(err, &common.ErrNoValue{}, "child.keyMapping.password should be absent")
+
+	_, err = common.Values(coalesced).PathValue("child.ingress.configureCertmanager")
+	is.ErrorAs(err, &common.ErrNoValue{}, "child.ingress.configureCertmanager should be absent so pluck falls through to global")
+}
+
+// Stricter case: user overrides a sibling key in the same map containing the nil.
+func TestProcessDependenciesNilCleanedWithPartialSameMapVals(t *testing.T) {
+	is := assert.New(t)
+
+	subchart := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "child"},
+		Values: map[string]any{
+			"keyMapping": map[string]any{
+				"password": nil,
+				"format":   "bcrypt",
+			},
+		},
+	}
+	parent := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:         "parent",
+			Dependencies: []*chart.Dependency{{Name: "child"}},
+		},
+		Values: map[string]any{},
+	}
+	parent.AddDependency(subchart)
+
+	coalesced := processAndCoalesce(t, parent, common.Values{
+		"child": map[string]any{
+			"keyMapping": map[string]any{
+				"format": "sha256",
+			},
+		},
+	})
+
+	v, err := common.Values(coalesced).PathValue("child.keyMapping.format")
+	is.NoError(err)
+	is.Equal("sha256", v)
+
+	_, err = common.Values(coalesced).PathValue("child.keyMapping.password")
+	is.ErrorAs(err, &common.ErrNoValue{}, "child.keyMapping.password should be absent")
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -37,6 +37,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/common/util"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 )
 
 func TestSortTemplates(t *testing.T) {
@@ -1512,7 +1513,6 @@ func TestTraceableError_NoTemplateForm(t *testing.T) {
 func TestRenderSubchartDefaultNilNoStringify(t *testing.T) {
 	modTime := time.Now()
 
-	// Subchart has a default with nil values
 	subchart := &chart.Chart{
 		Metadata: &chart.Metadata{Name: "child"},
 		Templates: []*common.File{
@@ -1524,19 +1524,29 @@ func TestRenderSubchartDefaultNilNoStringify(t *testing.T) {
 		},
 		Values: map[string]any{
 			"keyMapping": map[string]any{
-				"password": nil, // nil in chart defaults
+				"password": nil,
 			},
 		},
 	}
 
 	parent := &chart.Chart{
-		Metadata: &chart.Metadata{Name: "parent"},
-		Values:   map[string]any{},
+		Metadata: &chart.Metadata{
+			Name:         "parent",
+			Dependencies: []*chart.Dependency{{Name: "child"}},
+		},
+		Values: map[string]any{},
 	}
 	parent.AddDependency(subchart)
 
-	// Parent user values don't set keyMapping
-	injValues := map[string]any{}
+	injValues := map[string]any{
+		"child": map[string]any{
+			"someOtherKey": "someValue",
+		},
+	}
+
+	if err := chartutil.ProcessDependencies(parent, injValues); err != nil {
+		t.Fatalf("Failed to process dependencies: %s", err)
+	}
 
 	tmp, err := util.CoalesceValues(parent, injValues)
 	if err != nil {


### PR DESCRIPTION
Failing tests pinning the gap left open after #31979: when the parent supplies any value under a subchart, coalescing routes through `merge=true` and bypasses `cleanNilValues`, so subchart-default nils survive.

Adds in `pkg/chart/v2/util/dependencies_test.go`:
- `…NoUserSubchartVals` — baseline, passes.
- `…WithUnrelatedSubchartVals` — fails; unrelated sibling key triggers the leak.
- `…WithPartialSameMapVals` — fails; sibling nil in same map survives an override.

Also tightens `TestRenderSubchartDefaultNilNoStringify` to call `ProcessDependencies`, matching the real coalesce path. Tests-only; baseline for the follow-up fix.

**Special notes for your reviewer**:

So far just adds test coverage for the remaining nil values merge regression.
I did not want to pollute the PR with an AI Slop "fix".

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
