### PR TITLE
fix(scripts): check HELM_INSTALL_DIR instead of $PATH in get-helm-3

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -267,9 +267,9 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
   set +e
-  HELM="$(command -v $BINARY_NAME)"
-  if [ "$?" = "1" ]; then
-    echo "$BINARY_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
+  HELM="$HELM_INSTALL_DIR/$BINARY_NAME"
+  if [ ! -x "$HELM" ]; then
+    echo "$BINARY_NAME not found or not executable at $HELM_INSTALL_DIR/$BINARY_NAME"
     exit 1
   fi
   set -e


### PR DESCRIPTION

**What this PR does / why we need it**:

`testVersion()` in `get-helm-3` verifies install using `command -v`, which only checks `$PATH` resolution. The binary is installed directly to `$HELM_INSTALL_DIR`, independent of `$PATH`, so the script falsely fails (exit 1) whenever `$HELM_INSTALL_DIR` isn't on `$PATH` - common in minimal containers, CI runners, and minikube - VMs  even though install succeeded.

Fix: check the binary at its actual installed location instead.

```diff
 testVersion() {
   set +e
-  HELM="$(command -v $BINARY_NAME)"
-  if [ "$?" = "1" ]; then
+  HELM="$HELM_INSTALL_DIR/$BINARY_NAME"
+  if [ ! -x "$HELM" ]; then
     echo "$BINARY_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
     exit 1
   fi
   set -e
 }
```

2-line change, no other lines touched. Still correctly fails on a missing or non-executable binary.

**Special notes for your reviewer**:

Tested both the bug repro and a normal install:

```
$ PATH="/usr/bin:/bin" ./scripts/get-helm-3            # default dir, off PATH
exit code: 0

$ PATH="/usr/bin:/bin" HELM_INSTALL_DIR=/tmp/helmtest ./scripts/get-helm-3
exit code: 0
$ ls -la /tmp/helmtest/helm
-rwxr-xr-x 1 root root 58794146 ... /tmp/helmtest/helm
```

Previously both exited 1 with `helm not found. Is ... on your $PATH?` despite a successful install.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

closes #32272