### PR TITLE
fix: improve clarity of coalesce warning messages

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -143,14 +143,14 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	if destglob, ok := dest[common.GlobalKey]; !ok {
 		dg = make(map[string]any)
 	} else if dg, ok = destglob.(map[string]any); !ok {
-		printf("warning: skipping globals because destination %s is not a table.", common.GlobalKey)
+		printf("warning: skipping globals because destination %s is not a mapping.", common.GlobalKey)
 		return
 	}
 
 	if srcglob, ok := src[common.GlobalKey]; !ok {
 		sg = make(map[string]any)
 	} else if sg, ok = srcglob.(map[string]any); !ok {
-		printf("warning: skipping globals because source %s is not a table.", common.GlobalKey)
+		printf("warning: skipping globals because source %s is not a mapping.", common.GlobalKey)
 		return
 	}
 
@@ -180,7 +180,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 			}
 		} else if dv, ok := dg[key]; ok && istable(dv) {
 			// It's not clear if this condition can actually ever trigger.
-			printf("key %s is table. Skipping", key)
+			printf("key %s is a mapping. Skipping", key)
 		} else {
 			// TODO: Do we need to do any additional checking on the value?
 			dg[key] = val
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: destination is a mapping, but the provided value is not. Use a YAML map (key:value pairs) for this key.", subPrefix, key)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true
@@ -347,10 +347,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite mapping with non-mapping value for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a mapping. Ignoring non-mapping value (%v)", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -180,7 +180,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 			}
 		} else if dv, ok := dg[key]; ok && istable(dv) {
 			// It's not clear if this condition can actually ever trigger.
-			printf("key %s is a mapping. Skipping", key)
+			printf("warning: key %s is a mapping. Skipping.", key)
 		} else {
 			// TODO: Do we need to do any additional checking on the value?
 			dg[key] = val
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: destination is a mapping, but the provided value is not. Use a YAML map (key:value pairs) for this key.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: destination is a mapping, but the provided value is not.", subPrefix, key)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -720,9 +720,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: destination is a mapping, but the provided value is not. Use a YAML map (key:value pairs) for this key.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a mapping. Ignoring non-mapping value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite mapping with non-mapping value for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "skipped value for level1.level2.level3.boat")
+	assert.Contains(t, warnings, "destination for level1.level2.level3.spear.tip is a mapping")
+	assert.Contains(t, warnings, "cannot overwrite mapping with non-mapping value for level1.level2.level3.spear.sail")
 }
 
 func TestConcatPrefix(t *testing.T) {

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -720,9 +720,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: destination is a mapping, but the provided value is not. Use a YAML map (key:value pairs) for this key.")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a mapping. Ignoring non-mapping value (true)")
+	assert.Contains(t, warnings, "warning: cannot overwrite mapping with non-mapping value for level1.level2.level3.spear.sail (map[cotton:true])")
 }
 
 func TestConcatPrefix(t *testing.T) {


### PR DESCRIPTION
## What

Replaces the ambiguous term "table" with "mapping" in all user-facing coalesce warning messages.

## Why

Fixes #11118

Users see warnings like:

```
warning: destination for cassandra.dbUser.existingSecret is a table. Ignoring non-table value ()
```

The word "table" is Helm-internal jargon that doesn't help users understand what went wrong. "Mapping" aligns with YAML terminology and makes the message immediately clearer.

## Changes

**Before → After:**
- `"Not a table."` → `"destination is a mapping, but the provided value is not. Use a YAML map (key:value pairs) for this key."`
- `"is a table. Ignoring non-table value"` → `"is a mapping. Ignoring non-mapping value"`
- `"cannot overwrite table with non table"` → `"cannot overwrite mapping with non-mapping value"`
- `"skipping globals because destination/source %s is not a table."` → `"is not a mapping."`
- `"key %s is table. Skipping"` → `"key %s is a mapping. Skipping"`

The internal `istable()` function is unchanged — this only touches user-facing warning strings.

## Testing

- `go test ./pkg/chart/common/util/` — all pass
- `go test ./pkg/chart/common/...` — all pass
- Test assertions updated to match new messages