### PR TITLE
ci: check source for invisible Unicode codepoints

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,8 @@ jobs:
           check-latest: true
       - name: Test source headers are present
         run: make test-source-headers
+      - name: Test source for invisible Unicode
+        run: make test-source-unicode
       - name: Check if go modules need to be tidied
         run: go mod tidy -diff
       - name: Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ test-style:
 test-source-headers:
 	@scripts/validate-license.sh
 
+.PHONY: test-source-unicode
+test-source-unicode:
+	@scripts/check-invisible-unicode.sh
+
 .PHONY: test-acceptance
 test-acceptance: build
 	@if [ -d "${ACCEPTANCE_DIR}" ]; then \

--- a/scripts/check-invisible-unicode.sh
+++ b/scripts/check-invisible-unicode.sh
@@ -24,7 +24,7 @@ find_files() {
       -o -wholename '*third_party*' \
     \) -prune \
   \) \
-  \( -name '*.go' -o -name '*.sh' \)
+  -type f \( -name '*.go' -o -name '*.sh' \) -print0
 }
 
 # Disallow invisible or bidi Unicode codepoints in source files. These are
@@ -35,7 +35,7 @@ find_files() {
 #   U+FEFF         byte order mark / zero-width no-break space
 #   U+202A-U+202E  bidi explicit formatting
 #   U+2066-U+2069  bidi isolates
-matches=$(find_files | xargs perl -CSD -ne '
+matches=$(find_files | xargs -0 perl -CSD -ne '
   if (/[\x{200B}-\x{200D}\x{FEFF}\x{202A}-\x{202E}\x{2066}-\x{2069}]/) {
     chomp;
     print "$ARGV:$.: $_\n";

--- a/scripts/check-invisible-unicode.sh
+++ b/scripts/check-invisible-unicode.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+IFS=$'\n\t'
+
+find_files() {
+  find . -not \( \
+    \( \
+      -wholename './.git' \
+      -o -wholename '*testdata*' \
+      -o -wholename '*third_party*' \
+    \) -prune \
+  \) \
+  \( -name '*.go' -o -name '*.sh' \)
+}
+
+# Disallow invisible or bidi Unicode codepoints in source files. These are
+# usually invisible to reviewers but can hide behavior changes ("trojan
+# source") or trip downstream scanners on consumers that vendor the module.
+#
+#   U+200B-U+200D  zero-width space / non-joiner / joiner
+#   U+FEFF         byte order mark / zero-width no-break space
+#   U+202A-U+202E  bidi explicit formatting
+#   U+2066-U+2069  bidi isolates
+matches=$(find_files | xargs perl -CSD -ne '
+  if (/[\x{200B}-\x{200D}\x{FEFF}\x{202A}-\x{202E}\x{2066}-\x{2069}]/) {
+    chomp;
+    print "$ARGV:$.: $_\n";
+  }
+  close ARGV if eof;
+' || :)
+
+if [[ -n "$matches" ]]; then
+  echo "Disallowed invisible or bidi Unicode codepoints found:"
+  echo "$matches"
+  exit 1
+fi


### PR DESCRIPTION
adds a CI step that scans .go and .sh files for invisible and bidi Unicode codepoints, the same class as the U+200B characters cleaned up in #32134. mirrors the existing test-source-headers pattern: `scripts/check-invisible-unicode.sh`, a `test-source-unicode` make target, and one step in build-test.yml between the source-headers check and the module-tidy check.

covers the codepoints listed in the issue:

- U+200B-U+200D zero-width space, non-joiner, joiner
- U+FEFF byte order mark / zero-width no-break space
- U+202A-U+202E bidi explicit formatting
- U+2066-U+2069 bidi isolates ("trojan source")

uses perl with `-CSD` so it works the same on macOS and the Ubuntu CI runner. excludes `.git`, `testdata`, and `third_party` via the same `find_files` shape `validate-license.sh` uses. tested locally against a clean tree (exit 0), a poisoned `.go` file with U+200B in a comment, a `.sh` file with a bidi PDI, a `.go` file starting with a BOM, and a poisoned file under `testdata/` (correctly skipped).

opted for a shell check rather than enabling `bidichk` in `.golangci.yml` because `bidichk` covers the bidi class but not the zero-width characters that triggered the original Renovate warning.

Fixes #32137