### PR TITLE
fix: skip non-Pods when fetching test logs

### DIFF
--- a/pkg/action/release_testing.go
+++ b/pkg/action/release_testing.go
@@ -138,6 +138,10 @@ func (r *ReleaseTesting) GetPodLogs(out io.Writer, rel *release.Release) error {
 				if len(r.Filters[IncludeNameFilter]) > 0 && !slices.Contains(r.Filters[IncludeNameFilter], h.Name) {
 					continue
 				}
+
+				if h.Kind != "Pod" {
+					continue
+				}
 				if err := r.getContainerLogs(out, client, h.Name); err != nil {
 					return err
 				}

--- a/pkg/action/release_testing_test.go
+++ b/pkg/action/release_testing_test.go
@@ -65,11 +65,18 @@ func TestReleaseTestingGetPodLogs_FilterEvents(t *testing.T) {
 
 	hooks := []*release.Hook{
 		{
+			Kind:   "Pod",
 			Name:   "event-1",
 			Events: []release.HookEvent{release.HookTest},
 		},
 		{
+			Kind:   "Pod",
 			Name:   "event-2",
+			Events: []release.HookEvent{release.HookTest},
+		},
+		{
+			Kind:   "ConfigMap",
+			Name:   "event-3",
 			Events: []release.HookEvent{release.HookTest},
 		},
 	}
@@ -80,6 +87,25 @@ func TestReleaseTestingGetPodLogs_FilterEvents(t *testing.T) {
 	assert.Empty(t, out.String())
 }
 
+func TestReleaseTestingGetPodLogs_ExcludeFilter_SkipsPodHook(t *testing.T) {
+	config := actionConfigFixture(t)
+	require.NoError(t, config.Init(cli.New().RESTClientGetter(), "", os.Getenv("HELM_DRIVER")))
+	client := NewReleaseTesting(config)
+	client.Filters[ExcludeNameFilter] = []string{"excluded-pod"}
+
+	hooks := []*release.Hook{
+		{
+			Kind:   "Pod",
+			Name:   "excluded-pod",
+			Events: []release.HookEvent{release.HookTest},
+		},
+	}
+
+	out := &bytes.Buffer{}
+	require.NoError(t, client.GetPodLogs(out, &release.Release{Hooks: hooks}))
+	assert.Empty(t, out.String())
+}
+
 func TestReleaseTestingGetPodLogs_PodRetrievalError(t *testing.T) {
 	config := actionConfigFixture(t)
 	require.NoError(t, config.Init(cli.New().RESTClientGetter(), "", os.Getenv("HELM_DRIVER")))
@@ -87,12 +113,36 @@ func TestReleaseTestingGetPodLogs_PodRetrievalError(t *testing.T) {
 
 	hooks := []*release.Hook{
 		{
+			Kind:   "Pod",
 			Name:   "event-1",
 			Events: []release.HookEvent{release.HookTest},
 		},
 	}
 
 	require.ErrorContains(t, client.GetPodLogs(&bytes.Buffer{}, &release.Release{Hooks: hooks}), "unable to get pod")
+}
+
+func TestReleaseTestingGetPodLogs_SkipNonPodHooks(t *testing.T) {
+	config := actionConfigFixture(t)
+	require.NoError(t, config.Init(cli.New().RESTClientGetter(), "", os.Getenv("HELM_DRIVER")))
+	client := NewReleaseTesting(config)
+
+	hooks := []*release.Hook{
+		{
+			Name:   "cm-hook",
+			Kind:   "ConfigMap",
+			Events: []release.HookEvent{release.HookTest},
+		},
+		{
+			Name:   "secret-hook",
+			Kind:   "Secret",
+			Events: []release.HookEvent{release.HookTest},
+		},
+	}
+
+	out := &bytes.Buffer{}
+	require.NoError(t, client.GetPodLogs(out, &release.Release{Hooks: hooks}))
+	assert.Empty(t, out.String())
 }
 
 func TestReleaseTesting_WaitOptionsPassedDownstream(t *testing.T) {


### PR DESCRIPTION

**What this PR does / why we need it**:
in our test hooks we need to create non-pod resurces ConfigMap in our case.
`helm test --logs` iterates every release hook asks the Kubernetes Pods API for its logs.
This leads to `helm test --logs` to fail and produce some strange log messages:

```
❯ helm test moto -n moto-test --logs
NAME: moto
LAST DEPLOYED: Sun May 17 13:13:29 2026
NAMESPACE: moto-test
STATUS: deployed
REVISION: 2
DESCRIPTION: Upgrade complete
TEST SUITE:     moto-test-files-configmap
Last Started:   Sun May 17 13:13:43 2026
Last Completed: Sun May 17 13:13:43 2026
Phase:          Succeeded
TEST SUITE:     moto-identity-test-sh
Last Started:   Sun May 17 13:13:45 2026
Last Completed: Sun May 17 13:13:47 2026
Phase:          Succeeded

Error: unable to get pod logs for moto-test-files-configmap: pods "moto-test-files-configmap" not found
```

Plase pay attention to `moto-test-files-configmap` used as pod name.

**Special notes for your reviewer**:

## Test plan 
Compile helm and run it against problematic resources:

❯ helm test moto -n moto-test --logs
NAME: moto
LAST DEPLOYED: Sun May 17 16:22:11 2026
NAMESPACE: moto-test
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE:     moto-test-files-configmap
Last Started:   Sun May 17 16:22:16 2026
Last Completed: Sun May 17 16:22:16 2026
Phase:          Succeeded
TEST SUITE:     moto-identity-test-sh
Last Started:   Sun May 17 16:22:17 2026
Last Completed: Sun May 17 16:22:19 2026
Phase:          Succeeded

Error: unable to get pod logs for moto-test-files-configmap: pods "moto-test-files-configmap" not found

❯ ~/Documents/open_source/helm/bin/helm test moto -n moto-test --logs
NAME: moto
LAST DEPLOYED: Sun May 17 16:22:11 2026
NAMESPACE: moto-test
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE:     moto-test-files-configmap
Last Started:   Sun May 17 16:22:42 2026
Last Completed: Sun May 17 16:22:42 2026
Phase:          Succeeded
TEST SUITE:     moto-identity-test-sh
Last Started:   Sun May 17 16:22:42 2026
Last Completed: Sun May 17 16:22:44 2026
Phase:          Succeeded

POD LOGS: moto-identity-test-sh (test-container)
{
    "UserId": "AKIAIOSFODNN7EXAMPLE",
    "Account": "123456789012",
    "Arn": "arn:aws:sts::123456789012:user/moto"
}

**If applicable**:
- [x] this PR contains unit tests
