### PR TITLE
refactor(internal): convert tests to testify assert/require

### DIFF
--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -22,6 +22,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestAtomicWriteFile tests the happy path of AtomicWriteFile function.
@@ -35,28 +38,17 @@ func TestAtomicWriteFile(t *testing.T) {
 	mode := os.FileMode(0644)
 
 	err := AtomicWriteFile(testpath, reader, mode)
-	if err != nil {
-		t.Errorf("AtomicWriteFile error: %s", err)
-	}
+	assert.NoError(t, err)
 
 	got, err := os.ReadFile(testpath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if stringContent != string(got) {
-		t.Fatalf("expected: %s, got: %s", stringContent, string(got))
-	}
+	require.Equal(t, stringContent, string(got))
 
 	gotinfo, err := os.Stat(testpath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if mode != gotinfo.Mode() {
-		t.Fatalf("expected %s: to be the same mode as %s",
-			mode, gotinfo.Mode())
-	}
+	require.Equal(t, mode, gotinfo.Mode())
 }
 
 // TestAtomicWriteFile_CreateTempError tests the error path when os.CreateTemp fails
@@ -67,9 +59,7 @@ func TestAtomicWriteFile_CreateTempError(t *testing.T) {
 	mode := os.FileMode(0644)
 
 	err := AtomicWriteFile(invalidPath, reader, mode)
-	if err == nil {
-		t.Error("Expected error when CreateTemp fails, but got nil")
-	}
+	assert.Error(t, err, "Expected error when CreateTemp fails")
 }
 
 // TestAtomicWriteFile_EmptyContent tests with empty content
@@ -81,18 +71,12 @@ func TestAtomicWriteFile_EmptyContent(t *testing.T) {
 	mode := os.FileMode(0644)
 
 	err := AtomicWriteFile(testpath, reader, mode)
-	if err != nil {
-		t.Errorf("AtomicWriteFile error with empty content: %s", err)
-	}
+	assert.NoError(t, err, "AtomicWriteFile error with empty content")
 
 	got, err := os.ReadFile(testpath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if len(got) != 0 {
-		t.Fatalf("expected empty content, got: %s", string(got))
-	}
+	require.Empty(t, got)
 }
 
 // TestAtomicWriteFile_LargeContent tests with large content
@@ -106,18 +90,12 @@ func TestAtomicWriteFile_LargeContent(t *testing.T) {
 	mode := os.FileMode(0644)
 
 	err := AtomicWriteFile(testpath, reader, mode)
-	if err != nil {
-		t.Errorf("AtomicWriteFile error with large content: %s", err)
-	}
+	assert.NoError(t, err, "AtomicWriteFile error with large content")
 
 	got, err := os.ReadFile(testpath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if largeContent != string(got) {
-		t.Fatalf("expected large content to match, got different length: %d vs %d", len(largeContent), len(got))
-	}
+	require.Equal(t, largeContent, string(got))
 }
 
 // TestPlatformAtomicWriteFile_OverwritesExisting verifies that the platform
@@ -127,21 +105,13 @@ func TestPlatformAtomicWriteFile_OverwritesExisting(t *testing.T) {
 	path := filepath.Join(dir, "overwrite_test")
 
 	first := bytes.NewReader([]byte("first"))
-	if err := PlatformAtomicWriteFile(path, first, 0644); err != nil {
-		t.Fatalf("first write failed: %v", err)
-	}
+	require.NoError(t, PlatformAtomicWriteFile(path, first, 0644), "first write failed")
 
 	second := bytes.NewReader([]byte("second"))
-	if err := PlatformAtomicWriteFile(path, second, 0644); err != nil {
-		t.Fatalf("second write failed: %v", err)
-	}
+	require.NoError(t, PlatformAtomicWriteFile(path, second, 0644), "second write failed")
 
 	contents, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed reading result: %v", err)
-	}
+	require.NoError(t, err, "failed reading result")
 
-	if string(contents) != "second" {
-		t.Fatalf("expected file to be overwritten, got %q", string(contents))
-	}
+	require.Equal(t, "second", string(contents))
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -19,6 +19,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/registry"
 )
@@ -149,34 +152,24 @@ func TestResolve(t *testing.T) {
 				if tt.err {
 					return
 				}
-				t.Fatal(err)
+				require.NoError(t, err)
 			}
 
 			if tt.err {
-				t.Fatalf("Expected error in test %q", tt.name)
+				require.Failf(t, "Expected error in test %q", tt.name)
 			}
 
-			if h, err := HashReq(tt.req, tt.expect.Dependencies); err != nil {
-				t.Fatal(err)
-			} else if h != l.Digest {
-				t.Errorf("%q: hashes don't match.", tt.name)
-			}
+			h, err := HashReq(tt.req, tt.expect.Dependencies)
+			require.NoError(t, err)
+			assert.Equal(t, l.Digest, h, "%q: hashes don't match.", tt.name)
 
 			// Check fields.
-			if len(l.Dependencies) != len(tt.req) {
-				t.Errorf("%s: wrong number of dependencies in lock", tt.name)
-			}
+			assert.Len(t, l.Dependencies, len(tt.req), "%s: wrong number of dependencies in lock", tt.name)
 			d0 := l.Dependencies[0]
 			e0 := tt.expect.Dependencies[0]
-			if d0.Name != e0.Name {
-				t.Errorf("%s: expected name %s, got %s", tt.name, e0.Name, d0.Name)
-			}
-			if d0.Repository != e0.Repository {
-				t.Errorf("%s: expected repo %s, got %s", tt.name, e0.Repository, d0.Repository)
-			}
-			if d0.Version != e0.Version {
-				t.Errorf("%s: expected version %s, got %s", tt.name, e0.Version, d0.Version)
-			}
+			assert.Equal(t, e0.Name, d0.Name, tt.name)
+			assert.Equal(t, e0.Repository, d0.Repository, tt.name)
+			assert.Equal(t, e0.Version, d0.Version, tt.name)
 		})
 	}
 }
