### PR TITLE
feat(downloader): add oci digest tracking support for helm v4 depende…

### DIFF
--- a/internal/chart/v3/dependency.go
+++ b/internal/chart/v3/dependency.go
@@ -36,6 +36,8 @@ type Dependency struct {
 	// Appending `index.yaml` to this string should result in a URL that can be
 	// used to fetch the repository index.
 	Repository string `json:"repository" yaml:"repository"`
+	// Digest
+	Digest string `json: "digest,omitempty" yaml: "digest,omitempty"`
 	// A yaml path that resolves to a boolean, used for enabling/disabling charts (e.g. subchart1.enabled )
 	Condition string `json:"condition,omitempty" yaml:"condition,omitempty"`
 	// Tags can be used to group charts for enabling/disabling together
@@ -59,6 +61,7 @@ func (d *Dependency) Validate() error {
 	d.Name = sanitizeString(d.Name)
 	d.Version = sanitizeString(d.Version)
 	d.Repository = sanitizeString(d.Repository)
+	d.Digest = sanitizeString(d.Digest)
 	d.Condition = sanitizeString(d.Condition)
 	for i := range d.Tags {
 		d.Tags[i] = sanitizeString(d.Tags[i])

--- a/internal/chart/v3/dependency.go
+++ b/internal/chart/v3/dependency.go
@@ -37,7 +37,7 @@ type Dependency struct {
 	// used to fetch the repository index.
 	Repository string `json:"repository" yaml:"repository"`
 	// Digest
-	Digest string `json: "digest,omitempty" yaml: "digest,omitempty"`
+	Digest string `json:"digest,omitempty" yaml:"digest,omitempty"`
 	// A yaml path that resolves to a boolean, used for enabling/disabling charts (e.g. subchart1.enabled )
 	Condition string `json:"condition,omitempty" yaml:"condition,omitempty"`
 	// Tags can be used to group charts for enabling/disabling together

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -62,3 +62,12 @@ func (r *v3DependencyAccessor) Name() string {
 func (r *v3DependencyAccessor) Alias() string {
 	return r.dep.Alias
 }
+
+func (r v2DependencyAccessor) Digest() string {
+	// helm v2 doesn't use digest, return empty sting
+	return ""
+}
+
+func (r v3DependencyAccessor) Digest() string {
+	return r.dep.Digest
+}

--- a/pkg/chart/interfaces.go
+++ b/pkg/chart/interfaces.go
@@ -41,4 +41,5 @@ type Accessor interface {
 type DependencyAccessor interface {
 	Name() string
 	Alias() string
+	Digest() string
 }

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -43,6 +43,7 @@ import (
 	"helm.sh/helm/v4/pkg/helmpath"
 	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/repo/v1"
+	pkgchart "helm.sh/helm/v4/pkg/chart"
 )
 
 // ErrRepoNotFound indicates that chart repositories can't be found in local repo cache.
@@ -315,7 +316,8 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 
 		// Any failure to resolve/download a chart should fail:
 		// https://github.com/helm/helm/issues/1439
-		churl, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err := m.findChartURL(dep.Name, dep.Version, dep.Repository, repos)
+		depAccessor, _ := pkgchart.NewDependencyAccessor(dep)
+		churl, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err := m.findChartURL(dep.Name, dep.Version, depAccessor.Digest(), dep.Repository, repos)
 		if err != nil {
 			saveError = fmt.Errorf("could not find %s: %w", churl, err)
 			break
@@ -725,8 +727,11 @@ func (m *Manager) parallelRepoUpdate(repos []*repo.Entry) error {
 // repoURL is the repository to search
 //
 // If it finds a URL that is "relative", it will prepend the repoURL.
-func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*repo.ChartRepository) (url, username, password string, insecureSkipTLSVerify, passCredentialsAll bool, caFile, certFile, keyFile string, err error) {
+func (m *Manager) findChartURL(name, version, digest, repoURL string, repos map[string]*repo.ChartRepository) (url, username, password string, insecureSkipTLSVerify, passCredentialsAll bool, caFile, certFile, keyFile string, err error) {
 	if registry.IsOCI(repoURL) {
+		if digest != ""{
+			return fmt.Sprintf("%s/%s@%s", repoURL, name, digest), "", "", false, false, "", "", "", nil
+		}
 		return fmt.Sprintf("%s/%s:%s", repoURL, name, version), "", "", false, false, "", "", "", nil
 	}
 

--- a/pkg/downloader/manager_test.go
+++ b/pkg/downloader/manager_test.go
@@ -71,7 +71,7 @@ func TestFindChartURL(t *testing.T) {
 	version := "0.1.0"
 	repoURL := "http://example.com/charts"
 
-	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err := m.findChartURL(name, version, repoURL, repos)
+	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err := m.findChartURL(name, version, "", repoURL, repos)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFindChartURL(t *testing.T) {
 	version = "1.2.3"
 	repoURL = "https://example-https-insecureskiptlsverify.com"
 
-	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err = m.findChartURL(name, version, repoURL, repos)
+	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err = m.findChartURL(name, version, "", repoURL, repos)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestFindChartURL(t *testing.T) {
 	version = "1.2.3"
 	repoURL = "http://example.com/helm"
 
-	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err = m.findChartURL(name, version, repoURL, repos)
+	churl, username, password, insecureSkipTLSVerify, passcredentialsall, _, _, _, err = m.findChartURL(name, version, "", repoURL, repos)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Purpose
Resolves #32133. Adds capability to track and construct immutable asset checksum references (`@sha256:`) instead of relying purely on mutable version tags when fetching `oci://` chart dependencies during engine routing.

### Backward Compatibility & Design Decisions
Addressing the concern that adding structural tracking could introduce breaking changes or require waiting for strict `charts v3` schemas:

1. **Schema Isolation:** The legacy `v2` structural layouts (tracked inside `internal/resolver/resolver.go`) remain completely pristine and unmodified. No fields were added to the underlying legacy struct data, ensuring older chart configurations maintain full backward compatibility.
2. **Interface Abstractions:** This feature utilizes the Helm v4 `DependencyAccessor` wrapper logic layer. The engine safely extracts and maps the dynamic OCI metadata values at the engine runtime layer within `pkg/downloader/manager.go`.
3. **Collision Avoidance:** Leverages a local import nickname alias (`pkgchart`) to cleanly isolate modern v4 package functions away from v2 namespace declarations present inside the downloader engine.

### Verification Results
All package layer tests pass cleanly, confirming zero regressions to downstream components:
- `go test ./internal/resolver/...` -> OK
- `go test ./pkg/downloader/...` -> OK
- `go test ./pkg/...` -> OK
