### PR TITLE
refactor(pkg): convert tests to testify assert/require

### DIFF
--- a/pkg/gates/gates_test.go
+++ b/pkg/gates/gates_test.go
@@ -18,6 +18,8 @@ package gates
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const name string = "HELM_EXPERIMENTAL_FEATURE"
@@ -25,31 +27,23 @@ const name string = "HELM_EXPERIMENTAL_FEATURE"
 func TestIsEnabled(t *testing.T) {
 	g := Gate(name)
 
-	if g.IsEnabled() {
-		t.Errorf("feature gate shows as available, but the environment variable %s was not set", name)
-	}
+	assert.False(t, g.IsEnabled(), "feature gate shows as available, but the environment variable %s was not set", name)
 
 	t.Setenv(name, "1")
 
-	if !g.IsEnabled() {
-		t.Errorf("feature gate shows as disabled, but the environment variable %s was set", name)
-	}
+	assert.True(t, g.IsEnabled(), "feature gate shows as disabled, but the environment variable %s was set", name)
 }
 
 func TestError(t *testing.T) {
 	os.Unsetenv(name)
 	g := Gate(name)
 
-	if g.Error().Error() != "this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_FEATURE=1 in your environment to use this feature" {
-		t.Errorf("incorrect error message. Received %s", g.Error().Error())
-	}
+	assert.Equal(t, "this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_FEATURE=1 in your environment to use this feature", g.Error().Error())
 }
 
 func TestString(t *testing.T) {
 	os.Unsetenv(name)
 	g := Gate(name)
 
-	if g.String() != "HELM_EXPERIMENTAL_FEATURE" {
-		t.Errorf("incorrect string representation. Received %s", g.String())
-	}
+	assert.Equal(t, "HELM_EXPERIMENTAL_FEATURE", g.String())
 }

--- a/pkg/helmpath/home_unix_test.go
+++ b/pkg/helmpath/home_unix_test.go
@@ -16,8 +16,9 @@
 package helmpath
 
 import (
-	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
 )
@@ -26,20 +27,13 @@ func TestHelmHome(t *testing.T) {
 	t.Setenv(xdg.CacheHomeEnvVar, "/cache")
 	t.Setenv(xdg.ConfigHomeEnvVar, "/config")
 	t.Setenv(xdg.DataHomeEnvVar, "/data")
-	isEq := func(t *testing.T, got, expected string) {
-		t.Helper()
-		if expected != got {
-			t.Error(runtime.GOOS)
-			t.Errorf("Expected %q, got %q", expected, got)
-		}
-	}
 
-	isEq(t, CachePath(), "/cache/helm")
-	isEq(t, ConfigPath(), "/config/helm")
-	isEq(t, DataPath(), "/data/helm")
+	assert.Equal(t, "/cache/helm", CachePath())
+	assert.Equal(t, "/config/helm", ConfigPath())
+	assert.Equal(t, "/data/helm", DataPath())
 
 	// test to see if lazy-loading environment variables at runtime works
 	t.Setenv(xdg.CacheHomeEnvVar, "/cache2")
 
-	isEq(t, CachePath(), "/cache2/helm")
+	assert.Equal(t, "/cache2/helm", CachePath())
 }

--- a/pkg/helmpath/home_windows_test.go
+++ b/pkg/helmpath/home_windows_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
 )
 
@@ -26,18 +28,13 @@ func TestHelmHome(t *testing.T) {
 	os.Setenv(xdg.CacheHomeEnvVar, "c:\\")
 	os.Setenv(xdg.ConfigHomeEnvVar, "d:\\")
 	os.Setenv(xdg.DataHomeEnvVar, "e:\\")
-	isEq := func(t *testing.T, a, b string) {
-		if a != b {
-			t.Errorf("Expected %q, got %q", b, a)
-		}
-	}
 
-	isEq(t, CachePath(), "c:\\helm")
-	isEq(t, ConfigPath(), "d:\\helm")
-	isEq(t, DataPath(), "e:\\helm")
+	assert.Equal(t, "c:\\helm", CachePath())
+	assert.Equal(t, "d:\\helm", ConfigPath())
+	assert.Equal(t, "e:\\helm", DataPath())
 
 	// test to see if lazy-loading environment variables at runtime works
 	os.Setenv(xdg.CacheHomeEnvVar, "f:\\")
 
-	isEq(t, CachePath(), "f:\\helm")
+	assert.Equal(t, "f:\\helm", CachePath())
 }

--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/homedir"
 
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
@@ -36,17 +37,13 @@ func TestDataPath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 
 	t.Setenv(xdg.DataHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 }
 
 func TestConfigPath(t *testing.T) {
@@ -54,17 +51,13 @@ func TestConfigPath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", "Preferences", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 
 	t.Setenv(xdg.ConfigHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 }
 
 func TestCachePath(t *testing.T) {
@@ -72,15 +65,11 @@ func TestCachePath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", "Caches", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 
 	t.Setenv(xdg.CacheHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 }

--- a/pkg/helmpath/lazypath_unix_test.go
+++ b/pkg/helmpath/lazypath_unix_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/homedir"
 
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
@@ -33,47 +34,35 @@ const (
 func TestDataPath(t *testing.T) {
 	expected := filepath.Join(homedir.HomeDir(), ".local", "share", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 
 	t.Setenv(xdg.DataHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 }
 
 func TestConfigPath(t *testing.T) {
 	expected := filepath.Join(homedir.HomeDir(), ".config", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 
 	t.Setenv(xdg.ConfigHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 }
 
 func TestCachePath(t *testing.T) {
 	expected := filepath.Join(homedir.HomeDir(), ".cache", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 
 	t.Setenv(xdg.CacheHomeEnvVar, "/tmp")
 
 	expected = filepath.Join("/tmp", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 }

--- a/pkg/helmpath/lazypath_windows_test.go
+++ b/pkg/helmpath/lazypath_windows_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/homedir"
 
 	"helm.sh/helm/v4/pkg/helmpath/xdg"
@@ -37,17 +38,13 @@ func TestDataPath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "foo", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 
 	os.Setenv(xdg.DataHomeEnvVar, filepath.Join(homedir.HomeDir(), "xdg"))
 
 	expected = filepath.Join(homedir.HomeDir(), "xdg", appName, testFile)
 
-	if lazy.dataPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.dataPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.dataPath(testFile))
 }
 
 func TestConfigPath(t *testing.T) {
@@ -56,17 +53,13 @@ func TestConfigPath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "foo", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 
 	os.Setenv(xdg.ConfigHomeEnvVar, filepath.Join(homedir.HomeDir(), "xdg"))
 
 	expected = filepath.Join(homedir.HomeDir(), "xdg", appName, testFile)
 
-	if lazy.configPath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.configPath(testFile))
-	}
+	assert.Equal(t, expected, lazy.configPath(testFile))
 }
 
 func TestCachePath(t *testing.T) {
@@ -75,15 +68,11 @@ func TestCachePath(t *testing.T) {
 
 	expected := filepath.Join(homedir.HomeDir(), "foo", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 
 	os.Setenv(xdg.CacheHomeEnvVar, filepath.Join(homedir.HomeDir(), "xdg"))
 
 	expected = filepath.Join(homedir.HomeDir(), "xdg", appName, testFile)
 
-	if lazy.cachePath(testFile) != expected {
-		t.Errorf("expected '%s', got '%s'", expected, lazy.cachePath(testFile))
-	}
+	assert.Equal(t, expected, lazy.cachePath(testFile))
 }

--- a/pkg/ignore/rules_test.go
+++ b/pkg/ignore/rules_test.go
@@ -41,7 +41,7 @@ one/more
 	r, err := parseString(rules)
 	require.NoError(t, err, "Error parsing rules")
 
-	assert.Len(t, r.patterns, 4)
+	require.Len(t, r.patterns, 4)
 
 	expects := []string{"foo", "bar/*", "baz/bar/foo.txt", "one/more"}
 	for i, p := range r.patterns {

--- a/pkg/ignore/rules_test.go
+++ b/pkg/ignore/rules_test.go
@@ -21,6 +21,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testdata = "./testdata"
@@ -36,22 +39,14 @@ baz/bar/foo.txt
 one/more
 `
 	r, err := parseString(rules)
-	if err != nil {
-		t.Fatalf("Error parsing rules: %s", err)
-	}
+	require.NoError(t, err, "Error parsing rules")
 
-	if len(r.patterns) != 4 {
-		t.Errorf("Expected 4 rules, got %d", len(r.patterns))
-	}
+	assert.Len(t, r.patterns, 4)
 
 	expects := []string{"foo", "bar/*", "baz/bar/foo.txt", "one/more"}
 	for i, p := range r.patterns {
-		if p.raw != expects[i] {
-			t.Errorf("Expected %q, got %q", expects[i], p.raw)
-		}
-		if p.match == nil {
-			t.Errorf("Expected %s to have a matcher function.", p.raw)
-		}
+		assert.Equal(t, expects[i], p.raw)
+		assert.NotNil(t, p.match, "Expected %s to have a matcher function.", p.raw)
 	}
 }
 
@@ -59,26 +54,19 @@ func TestParseFail(t *testing.T) {
 	shouldFail := []string{"foo/**/bar", "[z-"}
 	for _, fail := range shouldFail {
 		_, err := parseString(fail)
-		if err == nil {
-			t.Errorf("Rule %q should have failed", fail)
-		}
+		assert.Error(t, err, "Rule %q should have failed", fail)
 	}
 }
 
 func TestParseFile(t *testing.T) {
 	f := filepath.Join(testdata, HelmIgnore)
-	if _, err := os.Stat(f); err != nil {
-		t.Fatalf("Fixture %s missing: %s", f, err)
-	}
+	_, err := os.Stat(f)
+	require.NoError(t, err, "Fixture %s missing", f)
 
 	r, err := ParseFile(f)
-	if err != nil {
-		t.Fatalf("Failed to parse rules file: %s", err)
-	}
+	require.NoError(t, err, "Failed to parse rules file")
 
-	if len(r.patterns) != 3 {
-		t.Errorf("Expected 3 patterns, got %d", len(r.patterns))
-	}
+	assert.Len(t, r.patterns, 3)
 }
 
 func TestIgnore(t *testing.T) {
@@ -126,17 +114,11 @@ func TestIgnore(t *testing.T) {
 
 	for _, test := range tests {
 		r, err := parseString(test.pattern)
-		if err != nil {
-			t.Fatalf("Failed to parse: %s", err)
-		}
+		require.NoError(t, err, "Failed to parse: %s", test.pattern)
 		fi, err := os.Stat(filepath.Join(testdata, test.name))
-		if err != nil {
-			t.Fatalf("Fixture missing: %s", err)
-		}
+		require.NoError(t, err, "Fixture missing: %s", test.name)
 
-		if r.Ignore(test.name, fi) != test.expect {
-			t.Errorf("Expected %q to be %v for pattern %q", test.name, test.expect, test.pattern)
-		}
+		assert.Equal(t, test.expect, r.Ignore(test.name, fi), "Expected %q to be %v for pattern %q", test.name, test.expect, test.pattern)
 	}
 }
 
@@ -144,9 +126,7 @@ func TestAddDefaults(t *testing.T) {
 	r := Rules{}
 	r.AddDefaults()
 
-	if len(r.patterns) != 1 {
-		t.Errorf("Expected 1 default patterns, got %d", len(r.patterns))
-	}
+	assert.Len(t, r.patterns, 1)
 }
 
 func parseString(str string) (*Rules, error) {


### PR DESCRIPTION


**What this PR does / why we need it**:
Standardizes test code to use `github.com/stretchr/testify/assert`/`require` by converting from native Go testing patterns (t.Errorf, t.Fatalf, t.Error, t.Fatal) to `github.com/stretchr/testify/assert`/`require` equivalents (assert.X, require.X).

This PR converts the `pkg/gates`, `pkg/kubeenv`, `pkg/ignore`, and `pkg/helmpath` test files 

`github.com/stretchr/testify/assert`/`require` has become the de facto standard in Helm's code base. One-line check logic provides better readability, and tests the positive case ie.
```
assert.Equal(t, a, b)
```

rather than:
```
# assert a == b
# note that the comparison logic is inverted, and the error string needs to be manually typed
if a != b { 
    t.Fail("a is not equal to b: a = %d, b = %d", a, b)
}
``` 

**Special notes for your reviewer**:

Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
