### PR TITLE
ci: track GitHub Actions updates on dev-v3 via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - # Keep dev-v3 GitHub Actions up to date, while Helm v3 is within support
+    package-ecosystem: "github-actions"
+    target-branch: "dev-v3"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## What this does

Adds a `github-actions` Dependabot update block targeting the `dev-v3` branch, alongside the existing `gomod` → `dev-v3` and `github-actions` → `main` blocks.

## Why

Dependabot reads its configuration **only from the default branch** (`main`). Today the `github-actions` ecosystem is configured for `main` only, so GitHub Actions version bumps are never opened against `dev-v3`. (Note: `dev-v3` carries its own `.github/dependabot.yml` with an actions block, but that file is ignored — non-default-branch Dependabot configs have no effect.)

The result is drift: `dev-v3` workflows fall behind `main`. Concretely, `dev-v3` was left on `govulncheck-action@v1.0.4` while `main` moved to `v1.1.0`, which caused dependency PRs on `dev-v3` to fail govulncheck on GO-2026-5932 (the unmaintained `golang.org/x/crypto/openpgp` advisory, no fix available). See the companion fix #32335.

With this block, Dependabot will open Action bumps against `dev-v3` on the daily schedule (and the branch's row becomes triggerable from the Dependabot dashboard), keeping it in sync with `main` for as long as Helm v3 is supported.