### PR TITLE
fix: clarify coalesce warning messages

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: expected a map, got non-map value (%v)", subPrefix, key, val)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true
@@ -347,10 +347,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite map with non-map for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a map. Ignoring non-map value (%v)", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -720,9 +720,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: expected a map, got non-map value (true)")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a map. Ignoring non-map value (true)")
+	assert.Contains(t, warnings, "warning: cannot overwrite map with non-map for level1.level2.level3.spear.sail (map[cotton:true])")
 }
 
 func TestConcatPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR updates Helm's coalesce warnings to use clearer wording for map value conflicts.

- replaces "table" and "non-table" with "map" and "non-map"
- makes the skipped-value warning more explicit
- updates the related unit test expectations

## Why
This makes the warning output easier for Helm users to understand and addresses the confusion described in the linked issue.

## Testing
Could not run the package test in this environment. The local machine does not have Go installed, and the Docker daemon is not running.

Closes #11118