### PR TITLE
docs: Missing docs on ownership annotations

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -127,6 +127,20 @@ supply a version number with the '--version' flag.
 
 To see the list of chart repositories, use 'helm repo list'. To search for
 charts in a repository, use 'helm search'.
+
+RESOURCE OWNERSHIP
+
+When Helm installs a chart, it adds the following metadata to every Kubernetes
+resource it creates:
+
+  - Label:      app.kubernetes.io/managed-by=Helm
+  - Annotation: meta.helm.sh/release-name=<release-name>
+  - Annotation: meta.helm.sh/release-namespace=<release-namespace>
+
+These are used to track ownership. If a resource already exists in the cluster
+without these annotations, Helm will refuse to install and return an error. To
+adopt pre-existing resources into the release, use '--take-ownership'. Helm will
+then add the ownership metadata and manage those resources going forward.
 `
 
 func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -138,9 +138,10 @@ resource it creates:
   - Annotation: meta.helm.sh/release-namespace=<release-namespace>
 
 These are used to track ownership. If a resource already exists in the cluster
-without these annotations, Helm will refuse to install and return an error. To
-adopt pre-existing resources into the release, use '--take-ownership'. Helm will
-then add the ownership metadata and manage those resources going forward.
+without this metadata, or with metadata pointing to a different release or
+namespace, Helm will refuse to install and return an error. To adopt such
+pre-existing resources into the release, use '--take-ownership'. Helm will then
+add the ownership metadata and manage those resources going forward.
 `
 
 func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -89,10 +89,10 @@ Helm tracks ownership of Kubernetes resources using the following metadata:
   - Annotation: meta.helm.sh/release-name=<release-name>
   - Annotation: meta.helm.sh/release-namespace=<release-namespace>
 
-During an upgrade, if a resource exists in the cluster without these annotations
-(or with annotations pointing to a different release), Helm will return an error.
-To take ownership of such resources and have Helm manage them going forward, use
-'--take-ownership'.
+During an upgrade, if a resource exists in the cluster without this metadata
+(or with metadata pointing to a different release or namespace), Helm will
+return an error. To take ownership of such resources and have Helm manage them
+going forward, use '--take-ownership'.
 `
 
 func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -80,6 +80,19 @@ or '--set' flags. Priority is given to new values.
 The --dry-run flag will output all generated chart manifests, including Secrets
 which can contain sensitive values. To hide Kubernetes Secrets use the
 --hide-secret flag. Please carefully consider how and when these flags are used.
+
+RESOURCE OWNERSHIP
+
+Helm tracks ownership of Kubernetes resources using the following metadata:
+
+  - Label:      app.kubernetes.io/managed-by=Helm
+  - Annotation: meta.helm.sh/release-name=<release-name>
+  - Annotation: meta.helm.sh/release-namespace=<release-namespace>
+
+During an upgrade, if a resource exists in the cluster without these annotations
+(or with annotations pointing to a different release), Helm will return an error.
+To take ownership of such resources and have Helm manage them going forward, use
+'--take-ownership'.
 `
 
 func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {


### PR DESCRIPTION
## Summary

The `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations (along with the `app.kubernetes.io/managed-by=Helm` label) are used by Helm to track ownership of Kubernetes resources.


## Root cause

The `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations
(along with the `app.kubernetes.io/managed-by=Helm` label) are used by Helm to track
ownership of Kubernetes resources. These are defined in `pkg/action/validate.go` as
`helmReleaseNameAnnotation` and `helmReleaseNamespaceAnnotation`. However, neither the
`helm install` nor `helm upgrade` command help text explained these annotations or the
`--take-ownership` flag that lets users adopt pre-existing resources. Users had no
in-tool documentation to discover or understand the ownership mechanism.


## What changed

Added a "RESOURCE OWNERSHIP" section to the `installDesc` constant in
`pkg/cmd/install.go` (`newInstallCmd`) and the `upgradeDesc` constant in
`pkg/cmd/upgrade.go` (`newUpgradeCmd`). Each section lists the three ownership
metadata items Helm applies:

- `app.kubernetes.io/managed-by=Helm` (label)
- `meta.helm.sh/release-name=<release-name>` (annotation)
- `meta.helm.sh/release-namespace=<release-namespace>` (annotation)

And explains how the `--take-ownership` flag allows adopting resources that already
exist in the cluster without this ownership metadata.


## Issue

Fixes #12869

Issue: https://github.com/helm/helm/issues/12869


## Diffstat

```
pkg/cmd/install.go | 15 +++++++++++++++
 pkg/cmd/upgrade.go | 13 +++++++++++++
 2 files changed, 28 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.