### PR TITLE
fix: remove malformed gzip extra field from chart archives

### DIFF
--- a/internal/chart/v3/util/save.go
+++ b/internal/chart/v3/util/save.go
@@ -33,8 +33,6 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 )
 
-var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
-
 // SaveDir saves a chart as files in a directory.
 //
 // This takes the chart name, and creates a new subdirectory inside of the given dest
@@ -132,7 +130,6 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 
 	// Wrap in gzip writer
 	zipper := gzip.NewWriter(f)
-	zipper.Extra = headerBytes
 	zipper.Comment = "Helm"
 
 	// Wrap in tar writer

--- a/internal/chart/v3/util/save_test.go
+++ b/internal/chart/v3/util/save_test.go
@@ -295,7 +295,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "5bfea18cc3c8cbc265744bc32bffa9489a4dbe87d6b51b90f4255e4839d35e03",
+			want: "65339a30a09d0ff78e0c050e9820b3c107dc8dc15b76d2f17801f5f0a63dfe98",
 		},
 		{
 			name: "Package 2 files",
@@ -317,7 +317,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "a240365c21e0a2f4a57873132a9b686566a612d08bcb3f20c9446bfff005ccce",
+			want: "184e2006080279a8fb4b761e6c3339fff5e61a44a7fb81464ab18616680eb5f1",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/chart/v2/util/save.go
+++ b/pkg/chart/v2/util/save.go
@@ -33,8 +33,6 @@ import (
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 )
 
-var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
-
 // SaveDir saves a chart as files in a directory.
 //
 // This takes the chart name, and creates a new subdirectory inside of the given dest
@@ -132,7 +130,6 @@ func Save(c *chart.Chart, outDir string) (string, error) {
 
 	// Wrap in gzip writer
 	zipper := gzip.NewWriter(f)
-	zipper.Extra = headerBytes
 	zipper.Comment = "Helm"
 
 	// Wrap in tar writer

--- a/pkg/chart/v2/util/save_test.go
+++ b/pkg/chart/v2/util/save_test.go
@@ -299,7 +299,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "fea2662522317b65c2788ff9e5fc446a9264830038dac618d4449493d99b3257",
+			want: "a16e5fddf319dd0397b2618e57a36ffc10d62711d7c7dba4ebac7b2e2b48d16f",
 		},
 		{
 			name: "Package 2 files",
@@ -321,7 +321,7 @@ func TestRepeatableSave(t *testing.T) {
 				Schema:        []byte("{\n  \"title\": \"Values\"\n}"),
 				SchemaModTime: modTime,
 			},
-			want: "7ae92b2f274bb51ea3f1969e4187d78cc52b5f6f663b44b8fb3b40bcb8ee46f3",
+			want: "f84379ab087642fca492f22143a6e2c13c99c18e68b0c7c041bd65bdbac3ab77",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## What this PR does

Removes the malformed gzip extra field from chart archives produced by .

## Why

The gzip extra field set by helm package does not conform to [RFC 1952 section 2.3.1.1](https://www.rfc-editor.org/rfc/rfc1952.html#page-8). The extra field contains a base64-encoded string that is not properly formatted with SI1/SI2/LEN subsections, causing errors in strict gzip implementations like the Bazel downloader.

As noted by @gjenkins8 in #31844:
> Probably the best option is to remove setting it (though, this won't apply retrospectively to all the existing Helm archives out there, of course).

## Changes

- Removed  variable from  and 
- Removed  assignment
- Updated test hash expectations in 

## Test results

All save-related tests pass:
-  ✅
-  ✅  
-  ✅
-  ✅

Fixes #31844