### PR TITLE
chore(deps): bump github/codeql-action/analyze from 4.36.2 to 4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # pinv4.36.2
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # pinv4.37.0


### PR DESCRIPTION
## What this does

Bumps `github/codeql-action/analyze` from **4.36.2** to **4.37.0** in `.github/workflows/codeql-analysis.yml`.

## Why

The `init` and `autobuild` steps were already bumped to 4.37.0 (#32313, #32305), and `upload-sarif` in `scorecards.yml` (#32311), but the `analyze` step was left at 4.36.2 — there was no dependabot PR for it. The mixed versions break CodeQL on `main`:

```
##[error]Loaded a configuration file for version '4.37.0', but running version '4.36.2'
```

This aligns `analyze` with the other `codeql-action` steps (same pinned SHA `99df26d4` = v4.37.0).