### PR TITLE
Fix: remove trailing whitespace in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ linters:
     - whitespace
 
   exclusions:
-  
+
     generated: lax
 
     presets:


### PR DESCRIPTION
Remove trailing whitespace on line 50 of the golangci-lint configuration file.