### PR TITLE
fix(engine): guard Files.Lines against empty file panic

### DIFF
--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -154,12 +154,10 @@ func (f files) AsSecrets() string {
 // {{ range .Files.Lines "foo/bar.html" }}
 // {{ . }}{{ end }}
 func (f files) Lines(path string) []string {
-	if f == nil || f[path] == nil {
+	if f == nil || len(f[path]) == 0 {
 		return []string{}
 	}
 	s := string(f[path])
-	if s[len(s)-1] == '\n' {
-		s = s[:len(s)-1]
-	}
+	s = strings.TrimSuffix(s, "\n")
 	return strings.Split(s, "\n")
 }

--- a/pkg/engine/files_test.go
+++ b/pkg/engine/files_test.go
@@ -30,6 +30,7 @@ var cases = []struct {
 	{"story/author.txt", "Joseph Conrad"},
 	{"multiline/test.txt", "bar\nfoo\n"},
 	{"multiline/test_with_blank_lines.txt", "bar\nfoo\n\n\n"},
+	{"multiline/empty.txt", ""},
 }
 
 func getTestFiles() files {
@@ -94,8 +95,13 @@ func TestLines(t *testing.T) {
 
 	out := f.Lines("multiline/test.txt")
 	as.Len(out, 2)
-
 	as.Equal("bar", out[0])
+
+	outEmpty := f.Lines("multiline/empty.txt")
+	as.Len(outEmpty, 0)
+
+	outNonExistent := f.Lines("nonexistent.txt")
+	as.Len(outNonExistent, 0)
 }
 
 func TestBlankLines(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a runtime panic in the `.Files.Lines` template helper function when referencing an empty file inside a chart.

An empty file inside a chart is loaded and stored as a non-nil, zero-length byte slice (`[]byte{}`). The function previously checked only `f[path] == nil`, which evaluated to `false`, and then attempted to trim the newline character using `s[len(s)-1]` on the empty string `s`, resulting in a panic: `runtime error: index out of range [-1]`.

To resolve this, we:
- Guard the helper by checking if the slice length is zero: `len(f[path]) == 0`.
- Trim the trailing newline safely using `strings.TrimSuffix(s, "\n")`.

closes #32279

**Special notes for your reviewer**:
- Checked and verified that behavior remains identical for non-empty files (both with and without trailing newlines) and non-existent files.
- Added unit test cases for empty files and non-existent files under `TestLines` in `pkg/engine/files_test.go`.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility