### PR TITLE
docs: update outdated v3 references to v4 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,13 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
-We use milestones to track progress of specific planned releases. The current stable major release is the latest Helm version.
+We use milestones to track progress of specific planned releases.
 
-For example, if the latest currently-released version is `4.0.0`, an issue/PR which pertains to a
-specific upcoming bugfix or feature release could fall into one of two different active milestones:
-`4.0.1` or `4.1.0`.
+For example, if the latest currently-released version is `X.Y.Z`, an issue/PR which pertains to a specific upcoming bugfix or feature release could fall into one of two different active milestones:
+`X.Y.(Z+1)` or `X.(Y+1).0`.
 
-Issues and PRs which are deemed backwards-incompatible may be tracked using the relevant version label for major version discussions.
+Issues and PRs which are deemed backwards-incompatible may be added to the next major version
+discussion using the relevant version label (e.g. [label:v4.x](https://github.com/helm/helm/labels/v4.x)).
 
 An issue or PR that we are not sure if we will be addressing will not be added to any milestone.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,15 +116,15 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
-We use milestones to track progress of specific planned releases. Helm v4 is the current stable release.
+We use milestones to track progress of specific planned releases. Helm is the current stable release.
 
 For example, if the latest currently-released version is `4.0.0`, an issue/PR which pertains to a
 specific upcoming bugfix or feature release could fall into one of two different active milestones:
 `4.0.1` or `4.1.0`.
 
-Issues and PRs which are deemed backwards-incompatible may be added to the next major version discussion
-with [label:v4.x](https://github.com/helm/helm/labels/v4.x). An issue or PR that we are not
-sure if we will be addressing will not be added to any milestone.
+Issues and PRs which are deemed backwards-incompatible may be tracked under the relevant major version discussion using the appropriate label.
+
+An issue or PR that we are not sure if we will be addressing will not be added to any milestone.
 
 A milestone (and hence release) can be closed when all outstanding issues/PRs have been closed
 or moved to another milestone and the associated release has been published.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,14 +116,14 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
-We use milestones to track progress of specific planned releases.
+We use milestones to track progress of specific planned releases. Helm v4 is the current stable release.
 
-For example, if the latest currently-released version is `3.2.1`, an issue/PR which pertains to a
+For example, if the latest currently-released version is `4.0.0`, an issue/PR which pertains to a
 specific upcoming bugfix or feature release could fall into one of two different active milestones:
-`3.2.2` or `3.3.0`.
+`4.0.1` or `4.1.0`.
 
-Issues and PRs which are deemed backwards-incompatible may be added to the discussion items for
-Helm 4 with [label:v4.x](https://github.com/helm/helm/labels/v4.x). An issue or PR that we are not
+Issues and PRs which are deemed backwards-incompatible may be added to the next major version discussion
+with [label:v4.x](https://github.com/helm/helm/labels/v4.x). An issue or PR that we are not
 sure if we will be addressing will not be added to any milestone.
 
 A milestone (and hence release) can be closed when all outstanding issues/PRs have been closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,13 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
-We use milestones to track progress of specific planned releases. Helm is the current stable release.
+We use milestones to track progress of specific planned releases. The current stable major release is the latest Helm version.
 
 For example, if the latest currently-released version is `4.0.0`, an issue/PR which pertains to a
 specific upcoming bugfix or feature release could fall into one of two different active milestones:
 `4.0.1` or `4.1.0`.
 
-Issues and PRs which are deemed backwards-incompatible may be tracked under the relevant major version discussion using the appropriate label.
+Issues and PRs which are deemed backwards-incompatible may be tracked using the relevant version label for major version discussions.
 
 An issue or PR that we are not sure if we will be addressing will not be added to any milestone.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,6 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
-## Milestones
-
 We use milestones to track progress of specific planned releases.
 
 For example, if the latest currently-released version is `1.2.3`, an issue/PR which pertains to a specific upcoming bugfix or feature release could fall into one of two different active milestones: `1.2.4` (next patch) or `1.3.0` (next minor).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,10 +116,11 @@ that we're already aware of. It is also worth asking on the Slack channels.
 
 ## Milestones
 
+## Milestones
+
 We use milestones to track progress of specific planned releases.
 
-For example, if the latest currently-released version is `X.Y.Z`, an issue/PR which pertains to a specific upcoming bugfix or feature release could fall into one of two different active milestones:
-`X.Y.(Z+1)` or `X.(Y+1).0`.
+For example, if the latest currently-released version is `1.2.3`, an issue/PR which pertains to a specific upcoming bugfix or feature release could fall into one of two different active milestones: `1.2.4` (next patch) or `1.3.0` (next minor).
 
 Issues and PRs which are deemed backwards-incompatible may be added to the next major version
 discussion using the relevant version label (e.g. [label:v4.x](https://github.com/helm/helm/labels/v4.x)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ We use milestones to track progress of specific planned releases.
 For example, if the latest currently-released version is `1.2.3`, an issue/PR which pertains to a specific upcoming bugfix or feature release could fall into one of two different active milestones: `1.2.4` (next patch) or `1.3.0` (next minor).
 
 Issues and PRs which are deemed backwards-incompatible may be added to the next major version
-discussion using the relevant version label (e.g. [label:v4.x](https://github.com/helm/helm/labels/v4.x)).
+discussion using the relevant version label (e.g. [label:v5.x](https://github.com/helm/helm/labels/v5.x)).
 
 An issue or PR that we are not sure if we will be addressing will not be added to any milestone.
 


### PR DESCRIPTION
## What this PR does / why it is needed

This PR updates outdated documentation references in CONTRIBUTING.md to align with the current Helm v4 release.

## Changes made

- Replaced hardcoded version examples (v3.x/v4.x) with generic placeholders (1.2.3 → 1.2.4/1.3.0)
- Made backwards-incompatible label reference generic with example link
- Removed potentially stale "current stable release" statement

## Type of change

- [x] Documentation update

## Notes for reviewers

This is a documentation cleanup to reduce confusion for new contributors regarding version references and milestone examples.
