### PR TITLE
fix(coalesce): suppress false warning when value is an empty map

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -350,7 +350,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			// Only warn if the value is a non‑empty map, otherwise skip silently
+			if m, ok := val.(map[string]any); !ok || len(m) > 0 {
+				printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			}
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -350,7 +350,8 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			// Only warn if the value is a non‑empty map, otherwise skip silently
+			// Suppress warning when user supplies an empty map (nil-like);
+			// still warn for non-map values and non-empty maps.
 			if m, ok := val.(map[string]any); !ok || len(m) > 0 {
 				printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
 			}

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -926,3 +926,34 @@ func TestCoalesceValuesSubchartNilCleanedWhenUserPartiallyOverrides(t *testing.T
 	_, ok = keyMapping["password"]
 	is.False(ok, "Expected keyMapping.password (nil from chart defaults) to be removed even when user partially overrides the map")
 }
+func TestCoalesceValuesEmptyMapNoWarning(t *testing.T) {
+	warnings := make([]string, 0)
+	printf := func(format string, v ...any) {
+		t.Logf(format, v...)
+		warnings = append(warnings, fmt.Sprintf(format, v...))
+	}
+
+	// Chart default has a map key "data"
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "test"},
+		Values: map[string]any{
+			"data": map[string]any{
+				"existing": "value",
+			},
+		},
+	}
+
+	// User supplies an empty map for "data" – should NOT trigger a warning
+	vals := map[string]any{
+		"data": map[string]any{},
+	}
+
+	_, err := coalesce(printf, c, vals, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings, but got: %v", warnings)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When coalescing values, an empty map (`map[string]interface{}{}`) would
still trigger the “destination for X is a table” warning. This is
misleading because an empty map is essentially nil‑like and should be
ignored. This PR adds a length check so empty maps no longer produce a
false warning.

Ref: #11118

**Special notes for your reviewer**:
- This complements #31838 (wording) and #32071 (log level) by fixing the
  original false‑positive warning.
- Only warns when the non‑table value is a non‑empty map, or a non‑map type.
- Added a unit test (`TestCoalesceValuesEmptyMapNoWarning`).

**If applicable**:
- [ ] this PR contains user-facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility


<img width="1351" height="190" alt="Screenshot 2026-06-02 150445" src="https://github.com/user-attachments/assets/aef16e87-32d3-4d1c-bb2f-ac80403c60a8" />
