### PR TITLE
fix(provenance): check error return in Digest and encodeRelease

### DIFF
--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -388,7 +388,7 @@ func DigestFile(filename string) (string, error) {
 func Digest(in io.Reader) (string, error) {
 	hash := crypto.SHA256.New()
 	if _, err := io.Copy(hash, in); err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/pkg/storage/driver/util.go
+++ b/pkg/storage/driver/util.go
@@ -46,9 +46,12 @@ func encodeRelease(rls *rspb.Release) (string, error) {
 		return "", err
 	}
 	if _, err = w.Write(b); err != nil {
+		w.Close()
 		return "", err
 	}
-	w.Close()
+	if err = w.Close(); err != nil {
+		return "", err
+	}
 
 	return b64.EncodeToString(buf.Bytes()), nil
 }


### PR DESCRIPTION
## What this PR does

Fixes two swallowed errors in the provenance and storage layers:

1. **`pkg/provenance/sign.go` — `Digest()`**: `return "", nil` instead of `return "", err` on `io.Copy` failure. This returns an empty string as a valid SHA-256 digest, which can cause chart provenance verification to silently produce wrong results.

2. **`pkg/storage/driver/util.go` — `encodeRelease()`**: `gzip.Writer.Close()` error discarded. Close flushes remaining data and writes the gzip footer; if it fails, the buffer contains a truncated stream that will be base64-encoded and stored in a Secret/ConfigMap. Also added close on the Write error path where the writer was leaked.

## AI Disclosure

Developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. All code reviewed and verified by the human author.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>
Assisted-by: Grok/xAI