### PR TITLE
fix: Helm doesn't wait for Custom Resources on new releases using `upgrade...

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -207,11 +207,15 @@ func (w *statusWaiter) wait(ctx context.Context, resourceList ResourceList, sw w
 	errs := []error{}
 	for _, id := range resources {
 		rs := statusCollector.ResourceStatuses[id]
-		if rs.Status == status.CurrentStatus {
+		reportedStatus := rs.Status
+		if reportedStatus == status.CurrentStatus && customResourceStatusPending(rs.Resource) {
+			reportedStatus = status.InProgressStatus
+		}
+		if reportedStatus == status.CurrentStatus {
 			continue
 		}
 		errs = append(errs, fmt.Errorf("resource %s/%s/%s not ready. status: %s, message: %s",
-			rs.Identifier.GroupKind.Kind, rs.Identifier.Namespace, rs.Identifier.Name, rs.Status, rs.Message))
+			rs.Identifier.GroupKind.Kind, rs.Identifier.Namespace, rs.Identifier.Name, reportedStatus, rs.Message))
 	}
 	if err := ctx.Err(); err != nil {
 		errs = append(errs, err)
@@ -254,6 +258,15 @@ func statusObserver(cancel context.CancelFunc, desired status.Status, logger *sl
 			if rs.Status == status.FailedStatus && desired == status.CurrentStatus {
 				continue
 			}
+			// A freshly created custom resource whose controller has not yet observed
+			// it has an empty status, which kstatus reports as Current. Treat such a
+			// resource as still in progress so we keep waiting until its controller has
+			// reconciled it. See https://github.com/helm/helm/issues/32066.
+			if desired == status.CurrentStatus && rs.Status == status.CurrentStatus && customResourceStatusPending(rs.Resource) {
+				rsCopy := *rs
+				rsCopy.Status = status.InProgressStatus
+				rs = &rsCopy
+			}
 			rss = append(rss, rs)
 			if rs.Status != desired {
 				nonDesiredResources = append(nonDesiredResources, rs)
@@ -275,6 +288,44 @@ func statusObserver(cancel context.CancelFunc, desired status.Status, logger *sl
 			logger.Debug("waiting for resource", "namespace", first.Identifier.Namespace, "name", first.Identifier.Name, "kind", first.Identifier.GroupKind.Kind, "expectedStatus", desired, "actualStatus", first.Status)
 		}
 	}
+}
+
+// customResourceStatusPending reports whether u is a freshly created custom
+// resource whose controller has not yet written any status. kstatus reports
+// such a resource as Current because its .status is still empty, which can
+// cause Helm to stop waiting before the controller has reconciled the resource
+// (helm/helm#32066). We only return true when there is positive evidence that a
+// controller is expected to populate status:
+//   - The resource is not one of the built-in types kstatus already understands.
+//   - metadata.generation is non-zero (the API server tracks the spec
+//     generation for the object).
+//   - The .status object is still effectively empty (the controller has not
+//     written anything to it yet).
+//
+// As soon as the controller writes any status we defer to the normal kstatus
+// computation, so a resource is never blocked forever on account of this
+// heuristic.
+func customResourceStatusPending(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return false
+	}
+	if status.GetLegacyConditionsFn(u) != nil {
+		return false
+	}
+	generation, found, err := unstructured.NestedInt64(u.Object, "metadata", "generation")
+	if err != nil || !found || generation == 0 {
+		return false
+	}
+	// If the controller has written anything to .status, defer to the normal
+	// kstatus computation rather than overriding its result.
+	statusMap, found, err := unstructured.NestedMap(u.Object, "status")
+	if err != nil {
+		return false
+	}
+	if found && len(statusMap) > 0 {
+		return false
+	}
+	return true
 }
 
 type hookOnlyWaiter struct {

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/resource"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -59,6 +60,29 @@ status:
   - type: Ready
     status: "True"
   phase: Running
+`
+
+var customResourceNoStatusManifest = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello-knative
+  namespace: ns
+  generation: 1
+`
+
+var customResourceReadyManifest = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello-knative
+  namespace: ns
+  generation: 1
+status:
+  observedGeneration: 1
+  conditions:
+  - type: Ready
+    status: "True"
 `
 
 var podNoStatusManifest = `
@@ -448,6 +472,86 @@ func TestStatusWait(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestStatusWaitCustomResourcePending(t *testing.T) {
+	t.Parallel()
+	customResourceGVK := schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1", Kind: "Service"}
+	customResourceGVR := schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
+	customListKinds := map[schema.GroupVersionResource]string{customResourceGVR: "ServiceList"}
+
+	resourceListFor := func(objs []runtime.Object) ResourceList {
+		rl := ResourceList{}
+		for _, obj := range objs {
+			u := obj.(*unstructured.Unstructured)
+			rl = append(rl, &resource.Info{
+				Object:    u,
+				Name:      u.GetName(),
+				Namespace: u.GetNamespace(),
+			})
+		}
+		return rl
+	}
+
+	t.Run("freshly created custom resource is not reported ready before its controller reconciles it", func(t *testing.T) {
+		t.Parallel()
+		// Use a scheme local to this subtest. NewSimpleDynamicClientWithCustomListKinds
+		// registers the custom list kind into the scheme it is given, so sharing the
+		// global scheme.Scheme across parallel tests would be a data race.
+		fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), customListKinds)
+		fakeMapper := testutil.NewFakeRESTMapper(customResourceGVK)
+		statusWaiter := statusWaiter{
+			client:     fakeClient,
+			restMapper: fakeMapper,
+		}
+		statusWaiter.SetLogger(slog.Default().Handler())
+		objs := getRuntimeObjFromManifests(t, []string{customResourceNoStatusManifest})
+		for _, obj := range objs {
+			u := obj.(*unstructured.Unstructured)
+			gvr := getGVR(t, fakeMapper, u)
+			require.NoError(t, fakeClient.Tracker().Create(gvr, u, u.GetNamespace()))
+		}
+		err := statusWaiter.Wait(resourceListFor(objs), time.Second*2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resource Service/ns/hello-knative not ready. status: InProgress")
+		assert.Contains(t, err.Error(), "context deadline exceeded")
+	})
+
+	t.Run("custom resource is reported ready once its controller has reconciled it", func(t *testing.T) {
+		t.Parallel()
+		// Use a scheme local to this subtest (see note above) to avoid racing on
+		// the global scheme.Scheme with the other parallel subtest.
+		fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), customListKinds)
+		fakeMapper := testutil.NewFakeRESTMapper(customResourceGVK)
+		statusWaiter := statusWaiter{
+			client:     fakeClient,
+			restMapper: fakeMapper,
+		}
+		statusWaiter.SetLogger(slog.Default().Handler())
+		objs := getRuntimeObjFromManifests(t, []string{customResourceNoStatusManifest})
+		u := objs[0].(*unstructured.Unstructured)
+		gvr := getGVR(t, fakeMapper, u)
+		require.NoError(t, fakeClient.Tracker().Create(gvr, u, u.GetNamespace()))
+
+		// Build the "reconciled" object on the test goroutine; only the tracker
+		// update runs in the background goroutine, and its error is reported back
+		// over a channel so we never touch t or testify from another goroutine.
+		ready := getRuntimeObjFromManifests(t, []string{customResourceReadyManifest})[0].(*unstructured.Unstructured)
+		const reconcileDelay = 500 * time.Millisecond
+		updateErrCh := make(chan error, 1)
+		go func() {
+			time.Sleep(reconcileDelay)
+			updateErrCh <- fakeClient.Tracker().Update(gvr, ready, ready.GetNamespace())
+		}()
+
+		start := time.Now()
+		err := statusWaiter.Wait(resourceListFor(objs), time.Second*10)
+		require.NoError(t, err)
+		require.NoError(t, <-updateErrCh)
+		// Wait must not succeed before the controller reconciled the resource;
+		// otherwise it would be reporting success prematurely (the bug in #32066).
+		require.GreaterOrEqual(t, time.Since(start), reconcileDelay)
+	})
 }
 
 func TestWaitForJobComplete(t *testing.T) {


### PR DESCRIPTION
## Summary

The behavior difference between `helm install --wait` and `helm upgrade --install --wait` is not caused by wait options being dropped on the way into the install code.


## Root cause

The behavior difference between `helm install --wait` and `helm upgrade --install --wait`
is not caused by wait options being dropped on the way into the install code. I verified
that `pkg/cmd/upgrade.go` copies `WaitStrategy`, `WaitForJobs` and `Timeout` onto the
install client, and both commands funnel through the same `runInstall` and install action,
so the wait configuration is identical.

The real cause is a race in the kstatus based status watcher (`pkg/kube/statuswait.go`)
when a brand new custom resource is created:

1. Helm creates the custom resource (for example a Knative `serving.knative.dev/v1`
 `Service`) for a release that does not exist yet.
2. Helm immediately starts watching it. The informer's initial list returns the resource
 with an empty `.status` because the controller has not reconciled it yet.
3. kstatus (`status.Compute` in `github.com/fluxcd/cli-utils`) has no type specific rule
 for the custom kind, finds no `status.observedGeneration` mismatch and no conditions,
 and falls back to "the absence of any known conditions means the resource is current",
 returning `Current`.
4. Helm's observer sees the aggregate status reach `Current` and stops waiting, reporting
 success before the resource is actually ready.

This matches the symptom in the issue (a CR briefly shown as `Unknown`, then Helm reporting
"all resources achieved desired status" before the underlying Pods are ready). It is timing
dependent, which is why it reproduces reliably in low latency environments (such as CI close
to the API server) and on first installs where the CR has no prior `.status`. When the
release already exists the CR already has a populated `.status` from a previous
reconciliation, so kstatus correctly keeps waiting and the bug does not appear.


## What changed

`pkg/kube/statuswait.go`
- Added `customResourceStatusPending`, which detects a freshly created custom resource whose
 controller has not yet observed it. It returns true only when there is positive evidence
 that a controller is expected to populate status, to keep the change safe:
 - the kind is not one of the built-in types kstatus already understands
 (`status.GetLegacyConditionsFn` returns nil), so Services, Deployments, Jobs, Pods,
 StatefulSets, CRDs, etc. are never affected;
 - `metadata.generation` is set. The API server only maintains `metadata.generation` for
 resources whose CRD enables the `status` subresource, which implies a controller is
 expected to report status. Config style CRDs without a status subresource never get a
 generation, so they are skipped and never block;
 - the controller has not yet reported `status.observedGeneration` or any
 `status.conditions`. As soon as either is present we defer to the normal kstatus
 computation, so resources that legitimately omit one of these fields are not blocked
 forever.
- In `statusObserver`, when waiting for `Current`, a resource that is reported `Current` but
 is still a pending fresh custom resource is treated as `InProgress` for aggregation, so
 Helm keeps waiting until the controller reconciles it.
- In `wait`, the timeout error reporting uses the same adjustment so a stuck custom resource
 is reported as `not ready. status: InProgress` instead of being silently treated as ready.

`pkg/kube/statuswait_test.go`
- Added `customResourceNoStatusManifest` and `customResourceReadyManifest` fixtures
 (a Knative style `serving.knative.dev/v1` `Service`).
- Added `TestStatusWaitCustomResourcePending` with two cases:
 - a freshly created custom resource with no status is not reported ready and the wait
 times out with `resource Service/ns/hello-knative not ready. status: InProgress`;
 - the same resource becomes ready once a simulated controller writes
 `observedGeneration` and a `Ready` condition, and the wait then succeeds.


## Issue

Fixes #32066

Issue: https://github.com/helm/helm/issues/32066


## Diffstat

```
pkg/kube/statuswait.go | 52 +++++++++++++++++++++++++-
 pkg/kube/statuswait_test.go | 91 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 141 insertions(+), 2 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.