### PR TITLE
fix: install plugins into the first HELM_PLUGINS directory

### DIFF
--- a/internal/plugin/installer/base.go
+++ b/internal/plugin/installer/base.go
@@ -41,5 +41,11 @@ func (b *base) Path() string {
 	if b.Source == "" {
 		return ""
 	}
-	return filepath.Join(b.PluginsDirectory, filepath.Base(b.Source))
+
+	pluginsDirectory := b.PluginsDirectory
+	if pluginsDirectories := filepath.SplitList(b.PluginsDirectory); len(pluginsDirectories) > 0 {
+		pluginsDirectory = pluginsDirectories[0]
+	}
+
+	return filepath.Join(pluginsDirectory, filepath.Base(b.Source))
 }

--- a/internal/plugin/installer/base_test.go
+++ b/internal/plugin/installer/base_test.go
@@ -14,10 +14,16 @@ limitations under the License.
 package installer // import "helm.sh/helm/v4/internal/plugin/installer"
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 )
 
 func TestPath(t *testing.T) {
+	pluginsDir := filepath.Join(string(filepath.Separator), "helm", "data", "plugins")
+	systemPluginsDir := filepath.Join(string(filepath.Separator), "helm", "system", "plugins")
+	pluginSource := "https://github.com/jkroepke/helm-secrets"
+
 	tests := []struct {
 		source         string
 		helmPluginsDir string
@@ -25,16 +31,16 @@ func TestPath(t *testing.T) {
 	}{
 		{
 			source:         "",
-			helmPluginsDir: "/helm/data/plugins",
+			helmPluginsDir: pluginsDir,
 			expectPath:     "",
 		}, {
-			source:         "https://github.com/jkroepke/helm-secrets",
-			helmPluginsDir: "/helm/data/plugins",
-			expectPath:     "/helm/data/plugins/helm-secrets",
+			source:         pluginSource,
+			helmPluginsDir: pluginsDir,
+			expectPath:     filepath.Join(pluginsDir, filepath.Base(pluginSource)),
 		}, {
-			source:         "https://github.com/jkroepke/helm-secrets",
-			helmPluginsDir: "/helm/data/plugins:/helm/system/plugins",
-			expectPath:     "/helm/data/plugins/helm-secrets",
+			source:         pluginSource,
+			helmPluginsDir: fmt.Sprintf("%s%c%s", pluginsDir, filepath.ListSeparator, systemPluginsDir),
+			expectPath:     filepath.Join(pluginsDir, filepath.Base(pluginSource)),
 		},
 	}
 

--- a/internal/plugin/installer/base_test.go
+++ b/internal/plugin/installer/base_test.go
@@ -31,6 +31,10 @@ func TestPath(t *testing.T) {
 			source:         "https://github.com/jkroepke/helm-secrets",
 			helmPluginsDir: "/helm/data/plugins",
 			expectPath:     "/helm/data/plugins/helm-secrets",
+		}, {
+			source:         "https://github.com/jkroepke/helm-secrets",
+			helmPluginsDir: "/helm/data/plugins:/helm/system/plugins",
+			expectPath:     "/helm/data/plugins/helm-secrets",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- use the first path entry from `HELM_PLUGINS` when computing the install destination
- keep plugin installation aligned with plugin loading behavior
- add a regression test for multi-directory `HELM_PLUGINS`

## Why
Helm already loads plugins from a path list, but installation was treating the full `HELM_PLUGINS` value as a single directory. This caused new plugins to be installed into a literal colon-separated path instead of the first configured plugins directory.

Closes #11310.

## Testing
- `PATH=/tmp/go/bin:$PATH /tmp/go/bin/go test ./internal/plugin/installer -run TestPath -count=1`
