### PR TITLE
refactor(repotest): convert tests to testify assert/require

### DIFF
--- a/pkg/repo/v1/repotest/server.go
+++ b/pkg/repo/v1/repotest/server.go
@@ -30,6 +30,8 @@ import (
 	"github.com/distribution/distribution/v3/registry"
 	_ "github.com/distribution/distribution/v3/registry/auth/htpasswd"           // used for docker test registry
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory" // used for docker test registry
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"sigs.k8s.io/yaml"
 
@@ -44,9 +46,8 @@ func BasicAuthMiddleware(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	return http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
-		if !ok || username != "username" || password != "password" {
-			t.Errorf("Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
-		}
+		assert.True(t, ok && username == "username" && password == "password",
+			"Expected request to use basic auth and for username == 'username' and password == 'password', got '%v', '%s', '%s'", ok, username, password)
 	})
 }
 
@@ -97,9 +98,8 @@ func NewTempServer(t *testing.T, options ...ServerOption) *Server {
 	t.Cleanup(func() { os.RemoveAll(srv.docroot) })
 
 	if srv.chartSourceGlob != "" {
-		if _, err := srv.CopyCharts(srv.chartSourceGlob); err != nil {
-			t.Fatal(err)
-		}
+		_, err := srv.CopyCharts(srv.chartSourceGlob)
+		require.NoError(t, err)
 	}
 
 	return srv
@@ -109,9 +109,7 @@ func NewTempServer(t *testing.T, options ...ServerOption) *Server {
 func newServer(t *testing.T, docroot string, options ...ServerOption) *Server {
 	t.Helper()
 	absdocroot, err := filepath.Abs(docroot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	s := &Server{
 		docroot: absdocroot,
@@ -131,9 +129,7 @@ func newServer(t *testing.T, docroot string, options ...ServerOption) *Server {
 	s.start()
 
 	// Add the testing repository as the only repo. Server must be started for the server's URL to be valid
-	if err := setTestingRepository(s.URL(), filepath.Join(s.docroot, "repositories.yaml")); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, setTestingRepository(s.URL(), filepath.Join(s.docroot, "repositories.yaml")))
 
 	return s
 }
@@ -169,22 +165,16 @@ func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
 	testUsername, testPassword := "username", "password"
 
 	pwBytes, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
-	if err != nil {
-		t.Fatal("error generating bcrypt password for test htpasswd file")
-	}
+	require.NoError(t, err, "error generating bcrypt password for test htpasswd file")
 	htpasswdPath := filepath.Join(dir, testHtpasswdFileBasename)
 	err = os.WriteFile(htpasswdPath, fmt.Appendf(nil, "%s:%s\n", testUsername, string(pwBytes)), 0o644)
-	if err != nil {
-		t.Fatal("error creating test htpasswd file")
-	}
+	require.NoError(t, err, "error creating test htpasswd file")
 
 	// Registry config
 	config := &configuration.Configuration{}
 	lnCfg := net.ListenConfig{}
 	ln, err := lnCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("error finding free port for test registry: %v", err)
-	}
+	require.NoError(t, err, "error finding free port for test registry")
 	defer ln.Close()
 
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -201,9 +191,7 @@ func NewOCIServer(t *testing.T, dir string) (*OCIServer, error) {
 	registryURL := fmt.Sprintf("localhost:%d", port)
 
 	r, err := registry.NewRegistry(t.Context(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return &OCIServer{
 		Registry:     r,
@@ -237,53 +225,37 @@ func (srv *OCIServer) RunWithReturn(t *testing.T, opts ...OCIServerOpt) *OCIServ
 		ociRegistry.ClientOptWriter(os.Stdout),
 		ociRegistry.ClientOptCredentialsFile(credentialsFile),
 	)
-	if err != nil {
-		t.Fatalf("error creating registry client: %v", err)
-	}
+	require.NoError(t, err, "error creating registry client")
 
 	err = registryClient.Login(
 		srv.RegistryURL,
 		ociRegistry.LoginOptBasicAuth(srv.TestUsername, srv.TestPassword),
 		ociRegistry.LoginOptInsecure(true),
 		ociRegistry.LoginOptPlainText(true))
-	if err != nil {
-		t.Fatalf("error logging into registry with good credentials: %v", err)
-	}
+	require.NoError(t, err, "error logging into registry with good credentials")
 
 	ref := srv.RegistryURL + "/u/ocitestuser/oci-dependent-chart:0.1.0"
 
 	err = chartutil.ExpandFile(srv.Dir, filepath.Join(srv.Dir, "oci-dependent-chart-0.1.0.tgz"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// valid chart
 	ch, err := loader.LoadDir(filepath.Join(srv.Dir, "oci-dependent-chart"))
-	if err != nil {
-		t.Fatal("error loading chart")
-	}
+	require.NoError(t, err, "error loading chart")
 
 	err = os.RemoveAll(filepath.Join(srv.Dir, "oci-dependent-chart"))
-	if err != nil {
-		t.Fatal("error removing chart before push")
-	}
+	require.NoError(t, err, "error removing chart before push")
 
 	// save it back to disk..
 	absPath, err := chartutil.Save(ch, srv.Dir)
-	if err != nil {
-		t.Fatal("could not create chart archive")
-	}
+	require.NoError(t, err, "could not create chart archive")
 
 	// load it into memory...
 	contentBytes, err := os.ReadFile(absPath)
-	if err != nil {
-		t.Fatal("could not load chart into memory")
-	}
+	require.NoError(t, err, "could not load chart into memory")
 
 	result, err := registryClient.Push(contentBytes, ref)
-	if err != nil {
-		t.Fatalf("error pushing dependent chart: %s", err)
-	}
+	require.NoError(t, err, "error pushing dependent chart")
 	t.Logf("Manifest.Digest: %s, Manifest.Size: %d, "+
 		"Config.Digest: %s, Config.Size: %d, "+
 		"Chart.Digest: %s, Chart.Size: %d",
@@ -306,14 +278,10 @@ func (srv *OCIServer) RunWithReturn(t *testing.T, opts ...OCIServerOpt) *OCIServ
 	absPath = filepath.Join(srv.Dir,
 		fmt.Sprintf("%s-%s.tgz", c.Metadata.Name, c.Metadata.Version))
 	contentBytes, err = os.ReadFile(absPath)
-	if err != nil {
-		t.Fatal("could not load chart into memory")
-	}
+	require.NoError(t, err, "could not load chart into memory")
 
 	result, err = registryClient.Push(contentBytes, dependingRef)
-	if err != nil {
-		t.Fatalf("error pushing depending chart: %s", err)
-	}
+	require.NoError(t, err, "error pushing depending chart")
 	t.Logf("Manifest.Digest: %s, Manifest.Size: %d, "+
 		"Config.Digest: %s, Config.Size: %d, "+
 		"Chart.Digest: %s, Chart.Size: %d",

--- a/pkg/repo/v1/repotest/server_test.go
+++ b/pkg/repo/v1/repotest/server_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
@@ -40,18 +41,11 @@ func TestServer(t *testing.T) {
 	defer srv.Stop()
 
 	c, err := srv.CopyCharts("testdata/*.tgz")
-	if err != nil {
-		// Some versions of Go don't correctly fire defer on Fatal.
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if len(c) != 1 {
-		t.Errorf("Unexpected chart count: %d", len(c))
-	}
+	assert.Len(t, c, 1)
 
-	if filepath.Base(c[0]) != "examplechart-0.1.0.tgz" {
-		t.Errorf("Unexpected chart: %s", c[0])
-	}
+	assert.Equal(t, "examplechart-0.1.0.tgz", filepath.Base(c[0]))
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/examplechart-0.1.0.tgz", http.NoBody)
 	require.NoError(t, err)
@@ -60,9 +54,7 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 	res.Body.Close()
 
-	if res.ContentLength < 500 {
-		t.Errorf("Expected at least 500 bytes of data, got %d", res.ContentLength)
-	}
+	assert.GreaterOrEqual(t, res.ContentLength, int64(500))
 
 	req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/index.yaml", http.NoBody)
 	require.NoError(t, err)
@@ -73,27 +65,19 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 
 	m := repo.NewIndexFile()
-	if err := yaml.Unmarshal(data, m); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, yaml.Unmarshal(data, m))
 
-	if l := len(m.Entries); l != 1 {
-		t.Fatalf("Expected 1 entry, got %d", l)
-	}
+	require.Len(t, m.Entries, 1)
 
 	expect := "examplechart"
-	if !m.Has(expect, "0.1.0") {
-		t.Errorf("missing %q", expect)
-	}
+	assert.True(t, m.Has(expect, "0.1.0"), "missing %q", expect)
 
 	req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/index.yaml-nosuchthing", http.NoBody)
 	require.NoError(t, err)
 	res, err = client.Do(req)
 	require.NoError(t, err)
 	res.Body.Close()
-	if res.StatusCode != http.StatusNotFound {
-		t.Fatalf("Expected 404, got %d", res.StatusCode)
-	}
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
 func TestNewTempServer(t *testing.T) {
@@ -125,9 +109,7 @@ func TestNewTempServer(t *testing.T) {
 			)
 			defer srv.Stop()
 
-			if srv.srv.URL == "" {
-				t.Fatal("unstarted server")
-			}
+			require.NotEmpty(t, srv.srv.URL, "unstarted server")
 
 			client := srv.Client()
 
@@ -137,9 +119,7 @@ func TestNewTempServer(t *testing.T) {
 				res, err := client.Do(req)
 				require.NoError(t, err)
 				res.Body.Close()
-				if res.StatusCode != http.StatusOK {
-					t.Errorf("Expected 200, got %d", res.StatusCode)
-				}
+				assert.Equal(t, http.StatusOK, res.StatusCode)
 			}
 			{
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodHead, srv.URL()+"/examplechart-0.1.0.tgz", http.NoBody)
@@ -147,18 +127,14 @@ func TestNewTempServer(t *testing.T) {
 				res, err := client.Do(req)
 				require.NoError(t, err)
 				res.Body.Close()
-				if res.StatusCode != http.StatusOK {
-					t.Errorf("Expected 200, got %d", res.StatusCode)
-				}
+				assert.Equal(t, http.StatusOK, res.StatusCode)
 			}
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/examplechart-0.1.0.tgz", http.NoBody)
 			require.NoError(t, err)
 			res, err := client.Do(req)
 			require.NoError(t, err)
 			res.Body.Close()
-			if res.ContentLength < 500 {
-				t.Errorf("Expected at least 500 bytes of data, got %d", res.ContentLength)
-			}
+			assert.GreaterOrEqual(t, res.ContentLength, int64(500))
 			req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/index.yaml", http.NoBody)
 			require.NoError(t, err)
 			res, err = client.Do(req)
@@ -167,24 +143,16 @@ func TestNewTempServer(t *testing.T) {
 			res.Body.Close()
 			require.NoError(t, err)
 			m := repo.NewIndexFile()
-			if err := yaml.Unmarshal(data, m); err != nil {
-				t.Fatal(err)
-			}
-			if l := len(m.Entries); l != 1 {
-				t.Fatalf("Expected 1 entry, got %d", l)
-			}
+			require.NoError(t, yaml.Unmarshal(data, m))
+			require.Len(t, m.Entries, 1)
 			expect := "examplechart"
-			if !m.Has(expect, "0.1.0") {
-				t.Errorf("missing %q", expect)
-			}
+			assert.True(t, m.Has(expect, "0.1.0"), "missing %q", expect)
 			req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL()+"/index.yaml-nosuchthing", http.NoBody)
 			require.NoError(t, err)
 			res, err = client.Do(req)
 			require.NoError(t, err)
 			res.Body.Close()
-			if res.StatusCode != http.StatusNotFound {
-				t.Fatalf("Expected 404, got %d", res.StatusCode)
-			}
+			require.Equal(t, http.StatusNotFound, res.StatusCode)
 		})
 	}
 }
@@ -199,7 +167,5 @@ func TestNewTempServer_TLS(t *testing.T) {
 	)
 	defer srv.Stop()
 
-	if !strings.HasPrefix(srv.URL(), "https://") {
-		t.Fatal("non-TLS server")
-	}
+	require.True(t, strings.HasPrefix(srv.URL(), "https://"), "non-TLS server")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Replace native Go testing patterns (`t.Errorf`, `t.Fatalf`, `t.Error`, `t.Fatal`) with `github.com/stretchr/testify` equivalents (`assert.X`, `require.X`) for improved test readability and error messages.

This PR converts the `pkg/repo/v1/repotest` test files 

**Special notes for your reviewer**:
Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
