### PR TITLE
ci: Fix empty and len testifylint violations across test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,13 +99,11 @@ linters:
 
     testifylint:
       disable:
-        - empty
         - encoded-compare
         - equal-values
         - expected-actual
         - float-compare
         - go-require
-        - len
         - nil-compare
         - require-error
         - suite-dont-use-pkg

--- a/internal/chart/v3/chart_test.go
+++ b/internal/chart/v3/chart_test.go
@@ -59,7 +59,7 @@ func TestCRDs(t *testing.T) {
 
 	is := assert.New(t)
 	crds := chrt.CRDs()
-	is.Equal(2, len(crds))
+	is.Len(crds, 2)
 	is.Equal("crds/foo.yaml", crds[0].Name)
 	is.Equal("crds/foo/bar/baz.yaml", crds[1].Name)
 }

--- a/internal/chart/v3/lint/rules/crds_test.go
+++ b/internal/chart/v3/lint/rules/crds_test.go
@@ -62,5 +62,5 @@ metadata:
 	linter := support.Linter{ChartDir: chartDir}
 	Crds(&linter)
 
-	assert.Len(t, linter.Messages, 0)
+	assert.Empty(t, linter.Messages)
 }

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -208,7 +208,7 @@ func TestLoadAllDir_Empty(t *testing.T) {
 	emptyDir := t.TempDir()
 	plugs, err := LoadAllDir(emptyDir, func(_ string, err error) error { return err })
 	require.NoError(t, err)
-	assert.Len(t, plugs, 0)
+	assert.Empty(t, plugs)
 }
 
 func TestLoadAllPluginsDir(t *testing.T) {

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1742,7 +1742,7 @@ data:
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, len(tt.expectedFiles), len(files))
+				assert.Len(t, files, len(tt.expectedFiles))
 
 				for expectedFile, expectedContent := range tt.expectedFiles {
 					actualContent, exists := files[expectedFile]
@@ -1793,7 +1793,7 @@ data:
 	require.NoError(t, err)
 
 	// Compare the results
-	assert.Equal(t, len(originalFiles), len(reconstructed))
+	assert.Len(t, reconstructed, len(originalFiles))
 	for filename, originalContent := range originalFiles {
 		reconstructedContent, exists := reconstructed[filename]
 		assert.True(t, exists, "File %s should exist in reconstructed files", filename)
@@ -1830,7 +1830,7 @@ func TestRenderResources_PostRenderer_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, hooks)
 	assert.NotNil(t, buf)
-	assert.Equal(t, "", notes)
+	assert.Empty(t, notes)
 	expectedBuf := `---
 # Source: yellow/templates/foodpie
 foodpie: world
@@ -1948,7 +1948,7 @@ func TestRenderResources_PostRenderer_Integration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, hooks)
 	assert.NotNil(t, buf)
-	assert.Equal(t, "", notes) // Notes should be empty for this test
+	assert.Empty(t, notes) // Notes should be empty for this test
 
 	// Verify that the post-renderer modifications are present in the output
 	output := buf.String()
@@ -1987,7 +1987,7 @@ func TestRenderResources_NoPostRenderer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, hooks)
 	assert.NotNil(t, buf)
-	assert.Equal(t, "", notes)
+	assert.Empty(t, notes)
 }
 
 func TestRenderResources_PostRenderer_DuplicateResourceInHookAndTemplate(t *testing.T) {

--- a/pkg/action/get_metadata_test.go
+++ b/pkg/action/get_metadata_test.go
@@ -279,9 +279,9 @@ func TestGetMetadata_Run_WithMixedDependencies(t *testing.T) {
 
 	// Verify dependencies without aliases
 	assert.Equal(t, "nginx", dep1.Name())
-	assert.Equal(t, "", dep1.Alias())
+	assert.Empty(t, dep1.Alias())
 	assert.Equal(t, "postgresql", dep3.Name())
-	assert.Equal(t, "", dep3.Alias())
+	assert.Empty(t, dep3.Alias())
 }
 
 func TestGetMetadata_Run_WithAnnotations(t *testing.T) {
@@ -485,7 +485,7 @@ func TestGetMetadata_Run_EmptyAppVersion(t *testing.T) {
 	result, err := client.Run(releaseName)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", result.AppVersion)
+	assert.Empty(t, result.AppVersion)
 }
 
 func TestMetadata_FormattedDepNames(t *testing.T) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -204,8 +204,8 @@ func TestInstallRelease(t *testing.T) {
 	is.Equal(rel.Hooks[0].Events[0], release.HookPostInstall)
 	is.Equal(rel.Hooks[0].Events[1], release.HookPreDelete, "Expected event 0 is pre-delete")
 
-	is.NotEqual(len(res.Manifest), 0)
-	is.NotEqual(len(rel.Manifest), 0)
+	is.NotEmpty(res.Manifest)
+	is.NotEmpty(rel.Manifest)
 	is.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world")
 	is.Equal(rel.Info.Description, "Install complete")
 
@@ -318,8 +318,8 @@ func TestInstallReleaseWithValues(t *testing.T) {
 	is.Equal(rel.Hooks[0].Events[0], release.HookPostInstall)
 	is.Equal(rel.Hooks[0].Events[1], release.HookPreDelete, "Expected event 0 is pre-delete")
 
-	is.NotEqual(len(res.Manifest), 0)
-	is.NotEqual(len(rel.Manifest), 0)
+	is.NotEmpty(res.Manifest)
+	is.NotEmpty(rel.Manifest)
 	is.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world")
 	is.Equal("Install complete", rel.Info.Description)
 	is.Equal(expectedUserValues, rel.Config)
@@ -359,8 +359,8 @@ func TestInstallRelease_WithNotes(t *testing.T) {
 	is.Equal(rel.Hooks[0].Manifest, manifestWithHook)
 	is.Equal(rel.Hooks[0].Events[0], release.HookPostInstall)
 	is.Equal(rel.Hooks[0].Events[1], release.HookPreDelete, "Expected event 0 is pre-delete")
-	is.NotEqual(len(res.Manifest), 0)
-	is.NotEqual(len(rel.Manifest), 0)
+	is.NotEmpty(res.Manifest)
+	is.NotEmpty(rel.Manifest)
 	is.Contains(rel.Manifest, "---\n# Source: hello/templates/hello\nhello: world")
 	is.Equal(rel.Info.Description, "Install complete")
 
@@ -582,7 +582,7 @@ func TestInstallRelease_FailedHooks(t *testing.T) {
 	res, err := releaserToV1Release(resi)
 	is.NoError(err)
 	is.Contains(res.Info.Description, "failed post-install")
-	is.Equal("", outBuffer.String())
+	is.Empty(outBuffer.String())
 	is.Equal(rcommon.StatusFailed, res.Info.Status)
 }
 

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -65,7 +65,7 @@ func TestList_Empty(t *testing.T) {
 	lister := NewList(actionConfigFixture(t))
 	list, err := lister.Run()
 	assert.NoError(t, err)
-	assert.Len(t, list, 0)
+	assert.Empty(t, list)
 }
 
 func newListFixture(t *testing.T) *List {
@@ -166,7 +166,7 @@ func TestList_LimitOffsetOutOfBounds(t *testing.T) {
 	makeMeSomeReleases(t, lister.cfg.Releases)
 	list, err := lister.Run()
 	is.NoError(err)
-	is.Len(list, 0)
+	is.Empty(list)
 
 	lister.Limit = 10
 	lister.Offset = 1

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -328,7 +328,7 @@ func TestUpgradeRelease_ReuseValues(t *testing.T) {
 		is.NoError(err)
 
 		is.Equal(common.StatusDeployed, updatedRes.Info.Status)
-		is.Equal(0, len(updatedRes.Chart.Dependencies()), "expected 0 dependencies")
+		is.Empty(updatedRes.Chart.Dependencies(), "expected 0 dependencies")
 
 		expectedValues := map[string]any{
 			"subchart": map[string]any{

--- a/pkg/chart/v2/chart_test.go
+++ b/pkg/chart/v2/chart_test.go
@@ -59,7 +59,7 @@ func TestCRDs(t *testing.T) {
 
 	is := assert.New(t)
 	crds := chrt.CRDs()
-	is.Equal(2, len(crds))
+	is.Len(crds, 2)
 	is.Equal("crds/foo.yaml", crds[0].Name)
 	is.Equal("crds/foo/bar/baz.yaml", crds[1].Name)
 }

--- a/pkg/chart/v2/lint/rules/crds_test.go
+++ b/pkg/chart/v2/lint/rules/crds_test.go
@@ -62,5 +62,5 @@ metadata:
 	linter := support.Linter{ChartDir: chartDir}
 	Crds(&linter)
 
-	assert.Len(t, linter.Messages, 0)
+	assert.Empty(t, linter.Messages)
 }

--- a/pkg/engine/files_test.go
+++ b/pkg/engine/files_test.go
@@ -107,5 +107,5 @@ func TestBlankLines(t *testing.T) {
 	as.Len(out, 4)
 
 	as.Equal("bar", out[0])
-	as.Equal("", out[3])
+	as.Empty(out[3])
 }

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -550,9 +550,9 @@ func TestUpdate(t *testing.T) {
 
 			// Special handling for the rollback test case
 			if name == "rollback after failed upgrade with removed resource" {
-				assert.Len(t, result.Created, 0, "expected 0 resource created, got %d", len(result.Created))
+				assert.Empty(t, result.Created, "expected 0 resource created, got %d", len(result.Created))
 				assert.Len(t, result.Updated, 1, "expected 1 resource updated, got %d", len(result.Updated))
-				assert.Len(t, result.Deleted, 0, "expected 0 resource deleted, got %d", len(result.Deleted))
+				assert.Empty(t, result.Deleted, "expected 0 resource deleted, got %d", len(result.Deleted))
 			} else {
 				assert.Len(t, result.Created, 1, "expected 1 resource created, got %d", len(result.Created))
 				assert.Len(t, result.Updated, 2, "expected 2 resource updated, got %d", len(result.Updated))

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -556,5 +556,5 @@ func testTags(suite *TestRegistry) {
 	// Query for tags and validate length
 	tags, err := suite.RegistryClient.Tags(ref)
 	suite.Require().NoError(err, "no error retrieving tags")
-	suite.Equal(1, len(tags))
+	suite.Len(tags, 1)
 }


### PR DESCRIPTION
Removes `empty` and `len` from testifylint's `disable` list and fixes all 21 violations across 13 test files.

**Rule changes:**
- **`len`**: `assert.Equal(t, n, len(x))` / `is.Equal(n, len(x))` → `assert.Len(t, x, n)` / `is.Len(x, n)`
- **`empty`**: `assert.Len(t, x, 0)`, `assert.Equal(t, "", x)`, `is.Equal(0, len(x))`, `is.NotEqual(len(x), 0)` → `assert.Empty` / `assert.NotEmpty` / `is.Empty` / `is.NotEmpty`

**Files updated:** `internal/chart/v3/chart_test.go`, `pkg/chart/v2/chart_test.go`, `internal/chart/v3/lint/rules/crds_test.go`, `pkg/chart/v2/lint/rules/crds_test.go`, `internal/plugin/loader_test.go`, `pkg/action/action_test.go`, `pkg/action/get_metadata_test.go`, `pkg/action/install_test.go`, `pkg/action/list_test.go`, `pkg/action/upgrade_test.go`, `pkg/engine/files_test.go`, `pkg/kube/client_test.go`, `pkg/registry/registry_test.go`, `.golangci.yml`

**Special notes for your reviewer**:

All changes are mechanical assertion rewrites; semantics are identical.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility