### PR TITLE
fix(action): reject invalid CRD install inputs

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -162,10 +162,22 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 	// We do these one file at a time in the order they were read.
 	totalItems := []*resource.Info{}
 	for _, obj := range crds {
+		if obj.File == nil {
+			return fmt.Errorf("failed to install CRD %s: file is empty", obj.Name)
+		}
+
+		if obj.File.Data == nil {
+			return fmt.Errorf("failed to install CRD %s: file data is empty", obj.Name)
+		}
+
 		// Read in the resources
 		res, err := i.cfg.KubeClient.Build(bytes.NewBuffer(obj.File.Data), false)
 		if err != nil {
 			return errors.Wrapf(err, "failed to install CRD %s", obj.Name)
+		}
+
+		if len(res) == 0 {
+			return fmt.Errorf("failed to install CRD %s: resources are empty", obj.Name)
 		}
 
 		// Send them to Kube

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -916,6 +916,59 @@ func TestInstallCRDsWithNilRESTClientGetter(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestInstallCRDsRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name           string
+		crd            chart.CRD
+		dummyResources kube.ResourceList
+		wantErr        string
+	}{
+		{
+			name: "nil file",
+			crd: chart.CRD{
+				Name: "test-crd",
+			},
+			wantErr: "file is empty",
+		},
+		{
+			name: "nil file data",
+			crd: chart.CRD{
+				Name: "test-crd",
+				File: &chart.File{Name: "crds/test-crd.yaml"},
+			},
+			wantErr: "file data is empty",
+		},
+		{
+			name: "empty resources",
+			crd: chart.CRD{
+				Name: "test-crd",
+				File: &chart.File{
+					Name: "crds/test-crd.yaml",
+					Data: []byte("kind: CustomResourceDefinition"),
+				},
+			},
+			dummyResources: kube.ResourceList{},
+			wantErr:        "resources are empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := actionConfigFixture(t)
+			if tt.dummyResources != nil {
+				config.KubeClient = &kubefake.FailingKubeClient{
+					PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
+					DummyResources:     tt.dummyResources,
+				}
+			}
+			instAction := NewInstall(config)
+
+			err := instAction.installCRDs([]chart.CRD{tt.crd})
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestInstallWithLabels(t *testing.T) {
 	is := assert.New(t)
 	instAction := installAction(t)


### PR DESCRIPTION
## Summary

This keeps the dev-v3 fix focused on invalid CRD install inputs that can otherwise lead to nil pointer or empty-resource handling problems in `installCRDs`.

`dev-v3` already contains the RESTClientGetter nil guard from a newer upstream change, so this PR no longer attempts to backport that part. It now only adds explicit validation for:

- `CRD.File == nil`
- `CRD.File.Data == nil`
- `KubeClient.Build` returning an empty resource list

## Changes

- `pkg/action/install.go`: return clear errors for invalid CRD input before dereferencing or indexing values
- `pkg/action/install_test.go`: add table-driven coverage for nil file, nil file data, and empty resource list cases

## Fixes

Refs #31552

## Test plan

- `go test ./pkg/action`