### PR TITLE
fix (internal/plugin): remove zero-width spaces from plugin name comment

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -77,5 +77,5 @@ type Output struct {
 
 // validPluginName is a regular expression that validates plugin names.
 //
-// Plugin names can only contain the ASCII characters a-z, A-Z, 0-9, ​_​ and ​-.
+// Plugin names can only contain the ASCII characters a-z, A-Z, 0-9, _ and -.
 var validPluginName = regexp.MustCompile("^[A-Za-z0-9_-]+$")


### PR DESCRIPTION
**What this PR does / why we need it**:

`internal/plugin/plugin.go:80` contains three U+200B (zero-width space) characters around `_` and `-` in a comment describing allowed plugin name characters. The comment renders identically without them — likely an artifact of pasting from a rich-text source where ZWSP was inserted to disable auto-formatting.

This shows up downstream: every project that vendors `helm.sh/helm/v4` and runs Renovate gets a repository-wide warning on its Dependency Dashboard:

> ⚠️ WARN: Hidden Unicode characters have been discovered in file(s) in your repository...

Renovate scans the whole working tree (including `vendor/`) for ZWSP/bidi-override codepoints and can't be told to skip a path for this specific check. Stripping the characters here clears the warning everywhere downstream in one shot.

Before (hex view):
```
// Plugin names can only contain the ASCII characters a-z, A-Z, 0-9, <U+200B>_<U+200B> and <U+200B>-.
```

After:
```
// Plugin names can only contain the ASCII characters a-z, A-Z, 0-9, _ and -.
```

**Special notes for your reviewer**:

Single-line comment-only change. No behavioural impact.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
