### PR TITLE
fix: downgrade templates directory check severity back to Info

### DIFF
--- a/internal/chart/v3/lint/rules/template.go
+++ b/internal/chart/v3/lint/rules/template.go
@@ -57,7 +57,7 @@ func TemplatesWithSkipSchemaValidation(linter *support.Linter, values map[string
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
 	// Templates directory is optional for now
-	templatesDirExists := linter.RunLinterRule(support.WarningSev, fpath, templatesDirExists(templatesPath))
+	templatesDirExists := linter.RunLinterRule(support.InfoSev, fpath, templatesDirExists(templatesPath))
 	if !templatesDirExists {
 		return
 	}

--- a/internal/chart/v3/lint/rules/template_test.go
+++ b/internal/chart/v3/lint/rules/template_test.go
@@ -462,3 +462,51 @@ func TestIsYamlFileExtension(t *testing.T) {
 		}
 	}
 }
+
+// TestMissingTemplatesDirIsInfo verifies that a chart without a templates
+// directory only produces an InfoSev message, not WarningSev.
+// This is a regression test for https://github.com/helm/helm/issues/8033
+// and ensures the fix from https://github.com/helm/helm/pull/11586 is not
+// reverted (as happened in https://github.com/helm/helm/pull/31019).
+func TestMissingTemplatesDirIsInfo(t *testing.T) {
+	mychart := chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: "v2",
+			Name:       "umbrella-chart",
+			Version:    "0.1.0",
+			Icon:       "satisfy-the-linting-gods.gif",
+		},
+		// No templates - this is valid for umbrella charts
+	}
+	tmpdir := t.TempDir()
+
+	if err := chartutil.SaveDir(&mychart, tmpdir); err != nil {
+		t.Fatal(err)
+	}
+
+	chartDir := filepath.Join(tmpdir, mychart.Name())
+
+	// Remove the templates directory to simulate an umbrella chart
+	os.RemoveAll(filepath.Join(chartDir, "templates"))
+
+	linter := support.Linter{ChartDir: chartDir}
+	Templates(&linter, values, namespace, strict)
+
+	// Should have exactly one message about the missing templates dir
+	if len(linter.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d: %v", len(linter.Messages), linter.Messages)
+	}
+
+	msg := linter.Messages[0]
+	if msg.Severity != support.InfoSev {
+		t.Errorf("Expected InfoSev (%d) for missing templates dir, got severity %d: %s",
+			support.InfoSev, msg.Severity, msg)
+	}
+
+	// HighestSeverity should be InfoSev, not WarningSev - this is what
+	// ensures helm lint --strict does not fail for umbrella charts.
+	if linter.HighestSeverity != support.InfoSev {
+		t.Errorf("Expected HighestSeverity to be InfoSev (%d), got %d",
+			support.InfoSev, linter.HighestSeverity)
+	}
+}

--- a/pkg/chart/v2/lint/rules/template.go
+++ b/pkg/chart/v2/lint/rules/template.go
@@ -87,7 +87,7 @@ func (t *templateLinter) Lint() {
 	templatesDir := "templates/"
 	templatesPath := filepath.Join(t.linter.ChartDir, templatesDir)
 
-	templatesDirExists := t.linter.RunLinterRule(support.WarningSev, templatesDir, templatesDirExists(templatesPath))
+	templatesDirExists := t.linter.RunLinterRule(support.InfoSev, templatesDir, templatesDirExists(templatesPath))
 	if !templatesDirExists {
 		return
 	}

--- a/pkg/chart/v2/lint/rules/template_test.go
+++ b/pkg/chart/v2/lint/rules/template_test.go
@@ -485,3 +485,55 @@ func TestIsYamlFileExtension(t *testing.T) {
 		}
 	}
 }
+
+// TestMissingTemplatesDirIsInfo verifies that a chart without a templates
+// directory only produces an InfoSev message, not WarningSev.
+// This is a regression test for https://github.com/helm/helm/issues/8033
+// and ensures the fix from https://github.com/helm/helm/pull/11586 is not
+// reverted (as happened in https://github.com/helm/helm/pull/31019).
+func TestMissingTemplatesDirIsInfo(t *testing.T) {
+	mychart := chart.Chart{
+		Metadata: &chart.Metadata{
+			APIVersion: "v2",
+			Name:       "umbrella-chart",
+			Version:    "0.1.0",
+			Icon:       "satisfy-the-linting-gods.gif",
+		},
+		// No templates - this is valid for umbrella charts
+	}
+	tmpdir := t.TempDir()
+
+	if err := chartutil.SaveDir(&mychart, tmpdir); err != nil {
+		t.Fatal(err)
+	}
+
+	chartDir := filepath.Join(tmpdir, mychart.Name())
+
+	// Remove the templates directory to simulate an umbrella chart
+	os.RemoveAll(filepath.Join(chartDir, "templates"))
+
+	linter := support.Linter{ChartDir: chartDir}
+	Templates(
+		&linter,
+		namespace,
+		values,
+		TemplateLinterSkipSchemaValidation(false))
+
+	// Should have exactly one message about the missing templates dir
+	if len(linter.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d: %v", len(linter.Messages), linter.Messages)
+	}
+
+	msg := linter.Messages[0]
+	if msg.Severity != support.InfoSev {
+		t.Errorf("Expected InfoSev (%d) for missing templates dir, got severity %d: %s",
+			support.InfoSev, msg.Severity, msg)
+	}
+
+	// HighestSeverity should be InfoSev, not WarningSev - this is what
+	// ensures helm lint --strict does not fail for umbrella charts.
+	if linter.HighestSeverity != support.InfoSev {
+		t.Errorf("Expected HighestSeverity to be InfoSev (%d), got %d",
+			support.InfoSev, linter.HighestSeverity)
+	}
+}


### PR DESCRIPTION
This downgrades the templates directory existence check from a Warning to an Info severity level, resolving a regression introduced in PR #31019. Umbrella charts without a templates directory will no longer cause 'helm lint --strict' to fail.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR downgrades the missing `templates/` directory check from Warning to Info severity. 

A regression introduced in PR #31019 reverted the previous fix from PR #11586. This re-introduced failing CI pipelines for users with umbrella charts (which legitimately do not need template directories) when running `helm lint --strict`. Since warnings are treated as errors under strict linting, this change prevents unnecessary failures for valid umbrella charts while still logging the info message.

Closes #8033

**Special notes for your reviewer**:
I've added regression tests (`TestMissingTemplatesDirIsInfo`) to both the v2 and v3 template rule test files to ensure this behavior is not accidentally reverted again.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
