### PR TITLE
Support cached .chart files for linting

### DIFF
--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -91,7 +91,7 @@ func lintChart(path string, vals map[string]any, namespace string, kubeVersion *
 	var chartPath string
 	linter := support.Linter{}
 
-	if strings.HasSuffix(path, ".tgz") || strings.HasSuffix(path, ".tar.gz") {
+	if strings.HasSuffix(path, ".tgz") || strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".chart") {
 		tempDir, err := os.MkdirTemp("", "helm-lint")
 		if err != nil {
 			return linter, fmt.Errorf("unable to create temp dir to extract tarball: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When linting a chart there's a special case for .tar.gz and .tgz, however, as Helm caches charts with the suffix .chart, it should also be treated like tar.gz/tgz and be extracted prior to linting.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
