### PR TITLE
fix(registry): request pull,push scope upfront to fix push auth on quay.io

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -717,6 +717,11 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	repository.PlainHTTP = c.plainHTTP
 	repository.Client = c.authorizer
 
+	ctx = auth.AppendRepositoryScope(ctx, registry.Reference{
+		Registry:   parsedRef.orasReference.Registry,
+		Repository: parsedRef.orasReference.Repository,
+	}, auth.ActionPull, auth.ActionPush)
+
 	manifestDescriptor, err = oras.ExtendedCopy(ctx, memoryStore, parsedRef.String(), repository, parsedRef.String(), oras.DefaultExtendedCopyOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What this PR does

When pushing a chart, ORAS performs an `Exists` check (HEAD request) before uploading blobs. Without explicit scope hints on the context, registries like quay.io respond to that check with a `pull`-only token and cache it. The subsequent push requests then fail with `401 Unauthorized` because the cached token lacks `push` permission.

Fix by calling `auth.AppendRepositoryScope` with both `pull` and `push` actions on the context before `oras.ExtendedCopy`, so the first auth request acquires a token that covers the full push operation.

## Related issue

Fixes #32144

## Testing

Existing registry test suite passes (`go test ./pkg/registry/...`).

## Checklist

- [x] Code compiles
- [x] Tests pass
- [x] DCO sign-off on commit (`Signed-off-by: Dale Orders <dale.orders@five9.com>`)