### PR TITLE
fix: resolve YAML aliases before flattening kind: List in post-render

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -33,6 +33,7 @@ import (
 	"text/template"
 	"time"
 
+	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -203,6 +204,12 @@ func annotateAndMerge(files map[string]string) (string, error) {
 			if strings.TrimSpace(doc) == "" {
 				continue
 			}
+			// kio.ParseAll flattens `kind: List` into one document per item; resolve aliases
+			// first so an anchor and its alias aren't split across documents (anchors are
+			// document-scoped), which would leave the alias dangling.
+			if resolved, rerr := resolveYAMLAliases(doc); rerr == nil {
+				doc = resolved
+			}
 			manifests, err := kio.ParseAll(doc)
 			if err != nil {
 				return "", fmt.Errorf("parsing %s: %w", fname, err)
@@ -221,6 +228,64 @@ func annotateAndMerge(files map[string]string) (string, error) {
 		return "", fmt.Errorf("writing merged docs: %w", err)
 	}
 	return merged, nil
+}
+
+// resolveYAMLAliases materializes YAML aliases within a single document, leaving
+// documents that contain none unchanged.
+func resolveYAMLAliases(doc string) (string, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(doc), &node); err != nil {
+		return "", err
+	}
+	if !resolveAliasNodes(&node) {
+		return doc, nil
+	}
+	stripAnchors(&node)
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&node); err != nil {
+		return "", err
+	}
+	_ = enc.Close()
+	return buf.String(), nil
+}
+
+// resolveAliasNodes replaces alias nodes with a deep copy of their anchor target,
+// returning true if any replacement was made.
+func resolveAliasNodes(n *yaml.Node) bool {
+	changed := false
+	for i, c := range n.Content {
+		if c.Kind == yaml.AliasNode && c.Alias != nil {
+			n.Content[i] = deepCopyClearAnchor(c.Alias)
+			changed = true
+			continue
+		}
+		if resolveAliasNodes(c) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// deepCopyClearAnchor returns a deep copy of n with anchors removed.
+func deepCopyClearAnchor(n *yaml.Node) *yaml.Node {
+	cp := *n
+	cp.Anchor = ""
+	cp.Alias = nil
+	cp.Content = make([]*yaml.Node, len(n.Content))
+	for i, c := range n.Content {
+		cp.Content[i] = deepCopyClearAnchor(c)
+	}
+	return &cp
+}
+
+// stripAnchors clears any remaining anchor names in the tree.
+func stripAnchors(n *yaml.Node) {
+	n.Anchor = ""
+	for _, c := range n.Content {
+		stripAnchors(c)
+	}
 }
 
 // splitAndDeannotate reconstructs individual files from a merged YAML stream,

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -207,8 +207,9 @@ func annotateAndMerge(files map[string]string) (string, error) {
 			// kio.ParseAll flattens `kind: List` into one document per item; resolve aliases
 			// first so an anchor and its alias aren't split across documents (anchors are
 			// document-scoped), which would leave the alias dangling.
-			if resolved, rerr := resolveYAMLAliases(doc); rerr == nil {
-				doc = resolved
+			doc, err := resolveYAMLAliases(doc)
+			if err != nil {
+				return "", fmt.Errorf("resolving aliases in %s: %w", fname, err)
 			}
 			manifests, err := kio.ParseAll(doc)
 			if err != nil {
@@ -235,7 +236,9 @@ func annotateAndMerge(files map[string]string) (string, error) {
 func resolveYAMLAliases(doc string) (string, error) {
 	var node yaml.Node
 	if err := yaml.Unmarshal([]byte(doc), &node); err != nil {
-		return "", err
+		// Preserve the surrounding code's leniency for badly-formed docs;
+		// kio.ParseAll reports them downstream.
+		return doc, nil
 	}
 	if !resolveAliasNodes(&node) {
 		return doc, nil
@@ -247,7 +250,9 @@ func resolveYAMLAliases(doc string) (string, error) {
 	if err := enc.Encode(&node); err != nil {
 		return "", err
 	}
-	_ = enc.Close()
+	if err := enc.Close(); err != nil {
+		return "", err
+	}
 	return buf.String(), nil
 }
 

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -511,6 +511,70 @@ data:
 `,
 		},
 		{
+			name: "kind List with anchor shared across items",
+			files: map[string]string{
+				"templates/list.yaml": `
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-a
+  data: &shared
+    key: value
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-b
+  data: *shared`,
+			},
+			expected: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-a
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/list.yaml'
+data:
+  key: value
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-b
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/list.yaml'
+data:
+  key: value
+`,
+		},
+		{
+			name: "anchor and alias within a single manifest",
+			files: map[string]string{
+				"templates/cm.yaml": `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+  defaults: &d
+    a: "1"
+  prod: *d`,
+			},
+			expected: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  annotations:
+    postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
+data:
+  defaults:
+    a: "1"
+  prod:
+    a: "1"
+`,
+		},
+		{
 			name: "partials and empty files are removed",
 			files: map[string]string{
 				"templates/cm.yaml": `


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes #32203.

When a post-renderer is configured, `annotateAndMerge` feeds each rendered document to `kio.ParseAll`, which flattens a `kind: List` into one document per item. An anchor defined on one item and an alias referencing it on another item were then split across separate `---` documents; because YAML anchors are document-scoped, the alias became dangling and rendering failed with `unknown anchor 'shared' referenced`. The bug only manifests when a post-renderer is set, the plain path never goes through `kio`.

**How it works**:

`annotateAndMerge` now materializes YAML aliases within each document before `kio.ParseAll` processes it. At that point the document is still valid (anchor and alias share one document), so aliases resolve cleanly and every emitted document is self-contained.

Resolution:
- is a no-op for documents with no aliases (returned unchanged, byte-for-byte)
- is best-effort; on any error it falls through to the original document, so behavior is unchanged for inputs it can't handle.

**Behavior change**:

For documents that do contain aliases, the post-render output is now materialized (anchors expanded). This matches what the cluster already receives, objects are parsed (resolving anchors) before apply, and the non-post-render path is unaffected.

**Tests**:

- New `TestAnnotateAndMerge` cases: a `kind: List` with an anchor shared across items, and an anchor/alias within a single manifest.
- All existing `pkg/action` tests pass unchanged.

**Special notes for your reviewer**:

The fix is localized to `annotateAndMerge` plus three small unexported helpers (`resolveYAMLAliases`, `resolveAliasNodes`, `deepCopyClearAnchor`, `stripAnchors`) using `go.yaml.in/yaml/v3`, already a direct dependency. Deep-copy + clear-anchor avoids re-emitting duplicate `&anchor` definitions when one anchor is referenced multiple times.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
