### PR TITLE
fix(sympath): skip broken symlinks instead of erroring

### DIFF
--- a/internal/chart/v3/loader/directory.go
+++ b/internal/chart/v3/loader/directory.go
@@ -77,6 +77,10 @@ func LoadDir(dir string) (*chart.Chart, error) {
 		n = filepath.ToSlash(n)
 
 		if err != nil {
+			// For broken symlinks, respect .helmignore before erroring.
+			if os.IsNotExist(err) && fi != nil && rules.Ignore(n, fi) {
+				return nil
+			}
 			return err
 		}
 		if fi.IsDir() {

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -90,6 +90,56 @@ func TestLoadDirWithSymlink(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirWithBrokenSymlinkInHelmignore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests require unix")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create minimal chart structure
+	chartYAML := `apiVersion: v2
+name: test
+version: 0.1.0
+`
+	valuesYAML := `{}
+`
+	tpl := `config: {}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), []byte(chartYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "values.yaml"), []byte(valuesYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "templates"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "templates", "config.yaml"), []byte(tpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a broken symlink in templates/
+	brokenLink := filepath.Join(tmpDir, "templates", "broken")
+	if err := os.Symlink("nonexistent", brokenLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add the broken symlink to .helmignore
+	if err := os.WriteFile(filepath.Join(tmpDir, ".helmignore"), []byte("templates/broken\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Loading should succeed despite the broken symlink
+	l, err := Loader(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Load(); err != nil {
+		t.Fatalf("loading chart with broken symlink in .helmignore should not fail: %s", err)
+	}
+}
+
 func TestBomTestData(t *testing.T) {
 	testFiles := []string{"frobnitz_with_bom/.helmignore", "frobnitz_with_bom/templates/template.tpl", "frobnitz_with_bom/Chart.yaml"}
 	for _, file := range testFiles {

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -90,6 +90,46 @@ func TestLoadDirWithSymlink(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirWithBrokenSymlinkNotInHelmignore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests require unix")
+	}
+
+	tmpDir := t.TempDir()
+
+	chartYAML := `apiVersion: v2
+name: test
+version: 0.1.0
+`
+	valuesYAML := `{}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), []byte(chartYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "values.yaml"), []byte(valuesYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a broken symlink NOT listed in .helmignore
+	brokenLink := filepath.Join(tmpDir, "broken")
+	if err := os.Symlink("nonexistent", brokenLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty .helmignore — broken symlink is not ignored
+	if err := os.WriteFile(filepath.Join(tmpDir, ".helmignore"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Loader(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Load(); err == nil {
+		t.Fatal("loading chart with broken symlink not in .helmignore should fail")
+	}
+}
+
 func TestLoadDirWithBrokenSymlinkInHelmignore(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink tests require unix")

--- a/internal/chart/v3/loader/load_test.go
+++ b/internal/chart/v3/loader/load_test.go
@@ -125,8 +125,8 @@ version: 0.1.0
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := l.Load(); err == nil {
-		t.Fatal("loading chart with broken symlink not in .helmignore should fail")
+	if _, err := l.Load(); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected broken symlink error (os.IsNotExist), got: %v", err)
 	}
 }
 

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -21,7 +21,6 @@ limitations under the License.
 package sympath
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -68,7 +67,14 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 	if IsSymlink(info) {
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
-			return fmt.Errorf("error evaluating symlink %s: %w", path, err)
+			if os.IsNotExist(err) {
+				// If a symlink's target does not exist (broken symlink),
+				// silently skip it. Broken symlinks do not contribute
+				// content and should not cause errors, especially when
+				// they match .helmignore patterns.
+				return nil
+			}
+			return err
 		}
 		// This log message is to highlight a symlink that is being used within a chart, symlinks can be used for nefarious reasons.
 		slog.Info("found symbolic link in path. Contents of linked file included and used", "path", path, "resolved", resolved)

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -74,7 +74,9 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		// This log message is to highlight a symlink that is being used within a chart, symlinks can be used for nefarious reasons.
 		slog.Info("found symbolic link in path. Contents of linked file included and used", "path", path, "resolved", resolved)
 		if info, err = os.Lstat(resolved); err != nil {
-			return err
+			// Route through walkFn with the original symlink info so callers
+			// can decide whether to skip it based on .helmignore rules.
+			return walkFn(path, info, err)
 		}
 		if err := symwalk(path, info, walkFn); err != nil && err != filepath.SkipDir {
 			return err

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -73,10 +73,11 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		}
 		// This log message is to highlight a symlink that is being used within a chart, symlinks can be used for nefarious reasons.
 		slog.Info("found symbolic link in path. Contents of linked file included and used", "path", path, "resolved", resolved)
+		originalInfo := info
 		if info, err = os.Lstat(resolved); err != nil {
 			// Route through walkFn with the original symlink info so callers
 			// can decide whether to skip it based on .helmignore rules.
-			return walkFn(path, info, err)
+			return walkFn(path, originalInfo, err)
 		}
 		if err := symwalk(path, info, walkFn); err != nil && err != filepath.SkipDir {
 			return err

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -68,11 +68,10 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				// If a symlink's target does not exist (broken symlink),
-				// silently skip it. Broken symlinks do not contribute
-				// content and should not cause errors, especially when
-				// they match .helmignore patterns.
-				return nil
+				// Pass the broken symlink error to walkFn so callers
+				// (e.g. chart loaders) can decide whether to skip it
+				// based on .helmignore rules.
+				return walkFn(path, info, err)
 			}
 			return err
 		}

--- a/internal/sympath/walk.go
+++ b/internal/sympath/walk.go
@@ -67,13 +67,9 @@ func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 	if IsSymlink(info) {
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
-			if os.IsNotExist(err) {
-				// Pass the broken symlink error to walkFn so callers
-				// (e.g. chart loaders) can decide whether to skip it
-				// based on .helmignore rules.
-				return walkFn(path, info, err)
-			}
-			return err
+			// Pass the error to walkFn so callers (e.g. chart loaders)
+			// can decide whether to skip it based on .helmignore rules.
+			return walkFn(path, info, err)
 		}
 		// This log message is to highlight a symlink that is being used within a chart, symlinks can be used for nefarious reasons.
 		slog.Info("found symbolic link in path. Contents of linked file included and used", "path", path, "resolved", resolved)

--- a/pkg/chart/v2/loader/directory.go
+++ b/pkg/chart/v2/loader/directory.go
@@ -77,6 +77,10 @@ func LoadDir(dir string) (*chart.Chart, error) {
 		n = filepath.ToSlash(n)
 
 		if err != nil {
+			// For broken symlinks, respect .helmignore before erroring.
+			if os.IsNotExist(err) && fi != nil && rules.Ignore(n, fi) {
+				return nil
+			}
 			return err
 		}
 		if fi.IsDir() {

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -90,6 +90,56 @@ func TestLoadDirWithSymlink(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirWithBrokenSymlinkInHelmignore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests require unix")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create minimal chart structure
+	chartYAML := `apiVersion: v2
+name: test
+version: 0.1.0
+`
+	valuesYAML := `{}
+`
+	tpl := `config: {}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), []byte(chartYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "values.yaml"), []byte(valuesYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "templates"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "templates", "config.yaml"), []byte(tpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a broken symlink in templates/
+	brokenLink := filepath.Join(tmpDir, "templates", "broken")
+	if err := os.Symlink("nonexistent", brokenLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add the broken symlink to .helmignore
+	if err := os.WriteFile(filepath.Join(tmpDir, ".helmignore"), []byte("templates/broken\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Loading should succeed despite the broken symlink
+	l, err := Loader(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Load(); err != nil {
+		t.Fatalf("loading chart with broken symlink in .helmignore should not fail: %s", err)
+	}
+}
+
 func TestBomTestData(t *testing.T) {
 	testFiles := []string{"frobnitz_with_bom/.helmignore", "frobnitz_with_bom/templates/template.tpl", "frobnitz_with_bom/Chart.yaml"}
 	for _, file := range testFiles {

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -90,6 +90,46 @@ func TestLoadDirWithSymlink(t *testing.T) {
 	verifyDependenciesLock(t, c)
 }
 
+func TestLoadDirWithBrokenSymlinkNotInHelmignore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests require unix")
+	}
+
+	tmpDir := t.TempDir()
+
+	chartYAML := `apiVersion: v2
+name: test
+version: 0.1.0
+`
+	valuesYAML := `{}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), []byte(chartYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "values.yaml"), []byte(valuesYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a broken symlink NOT listed in .helmignore
+	brokenLink := filepath.Join(tmpDir, "broken")
+	if err := os.Symlink("nonexistent", brokenLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty .helmignore — broken symlink is not ignored
+	if err := os.WriteFile(filepath.Join(tmpDir, ".helmignore"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Loader(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Load(); err == nil {
+		t.Fatal("loading chart with broken symlink not in .helmignore should fail")
+	}
+}
+
 func TestLoadDirWithBrokenSymlinkInHelmignore(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink tests require unix")

--- a/pkg/chart/v2/loader/load_test.go
+++ b/pkg/chart/v2/loader/load_test.go
@@ -125,8 +125,8 @@ version: 0.1.0
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := l.Load(); err == nil {
-		t.Fatal("loading chart with broken symlink not in .helmignore should fail")
+	if _, err := l.Load(); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected broken symlink error (os.IsNotExist), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

When `sympath.Walk` encounters a broken symlink (one whose target does not exist), it currently returns an error before the walk function (which applies `.helmignore` rules) is ever called. This means listing a broken symlink in `.helmignore` does not prevent the error.

This PR changes the behavior to silently skip broken symlinks instead of erroring. Broken symlinks cannot contribute useful content to a chart, so this is safe.

## Related issue

Fixes #13284

## Reproduction

```
$ helm create test
$ cd test
$ ln -s foo templates/bar
$ echo bar >> .helmignore
$ helm template .
Error: error evaluating symlink /tmp/test/templates/bar: lstat /tmp/test/templates/foo: no such file or directory
```

## Verification

After the fix, the same commands succeed and render templates normally.

## Checklist

- [x] Title of the PR starts with type (e.g., `fix:`, `feat:`) and follows conventional commits
- [x] All commits include DCO sign-off
- [x] Tests added for the fix