### PR TITLE
fix(engine): prevent Files.Lines panic on empty file (backport to v3)

### DIFF
--- a/pkg/engine/files.go
+++ b/pkg/engine/files.go
@@ -154,7 +154,7 @@ func (f files) AsSecrets() string {
 // {{ range .Files.Lines "foo/bar.html" }}
 // {{ . }}{{ end }}
 func (f files) Lines(path string) []string {
-	if f == nil || f[path] == nil {
+	if f == nil || len(f[path]) == 0 {
 		return []string{}
 	}
 	s := string(f[path])

--- a/pkg/engine/files_test.go
+++ b/pkg/engine/files_test.go
@@ -30,6 +30,8 @@ var cases = []struct {
 	{"story/author.txt", "Joseph Conrad"},
 	{"multiline/test.txt", "bar\nfoo\n"},
 	{"multiline/test_with_blank_lines.txt", "bar\nfoo\n\n\n"},
+	{"empty/empty.txt", ""},
+	{"empty/newline_only.txt", "\n"},
 }
 
 func getTestFiles() files {
@@ -108,4 +110,32 @@ func TestBlankLines(t *testing.T) {
 
 	as.Equal("bar", out[0])
 	as.Equal("", out[3])
+}
+
+func TestLinesEmptyFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("empty/empty.txt")
+	as.Empty(out)
+}
+
+func TestLinesNewlineOnlyFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("empty/newline_only.txt")
+	as.Len(out, 1)
+	as.Empty(out[0])
+}
+
+func TestLinesMissingFile(t *testing.T) {
+	as := assert.New(t)
+
+	f := getTestFiles()
+
+	out := f.Lines("nonexistent.txt")
+	as.Empty(out)
 }


### PR DESCRIPTION
Backport of #32290 to `dev-v3`.

### Problem

`Files.Lines` guards against a nil entry (`f[path] == nil`) but an empty file inside a chart archive is stored as a non-nil zero-length `[]byte`. The guard passes, the code then indexes `s[len(s)-1]` to strip a trailing newline, and panics with an index-out-of-range. The engine recovers the panic into a render error, so every `helm install`, `helm upgrade`, or `helm lint` that references an empty file with `{{ .Files.Lines ... }}` fails.

### Fix

Change the guard from `f[path] == nil` to `len(f[path]) == 0`, returning an empty slice for both missing and empty files (matching the documented behaviour for missing files).

### Tests

Three new table-driven cases:

| Case | Expected |
|---|---|
| Empty file (`""`) | empty slice (no panic) |
| Newline-only (`"\n"`) | `[""]` — one empty element |
| Missing file | empty slice (pre-existing behaviour, regression guard) |

Tests verified red on unfixed code (panic recovered as "index out of range"), green on fixed code.

### Relation to main

This is a direct cherry-pick of the same commit from #32290 (targeting `main`). Cherry-pick applied cleanly with no conflicts. Requested as a v3 backport because the v3 bug-fix window closes today (8 July 2026).