### PR TITLE
docs: fix typo in helm version command description

### DIFF
--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -30,7 +30,7 @@ import (
 const versionDesc = `
 Show the version for Helm.
 
-This will print a representation the version of Helm.
+This will print a representation of the version of Helm.
 The output will look something like this:
 
 version.BuildInfo{Version:"v3.2.1", GitCommit:"fe51cd1e31e6a202cba7dead9552a6d418ded79a", GitTreeState:"clean", GoVersion:"go1.13.10"}


### PR DESCRIPTION
The `helm version` long help reads "This will print a representation the version of Helm." — added the missing "of" so it reads "a representation of the version of Helm."
