### PR TITLE
fix(values): preserve parent subchart null overrides

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -266,11 +266,13 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 			// If the key is not in v, copy it from nv.
 			// When coalescing, skip chart default nils and clean nils from
 			// nested maps so they don't shadow globals or produce %!s(<nil>).
+			// But when the key targets a child chart, nils in the parent's
+			// values are intentional overrides for the child chart defaults.
 			if !merge {
 				if val == nil {
 					continue
 				}
-				if sub, ok := val.(map[string]any); ok {
+				if sub, ok := val.(map[string]any); ok && !childChartMergeTrue(c, key, merge) {
 					cleanNilValues(sub)
 				}
 			}

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -926,3 +926,49 @@ func TestCoalesceValuesSubchartNilCleanedWhenUserPartiallyOverrides(t *testing.T
 	_, ok = keyMapping["password"]
 	is.False(ok, "Expected keyMapping.password (nil from chart defaults) to be removed even when user partially overrides the map")
 }
+
+// TestCoalesceValuesParentSubchartNullOverrideWithoutUserValues tests that a
+// null in a parent's values.yaml under a subchart scope erases the subchart's
+// default even when no user-provided values target that subchart.
+// Regression test for issue #32132.
+func TestCoalesceValuesParentSubchartNullOverrideWithoutUserValues(t *testing.T) {
+	is := assert.New(t)
+
+	subchart := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "child"},
+		Values: map[string]any{
+			"securityContext": map[string]any{
+				"runAsGroup":   65534,
+				"runAsNonRoot": true,
+				"runAsUser":    65534,
+			},
+		},
+	}
+
+	parent := withDeps(&chart.Chart{
+		Metadata: &chart.Metadata{Name: "parent"},
+		Values: map[string]any{
+			"child": map[string]any{
+				"securityContext": map[string]any{
+					"runAsGroup": nil,
+					"runAsUser":  nil,
+				},
+			},
+		},
+	}, subchart)
+
+	v, err := CoalesceValues(parent, map[string]any{})
+	is.NoError(err)
+
+	childVals, ok := v["child"].(map[string]any)
+	is.True(ok, "child values should be a map")
+
+	securityContext, ok := childVals["securityContext"].(map[string]any)
+	is.True(ok, "securityContext should be a map")
+
+	_, ok = securityContext["runAsGroup"]
+	is.False(ok, "Expected parent null override to erase subchart runAsGroup default")
+	_, ok = securityContext["runAsUser"]
+	is.False(ok, "Expected parent null override to erase subchart runAsUser default")
+	is.Equal(true, securityContext["runAsNonRoot"], "Subchart default not nulled by the parent should be preserved")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When a parent chart defines a subchart-scoped value as `null` in its own `values.yaml`, that null is an intentional override for the subchart default. The current `coalesceValues` else-branch cleans nested nils before the dependency coalescing pass when no user-provided values target that subchart, so the subchart default leaks back into the rendered values.

This keeps nils under child chart scope keys intact during the parent pass, while still cleaning ordinary chart-default nils. The added regression test covers the no-user-values case from #32132 where parent `values.yaml` erases `runAsUser` / `runAsGroup` from a subchart `securityContext`.

Closes #32132.

**Special notes for your reviewer**:

Related PRs #32092 / #32097 cover the sibling case where subchart-default nils leak when user values exist under the subchart scope. This PR targets the opposite path called out in #32132: parent-defined subchart null overrides were stripped in the `coalesceValues` `else` branch before the subchart pass.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

Tested with:

```console
$ go test ./pkg/chart/common/util -run 'TestCoalesceValues(ParentSubchartNullOverrideWithoutUserValues|SubchartDefaultNilsCleaned|UserNullErasesSubchartDefault|SubchartNilDoesNotShadowGlobal|SubchartNilCleanedWhenUserPartiallyOverrides)|TestCoalesceValues$|TestMergeValues$' -count=1
ok  	helm.sh/helm/v4/pkg/chart/common/util	0.060s

$ go test ./pkg/chart/common/util -count=1
ok  	helm.sh/helm/v4/pkg/chart/common/util	0.101s

$ git diff --check
# no output
```
