### PR TITLE
docs: fix typo in deprecated API godoc

### DIFF
--- a/internal/chart/v3/lint/rules/deprecations.go
+++ b/internal/chart/v3/lint/rules/deprecations.go
@@ -28,7 +28,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-// deprecatedAPIError indicates than an API is deprecated in Kubernetes
+// deprecatedAPIError indicates that an API is deprecated in Kubernetes
 type deprecatedAPIError struct {
 	Deprecated string
 	Message    string

--- a/pkg/chart/v2/lint/rules/deprecations.go
+++ b/pkg/chart/v2/lint/rules/deprecations.go
@@ -28,7 +28,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-// deprecatedAPIError indicates than an API is deprecated in Kubernetes
+// deprecatedAPIError indicates that an API is deprecated in Kubernetes
 type deprecatedAPIError struct {
 	Deprecated string
 	Message    string


### PR DESCRIPTION
Fixes a small typo in deprecated API linter godoc comments. No behavior change.