### PR TITLE
ci: add checks to prevent invisible Unicode characters in Go source

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,8 @@ jobs:
           check-latest: true
       - name: Test source headers are present
         run: make test-source-headers
+      - name: Check for invisible Unicode characters (ZWSP/BOM) in Go source
+        run: make test-unicode-invisible
       - name: Check if go modules need to be tidied
         run: go mod tidy -diff
       - name: Run unit tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
 
   # Keep sorted alphabetically
   enable:
+    - bidichk
     - depguard
     - dupl
     - exhaustive

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,15 @@ test-style:
 test-source-headers:
 	@scripts/validate-license.sh
 
+# test-unicode-invisible fails if any Go source file contains invisible Unicode
+# codepoints that are invisible to reviewers but cause tooling noise or security
+# issues: zero-width spaces (U+200B–U+200D) and byte-order marks (U+FEFF).
+# Bidirectional/trojan-source characters (U+202A–U+202E, U+2066–U+2069) are
+# covered by the bidichk golangci-lint linter (see .golangci.yml).
+.PHONY: test-unicode-invisible
+test-unicode-invisible:
+	@scripts/check-unicode-invisible.sh
+
 .PHONY: test-acceptance
 test-acceptance: build
 	@if [ -d "${ACCEPTANCE_DIR}" ]; then \

--- a/scripts/check-unicode-invisible.sh
+++ b/scripts/check-unicode-invisible.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check-unicode-invisible.sh detects invisible Unicode codepoints in Go source
+# files that are harmless to a compiler but invisible to reviewers:
+#
+#   U+200B–U+200D  zero-width space / non-joiner / joiner  (ZWSP class)
+#   U+FEFF         byte-order mark / zero-width no-break space (BOM)
+#
+# The bidichk golangci-lint linter covers the bidirectional/trojan-source
+# range (U+202A–U+202E, U+2066–U+2069). This script fills the gap for the
+# ZWSP and BOM codepoints that bidichk does not report.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+find_go_files() {
+  # Prune common vendored/generated directories by *directory name* to avoid
+  # accidentally excluding files that merely contain the substring.
+  find . \
+    \( -type d \( -name .git -o -name testdata -o -name third_party -o -name vendor \) -prune \) \
+    -o \( -type f -name '*.go' -print0 \)
+}
+
+FILELIST=$(mktemp "${TMPDIR:-/tmp}/check-unicode-files.XXXXXX")
+FINDERR=$(mktemp "${TMPDIR:-/tmp}/check-unicode-finderr.XXXXXX")
+trap 'rm -f "$FILELIST" "$FINDERR"' EXIT
+
+if ! find_go_files >"$FILELIST" 2>"$FINDERR"; then
+  echo "ERROR: failed to enumerate Go source files." >&2
+  cat "$FINDERR" >&2 || true
+  exit 2
+fi
+
+# Fail loudly on any traversal errors (permission issues, broken symlinks, etc.)
+# rather than silently passing with an incomplete file list.
+if [[ -s "$FINDERR" ]]; then
+  echo "ERROR: errors occurred while enumerating Go source files:" >&2
+  cat "$FINDERR" >&2 || true
+  exit 2
+fi
+
+# If this script is run from the wrong directory, we may find no Go files.
+# Treat that as an error so CI/local runs do not silently pass.
+if [[ ! -s "$FILELIST" ]]; then
+  echo "ERROR: no Go source files found (are you running from the repo root?)" >&2
+  exit 2
+fi
+
+# Run the checker separately from find so enumeration failures are not
+# misreported as Unicode detections or Python errors. Exit codes:
+#   0  – no invisible characters found
+#   1  – one or more invisible characters detected
+#   2  – unexpected OS/tool error (file unreadable, etc.)
+rc=0
+python3 - "$FILELIST" <<'PYEOF' || rc=$?
+import sys
+
+# Invisible codepoints to detect (ZWSP class + BOM). Bidi/trojan-source chars
+# (U+202A-U+202E, U+2066-U+2069) are handled by the bidichk golangci-lint linter.
+INVISIBLE = frozenset('\u200b\u200c\u200d\ufeff')
+
+try:
+    with open(sys.argv[1], 'rb') as listfh:
+        paths = listfh.read().split(b'\0')
+except OSError as exc:
+    print('error: could not read file list: {}'.format(exc), file=sys.stderr)
+    sys.exit(2)
+
+found = False
+for raw in paths:
+    if not raw:  # trailing NUL produces an empty token
+        continue
+    path = raw.decode('utf-8', errors='surrogateescape')
+    try:
+        with open(path, encoding='utf-8', errors='strict') as fh:
+            for lineno, text in enumerate(fh, 1):
+                hits = sorted({c for c in text if c in INVISIBLE})
+                if hits:
+                    names = ', '.join('U+{:04X}'.format(ord(c)) for c in hits)
+                    print('{}:{}: invisible Unicode character(s) found: {}'.format(
+                        path, lineno, names))
+                    found = True
+    except UnicodeDecodeError as exc:
+        print('error: could not decode {} as UTF-8: {}'.format(path, exc), file=sys.stderr)
+        sys.exit(2)
+    except OSError as exc:
+        print('error: could not read {}: {}'.format(path, exc), file=sys.stderr)
+        sys.exit(2)
+
+sys.exit(1 if found else 0)
+PYEOF
+
+case $rc in
+  0) ;;
+  1)
+    echo "FAIL: invisible Unicode character(s) (ZWSP/BOM) detected in Go source."
+    echo "Remove or replace the offending characters and re-run 'make test-unicode-invisible'."
+    exit 1
+    ;;
+  2)
+    echo "ERROR: unicode check failed while reading Go source files."
+    echo "Ensure all Go source files are readable and try again."
+    exit 2
+    ;;
+  *)
+    echo "ERROR: unicode check failed with unexpected exit code $rc."
+    echo "Ensure python3 is installed and try again."
+    exit "$rc"
+    ;;
+esac

