### PR TITLE
docs: clarify Helm ownership annotations in CLI help

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -209,7 +209,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.StringToStringVarP(&client.Labels, "labels", "l", nil, "Labels that would be added to release metadata. Should be divided by comma.")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
 	f.BoolVar(&client.HideNotes, "hide-notes", false, "if set, do not show notes in install output. Does not affect presence in chart metadata")
-	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for helm annotations and take ownership of the existing resources")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, install will ignore the check for Helm ownership annotations (such as meta.helm.sh/release-name and meta.helm.sh/release-namespace) and take ownership of the existing resources")
 
 	// For `helm template`, these notes flags are legacy, unused, and should not show in help, but
 	// must remain accepted for backwards compatibility in Helm 4. Deprecate and hide them for now

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -299,7 +299,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
-	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, upgrade will ignore the check for helm annotations and take ownership of the existing resources")
+	f.BoolVar(&client.TakeOwnership, "take-ownership", false, "if set, upgrade will ignore the check for Helm ownership annotations (such as meta.helm.sh/release-name and meta.helm.sh/release-namespace) and take ownership of the existing resources")
 	addDryRunFlag(cmd)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)


### PR DESCRIPTION
## Summary
This PR clarifies the `--take-ownership` help text for `helm install` and `helm upgrade`.

- explains that the flag applies to Helm ownership annotations
- names `meta.helm.sh/release-name`
- names `meta.helm.sh/release-namespace`

## Why
This makes the existing help text more explicit for users looking for documentation on those ownership annotations.

## Testing
Not run. Help text only.

Closes #12869