### PR TITLE
ci: enable bidichk linter to prevent invisible Unicode characters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
 
   # Keep sorted alphabetically
   enable:
+    - bidichk
     - depguard
     - dupl
     - exhaustive


### PR DESCRIPTION
Adds the `bidichk` linter to `.golangci.yml` to detect dangerous invisible Unicode characters (ZWSP, bidi controls) in source files during CI.

This integrates with the existing golangci-lint workflow — no new scripts or CI jobs needed.

Fixes #32137