### PR TITLE
refactor(downloader): order DiskCache.Get checks for overlayfs empty dirs

### DIFF
--- a/pkg/downloader/cache.go
+++ b/pkg/downloader/cache.go
@@ -59,14 +59,16 @@ func (c *DiskCache) Get(key [sha256.Size]byte, cacheType string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	// Empty files treated as not exist because there is no content.
-	if fi.Size() == 0 {
-		return p, os.ErrNotExist
-	}
 	// directories should never happen unless something outside helm is operating
 	// on this content.
 	if fi.IsDir() {
 		return p, errors.New("is a directory")
+	}
+	// Empty files treated as not exist because there is no content.
+	// IsDir must be checked first: some filesystems (e.g. overlay) report
+	// directory size as 0.
+	if fi.Size() == 0 {
+		return p, os.ErrNotExist
 	}
 	return p, nil
 }

--- a/pkg/downloader/cache.go
+++ b/pkg/downloader/cache.go
@@ -64,8 +64,8 @@ func (c *DiskCache) Get(key [sha256.Size]byte, cacheType string) (string, error)
 	if fi.IsDir() {
 		return p, errors.New("is a directory")
 	}
-	// Empty files treated as not exist because there is no content.
-	// IsDir must be checked first: some filesystems (e.g. overlay) report
+	// Empty files are treated as non-existent because there is no content.
+	// IsDir must be checked first: some filesystems (e.g. overlayfs) report
 	// directory size as 0.
 	if fi.Size() == 0 {
 		return p, os.ErrNotExist


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

`DiskCache.Get` treated `fi.Size() == 0` as a cache miss before `fi.IsDir()`. On some filesystems (e.g. overlay in containers), directories can report size `0`, so a directory at the cache path was returned as `os.ErrNotExist` instead of `"is a directory"`. That broke `TestDiskCache_PutAndGet/GetDirectory` in those environments and could mis-handle the same case in real use.

The fix is to check `IsDir()` first, then treat zero-size regular files as missing, with a short comment on why order matters.

closes #32100

**Special notes for your reviewer**:

No API changes. Existing `TestDiskCache_PutAndGet` subtests (including `GetDirectory` and `PutEmptyFile`) exercise the behavior; no new tests were added.
