### PR TITLE
fix(plugin): capture stderr during invocation

### DIFF
--- a/internal/plugin/error.go
+++ b/internal/plugin/error.go
@@ -15,15 +15,21 @@ limitations under the License.
 
 package plugin
 
+import "strconv"
+
 // InvokeExecError is returned when a plugin invocation returns a non-zero status/exit code
 // - subprocess plugin: child process exit code
 // - extism plugin: wasm function return code
 type InvokeExecError struct {
-	ExitCode int   // Exit code from plugin code execution
-	Err      error // Underlying error
+	ExitCode int    // Exit code from plugin code execution
+	Err      error  // Underlying error
+	Stderr   []byte // Captured stderr output
 }
 
 // Error implements the error interface
 func (e *InvokeExecError) Error() string {
+	if len(e.Stderr) > 0 {
+		return e.Err.Error() + ": " + strconv.Quote(string(e.Stderr))
+	}
 	return e.Err.Error()
 }

--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -169,17 +169,26 @@ func (r *SubprocessPluginRuntime) InvokeHook(event string) error {
 // right now we implement status and error return in 3 slightly different ways in this file
 // then replace the other three with a call to this func
 func executeCmd(prog *exec.Cmd, pluginName string) error {
+	var stderrBuf bytes.Buffer
+	if prog.Stderr != nil {
+		prog.Stderr = io.MultiWriter(prog.Stderr, &stderrBuf)
+	} else {
+		prog.Stderr = &stderrBuf
+	}
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
+			stderr := bytes.TrimSpace(stderrBuf.Bytes())
 			slog.Debug(
 				"plugin execution failed",
 				slog.String("pluginName", pluginName),
 				slog.String("error", err.Error()),
 				slog.Int("exitCode", eerr.ExitCode()),
-				slog.String("stderr", string(bytes.TrimSpace(eerr.Stderr))))
+				slog.String("stderr", string(stderr)),
+			)
 			return &InvokeExecError{
 				Err:      fmt.Errorf("plugin %q exited with error", pluginName),
 				ExitCode: eerr.ExitCode(),
+				Stderr:   stderr,
 			}
 		}
 

--- a/internal/plugin/runtime_subprocess_test.go
+++ b/internal/plugin/runtime_subprocess_test.go
@@ -16,9 +16,11 @@ limitations under the License.
 package plugin
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -83,4 +85,31 @@ func TestSubprocessPluginRuntime(t *testing.T) {
 	assert.Equal(t, 56, ieerr.ExitCode)
 
 	assert.Nil(t, output)
+}
+
+func TestExecuteCmdCapturesStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `echo "plugin error" >&2; exit 1`)
+	err := executeCmd(cmd, "test-plugin")
+
+	require.Error(t, err)
+	var ieerr *InvokeExecError
+	require.ErrorAs(t, err, &ieerr)
+	assert.Equal(t, 1, ieerr.ExitCode)
+	assert.Equal(t, []byte("plugin error"), ieerr.Stderr)
+	assert.Equal(t, `plugin "test-plugin" exited with error: "plugin error"`, ieerr.Error())
+}
+
+func TestExecuteCmdTeesStderr(t *testing.T) {
+	var existing bytes.Buffer
+	cmd := exec.Command("sh", "-c", `echo "plugin error" >&2; exit 1`)
+	cmd.Stderr = &existing
+
+	err := executeCmd(cmd, "test-plugin")
+
+	require.Error(t, err)
+	var ieerr *InvokeExecError
+	require.ErrorAs(t, err, &ieerr)
+	assert.Equal(t, 1, ieerr.ExitCode)
+	assert.Equal(t, []byte("plugin error"), ieerr.Stderr)
+	assert.Equal(t, "plugin error\n", existing.String())
 }

--- a/internal/plugin/runtime_subprocess_test.go
+++ b/internal/plugin/runtime_subprocess_test.go
@@ -87,8 +87,23 @@ func TestSubprocessPluginRuntime(t *testing.T) {
 	assert.Nil(t, output)
 }
 
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stderr, "plugin error\n")
+	os.Exit(1)
+}
+
+func helperStderrCmd(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
 func TestExecuteCmdCapturesStderr(t *testing.T) {
-	cmd := exec.Command("sh", "-c", `echo "plugin error" >&2; exit 1`)
+	cmd := helperStderrCmd(t)
 	err := executeCmd(cmd, "test-plugin")
 
 	require.Error(t, err)
@@ -101,7 +116,7 @@ func TestExecuteCmdCapturesStderr(t *testing.T) {
 
 func TestExecuteCmdTeesStderr(t *testing.T) {
 	var existing bytes.Buffer
-	cmd := exec.Command("sh", "-c", `echo "plugin error" >&2; exit 1`)
+	cmd := helperStderrCmd(t)
 	cmd.Stderr = &existing
 
 	err := executeCmd(cmd, "test-plugin")

--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -124,7 +124,7 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 				execErr := &plugin.InvokeExecError{}
 				if errors.As(err, &execErr) {
 					return CommandError{
-						error:    execErr.Err,
+						error:    execErr,
 						ExitCode: execErr.ExitCode,
 					}
 				}


### PR DESCRIPTION
Capture process stderr in plugin invocations via executeCmd.

Closes #31843

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Currently, there is an issue with all types of plugins not displaying the stderr on fail, which is the main way the user is
supposed to find out the reason for the failure. This PR fixes the stderr capture for both buffer and fd backed stderr
targets.

**Special notes for your reviewer**:

InvokeExecError structure has been changed to include stderr.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