@@ -231,13 +224,11 @@ func TestHashReq(t *testing.T) {
 				{Name: "alpine", Version: tt.lockVersion, Repository: "http://localhost:8879/charts"},
 			}
 			h, err := HashReq(req, lock)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !tt.wantError && expect != h {
-				t.Errorf("Expected %q, got %q", expect, h)
-			} else if tt.wantError && expect == h {
-				t.Errorf("Expected not %q, but same", expect)
+			require.NoError(t, err)
+			if !tt.wantError {
+				assert.Equal(t, expect, h)
+			} else {
+				assert.NotEqual(t, expect, h, "Expected not %q, but same", expect)
 			}
 		})
 	}
@@ -293,18 +284,16 @@ func TestGetLocalPath(t *testing.T) {
 				if tt.err {
 					return
 				}
-				t.Fatal(err)
+				require.NoError(t, err)
 			}
 			if tt.err {
-				t.Fatalf("Expected error in test %q", tt.name)
+				require.Failf(t, "Expected error in test %q", tt.name)
 			}
 			expect := tt.expect
 			if runtime.GOOS == "windows" {
 				expect = tt.winExpect
 			}
-			if p != expect {
-				t.Errorf("%q: expected %q, got %q", tt.name, expect, p)
-			}
+			assert.Equal(t, expect, p, tt.name)
 		})
 	}
 }

--- a/internal/tlsutil/tls_test.go
+++ b/internal/tlsutil/tls_test.go
@@ -19,6 +19,9 @@ package tlsutil
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const tlsTestDir = "../../testdata"
@@ -32,9 +35,7 @@ const (
 func testfile(t *testing.T, file string) (path string) {
 	t.Helper()
 	path, err := filepath.Abs(filepath.Join(tlsTestDir, file))
-	if err != nil {
-		t.Fatalf("error getting absolute path to test file %q: %v", file, err)
-	}
+	require.NoError(t, err, "error getting absolute path to test file %q", file)
 	return path
 }
 
@@ -50,38 +51,22 @@ func TestNewTLSConfig(t *testing.T) {
 			WithCertKeyPairFiles(certFile, keyFile),
 			WithCAFile(caCertFile),
 		)
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, err)
 
-		if got := len(cfg.Certificates); got != 1 {
-			t.Fatalf("expecting 1 client certificates, got %d", got)
-		}
-		if cfg.InsecureSkipVerify {
-			t.Fatal("insecure skip verify mismatch, expecting false")
-		}
-		if cfg.RootCAs == nil {
-			t.Fatal("mismatch tls RootCAs, expecting non-nil")
-		}
+		require.Len(t, cfg.Certificates, 1)
+		require.False(t, cfg.InsecureSkipVerify, "insecure skip verify mismatch, expecting false")
+		require.NotNil(t, cfg.RootCAs, "mismatch tls RootCAs, expecting non-nil")
 	}
 	{
 		cfg, err := NewTLSConfig(
 			WithInsecureSkipVerify(insecureSkipTLSVerify),
 			WithCAFile(caCertFile),
 		)
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, err)
 
-		if got := len(cfg.Certificates); got != 0 {
-			t.Fatalf("expecting 0 client certificates, got %d", got)
-		}
-		if cfg.InsecureSkipVerify {
-			t.Fatal("insecure skip verify mismatch, expecting false")
-		}
-		if cfg.RootCAs == nil {
-			t.Fatal("mismatch tls RootCAs, expecting non-nil")
-		}
+		require.Empty(t, cfg.Certificates)
+		require.False(t, cfg.InsecureSkipVerify, "insecure skip verify mismatch, expecting false")
+		require.NotNil(t, cfg.RootCAs, "mismatch tls RootCAs, expecting non-nil")
 	}
 
 	{
@@ -89,18 +74,10 @@ func TestNewTLSConfig(t *testing.T) {
 			WithInsecureSkipVerify(insecureSkipTLSVerify),
 			WithCertKeyPairFiles(certFile, keyFile),
 		)
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, err)
 
-		if got := len(cfg.Certificates); got != 1 {
-			t.Fatalf("expecting 1 client certificates, got %d", got)
-		}
-		if cfg.InsecureSkipVerify {
-			t.Fatal("insecure skip verify mismatch, expecting false")
-		}
-		if cfg.RootCAs != nil {
-			t.Fatal("mismatch tls RootCAs, expecting nil")
-		}
+		require.Len(t, cfg.Certificates, 1)
+		require.False(t, cfg.InsecureSkipVerify, "insecure skip verify mismatch, expecting false")
+		require.Nil(t, cfg.RootCAs, "mismatch tls RootCAs, expecting nil")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Replace native Go testing patterns (`t.Errorf`, `t.Fatalf`, `t.Error`, `t.Fatal`) with `github.com/stretchr/testify` equivalents (`assert.X`, `require.X`) for improved test readability and error messages.

This PR converts the `internal/fileutil`, `internal/tlsutil` and `internal/resolver` packages test files 

**Special notes for your reviewer**:
Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
