### PR TITLE
fix(lint): validate kubernetes resource names for chart names

### DIFF
--- a/pkg/chart/v2/lint/rules/chartfile.go
+++ b/pkg/chart/v2/lint/rules/chartfile.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/asaskevich/govalidator"
+	"k8s.io/apimachinery/pkg/api/validation"
 	"sigs.k8s.io/yaml"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -124,8 +126,8 @@ func validateChartName(cf *chart.Metadata) error {
 	// Chart names must also be valid Kubernetes metadata names so they can be
 	// used safely as resource name prefixes (lowercase, alphanumeric, hyphens
 	// and dots only; must start and end with an alphanumeric character).
-	if err := chartutil.ValidateMetadataName(cf.Name); err != nil {
-		return fmt.Errorf("chart name %q is not a valid Kubernetes name: use lowercase letters, digits, hyphens, and dots only (e.g. my-chart, my.chart)", cf.Name)
+	if errs := validation.NameIsDNSSubdomain(cf.Name, false); len(errs) > 0 {
+		return fmt.Errorf("chart name %q is not a valid Kubernetes name: %s", cf.Name, strings.Join(errs, ", "))
 	}
 	return nil
 }

--- a/pkg/chart/v2/lint/rules/chartfile.go
+++ b/pkg/chart/v2/lint/rules/chartfile.go
@@ -121,6 +121,12 @@ func validateChartName(cf *chart.Metadata) error {
 	if name != cf.Name {
 		return fmt.Errorf("chart name %q is invalid", cf.Name)
 	}
+	// Chart names must also be valid Kubernetes metadata names so they can be
+	// used safely as resource name prefixes (lowercase, alphanumeric, hyphens
+	// and dots only; must start and end with an alphanumeric character).
+	if err := chartutil.ValidateMetadataName(cf.Name); err != nil {
+		return fmt.Errorf("chart name %q is not a valid Kubernetes name: use lowercase letters, digits, hyphens, and dots only (e.g. my-chart, my.chart)", cf.Name)
+	}
 	return nil
 }
 

--- a/pkg/chart/v2/lint/rules/chartfile_test.go
+++ b/pkg/chart/v2/lint/rules/chartfile_test.go
@@ -61,6 +61,8 @@ func TestValidateChartName(t *testing.T) {
 	// empty name (badChart has name: "")
 	require.Error(t, validateChartName(badChart), "validateChartName to return a linter error, got no error")
 
+	assert.Error(t, validateChartName(badChartName), "expected validateChartName to return a linter error for an invalid name, got no error")
+
 	invalidNames := []struct {
 		name   string
 		reason string

--- a/pkg/chart/v2/lint/rules/chartfile_test.go
+++ b/pkg/chart/v2/lint/rules/chartfile_test.go
@@ -58,8 +58,30 @@ func TestValidateChartYamlFormat(t *testing.T) {
 }
 
 func TestValidateChartName(t *testing.T) {
+	// empty name (badChart has name: "")
 	require.Error(t, validateChartName(badChart), "validateChartName to return a linter error, got no error")
-	assert.Error(t, validateChartName(badChartName), "expected validateChartName to return a linter error for an invalid name, got no error")
+
+	invalidNames := []struct {
+		name   string
+		reason string
+	}{
+		{"../badchartname", "path traversal"},
+		{"MyInvalidChart", "uppercase letters"},
+		{"my_chart", "underscore"},
+		{"-my-chart", "leading hyphen"},
+		{"my-chart-", "trailing hyphen"},
+		{"my chart", "space"},
+	}
+	for _, tc := range invalidNames {
+		meta := &chart.Metadata{Name: tc.name}
+		assert.Error(t, validateChartName(meta), "expected validateChartName to return error for %q (%s), got nil", tc.name, tc.reason)
+	}
+
+	validNames := []string{"my-chart", "my.chart", "mychart", "my-chart-v2", "1-chart", "myinvalidchart"} // "myinvalidchart" is the lowercase twin of the invalid "MyInvalidChart", confirming uppercase triggers failure
+	for _, name := range validNames {
+		meta := &chart.Metadata{Name: name}
+		assert.NoError(t, validateChartName(meta), "expected validateChartName to return no error for %q", name)
+	}
 }
 
 func TestValidateChartVersion(t *testing.T) {

--- a/pkg/chart/v2/lint/rules/testdata/badchartname/Chart.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/badchartname/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 version: 0.1.0
-name: "MyInvalidChart"
+name: "../badchartname"
 type: application

--- a/pkg/chart/v2/lint/rules/testdata/badchartname/Chart.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/badchartname/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 version: 0.1.0
-name: "../badchartname"
+name: "MyInvalidChart"
 type: application


### PR DESCRIPTION
Fixes #10537

This PR improves `helm lint` validation for chart names to ensure they comply with Kubernetes metadata naming restrictions, preventing issues where charts are named with uppercase letters, underscores, etc. It achieves this by calling `chartutil.ValidateMetadataName`.