### PR TITLE
fix: suppress OCI pull metadata in template and show output

### DIFF
--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -225,8 +225,8 @@ func runShow(args []string, client *action.Show) (string, error) {
 	return client.Run(cp)
 }
 
-func addRegistryClient(out io.Writer, client *action.Show) error {
-	registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
+func addRegistryClient(_ io.Writer, client *action.Show) error {
+	registryClient, err := newRegistryClient(io.Discard, client.CertFile, client.KeyFile, client.CaFile,
 		client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 	if err != nil {
 		return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/show_test.go
+++ b/pkg/cmd/show_test.go
@@ -91,6 +91,39 @@ func TestShowPreReleaseChart(t *testing.T) {
 	}
 }
 
+func TestShowOCIChartDoesNotPrintRegistryPullMetadata(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ociSrv.Run(t)
+
+	contentTmp := t.TempDir()
+	outdir := srv.Root()
+	cmd := fmt.Sprintf("show chart oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0 --registry-config %s --content-cache %s --plain-http",
+		ociSrv.RegistryURL,
+		filepath.Join(outdir, "config.json"),
+		contentTmp,
+	)
+
+	_, out, err := executeActionCommand(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "Pulled: ") || strings.Contains(out, "Digest: ") {
+		t.Fatalf("expected OCI show output to exclude registry pull metadata, got: %s", out)
+	}
+	if !strings.Contains(out, "apiVersion:") {
+		t.Fatalf("expected chart metadata in output, got: %s", out)
+	}
+}
+
 func TestShowVersionCompletion(t *testing.T) {
 	repoFile := "testdata/helmhome/helm/repositories.yaml"
 	repoCache := "testdata/helmhome/helm/repository"

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -85,7 +85,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
-			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(io.Discard, client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -19,7 +19,10 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"helm.sh/helm/v4/pkg/repo/v1/repotest"
 )
 
 var chartPath = "testdata/testcharts/subchart"
@@ -168,6 +171,39 @@ func TestTemplateCmd(t *testing.T) {
 		},
 	}
 	runTestCmd(t, tests)
+}
+
+func TestTemplateOCIChartDoesNotPrintRegistryPullMetadata(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ociSrv.Run(t)
+
+	contentTmp := t.TempDir()
+	outdir := srv.Root()
+	cmd := fmt.Sprintf("template --generate-name oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0 --registry-config %s --content-cache %s --plain-http",
+		ociSrv.RegistryURL,
+		filepath.Join(outdir, "config.json"),
+		contentTmp,
+	)
+
+	_, out, err := executeActionCommand(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "Pulled: ") || strings.Contains(out, "Digest: ") {
+		t.Fatalf("expected OCI template output to exclude registry pull metadata, got: %s", out)
+	}
+	if !strings.Contains(out, "# Source:") {
+		t.Fatalf("expected rendered manifests in output, got: %s", out)
+	}
 }
 
 func TestTemplateVersionCompletion(t *testing.T) {


### PR DESCRIPTION
Fixes #32215

This backports the command-side writer change from main to release-4.2 so helm template and helm show chart stop mixing OCI pull metadata into machine-readable output.

Summary:
- route the registry client output for template and show to io.Discard
- add regression tests for OCI template and show chart output

Testing:
- added focused command tests for both affected paths
- CI will validate the release-4.2 backport
