### PR TITLE
fix: clarify coalesce map warnings

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -347,7 +347,7 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite map with non-map for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite map onto non-map for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
 			printf("warning: destination for %s is a map. Ignoring non-map value (%v)", fullkey, val)

--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -143,14 +143,14 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 	if destglob, ok := dest[common.GlobalKey]; !ok {
 		dg = make(map[string]any)
 	} else if dg, ok = destglob.(map[string]any); !ok {
-		printf("warning: skipping globals because destination %s is not a table.", common.GlobalKey)
+		printf("warning: skipping globals because destination %s is not a map.", common.GlobalKey)
 		return
 	}
 
 	if srcglob, ok := src[common.GlobalKey]; !ok {
 		sg = make(map[string]any)
 	} else if sg, ok = srcglob.(map[string]any); !ok {
-		printf("warning: skipping globals because source %s is not a table.", common.GlobalKey)
+		printf("warning: skipping globals because source %s is not a map.", common.GlobalKey)
 		return
 	}
 
@@ -180,7 +180,7 @@ func coalesceGlobals(printf printFn, dest, src map[string]any, prefix string, _ 
 			}
 		} else if dv, ok := dg[key]; ok && istable(dv) {
 			// It's not clear if this condition can actually ever trigger.
-			printf("key %s is table. Skipping", key)
+			printf("key %s is a map. Skipping", key)
 		} else {
 			// TODO: Do we need to do any additional checking on the value?
 			dg[key] = val
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: Not a map.", subPrefix, key)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true
@@ -347,10 +347,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite map with non-map for %s (%v)", fullkey, val)
 			}
 		} else if istable(dv) && val != nil {
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a map. Ignoring non-map value (%v)", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -720,9 +720,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	}
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a map.")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a map. Ignoring non-map value (true)")
+	assert.Contains(t, warnings, "warning: cannot overwrite map with non-map for level1.level2.level3.spear.sail (map[cotton:true])")
 }
 
 func TestConcatPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace user-facing coalesce warnings that say table with clearer map wording
- update the warning assertions in the coalesce tests

## Testing
- `go test ./pkg/chart/common/util -run TestCoalesceValuesWarnings -count=1`

Fixes #11118