### PR TITLE
refactor(pkg/cli): convert tests to testify assert/require

### DIFF
--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"helm.sh/helm/v4/internal/version"
 )
@@ -30,14 +32,10 @@ import (
 func TestSetNamespace(t *testing.T) {
 	settings := New()
 
-	if settings.namespace != "" {
-		t.Errorf("Expected empty namespace, got %s", settings.namespace)
-	}
+	assert.Empty(t, settings.namespace)
 
 	settings.SetNamespace("testns")
-	if settings.namespace != "testns" {
-		t.Errorf("Expected namespace testns, got %s", settings.namespace)
-	}
+	assert.Equal(t, "testns", settings.namespace)
 }
 
 func TestEnvSettings(t *testing.T) {
@@ -134,36 +132,16 @@ func TestEnvSettings(t *testing.T) {
 			settings.AddFlags(flags)
 			flags.Parse(strings.Split(tt.args, " "))
 
-			if settings.Debug != tt.debug {
-				t.Errorf("expected debug %t, got %t", tt.debug, settings.Debug)
-			}
-			if settings.Namespace() != tt.ns {
-				t.Errorf("expected namespace %q, got %q", tt.ns, settings.Namespace())
-			}
-			if settings.KubeContext != tt.kcontext {
-				t.Errorf("expected kube-context %q, got %q", tt.kcontext, settings.KubeContext)
-			}
-			if settings.MaxHistory != tt.maxhistory {
-				t.Errorf("expected maxHistory %d, got %d", tt.maxhistory, settings.MaxHistory)
-			}
-			if tt.kubeAsUser != settings.KubeAsUser {
-				t.Errorf("expected kAsUser %q, got %q", tt.kubeAsUser, settings.KubeAsUser)
-			}
-			if !reflect.DeepEqual(tt.kubeAsGroups, settings.KubeAsGroups) {
-				t.Errorf("expected kAsGroups %+v, got %+v", len(tt.kubeAsGroups), len(settings.KubeAsGroups))
-			}
-			if tt.kubeCaFile != settings.KubeCaFile {
-				t.Errorf("expected kCaFile %q, got %q", tt.kubeCaFile, settings.KubeCaFile)
-			}
-			if tt.burstLimit != settings.BurstLimit {
-				t.Errorf("expected BurstLimit %d, got %d", tt.burstLimit, settings.BurstLimit)
-			}
-			if tt.kubeInsecure != settings.KubeInsecureSkipTLSVerify {
-				t.Errorf("expected kubeInsecure %t, got %t", tt.kubeInsecure, settings.KubeInsecureSkipTLSVerify)
-			}
-			if tt.kubeTLSServer != settings.KubeTLSServerName {
-				t.Errorf("expected kubeTLSServer %q, got %q", tt.kubeTLSServer, settings.KubeTLSServerName)
-			}
+			assert.Equal(t, tt.debug, settings.Debug, "debug")
+			assert.Equal(t, tt.ns, settings.Namespace(), "namespace")
+			assert.Equal(t, tt.kcontext, settings.KubeContext, "kube-context")
+			assert.Equal(t, tt.maxhistory, settings.MaxHistory, "maxHistory")
+			assert.Equal(t, tt.kubeAsUser, settings.KubeAsUser, "kubeAsUser")
+			assert.True(t, reflect.DeepEqual(tt.kubeAsGroups, settings.KubeAsGroups), "kubeAsGroups")
+			assert.Equal(t, tt.kubeCaFile, settings.KubeCaFile, "kubeCaFile")
+			assert.Equal(t, tt.burstLimit, settings.BurstLimit, "burstLimit")
+			assert.Equal(t, tt.kubeInsecure, settings.KubeInsecureSkipTLSVerify, "kubeInsecure")
+			assert.Equal(t, tt.kubeTLSServer, settings.KubeTLSServerName, "kubeTLSServer")
 		})
 	}
 }
@@ -235,9 +213,7 @@ func TestEnvOrBool(t *testing.T) {
 				t.Setenv(tt.env, tt.val)
 			}
 			actual := envBoolOr(tt.env, tt.def)
