### PR TITLE
fix panic on repeated IsReachable calls

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -235,12 +235,15 @@ func New(getter genericclioptions.RESTClientGetter) *Client {
 
 // getKubeClient get or create a new KubernetesClientSet
 func (c *Client) getKubeClient() (kubernetes.Interface, error) {
-	var err error
-	if c.kubeClient == nil {
-		c.kubeClient, err = c.Factory.KubernetesClientSet()
+	if c.kubeClient != nil {
+		return c.kubeClient, nil
 	}
-
-	return c.kubeClient, err
+	kc, err := c.Factory.KubernetesClientSet()
+	if err != nil {
+		return nil, err
+	}
+	c.kubeClient = kc
+	return c.kubeClient, nil
 }
 
 // IsReachable tests connectivity to the cluster.

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -1416,6 +1416,26 @@ func TestIsReachable(t *testing.T) {
 	}
 }
 
+func TestIsReachableTwiceAfterClientCreationFailure(t *testing.T) {
+	refusedErr := errors.New("connection refused")
+	client := newTestClient(t)
+	client.Factory = &errorFactory{err: refusedErr}
+
+	assertReachableErr := func(label string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", label)
+		}
+		if !errors.Is(err, refusedErr) {
+			t.Fatalf("%s: expected error wrapping %v, got %v", label, refusedErr, err)
+		}
+	}
+
+	assertReachableErr("first call", client.IsReachable())
+	// Second call must return the same underlying error, not panic.
+	assertReachableErr("second call", client.IsReachable())
+}
+
 func TestIsIncompatibleServerError(t *testing.T) {
 	testCases := map[string]struct {
 		Err  error


### PR DESCRIPTION
- only cache kube client when creation succeeds
- add regression test for two failed reachability checks

Closes #32183 