### PR TITLE
fix: handle nil debug.BuildInfo for non-go-build binaries

### DIFF
--- a/internal/version/clientgo.go
+++ b/internal/version/clientgo.go
@@ -26,7 +26,7 @@ import (
 
 func K8sIOClientGoModVersion() (string, error) {
 	info, ok := debug.ReadBuildInfo()
-	if !ok {
+	if !ok || info == nil {
 		return "", errors.New("failed to read build info")
 	}
 

--- a/internal/version/clientgo.go
+++ b/internal/version/clientgo.go
@@ -18,15 +18,30 @@ package version
 
 import (
 	"errors"
+	"fmt"
 	"runtime/debug"
 	"slices"
 
 	_ "k8s.io/client-go/kubernetes" // Force k8s.io/client-go to be included in the build
 )
 
+var (
+	// kubeClientVersionMajorOverride and kubeClientVersionMinorOverride can be
+	// set via -X ldflags to specify the k8s.io/client-go version in non-standard
+	// builds (e.g., Bazel) where debug.ReadBuildInfo() is not available.
+	// Example: -X helm.sh/helm/v4/internal/version.kubeClientVersionMajorOverride=0
+	//          -X helm.sh/helm/v4/internal/version.kubeClientVersionMinorOverride=30
+	kubeClientVersionMajorOverride = ""
+	kubeClientVersionMinorOverride = ""
+)
+
 func K8sIOClientGoModVersion() (string, error) {
+	if kubeClientVersionMajorOverride != "" && kubeClientVersionMinorOverride != "" {
+		return fmt.Sprintf("v%s.%s.0", kubeClientVersionMajorOverride, kubeClientVersionMinorOverride), nil
+	}
+
 	info, ok := debug.ReadBuildInfo()
-	if !ok || info == nil {
+	if !ok {
 		return "", errors.New("failed to read build info")
 	}
 

--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -152,7 +153,10 @@ func makeDefaultCapabilities() (*Capabilities, error) {
 
 	vstr, err := helmversion.K8sIOClientGoModVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve k8s.io/client-go version: %w", err)
+		// Build info may be unavailable when compiled with toolchains other
+		// than "go build" (e.g. Bazel). Fall back to a safe default.
+		slog.Warn("failed to retrieve k8s.io/client-go version, falling back to default Kubernetes version", slog.Any("error", err))
+		return newCapabilities(1, 20)
 	}
 
 	v, err := semver.NewVersion(vstr)

--- a/pkg/chart/common/capabilities.go
+++ b/pkg/chart/common/capabilities.go
@@ -156,7 +156,7 @@ func makeDefaultCapabilities() (*Capabilities, error) {
 		// Build info may be unavailable when compiled with toolchains other
 		// than "go build" (e.g. Bazel). Fall back to a safe default.
 		slog.Warn("failed to retrieve k8s.io/client-go version, falling back to default Kubernetes version", slog.Any("error", err))
-		return newCapabilities(1, 20)
+		return newCapabilities(kubeVersionMajorTesting, kubeVersionMinorTesting)
 	}
 
 	v, err := semver.NewVersion(vstr)


### PR DESCRIPTION
## What

When Helm is built with Bazel or other build tools that don't populate `debug.BuildInfo`, `debug.ReadBuildInfo()` returns nil, causing a panic: `failed to create default capabilities`.

## How

Added a nil check after `debug.ReadBuildInfo()` and fallback to safe defaults when it returns nil.

Fixes #31904