### PR TITLE
fix: check for resource existence before scheduling deletion

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -33,6 +33,7 @@ import (
 	"github.com/fluxcd/cli-utils/pkg/kstatus/watcher"
 	"github.com/fluxcd/cli-utils/pkg/object"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -140,6 +141,14 @@ func (w *statusWaiter) waitForDelete(ctx context.Context, resourceList ResourceL
 	defer cancel()
 	resources := []object.ObjMetadata{}
 	for _, resource := range resourceList {
+		if err := resource.Get(); err != nil {
+			if apierrors.IsNotFound(err) {
+				w.Logger().Debug("waitForDelete: resource was already deleted", "namespace", resource.Namespace, "name", resource.Name)
+				continue
+			} else {
+				return err
+			}
+		}
 		obj, err := object.RuntimeToObjMeta(resource.Object)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
After upgrading from Helm v4.2.0 to v4.2.1, any helm upgrade --install --wait that deletes a resource and waits for it to be gone sits there for the entire --timeout instead of returning as soon as the resource is actually deleted.

closes: #32214

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
