### PR TITLE
feat(engine): add debug logging when lookup returns empty

### DIFF
--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -73,6 +73,12 @@ func newLookupFunction(clientProvider ClientProvider) lookupFunc {
 				if apierrors.IsNotFound(err) {
 					// Just return an empty interface when the object was not found.
 					// That way, users can use `if not (lookup ...)` in their templates.
+					slog.Debug("lookup: resource not found",
+						slog.String("apiVersion", apiversion),
+						slog.String("kind", kind),
+						slog.String("namespace", namespace),
+						slog.String("name", name),
+					)
 					return map[string]any{}, nil
 				}
 				return map[string]any{}, err
@@ -85,6 +91,11 @@ func newLookupFunction(clientProvider ClientProvider) lookupFunc {
 			if apierrors.IsNotFound(err) {
 				// Just return an empty interface when the object was not found.
 				// That way, users can use `if not (lookup ...)` in their templates.
+				slog.Debug("lookup: resource list not found",
+					slog.String("apiVersion", apiversion),
+					slog.String("kind", kind),
+					slog.String("namespace", namespace),
+				)
 				return map[string]any{}, nil
 			}
 			return map[string]any{}, err


### PR DESCRIPTION
When `lookup` cannot find the requested resource (`apierrors.IsNotFound`), add `slog.Debug()` calls so that users running `helm template --debug` can see why lookup returned an empty map instead of silently swallowing the not-found result.

The return value is unchanged — both branches still return `map[string]any{}, nil`. The `slog` package and `slog.String` are already imported/used in this file (`getDynamicClientOnKind`), so no new imports are needed.

**Files changed:**
- `pkg/engine/lookup_func.go`: add `slog.Debug(...)` in the `apierrors.IsNotFound` branch for single-object lookup and list lookup

Fixes #32101