### PR TITLE
fix: prevent nil pointer dereference in installCRDs when res is empty

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -172,6 +172,10 @@ func (i *Install) installCRDs(crds []chart.CRD) error {
 		if _, err := i.cfg.KubeClient.Create(res); err != nil {
 			// If the error is CRD already exists, continue.
 			if apierrors.IsAlreadyExists(err) {
+				if len(res) == 0 {
+					i.cfg.Log("CRD %s is already present. Skipping.", obj.Name)
+					continue
+				}
 				crdName := res[0].Name
 				i.cfg.Log("CRD %s is already present. Skipping.", crdName)
 				continue


### PR DESCRIPTION
## What this fixes

Helm 3.19 crashes with a nil pointer dereference when running helm template with a chart that has CRDs. The crash occurs in installCRDs at crdName := res[0].Name when KubeClient.Build returns an empty resource slice.

## Root cause

When KubeClient.Build returns an empty slice and the CRD already exists (apierrors.IsAlreadyExists), the code accesses res[0].Name without checking if res is empty, causing a panic.

## What I changed

Added a length check before accessing res[0]. If res is empty, fall back to using obj.Name for the log message.

Fixes #31552