--- a/scripts/check-unicode-invisible.sh
+++ b/scripts/check-unicode-invisible.sh
@@ -28,10 +28,12 @@ set -euo pipefail
 IFS=$'\n\t'
 
 find_go_files() {
-  # Prune common vendored/generated directories by *directory name* to avoid
-  # accidentally excluding files that merely contain the substring.
+  # Prune repository metadata and vendored/generated directories by *directory
+  # name* to avoid accidentally excluding files that merely contain the
+  # substring. Keep testdata in scope because Go fixtures can still be embedded
+  # or parsed.
   find . \
-    \( -type d \( -name .git -o -name testdata -o -name third_party -o -name vendor \) -prune \) \
+    \( -type d \( -name .git -o -name third_party -o -name vendor \) -prune \) -false \
     -o \( -type f -name '*.go' -print0 \)
 }
 
@@ -45,8 +47,9 @@ if ! find_go_files >"$FILELIST" 2>"$FINDERR"; then
   exit 2
 fi
 
-# Fail loudly on any traversal errors (permission issues, broken symlinks, etc.)
-# rather than silently passing with an incomplete file list.
+# Treat any find stderr output as fatal. Permission errors and other traversal
+# diagnostics may still leave find with a zero exit status on some platforms,
+# and a partial file list must not be reported as a clean scan.
 if [[ -s "$FINDERR" ]]; then
   echo "ERROR: errors occurred while enumerating Go source files:" >&2
   cat "$FINDERR" >&2 || true


### PR DESCRIPTION
Closes #32137

## Problem

PR #32134 removed zero-width space characters (U+200B) that had silently crept into Go source files and caused Renovate noise. Without an automated gate, the same class of invisible codepoints can reappear undetected.

This PR adds two complementary, low-overhead checks that together cover the full range of dangerous invisible characters:

## Solution

### 1. `bidichk` in golangci-lint (`.golangci.yml`)

Adds the `bidichk` linter to the existing `golangci-lint` run. `bidichk` detects bidirectional control characters (U+202A–U+202E, U+2066–U+2069) that underpin "trojan source" attacks (CVE-2021-42574). The linter has been part of golangci-lint since v1.43.0 and requires no extra tooling or CI changes — it is caught by the existing `golangci-lint.yml` workflow.

### 2. `scripts/check-unicode-invisible.sh` + `make test-unicode-invisible` (`.github/workflows/build-test.yml`)

Adds a portable Python-based script that detects the ZWSP/BOM class of invisible characters (U+200B–U+200D, U+FEFF) which `bidichk` does not cover. The script:
- Reports exact file, line number, and codepoint for each hit
- Uses Python 3 (available on all CI runners and developer machines without extra installs)
- Follows the `scripts/validate-license.sh` pattern already used in `build-test.yml`
- Produces no output and exits 0 when clean (verified against the full source tree)

A new `make test-unicode-invisible` target makes the check runnable locally without touching CI.

## Testing

Verified against the current source tree — zero false positives. Synthetic test with a U+200B in a `.go` file correctly reports the file/line and exits 1.

```
./zwsp_test.go:3: invisible Unicode character(s) found: U+200B
FAIL: invisible Unicode character(s) (ZWSP/BOM) detected in Go source.
```