### PR TITLE
fix(loader): ignore broken symlinks matched by helmignore

### DIFF
--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -69,7 +69,11 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 	if IsSymlink(info) {
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
-			return errors.Wrapf(err, "error evaluating symlink %s", path)
+			err = walkFn(path, info, errors.Wrapf(err, "error evaluating symlink %s", path))
+			if err != nil && err != filepath.SkipDir {
+				return err
+			}
+			return nil
 		}
 		//This log message is to highlight a symlink that is being used within a chart, symlinks can be used for nefarious reasons.
 		log.Printf("found symbolic link in path: %s resolves to %s. Contents of linked file included and used", path, resolved)

--- a/pkg/chart/loader/directory.go
+++ b/pkg/chart/loader/directory.go
@@ -77,20 +77,20 @@ func LoadDir(dir string) (*chart.Chart, error) {
 		// Normalize to / since it will also work on Windows
 		n = filepath.ToSlash(n)
 
+		// If a .helmignore file matches, skip this file.
+		if fi != nil && rules.Ignore(n, fi) {
+			if fi.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}
 		if fi.IsDir() {
 			// Directory-based ignore rules should involve skipping the entire
 			// contents of that directory.
-			if rules.Ignore(n, fi) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		// If a .helmignore file matches, skip this file.
-		if rules.Ignore(n, fi) {
 			return nil
 		}
 

--- a/pkg/chart/loader/load_test.go
+++ b/pkg/chart/loader/load_test.go
@@ -86,6 +86,42 @@ func TestLoadDirWithSymlink(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirWithIgnoredBrokenSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("apiVersion: v2\nname: broken-symlink\nversion: 0.1.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".helmignore"), []byte("templates/broken-link\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "templates"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("missing-target", filepath.Join(dir, "templates", "broken-link")); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Loader(dir)
+	if err != nil {
+		t.Fatalf("Failed to load testdata: %s", err)
+	}
+
+	c, err := l.Load()
+	if err != nil {
+		t.Fatalf("Failed to load chart with ignored broken symlink: %s", err)
+	}
+	for _, f := range c.Raw {
+		if f.Name == "templates/broken-link" {
+			t.Fatalf("ignored broken symlink was loaded")
+		}
+	}
+}
+
 func TestBomTestData(t *testing.T) {
 	testFiles := []string{"frobnitz_with_bom/.helmignore", "frobnitz_with_bom/templates/template.tpl", "frobnitz_with_bom/Chart.yaml"}
 	for _, file := range testFiles {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a chart contains a broken symlink matched by `.helmignore`, directory loading currently fails before the ignore rules can skip it because `sympath.Walk` resolves symlinks before invoking the loader callback.

This lets the walk callback handle symlink evaluation errors and checks `.helmignore` before returning walker errors when file information is available. Ignored broken symlinks are skipped, while non-ignored broken symlinks still return an error.

Closes #13284.

**Special notes for your reviewer**:

Added regression coverage for a chart with `.helmignore` entry `templates/broken-link` and a matching broken symlink.

Validation:

- `docker run --rm -v "$PWD:/src" -w /src golang:1.26.2 gofmt -w internal/sympath/walk.go pkg/chart/loader/directory.go pkg/chart/loader/load_test.go`
- `docker run --rm -v "$PWD:/src" -w /src golang:1.26.2 go test ./pkg/chart/loader ./internal/sympath`
- `docker run --rm -v "$PWD:/src" -w /src golang:1.26.2 go test ./pkg/chart/... ./internal/sympath`
- `git diff --check HEAD~1 HEAD`
