### PR TITLE
fix(chart): size v3Accessor.MetaDependencies from the metadata deps

### DIFF
--- a/pkg/chart/common.go
+++ b/pkg/chart/common.go
@@ -162,7 +162,7 @@ func (r *v3Accessor) Dependencies() []Charter {
 }
 
 func (r *v3Accessor) MetaDependencies() []Dependency {
-	var deps = make([]Dependency, len(r.chrt.Dependencies()))
+	var deps = make([]Dependency, len(r.chrt.Metadata.Dependencies))
 	for i, c := range r.chrt.Metadata.Dependencies {
 		deps[i] = c
 	}

--- a/pkg/chart/common_test.go
+++ b/pkg/chart/common_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chart
+
+import (
+	"testing"
+
+	v3 "helm.sh/helm/v4/internal/chart/v3"
+)
+
+// A v3 chart that declares a dependency in Chart.yaml but has not vendored it
+// under charts/ (the normal state before "helm dependency build") must not panic
+// when its metadata dependencies are read.
+func TestV3AccessorMetaDependenciesUnvendored(t *testing.T) {
+	c := &v3.Chart{Metadata: &v3.Metadata{
+		APIVersion:   "v3",
+		Name:         "x",
+		Version:      "1.0.0",
+		Dependencies: []*v3.Dependency{{Name: "foo", Version: "1.0.0", Repository: "https://example.com"}},
+	}}
+	acc, err := NewAccessor(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := acc.MetaDependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 meta dependency, got %d", len(deps))
+	}
+}


### PR DESCRIPTION
`v3Accessor.MetaDependencies` allocates the result slice from the number of loaded subcharts but fills it by iterating the declared dependencies:

```go
var deps = make([]Dependency, len(r.chrt.Dependencies())) // vendored subcharts
for i, c := range r.chrt.Metadata.Dependencies {          // declared in Chart.yaml
	deps[i] = c
}
```

When a chart declares more dependencies in `Chart.yaml` than it has vendored under `charts/` (the normal state before `helm dependency build`), `deps[i]` runs past the end of the slice and panics with an index-out-of-range.

`MetaDependencies` is called unconditionally on the loaded chart in `install`, `upgrade`, `package`, and `get metadata`, so any of those on a v3 chart with an unvendored dependency crashes. Minimal reproducer chart:

```yaml
apiVersion: v3
name: x
version: 1.0.0
dependencies:
- name: foo
  version: 1.0.0
  repository: https://example.com
```

The `v2Accessor` sibling already sizes the slice from `len(r.chrt.Metadata.Dependencies)`; this makes v3 do the same. Added a regression test.