### PR TITLE
fix(install): backport nil CRD guard from main to dev-v3 (fixes #31552)

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -162,10 +162,22 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 	// We do these one file at a time in the order they were read.
 	totalItems := []*resource.Info{}
 	for _, obj := range crds {
+		if obj.File == nil {
+			return errors.Errorf("failed to install CRD %s: file is empty", obj.Name)
+		}
+
+		if obj.File.Data == nil {
+			return errors.Errorf("failed to install CRD %s: file data is empty", obj.Name)
+		}
+
 		// Read in the resources
 		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.File.Data), false)
 		if err != nil {
 			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+		}
+
+		if len(res) == 0 {
+			return errors.Errorf("failed to install CRD %s: resources are empty", obj.Name)
 		}
 
 		// Send them to Kube
@@ -191,27 +203,29 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 		// the case when an action configuration is reused for multiple actions,
 		// as otherwise it is later loaded by ourselves when getCapabilities
 		// is called later on in the installation process.
-		if i.cfg.Capabilities != nil {
-			discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient()
+		if i.cfg.RESTClientGetter != nil {
+			if i.cfg.Capabilities != nil {
+				discoveryClient, err := i.cfg.RESTClientGetter.ToDiscoveryClient()
+				if err != nil {
+					return err
+				}
+
+				i.cfg.Log("Clearing discovery cache")
+				discoveryClient.Invalidate()
+
+				_, _ = discoveryClient.ServerGroups()
+			}
+
+			// Invalidate the REST mapper, since it will not have the new CRDs
+			// present.
+			restMapper, err := i.cfg.RESTClientGetter.ToRESTMapper()
 			if err != nil {
 				return err
 			}
-
-			i.cfg.Log("Clearing discovery cache")
-			discoveryClient.Invalidate()
-
-			_, _ = discoveryClient.ServerGroups()
-		}
-
-		// Invalidate the REST mapper, since it will not have the new CRDs
-		// present.
-		restMapper, err := i.cfg.RESTClientGetter.ToRESTMapper()
-		if err != nil {
-			return err
-		}
-		if resettable, ok := restMapper.(meta.ResettableRESTMapper); ok {
-			i.cfg.Log("Clearing REST mapper cache")
-			resettable.Reset()
+			if resettable, ok := restMapper.(meta.ResettableRESTMapper); ok {
+				i.cfg.Log("Clearing REST mapper cache")
+				resettable.Reset()
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## What this does

Backports the nil-pointer crash fix from PR #31578 (already merged to main) to the dev-v3 branch.

## Problem

helm template crashes with nil pointer dereference in pkg/action/install.go:175 when CRD resources resolve to empty slices. The crash path: res[0].Name on an empty slice after KubeClient.Build() returns no resources.

Fixes #31552

## Fix

Three guards added to installCRDs():
1. obj.File == nil — return error
2. obj.File.Data == nil — return error  
3. len(res) == 0 — return error instead of res[0] panic
4. RESTClientGetter nil check around discovery/mapper invalidation

## Testing

go test ./pkg/action/ -run TestInstall -count=1 → ok (30.323s)

## Related

- Original fix on main: #31578