### PR TITLE
fix(plugin): install into first plugin path

### DIFF
--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -32,8 +32,16 @@ func newBase(source string) base {
 	settings := cli.New()
 	return base{
 		Source:           source,
-		PluginsDirectory: settings.PluginsDirectory,
+		PluginsDirectory: firstPluginDir(settings.PluginsDirectory),
 	}
+}
+
+func firstPluginDir(pluginsDirectory string) string {
+	paths := filepath.SplitList(pluginsDirectory)
+	if len(paths) == 0 {
+		return pluginsDirectory
+	}
+	return paths[0]
 }
 
 // Path is where the plugin will be installed.

--- a/pkg/plugin/installer/base_test.go
+++ b/pkg/plugin/installer/base_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )

--- a/pkg/plugin/installer/base_test.go
+++ b/pkg/plugin/installer/base_test.go
@@ -15,6 +15,7 @@ package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -32,6 +33,10 @@ func TestPath(t *testing.T) {
 			source:         "https://github.com/jkroepke/helm-secrets",
 			helmPluginsDir: "/helm/data/plugins",
 			expectPath:     "/helm/data/plugins/helm-secrets",
+		}, {
+			source:         "https://github.com/jkroepke/helm-secrets",
+			helmPluginsDir: "/helm/user/plugins" + string(filepath.ListSeparator) + "/helm/shared/plugins",
+			expectPath:     "/helm/user/plugins/helm-secrets",
 		},
 	}
 

--- a/pkg/plugin/installer/base_test.go
+++ b/pkg/plugin/installer/base_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )

--- a/pkg/plugin/installer/http_installer.go
+++ b/pkg/plugin/installer/http_installer.go
@@ -159,7 +159,7 @@ func (i HTTPInstaller) Path() string {
 	if i.base.Source == "" {
 		return ""
 	}
-	return helmpath.DataPath("plugins", i.PluginName)
+	return filepath.Join(i.base.PluginsDirectory, i.PluginName)
 }
 
 // cleanJoin resolves dest as a subpath of root.

--- a/pkg/plugin/installer/http_installer_test.go
+++ b/pkg/plugin/installer/http_installer_test.go
@@ -127,6 +127,23 @@ func TestHTTPInstaller(t *testing.T) {
 
 }
 
+func TestHTTPInstallerPathWithPluginPathList(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Setenv("HELM_PLUGINS", first+string(filepath.ListSeparator)+second)
+
+	source := "https://example.com/plugins/fake-plugin-0.0.1.tar.gz"
+	i, err := NewHTTPInstaller(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expect := filepath.Join(first, "fake-plugin")
+	if i.Path() != expect {
+		t.Fatalf("expected path %q, got %q", expect, i.Path())
+	}
+}
+
 func TestHTTPInstallerNonExistentVersion(t *testing.T) {
 	ensure.HelmHome(t)
 	srv := mockArchiveServer()


### PR DESCRIPTION
## What this PR does / why we need it

When `HELM_PLUGINS` contains multiple paths, Helm already treats it as a path list when loading installed plugins. Plugin installation, however, used the raw `HELM_PLUGINS` value as a single destination path.

For example, with:

```sh
HELM_PLUGINS=/tmp/user/plugins:/tmp/shared/plugins
