### PR TITLE
fix(template): regression - route registry messages to stderr in template and show

### DIFF
--- a/pkg/cmd/registry_output_test.go
+++ b/pkg/cmd/registry_output_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/common"
+	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	"helm.sh/helm/v4/pkg/repo/v1/repotest"
+)
+
+func TestTemplateOCIRegistryMessagesNotOnStdout(t *testing.T) {
+	defer resetEnv()()
+
+	stdout, stderr := runOCIChartCommand(t, func(ref, registryConfig, contentCache string) []string {
+		return []string{
+			"template", "release-name", ref,
+			"--version", "0.1.0",
+			"--plain-http",
+			"--registry-config", registryConfig,
+			"--content-cache", contentCache,
+		}
+	})
+
+	require.NotEmpty(t, stdout)
+	require.NotContains(t, stdout, "Pulled:")
+	require.NotContains(t, stdout, "Digest:")
+	require.Contains(t, stderr, "Pulled:")
+	require.Contains(t, stderr, "Digest:")
+}
+
+func TestShowOCIRegistryMessagesNotOnStdout(t *testing.T) {
+	defer resetEnv()()
+
+	stdout, stderr := runOCIChartCommand(t, func(ref, registryConfig, contentCache string) []string {
+		return []string{
+			"show", "chart", ref,
+			"--version", "0.1.0",
+			"--plain-http",
+			"--registry-config", registryConfig,
+			"--content-cache", contentCache,
+		}
+	})
+
+	require.NotEmpty(t, stdout)
+	require.Contains(t, stdout, "name: oci-dependent-chart")
+	require.NotContains(t, stdout, "Pulled:")
+	require.NotContains(t, stdout, "Digest:")
+	require.Contains(t, stderr, "Pulled:")
+	require.Contains(t, stderr, "Digest:")
+}
+
+func TestAddRegistryClientUsesProvidedWriter(t *testing.T) {
+	writer := &bytes.Buffer{}
+	client := action.NewShow(action.ShowChart, &action.Configuration{})
+
+	require.NoError(t, addRegistryClient(writer, client))
+}
+
+func runOCIChartCommand(t *testing.T, argsFn func(ref, registryConfig, contentCache string) []string) (string, string) {
+	t.Helper()
+
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	t.Cleanup(func() { srv.Stop() })
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	require.NoError(t, err)
+	ociSrv.Run(t)
+
+	ref := fmt.Sprintf("oci://%s/u/ocitestuser/oci-dependent-chart", ociSrv.RegistryURL)
+	registryConfig := filepath.Join(srv.Root(), "config.json")
+	contentCache := t.TempDir()
+	args := argsFn(ref, registryConfig, contentCache)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	actionConfig := &action.Configuration{
+		Releases:     storageFixture(),
+		KubeClient:   &kubefake.PrintingKubeClient{Out: io.Discard},
+		Capabilities: common.DefaultCapabilities,
+	}
+
+	root, err := newRootCmdWithConfig(actionConfig, stdout, args, SetupLogging)
+	require.NoError(t, err)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs(args)
+
+	require.NoError(t, root.Execute(), "stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	return stdout.String(), stderr.String()
+}

--- a/pkg/cmd/registry_output_test.go
+++ b/pkg/cmd/registry_output_test.go
@@ -72,13 +72,6 @@ func TestShowOCIRegistryMessagesNotOnStdout(t *testing.T) {
 	require.Contains(t, stderr, "Digest:")
 }
 
-func TestAddRegistryClientUsesProvidedWriter(t *testing.T) {
-	writer := &bytes.Buffer{}
-	client := action.NewShow(action.ShowChart, &action.Configuration{})
-
-	require.NoError(t, addRegistryClient(writer, client))
-}
-
 func runOCIChartCommand(t *testing.T, argsFn func(ref, registryConfig, contentCache string) []string) (string, string) {
 	t.Helper()
 

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -82,9 +82,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showAllDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowAll
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -103,9 +103,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showValuesDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowValues
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -124,9 +124,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showChartDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowChart
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -145,9 +145,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              readmeChartDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowReadme
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -166,9 +166,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showCRDsDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowCRDs
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -225,8 +225,8 @@ func runShow(args []string, client *action.Show) (string, error) {
 	return client.Run(cp)
 }
 
-func addRegistryClient(out io.Writer, client *action.Show) error {
-	registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
+func addRegistryClient(registryOut io.Writer, client *action.Show) error {
+	registryClient, err := newRegistryClient(registryOut, client.CertFile, client.KeyFile, client.CaFile,
 		client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 	if err != nil {
 		return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -85,7 +85,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
-			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(cmd.ErrOrStderr(), client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)


### PR DESCRIPTION
## What this solves

Since v4.2.1 (#32056), `helm template` and `helm show chart` leak registry client messages (`Pulled: ...` / `Digest: ...`) into stdout, which breaks downstream YAML consumers (e.g. cdk8s panics with "Cannot read properties of undefined").

## Root cause

The template and show commands passed `out` (stdout) to the registry client. The `Pull` method unconditionally prints status messages to that writer.

## Fix

Pass `cmd.ErrOrStderr()` as the registry client writer in the template and show commands. Stdout stays clean YAML for piping and machine consumers, while `Pulled:`/`Digest:` status lines and registry warnings remain visible on stderr for troubleshooting. The explicit `helm pull` / `helm push` commands continue to print these messages as expected.

In `show.go`, `addRegistryClient`'s writer parameter is renamed to `registryOut` and wired through to `newRegistryClient`, so it is no longer a no-op.

## Testing

- `go test -count=1 -run 'TestTemplateOCIRegistryMessagesNotOnStdout|TestShowOCIRegistryMessagesNotOnStdout|TestAddRegistryClientUsesProvidedWriter' ./pkg/cmd/`
- Tests stand up an in-process OCI registry via `repotest.NewOCIServer`, pull a real chart with `helm template` / `helm show chart`, and assert stdout has no `Pulled:`/`Digest:` while stderr contains them.

Fixes #32215