### PR TITLE
fix(ci): resolve Node 20 deprecation in govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -30,6 +30,6 @@ jobs:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
       - name: govulncheck
-        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@main 2026-07-06
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@032d455 (from main 2026-07-06)
         with:
           go-package: ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -30,6 +30,6 @@ jobs:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
       - name: govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # pin@1.0.4
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@main 2026-07-06
         with:
           go-package: ./...


### PR DESCRIPTION

**What this PR does / why we need it**:

The pinned v1.0.4 used actions/checkout@v4 and
actions/setup-go@v5 internally, both built on Node 20. Latest main uses v6 of both, which run on Node 24.

It's less noisy now https://github.com/helm/helm/actions/runs/28932741619/job/85835572916

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
