### PR TITLE
refactor(cmd/helm): convert tests to testify assert/require

### DIFF
--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -18,13 +18,13 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"os/exec"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCliPluginExitCode(t *testing.T) {
@@ -62,20 +62,13 @@ func TestCliPluginExitCode(t *testing.T) {
 		err := cmd.Run()
 
 		exiterr := &exec.ExitError{}
-		ok := errors.As(err, &exiterr)
-		if !ok {
-			t.Fatalf("Unexpected error type returned by os.Exit: %T", err)
-		}
+		require.ErrorAs(t, err, &exiterr)
 
 		assert.Empty(t, stdout.String())
 
 		expectedStderr := "level=WARN msg=\"failed to load plugin (ignoring)\" plugin_yaml=../../pkg/cmd/testdata/helmhome/helm/plugins/noversion/plugin.yaml error=\"failed to load plugin \\\"../../pkg/cmd/testdata/helmhome/helm/plugins/noversion\\\": plugin `version` is required\"\nError: plugin \"exitwith\" exited with error\n"
-		if stderr.String() != expectedStderr {
-			t.Errorf("Expected %q written to stderr: Got %q", expectedStderr, stderr.String())
-		}
+		assert.Equal(t, expectedStderr, stderr.String())
 
-		if exiterr.ExitCode() != 43 {
-			t.Errorf("Expected exit code 43: Got %d", exiterr.ExitCode())
-		}
+		assert.Equal(t, 43, exiterr.ExitCode())
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Replace native Go testing patterns (`t.Errorf`, `t.Fatalf`, `t.Error`, `t.Fatal`) with `github.com/stretchr/testify` equivalents (`assert.X`, `require.X`) for improved test readability and error messages.

This PR converts the `cmd/helm` test files 

**Special notes for your reviewer**:
Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
