### PR TITLE
test: use assert.Empty for zero-length assertions in validate_test

### DIFF
--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -237,7 +237,7 @@ func TestVerifyOwnershipBeforeDelete(t *testing.T) {
 		ownedList, unownedList, _, err := verifyOwnershipBeforeDelete(resources, releaseName, releaseNamespace)
 		assert.NoError(t, err)
 		assert.Len(t, ownedList, 2)
-		assert.Len(t, unownedList, 0)
+		assert.Empty(t, unownedList)
 	})
 
 	// Test mix of owned and unowned resources
@@ -261,8 +261,8 @@ func TestVerifyOwnershipBeforeDelete(t *testing.T) {
 
 		ownedList, unownedList, _, err := verifyOwnershipBeforeDelete(resources, releaseName, releaseNamespace)
 		assert.NoError(t, err)
-		assert.Len(t, ownedList, 0)
-		assert.Len(t, unownedList, 0)
+		assert.Empty(t, ownedList)
+		assert.Empty(t, unownedList)
 	})
 
 	// Test resource with no ownership metadata
@@ -272,7 +272,7 @@ func TestVerifyOwnershipBeforeDelete(t *testing.T) {
 
 		ownedList, unownedList, _, err := verifyOwnershipBeforeDelete(resources, releaseName, releaseNamespace)
 		assert.NoError(t, err)
-		assert.Len(t, ownedList, 0)
+		assert.Empty(t, ownedList)
 		assert.Len(t, unownedList, 1)
 	})
 
@@ -283,7 +283,7 @@ func TestVerifyOwnershipBeforeDelete(t *testing.T) {
 
 		ownedList, unownedList, _, err := verifyOwnershipBeforeDelete(resources, releaseName, releaseNamespace)
 		assert.NoError(t, err)
-		assert.Len(t, ownedList, 0)
+		assert.Empty(t, ownedList)
 		assert.Len(t, unownedList, 1)
 	})
 


### PR DESCRIPTION
## What this PR does

Fixes the `golangci-lint` (testifylint) failures on `main` in `pkg/action/validate_test.go`.

testifylint flags `assert.Len(t, x, 0)` and wants `assert.Empty(t, x)` instead. There were 5 such assertions; the CI log only surfaced 3 of them because golangci-lint's default `max-same-issues: 3` caps identical messages, so fixing only the reported lines would have left two more to fail on the next run. This PR converts all 5.

## Why

The lint job on `main` (run `27759065054`) was failing:

```
pkg/action/validate_test.go:240:3: empty: use assert.Empty (testifylint)
pkg/action/validate_test.go:264:3: empty: use assert.Empty (testifylint)
pkg/action/validate_test.go:265:3: empty: use assert.Empty (testifylint)
```

## Testing

- `golangci-lint run --enable-only testifylint ./pkg/action/` → 0 issues
- `go test ./pkg/action/ -run TestVerifyOwnership` → ok