-			if actual != tt.expected {
-				t.Errorf("expected result %t, got %t", tt.expected, actual)
-			}
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -247,14 +223,10 @@ func TestUserAgentHeaderInK8sRESTClientConfig(t *testing.T) {
 
 	settings := New()
 	restConfig, err := settings.RESTClientGetter().ToRESTConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expectedUserAgent := version.GetUserAgent()
-	if restConfig.UserAgent != expectedUserAgent {
-		t.Errorf("expected User-Agent header %q in K8s REST client config, got %q", expectedUserAgent, restConfig.UserAgent)
-	}
+	assert.Equal(t, expectedUserAgent, restConfig.UserAgent)
 }
 
 func resetEnv() func() {

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -137,7 +136,7 @@ func TestEnvSettings(t *testing.T) {
 			assert.Equal(t, tt.kcontext, settings.KubeContext, "kube-context")
 			assert.Equal(t, tt.maxhistory, settings.MaxHistory, "maxHistory")
 			assert.Equal(t, tt.kubeAsUser, settings.KubeAsUser, "kubeAsUser")
-			assert.True(t, reflect.DeepEqual(tt.kubeAsGroups, settings.KubeAsGroups), "kubeAsGroups")
+			assert.Equal(t, tt.kubeAsGroups, settings.KubeAsGroups, "kubeAsGroups")
 			assert.Equal(t, tt.kubeCaFile, settings.KubeCaFile, "kubeCaFile")
 			assert.Equal(t, tt.burstLimit, settings.BurstLimit, "burstLimit")
 			assert.Equal(t, tt.kubeInsecure, settings.KubeInsecureSkipTLSVerify, "kubeInsecure")

--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,7 +213,7 @@ func TestReadFile(t *testing.T) {
 
 				// Test the function
 				got, err := readFile(actualFilePath, tt.providers)
-				assert.NoError(t, err, "readFile() expected no error for stdin")
+				require.NoError(t, err, "readFile() expected no error for stdin")
 				assert.Equal(t, testData, got)
 				return
 			}
@@ -360,8 +359,8 @@ func TestMergeValuesCLI(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
-			assert.True(t, reflect.DeepEqual(got, tt.expected), "MergeValues() = %v, want %v", got, tt.expected)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/pkg/cli/values/options_test.go
+++ b/pkg/cli/values/options_test.go
@@ -22,8 +22,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"helm.sh/helm/v4/pkg/getter"
 )
@@ -90,10 +92,7 @@ func TestReadFile(t *testing.T) {
 				tmpDir := t.TempDir()
 				filePath := filepath.Join(tmpDir, "test.txt")
 				content := []byte("local file content")
-				err := os.WriteFile(filePath, content, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, os.WriteFile(filePath, content, 0644))
 				return filePath, func() {} // cleanup handled by t.TempDir()
 			},
 			expectError:  false,
@@ -154,10 +153,7 @@ func TestReadFile(t *testing.T) {
 				fileName := "ftp_file.txt" // Valid filename for filesystem
 				filePath := filepath.Join(tmpDir, fileName)
 				content := []byte("local fallback content")
-				err := os.WriteFile(filePath, content, 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, os.WriteFile(filePath, content, 0644))
 				return filePath, func() {}
 			},
 			expectError:  false,
@@ -202,9 +198,7 @@ func TestReadFile(t *testing.T) {
 
 				// Create a pipe for stdin
 				r, w, err := os.Pipe()
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				defer r.Close()
 				defer w.Close()
 
@@ -220,28 +214,21 @@ func TestReadFile(t *testing.T) {
 
 				// Test the function
 				got, err := readFile(actualFilePath, tt.providers)
-				if err != nil {
-					t.Errorf("readFile() error = %v, expected no error for stdin", err)
-					return
-				}
-
-				if !bytes.Equal(got, testData) {
-					t.Errorf("readFile() = %v, want %v", got, testData)
-				}
+				assert.NoError(t, err, "readFile() expected no error for stdin")
+				assert.Equal(t, testData, got)
 				return
 			}
 
 			// Regular test cases
 			got, err := readFile(actualFilePath, tt.providers)
-			if (err != nil) != tt.expectError {
-				t.Errorf("readFile() error = %v, expectError %v", err, tt.expectError)
+			if tt.expectError {
+				assert.Error(t, err)
 				return
 			}
+			assert.NoError(t, err)
 
-			if !tt.expectError && tt.expectedData != nil {
-				if !bytes.Equal(got, tt.expectedData) {
-					t.Errorf("readFile() = %v, want %v", got, tt.expectedData)
-				}
+			if tt.expectedData != nil {
+				assert.Equal(t, tt.expectedData, got)
 			}
 		})
 	}
@@ -272,13 +259,8 @@ func TestReadFileErrorMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := readFile(tt.filePath, tt.providers)
-			if err == nil {
-				t.Errorf("readFile() expected error containing %q, got nil", tt.wantErr)
-				return
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("readFile() error = %v, want error containing %q", err, tt.wantErr)
-			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
 }
@@ -288,9 +270,7 @@ func TestReadFileOriginal(t *testing.T) {
 	var p getter.Providers
 	filePath := "%a.txt"
 	_, err := readFile(filePath, p)
-	if err == nil {
-		t.Error("Expected error when has special strings")
-	}
+	assert.Error(t, err, "Expected error when has special strings")
 }
 
 func TestMergeValuesCLI(t *testing.T) {
@@ -376,13 +356,12 @@ func TestMergeValuesCLI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.opts.MergeValues(getter.Providers{})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MergeValues() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("MergeValues() = %v, want %v", got, tt.expected)
-			}
+			assert.NoError(t, err)
+			assert.True(t, reflect.DeepEqual(got, tt.expected), "MergeValues() = %v, want %v", got, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Replace native Go testing patterns (`t.Errorf`, `t.Fatalf`, `t.Error`, `t.Fatal`) with `github.com/stretchr/testify` equivalents (`assert.X`, `require.X`) for improved test readability and error messages.

This PR converts the `pkg/cli` package test files 

**Special notes for your reviewer**:
Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
