### PR TITLE
test(action): poll for the interrupted install goroutine instead of a zero-margin sleep

### DIFF
--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -683,8 +683,10 @@ func TestInstallRelease_Wait_Interrupted(t *testing.T) {
 	is.Contains(err.Error(), "context canceled")
 
 	is.Equal(goroutines+1, instAction.getGoroutineCount()) // installation goroutine still is in background
-	time.Sleep(10 * time.Second)                           // wait for goroutine to finish
-	is.Equal(goroutines, instAction.getGoroutineCount())
+	// Poll until the background installation goroutine has finished.
+	is.Eventually(func() bool {
+		return instAction.getGoroutineCount() == goroutines
+	}, 30*time.Second, 10*time.Millisecond)
 }
 func TestInstallRelease_WaitForJobs(t *testing.T) {
 	is := assert.New(t)
@@ -782,8 +784,10 @@ func TestInstallRelease_RollbackOnFailure_Interrupted(t *testing.T) {
 	req.Error(err)
 	is.Equal(err, driver.ErrReleaseNotFound)
 	is.Equal(goroutines+1, instAction.getGoroutineCount()) // installation goroutine still is in background
-	time.Sleep(10 * time.Second)                           // wait for goroutine to finish
-	is.Equal(goroutines, instAction.getGoroutineCount())
+	// Poll until the background installation goroutine has finished.
+	is.Eventually(func() bool {
+		return instAction.getGoroutineCount() == goroutines
+	}, 30*time.Second, 10*time.Millisecond)
 }
 func TestNameTemplate(t *testing.T) {
 	testCases := []nameTemplateTestCase{


### PR DESCRIPTION
`TestInstallRelease_Wait_Interrupted` and `TestInstallRelease_RollbackOnFailure_Interrupted` verify that the detached installation goroutine has exited after the context is cancelled. They do so by sleeping a fixed **10s**:

```go
failer.WaitDuration = 10 * time.Second
...
is.Equal(goroutines+1, instAction.getGoroutineCount()) // still running
time.Sleep(10 * time.Second)                           // wait for goroutine to finish
is.Equal(goroutines, instAction.getGoroutineCount())
```

The problem: the sleep is **exactly** the `FailingKubeClient.WaitDuration` the goroutine blocks on, so it is a **zero-margin race**. The goroutine finishes at ~10s and the sleep expires at ~10s; if scheduler jitter under load lets the sleep win, `getGoroutineCount()` has not decremented yet and `is.Equal(goroutines, ...)` flakes.

This replaces the fixed sleep + point-in-time assertion with `is.Eventually` polling `getGoroutineCount()` (30s ceiling, 10ms tick). It returns as soon as the goroutine has actually completed and no longer races the exact wait duration.

Note this is a **robustness** change, not a speed-up — the goroutine is bounded by the 10s `WaitDuration`, so the common-case runtime is unchanged; the point is to stop racing it.

Verified locally: `go test ./pkg/action/ -run 'TestInstallRelease_Wait_Interrupted|TestInstallRelease_RollbackOnFailure_Interrupted'` — both pass. `gofmt`/`go vet` clean. Test-only; no change to install behavior.