### PR TITLE
chore(deps): bump golang/govulncheck-action from 1.0.4 to 1.1.0

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,6 +23,6 @@ jobs:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
       - name: govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # pin@1.0.4
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # pin@v1.1.0
         with:
           go-package: ./...


### PR DESCRIPTION
## What this does

Forward-ports the `golang/govulncheck-action` bump that already landed on `main` (commit `032d455`, released as **v1.1.0** on 2026-07-10) to the `dev-v3` workflow. Bumps the pin from `v1.0.4` (`b625fbe`) to `v1.1.0` (`032d455`).

## Why

`dev-v3` dependency PRs are currently failing the (non-required) `govulncheck` check on **GO-2026-5932** — the advisory that flags `golang.org/x/crypto/openpgp` as unmaintained / unsafe-by-design (**no fixed version exists**). It's reached only through Helm's own provenance/chart-signing code, which is unchanged.

`main` does **not** fail on this: its govulncheck-action was bumped on 2026-07-06/07-08 to a newer govulncheck that classifies this unmaintained-module advisory as informational ("your code doesn't appear to call these") rather than an affecting vulnerability. `dev-v3` was never updated because Dependabot's `github-actions` ecosystem is only configured for `main`, so Actions bumps never flow to `dev-v3`.

This PR brings `dev-v3` in line with `main` so the false-positive failure clears. A companion PR to `main` adds a `github-actions` → `dev-v3` Dependabot entry so this doesn't drift again.

## Verification

- SHA `032d455` is the exact commit tagged **v1.1.0** in `golang/govulncheck-action`.
- `main`'s scheduled govulncheck runs on this action version report `Your code is affected by 0 vulnerabilities` and pass.