### PR TITLE
Fix toYamlPretty integer output

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -95,13 +95,44 @@ func toYAMLPretty(v interface{}) string {
 	var data bytes.Buffer
 	encoder := goYaml.NewEncoder(&data)
 	encoder.SetIndent(2)
-	err := encoder.Encode(v)
+	err := encoder.Encode(normalizeYAMLScalars(v))
 
 	if err != nil {
 		// Swallow errors inside of a template.
 		return ""
 	}
 	return strings.TrimSuffix(data.String(), "\n")
+}
+
+func normalizeYAMLScalars(v any) any {
+	switch typedValue := v.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(typedValue))
+		for key, value := range typedValue {
+			normalized[key] = normalizeYAMLScalars(value)
+		}
+		return normalized
+	case map[any]any:
+		normalized := make(map[any]any, len(typedValue))
+		for key, value := range typedValue {
+			normalized[key] = normalizeYAMLScalars(value)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, len(typedValue))
+		for index, value := range typedValue {
+			normalized[index] = normalizeYAMLScalars(value)
+		}
+		return normalized
+	case float64:
+		// sigs.k8s.io/yaml may unmarshal integer YAML values as float64.
+		if typedValue == math.Trunc(typedValue) &&
+			typedValue > float64(math.MinInt64) &&
+			typedValue < float64(math.MaxInt64) {
+			return int64(typedValue)
+		}
+	}
+	return v
 }
 
 // fromYAML converts a YAML document into a map[string]interface{}.

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -19,6 +19,8 @@ package engine
 import (
 	"bytes"
 	"encoding/json"
+	"math"
+	"reflect"
 	"strings"
 	"text/template"
 
@@ -27,6 +29,8 @@ import (
 	"sigs.k8s.io/yaml"
 	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
+
+const maxSafeYAMLInteger = 1 << 53
 
 // funcMap returns a mapping of all of the functions that Engine has.
 //
@@ -95,9 +99,12 @@ func toYAMLPretty(v interface{}) string {
 	var data bytes.Buffer
 	encoder := goYaml.NewEncoder(&data)
 	encoder.SetIndent(2)
-	err := encoder.Encode(normalizeYAMLScalars(v))
 
-	if err != nil {
+	if err := encoder.Encode(normalizeYAMLScalars(v)); err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	if err := encoder.Close(); err != nil {
 		// Swallow errors inside of a template.
 		return ""
 	}
@@ -115,7 +122,7 @@ func normalizeYAMLScalars(v any) any {
 	case map[any]any:
 		normalized := make(map[any]any, len(typedValue))
 		for key, value := range typedValue {
-			normalized[key] = normalizeYAMLScalars(value)
+			normalized[normalizeYAMLMapKey(key)] = normalizeYAMLScalars(value)
 		}
 		return normalized
 	case []any:
@@ -126,13 +133,22 @@ func normalizeYAMLScalars(v any) any {
 		return normalized
 	case float64:
 		// sigs.k8s.io/yaml may unmarshal integer YAML values as float64.
-		if typedValue == math.Trunc(typedValue) &&
-			typedValue > float64(math.MinInt64) &&
-			typedValue < float64(math.MaxInt64) {
+		if typedValue == math.Trunc(typedValue) && math.Abs(typedValue) <= maxSafeYAMLInteger {
 			return int64(typedValue)
 		}
 	}
 	return v
+}
+
+func normalizeYAMLMapKey(key any) any {
+	normalized := normalizeYAMLScalars(key)
+	if normalized == nil {
+		return normalized
+	}
+	if reflect.TypeOf(normalized).Comparable() {
+		return normalized
+	}
+	return key
 }
 
 // fromYAML converts a YAML document into a map[string]interface{}.

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -160,9 +160,6 @@ func normalizeYAMLMapKey(key any) any {
 	if reflect.TypeOf(normalized).Comparable() {
 		return normalized
 	}
-	if reflect.TypeOf(key).Comparable() {
-		return key
-	}
 	return fmt.Sprint(normalized)
 }
 

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -30,7 +31,7 @@ import (
 	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
-const maxSafeYAMLInteger = 1 << 53
+const maxSafeYAMLInteger = (1 << 53) - 1
 
 // funcMap returns a mapping of all of the functions that Engine has.
 //
@@ -99,12 +100,23 @@ func toYAMLPretty(v interface{}) string {
 	var data bytes.Buffer
 	encoder := goYaml.NewEncoder(&data)
 	encoder.SetIndent(2)
+	closeEncoder := func() error {
+		if encoder == nil {
+			return nil
+		}
+		err := encoder.Close()
+		encoder = nil
+		return err
+	}
+	defer func() {
+		_ = closeEncoder()
+	}()
 
 	if err := encoder.Encode(normalizeYAMLScalars(v)); err != nil {
 		// Swallow errors inside of a template.
 		return ""
 	}
-	if err := encoder.Close(); err != nil {
+	if err := closeEncoder(); err != nil {
 		// Swallow errors inside of a template.
 		return ""
 	}
@@ -148,7 +160,10 @@ func normalizeYAMLMapKey(key any) any {
 	if reflect.TypeOf(normalized).Comparable() {
 		return normalized
 	}
-	return key
+	if reflect.TypeOf(key).Comparable() {
+		return key
+	}
+	return fmt.Sprint(normalized)
 }
 
 // fromYAML converts a YAML document into a map[string]interface{}.

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"text/template"
@@ -138,6 +139,53 @@ keyInElement1 = "valueInElement1"`,
 		err := template.Must(template.New("test").Funcs(funcMap()).Parse(tt.tpl)).Execute(&b, tt.vars)
 		assert.NoError(t, err)
 		assert.Equal(t, tt.expect, b.String(), tt.tpl)
+	}
+}
+
+func TestNormalizeYAMLScalars(t *testing.T) {
+	aboveSafeInteger := math.Nextafter(maxSafeYAMLInteger, math.Inf(1))
+
+	tests := []struct {
+		name   string
+		input  any
+		expect any
+	}{
+		{
+			name:   "non-integer floats stay floats",
+			input:  map[string]any{"value": 1.5},
+			expect: map[string]any{"value": 1.5},
+		},
+		{
+			name:   "safe integer floats become integers",
+			input:  map[string]any{"value": 1.0},
+			expect: map[string]any{"value": int64(1)},
+		},
+		{
+			name:   "unsafe integer floats stay floats",
+			input:  map[string]any{"value": aboveSafeInteger},
+			expect: map[string]any{"value": aboveSafeInteger},
+		},
+		{
+			name: "map keys and nested values are normalized",
+			input: map[any]any{
+				float64(2): float64(3),
+				"nested": map[any]any{
+					float64(4): []any{float64(5)},
+				},
+			},
+			expect: map[any]any{
+				int64(2): int64(3),
+				"nested": map[any]any{
+					int64(4): []any{int64(5)},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, normalizeYAMLScalars(tt.input))
+		})
 	}
 }
 

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -143,6 +143,7 @@ keyInElement1 = "valueInElement1"`,
 }
 
 func TestNormalizeYAMLScalars(t *testing.T) {
+	firstUnsafeInteger := float64(maxSafeYAMLInteger + 1)
 	aboveSafeInteger := math.Nextafter(maxSafeYAMLInteger, math.Inf(1))
 
 	tests := []struct {
@@ -164,6 +165,11 @@ func TestNormalizeYAMLScalars(t *testing.T) {
 			name:   "max safe integer float becomes integer",
 			input:  map[string]any{"value": float64(maxSafeYAMLInteger)},
 			expect: map[string]any{"value": int64(maxSafeYAMLInteger)},
+		},
+		{
+			name:   "first unsafe integer float stays float",
+			input:  map[string]any{"value": firstUnsafeInteger},
+			expect: map[string]any{"value": firstUnsafeInteger},
 		},
 		{
 			name:   "unsafe integer floats stay floats",

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -161,9 +161,24 @@ func TestNormalizeYAMLScalars(t *testing.T) {
 			expect: map[string]any{"value": int64(1)},
 		},
 		{
+			name:   "max safe integer float becomes integer",
+			input:  map[string]any{"value": float64(maxSafeYAMLInteger)},
+			expect: map[string]any{"value": int64(maxSafeYAMLInteger)},
+		},
+		{
 			name:   "unsafe integer floats stay floats",
 			input:  map[string]any{"value": aboveSafeInteger},
 			expect: map[string]any{"value": aboveSafeInteger},
+		},
+		{
+			name:   "safe negative integer floats become integers",
+			input:  map[string]any{"value": -float64(maxSafeYAMLInteger)},
+			expect: map[string]any{"value": -int64(maxSafeYAMLInteger)},
+		},
+		{
+			name:   "unsafe negative integer floats stay floats",
+			input:  map[string]any{"value": -aboveSafeInteger},
+			expect: map[string]any{"value": -aboveSafeInteger},
 		},
 		{
 			name: "map keys and nested values are normalized",
@@ -187,6 +202,11 @@ func TestNormalizeYAMLScalars(t *testing.T) {
 			assert.Equal(t, tt.expect, normalizeYAMLScalars(tt.input))
 		})
 	}
+}
+
+func TestNormalizeYAMLMapKey(t *testing.T) {
+	assert.Equal(t, int64(1), normalizeYAMLMapKey(float64(1)))
+	assert.Equal(t, "[1 key]", normalizeYAMLMapKey([]any{float64(1), "key"}))
 }
 
 // This test to check a function provided by sprig is due to a change in a

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -38,6 +38,10 @@ func TestFuncs(t *testing.T) {
 		expect: "baz:\n  - 1\n  - 2\n  - 3",
 		vars:   map[string]interface{}{"baz": []int{1, 2, 3}},
 	}, {
+		tpl:    `{{ toYamlPretty (fromYaml .) }}`,
+		expect: "foo: 1000000",
+		vars:   "foo: !!int 1000000",
+	}, {
 		tpl:    `{{ toToml . }}`,
 		expect: "foo = \"bar\"\n",
 		vars:   map[string]interface{}{"foo": "bar"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #32135.

`toYamlPretty` currently sends values parsed through `sigs.k8s.io/yaml` directly to the pretty YAML encoder. Integer YAML values can arrive as integral `float64` values, which `go-yaml` then emits in scientific notation, for example `1e+06`.

This normalizes integral float scalars before pretty encoding so integer values render as decimal integers, while fractional floats still render as floats.

**Special notes for your reviewer**:

Local `golangci-lint` is not installed, so I could not run `make test-style` without adding a large tool install.

Validation run locally:

- `GOMODCACHE=/tmp/helm-32135-gomodcache GOCACHE=/tmp/helm-32135-gocache go test ./pkg/engine -run TestFuncs -count=1`
- `GOMODCACHE=/tmp/helm-32135-gomodcache GOCACHE=/tmp/helm-32135-gocache go test ./pkg/engine -count=1`
- `GOMODCACHE=/tmp/helm-32135-gomodcache GOCACHE=/tmp/helm-32135-gocache make test-unit PKG=./pkg/engine`
- `git diff --check`
- `test -z "$(gofmt -l pkg/engine/funcs.go pkg/engine/funcs_test.go)"`

**If applicable**:
- [x] this PR contains user facing changes (bug fix; no docs needed)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
