### PR TITLE
Fix vanishing empty lines

### DIFF
--- a/internal/release/v2/util/manifest.go
+++ b/internal/release/v2/util/manifest.go
@@ -34,7 +34,7 @@ type SimpleHead struct {
 	} `json:"metadata,omitempty"`
 }
 
-var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+var sep = regexp.MustCompile(`(?m)^---[ \t]*`)
 
 // SplitManifests takes a manifest string and returns a map containing individual manifests.
 //

--- a/internal/release/v2/util/manifest_test.go
+++ b/internal/release/v2/util/manifest_test.go
@@ -74,7 +74,7 @@ spec:
 			name:  "whitespace-only doc after separator is skipped",
 			input: "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n---\n  \n",
 			expected: map[string]string{
-				"manifest-0": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1",
+				"manifest-0": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n",
 			},
 		},
 		{
@@ -110,7 +110,8 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -329,8 +330,8 @@ data:
 			},
 		},
 
-		// Multi-doc with block scalars: the regex consumes \s*\n before ---,
-		// so trailing newlines from non-last docs are stripped.
+		// Multi-doc with block scalars: the separator regex preserves trailing
+		// newlines from non-last documents.
 		{
 			name: "multi-doc block scalar clip (|) before separator",
 			input: `
@@ -354,7 +355,8 @@ metadata:
   name: test
 data:
   key: |
-    hello`,
+    hello
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -387,7 +389,10 @@ metadata:
   name: test
 data:
   key: |+
-    hello`,
+    hello
+
+
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -432,7 +437,8 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -460,11 +466,13 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm2`,
+  name: cm2
+`,
 				"manifest-2": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -493,11 +501,13 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm2`,
+  name: cm2
+`,
 				"manifest-2": `apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1198,9 +1198,9 @@ data:
 `,
 		},
 
-		// Multi-doc tests: block scalar doc is NOT the last document.
-		// SplitManifests' regex consumes \s*\n before ---, so trailing
-		// newlines from non-last docs are always stripped.
+		// Multi-doc block scalar tests where the block scalar document is NOT the last:
+		// the separator regex does not consume trailing newlines, so YAML chomping
+		// indicators (|, |+, |-) are respected.
 
 		// | (clip) in multi-doc (first doc)
 		{

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1229,7 +1229,7 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |
     hello
 ---
 apiVersion: v1
@@ -1269,7 +1269,7 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |
     hello
 ---
 apiVersion: v1
@@ -1310,7 +1310,7 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |
     hello
 ---
 apiVersion: v1
@@ -1473,7 +1473,7 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |
     hello
 ---
 apiVersion: v1
@@ -1513,8 +1513,9 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |+
     hello
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1554,8 +1555,10 @@ metadata:
   annotations:
     postrenderer.helm.sh/postrender-filename: 'templates/cm.yaml'
 data:
-  key: |-
+  key: |+
     hello
+
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/action/testdata/rbac.txt
+++ b/pkg/action/testdata/rbac.txt
@@ -8,6 +8,8 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/exec", "pods/log"]
   verbs: ["*"]
+
+
 ---
 # Source: hello/templates/rbac
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/cmd/testdata/output/object-order.txt
+++ b/pkg/cmd/testdata/output/object-order.txt
@@ -10,6 +10,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/01-a.yml
 # 2
@@ -22,6 +24,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/01-a.yml
 # 3
@@ -34,6 +38,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 5
@@ -46,6 +52,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 7
@@ -58,6 +66,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 8
@@ -70,6 +80,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 9
@@ -82,6 +94,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 10
@@ -94,6 +108,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 11
@@ -106,6 +122,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 12
@@ -118,6 +136,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 13
@@ -130,6 +150,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 14
@@ -142,6 +164,8 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+
 ---
 # Source: object-order/templates/02-b.yml
 # 15 (11th object within 02-b.yml, in order to test `SplitManifests` which assigns `manifest-10`
@@ -190,3 +214,5 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+
+

--- a/pkg/cmd/testdata/output/template-show-only-glob.txt
+++ b/pkg/cmd/testdata/output/template-show-only-glob.txt
@@ -8,6 +8,8 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
+
+
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,3 +24,5 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
+
+

--- a/pkg/cmd/testdata/output/template-show-only-multiple.txt
+++ b/pkg/cmd/testdata/output/template-show-only-multiple.txt
@@ -19,6 +19,7 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart
+
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -36,3 +37,5 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
+
+

--- a/pkg/cmd/testdata/output/template-show-only-one.txt
+++ b/pkg/cmd/testdata/output/template-show-only-one.txt
@@ -19,3 +19,4 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart
+

--- a/pkg/release/v1/util/manifest.go
+++ b/pkg/release/v1/util/manifest.go
@@ -34,7 +34,7 @@ type SimpleHead struct {
 	} `json:"metadata,omitempty"`
 }
 
-var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+var sep = regexp.MustCompile(`(?m)^---[ \t]*`)
 
 // SplitManifests takes a manifest string and returns a map containing individual manifests.
 //

--- a/pkg/release/v1/util/manifest_test.go
+++ b/pkg/release/v1/util/manifest_test.go
@@ -74,7 +74,7 @@ spec:
 			name:  "whitespace-only doc after separator is skipped",
 			input: "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n---\n  \n",
 			expected: map[string]string{
-				"manifest-0": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1",
+				"manifest-0": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n",
 			},
 		},
 		{
@@ -110,7 +110,8 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -329,8 +330,8 @@ data:
 			},
 		},
 
-		// Multi-doc with block scalars: the regex consumes \s*\n before ---,
-		// so trailing newlines from non-last docs are stripped.
+		// Multi-doc with block scalars: the separator regex preserves trailing
+		// newlines from non-last documents.
 		{
 			name: "multi-doc block scalar clip (|) before separator",
 			input: `
@@ -354,7 +355,8 @@ metadata:
   name: test
 data:
   key: |
-    hello`,
+    hello
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -387,7 +389,10 @@ metadata:
   name: test
 data:
   key: |+
-    hello`,
+    hello
+
+
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -432,7 +437,8 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -460,11 +466,13 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm2`,
+  name: cm2
+`,
 				"manifest-2": `apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -493,11 +501,13 @@ metadata:
 				"manifest-0": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm1`,
+  name: cm1
+`,
 				"manifest-1": `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cm2`,
+  name: cm2
+`,
 				"manifest-2": `apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fixes: #32326

From codex/gpt-5.6-sol:

> The only chart-visible changes are for block scalars at the end of a non-final document:
> 
> - `|-` and `>-`: unchanged; trailing newlines are explicitly stripped.
> - `|` and `>`: will now retain one final newline, as YAML specifies.
> - `|+` and `>+`: will now retain all trailing newlines, as YAML specifies.
> - Normal mappings, lists, quoted strings, and plain scalars: semantically unchanged.
> - Blank lines between ordinary documents: preserved but ignored by YAML parsers.
> 
> The theoretical compatibility risk is a chart that uses `|` or `|+` but accidentally depends on Helm stripping the newlines. Its rendered Kubernetes object would change. However, that chart currently depends on behavior contradicting its own YAML chomping indicator.
> 
> So: no expected chart rendering/install failures. Some workloads may observe corrected multiline-string values—the exact class currently broken by Helm. HAProxy starts working; `|-` users remain unaffected.