### PR TITLE
fix(engine): prevent Files.Lines panic on empty file

### DIFF
--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -154,7 +154,7 @@ func (f files) AsSecrets() string {
 // {{ range .Files.Lines "foo/bar.html" }}
 // {{ . }}{{ end }}
 func (f files) Lines(path string) []string {
-	if f == nil || f[path] == nil {
+	if f == nil || len(f[path]) == 0 {
 		return []string{}
 	}
 	s := string(f[path])

--- a/pkg/engine/files_test.go
+++ b/pkg/engine/files_test.go
@@ -30,6 +30,8 @@ var cases = []struct {
 	{"story/author.txt", "Joseph Conrad"},
 	{"multiline/test.txt", "bar\nfoo\n"},
 	{"multiline/test_with_blank_lines.txt", "bar\nfoo\n\n\n"},
+	{"empty/empty.txt", ""},
+	{"empty/newline_only.txt", "\n"},
 }
 
 func getTestFiles() files {
@@ -108,4 +110,32 @@ func TestBlankLines(t *testing.T) {
 
 	as.Equal("bar", out[0])
 	as.Empty(out[3])
+}
+
+func TestLinesEmptyFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("empty/empty.txt")
+	as.Empty(out)
+}
+
+func TestLinesNewlineOnlyFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("empty/newline_only.txt")
+	as.Len(out, 1)
+	as.Empty(out[0])
+}
+
+func TestLinesMissingFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("nonexistent.txt")
+	as.Empty(out)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`Files.Lines` panics with "index out of range [-1]" when the referenced file is empty. The guard checks `f[path] == nil`, but an empty file inside a chart is stored as a non-nil zero-length byte slice, so `s := string(f[path])` is `""` and the trailing-newline check `s[len(s)-1]` indexes `s[-1]`. The engine recovers the panic into a render error, so every `helm template` / `install` / `upgrade` / `lint` and every SDK `Engine.Render` call that hits the template fails non-zero.

This PR extends the guard to `len(f[path]) == 0` and returns an empty slice, matching the existing behaviour for missing files.

closes #32279

**Special notes for your reviewer**:

- The new `TestLinesEmptyFile` panics on the current code and passes with the one-line guard change (verified both directions locally).
- `TestLinesNewlineOnlyFile` pins the boundary case (`"\n"` → `[""]`), which is unchanged, and `TestLinesMissingFile` pins the missing-path behaviour.
- Happy to open the `dev-v3` backport right after this is reviewed — flagging the July 8th 2026 cutoff for v3 bug fixes.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility