### PR TITLE
fix(engine): propagate and handle chart accessor errors

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -77,7 +77,10 @@ func New(config *rest.Config) Engine {
 // section contains a value named "bar", that value will be passed on to the
 // bar chart during render time.
 func (e Engine) Render(chrt ci.Charter, values common.Values) (map[string]string, error) {
-	tmap := allTemplates(chrt, values)
+	tmap, err := allTemplates(chrt, values)
+	if err != nil {
+		return nil, err
+	}
 	return e.render(tmap)
 }
 
@@ -521,22 +524,24 @@ func (p byPathLen) Less(i, j int) bool {
 // allTemplates returns all templates for a chart and its dependencies.
 //
 // As it goes, it also prepares the values in a scope-sensitive manner.
-func allTemplates(c ci.Charter, vals common.Values) map[string]renderable {
+func allTemplates(c ci.Charter, vals common.Values) (map[string]renderable, error) {
 	templates := make(map[string]renderable)
-	recAllTpls(c, templates, vals)
-	return templates
+	if _, err := recAllTpls(c, templates, vals); err != nil {
+		return nil, err
+	}
+	return templates, nil
 }
 
 // recAllTpls recurses through the templates in a chart.
 //
 // As it recurses, it also sets the values to be appropriate for the template
 // scope.
-func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Values) map[string]any {
+func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Values) (map[string]any, error) {
 	vals := values.AsMap()
 	subCharts := make(map[string]any)
 	accessor, err := ci.NewAccessor(c)
 	if err != nil {
-		slog.Error("error accessing chart", "error", err)
+		return nil, fmt.Errorf("error accessing chart: %w", err)
 	}
 	chartMetaData := accessor.MetadataAsMap()
 	chartMetaData["IsRoot"] = accessor.IsRoot()
@@ -559,9 +564,15 @@ func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Val
 	}
 
 	for _, child := range accessor.Dependencies() {
-		// TODO: Handle error
-		sub, _ := ci.NewAccessor(child)
-		subCharts[sub.Name()] = recAllTpls(child, templates, next)
+		sub, err := ci.NewAccessor(child)
+		if err != nil {
+			return nil, fmt.Errorf("error accessing dependency chart: %w", err)
+		}
+		subTpls, err := recAllTpls(child, templates, next)
+		if err != nil {
+			return nil, err
+		}
+		subCharts[sub.Name()] = subTpls
 	}
 
 	newParentID := accessor.ChartFullPath()
@@ -579,7 +590,7 @@ func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Val
 		}
 	}
 
-	return next
+	return next, nil
 }
 
 // isTemplateValid returns true if the template is valid for the chart type

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -79,7 +79,7 @@ func New(config *rest.Config) Engine {
 func (e Engine) Render(chrt ci.Charter, values common.Values) (map[string]string, error) {
 	tmap, err := allTemplates(chrt, values)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("collecting templates: %w", err)
 	}
 	return e.render(tmap)
 }
@@ -570,7 +570,7 @@ func recAllTpls(c ci.Charter, templates map[string]renderable, values common.Val
 		}
 		subTpls, err := recAllTpls(child, templates, next)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering dependency chart %q at %q: %w", sub.Name(), sub.ChartFullPath(), err)
 		}
 		subCharts[sub.Name()] = subTpls
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -590,9 +590,21 @@ func TestAllTemplates(t *testing.T) {
 	}
 	dep1.AddDependency(dep2)
 
-	tpls := allTemplates(ch1, common.Values{})
+	tpls, err := allTemplates(ch1, common.Values{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 	if len(tpls) != 5 {
 		t.Errorf("Expected 5 charts, got %d", len(tpls))
+	}
+}
+
+func TestRenderInvalidChartType(t *testing.T) {
+	_, err := Render(struct{}{}, common.Values{})
+	if err == nil {
+		t.Error("Expected error when rendering invalid chart type, got nil")
+	} else if !strings.Contains(err.Error(), "unsupported chart type") {
+		t.Errorf("Expected error to contain 'unsupported chart type', got: %v", err)
 	}
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -599,8 +599,10 @@ func TestAllTemplates(t *testing.T) {
 	}
 }
 
+type unsupportedChart struct{}
+
 func TestRenderInvalidChartType(t *testing.T) {
-	_, err := Render(struct{}{}, common.Values{})
+	_, err := Render(unsupportedChart{}, common.Values{})
 	if err == nil {
 		t.Error("Expected error when rendering invalid chart type, got nil")
 	} else if !strings.Contains(err.Error(), "unsupported chart type") {


### PR DESCRIPTION
Ensure that errors returned by NewAccessor are propagated and handled correctly rather than ignored, which prevents a potential nil-pointer dereference panic in recAllTpls. Added TestRenderInvalidChartType to prevent future regressions.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR updates the Helm template rendering engine to cleanly handle and propagate errors returned by the chart accessor (`ci.NewAccessor`). Previously, the returned error was logged or discarded, which could cause a nil-pointer dereference panic if an unsupported or invalid chart type was supplied. 

We update the internal functions `allTemplates` and `recAllTpls` to return `error`, bubble up the errors to the public `Render` methods, and add testing coverage.

**Special notes for your reviewer**:
The modified functions `allTemplates` and `recAllTpls` are package-private, so this is a backwards-compatible change that does not alter any public-facing API signatures.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
