### PR TITLE
refactor(internal): convert tests to testify assert/require

### DIFF
--- a/internal/cli/output/color_test.go
+++ b/internal/cli/output/color_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"helm.sh/helm/v4/pkg/release/common"
 )
 
@@ -93,14 +95,12 @@ func TestColorizeStatus(t *testing.T) {
 
 			// In test environment, term.IsTerminal will be false, so we won't get color
 			// unless we're testing the logic without terminal detection
-			if hasColor && !tt.wantColor {
-				t.Errorf("ColorizeStatus() returned color when none expected: %q", result)
+			if hasColor {
+				assert.True(t, tt.wantColor, "ColorizeStatus() returned color when none expected: %q", result)
 			}
 
 			// Always check the status text is present
-			if !strings.Contains(result, tt.status.String()) {
-				t.Errorf("ColorizeStatus() = %q, want to contain %q", result, tt.status.String())
-			}
+			assert.Contains(t, result, tt.status.String())
 		})
 	}
 }
@@ -139,9 +139,7 @@ func TestColorizeHeader(t *testing.T) {
 			result := ColorizeHeader(tt.header, tt.noColor)
 
 			// Always check the header text is present
-			if !strings.Contains(result, tt.header) {
-				t.Errorf("ColorizeHeader() = %q, want to contain %q", result, tt.header)
-			}
+			assert.Contains(t, result, tt.header)
 		})
 	}
 }
@@ -180,9 +178,7 @@ func TestColorizeNamespace(t *testing.T) {
 			result := ColorizeNamespace(tt.namespace, tt.noColor)
 
 			// Always check the namespace text is present
-			if !strings.Contains(result, tt.namespace) {
-				t.Errorf("ColorizeNamespace() = %q, want to contain %q", result, tt.namespace)
-			}
+			assert.Contains(t, result, tt.namespace)
 		})
 	}
 }

--- a/internal/monocular/client_test.go
+++ b/internal/monocular/client_test.go
@@ -18,14 +18,13 @@ package monocular
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	c, err := New("https://hub.helm.sh")
-	if err != nil {
-		t.Errorf("error creating client: %s", err)
-	}
-	if c.BaseURL != "https://hub.helm.sh" {
-		t.Errorf("incorrect BaseURL. Expected \"https://hub.helm.sh\" but got %q", c.BaseURL)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "https://hub.helm.sh", c.BaseURL)
 }

--- a/internal/monocular/search_test.go
+++ b/internal/monocular/search_test.go
@@ -21,6 +21,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A search response for phpmyadmin containing 2 results
@@ -33,16 +36,10 @@ func TestSearch(t *testing.T) {
 	defer ts.Close()
 
 	c, err := New(ts.URL)
-	if err != nil {
-		t.Errorf("unable to create monocular client: %s", err)
-	}
+	require.NoError(t, err, "unable to create monocular client")
 
 	results, err := c.SearchWithContext(t.Context(), "phpmyadmin")
-	if err != nil {
-		t.Errorf("unable to search monocular: %s", err)
-	}
+	require.NoError(t, err, "unable to search monocular")
 
-	if len(results) != 2 {
-		t.Error("Did not receive the expected number of results")
-	}
+	assert.Len(t, results, 2)
 }

--- a/internal/sympath/walk_test.go
+++ b/internal/sympath/walk_test.go
@@ -24,6 +24,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Node struct {
@@ -80,21 +83,14 @@ func makeTree(t *testing.T) {
 	walkTree(tree, tree.name, func(path string, n *Node) {
 		if n.entries == nil {
 			if n.symLinkedTo != "" {
-				if err := os.Symlink(n.symLinkedTo, path); err != nil {
-					t.Fatalf("makeTree: %v", err)
-				}
+				require.NoError(t, os.Symlink(n.symLinkedTo, path), "makeTree")
 			} else {
 				fd, err := os.Create(path)
-				if err != nil {
-					t.Fatalf("makeTree: %v", err)
-					return
-				}
+				require.NoError(t, err, "makeTree")
 				fd.Close()
 			}
 		} else {
-			if err := os.Mkdir(path, 0770); err != nil {
-				t.Fatalf("makeTree: %v", err)
-			}
+			require.NoError(t, os.Mkdir(path, 0770), "makeTree")
 		}
 	})
 }
@@ -102,8 +98,8 @@ func makeTree(t *testing.T) {
 func checkMarks(t *testing.T, report bool) {
 	t.Helper()
 	walkTree(tree, tree.name, func(path string, n *Node) {
-		if n.marks != n.expectedMarks && report {
-			t.Errorf("node %s mark = %d; expected %d", path, n.marks, n.expectedMarks)
+		if report {
+			assert.Equal(t, n.expectedMarks, n.marks, "node %s", path)
 		}
 		n.marks = 0
 	})
@@ -137,16 +133,10 @@ func TestWalk(t *testing.T) {
 	}
 	// Expect no errors.
 	err := Walk(tree.name, markFn)
-	if err != nil {
-		t.Fatalf("no error expected, found: %s", err)
-	}
-	if len(errors) != 0 {
-		t.Fatalf("unexpected errors: %s", errors)
-	}
+	require.NoError(t, err)
+	require.Empty(t, errors, "unexpected errors")
 	checkMarks(t, true)
 
 	// cleanup
-	if err := os.RemoveAll(tree.name); err != nil {
-		t.Errorf("removeTree: %v", err)
-	}
+	assert.NoError(t, os.RemoveAll(tree.name), "removeTree")
 }

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package urlutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestURLJoin(t *testing.T) {
 	tests := []struct {
@@ -31,11 +35,9 @@ func TestURLJoin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got, err := URLJoin(tt.url, tt.paths...); err != nil {
-			t.Errorf("%s: error %q", tt.name, err)
-		} else if got != tt.expect {
-			t.Errorf("%s: expected %q, got %q", tt.name, tt.expect, got)
-		}
+		got, err := URLJoin(tt.url, tt.paths...)
+		assert.NoError(t, err, tt.name)
+		assert.Equal(t, tt.expect, got, tt.name)
 	}
 }
 
@@ -60,9 +62,7 @@ func TestEqual(t *testing.T) {
 		{"%/1234", "%/123", false},
 		{"/1234", "%/1234", false},
 	} {
-		if tt.match != Equal(tt.a, tt.b) {
-			t.Errorf("Expected %q==%q to be %t", tt.a, tt.b, tt.match)
-		}
+		assert.Equal(t, tt.match, Equal(tt.a, tt.b), "Expected %q==%q to be %t", tt.a, tt.b, tt.match)
 	}
 }
 
@@ -74,8 +74,7 @@ func TestExtractHostname(t *testing.T) {
 		"https://example.com:31337/not/with/a/bang/but/a/whimper": "example.com",
 	}
 	for start, expect := range tests {
-		if got, _ := ExtractHostname(start); got != expect {
-			t.Errorf("Got %q, expected %q", got, expect)
-		}
+		got, _ := ExtractHostname(start)
+		assert.Equal(t, expect, got)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Replace native Go testing patterns (`t.Errorf`, `t.Fatalf`, `t.Error`, `t.Fatal`) with `github.com/stretchr/testify` equivalents (`assert.X`, `require.X`) for improved test readability and error messages.

This PR converts the `internal/cli`, `internal/monocular`, `internal/sympath` & `internal/urlutil` packages test files 

**Special notes for your reviewer**:
Converted with AI

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
