### PR TITLE
fix(ci): pin govulncheck-action to the v1.1.0 release

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -30,6 +30,6 @@ jobs:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
       - name: govulncheck
-        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@032d455 (from main 2026-07-06)
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@v1.1.0
         with:
           go-package: ./...


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #32299 / #32301. `golang/govulncheck-action` published
**v1.1.0 on 2026-07-10**, tagging the exact `master` commit (`032d455`) the
`govulncheck` step was already pinned to.

This updates the pin comment to `# pin@v1.1.0` so it matches the repo's
`# pin@<tag>` convention and Dependabot can track the action by semver
again -- which resolves the trackability problem reported in #32301.

**Special notes for your reviewer**:

The pinned SHA is unchanged (`032d45514ae346b1db93c04b0c90b841c370344f`);
`v1.1.0` points to that commit, so CI behavior is identical -- only the
trailing comment changes.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
