### PR TITLE
fix(scripts): add cache-busting to Helm version checks

### DIFF
--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -114,12 +114,14 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://get.helm.sh/helm3-latest-version"
+    # Append a cache-busting query string to avoid CDN edge servers
+    # serving stale version files after a new release.
+    local latest_release_url="https://get.helm.sh/helm3-latest-version?ts=$(date +%s)"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      latest_release_response=$( curl -L --silent --show-error --fail -H "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
-      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
+      latest_release_response=$( wget "$latest_release_url" --header="Cache-Control: no-cache" -q -O - 2>&1 || true )
     fi
     TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
     if [ "x$TAG" == "x" ]; then

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -114,12 +114,13 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
+    # Cache behavior is provider-specific, so this mitigation is best effort.
     # The current CDN does not revalidate on the request no-cache directive,
     # so use a unique query while retaining no-cache for compliant intermediaries.
     local latest_release_url="https://get.helm.sh/helm3-latest-version?ts=$(date +%s)"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail -H "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
+      latest_release_response=$( curl -L --silent --show-error --fail --header "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
       latest_release_response=$( wget "$latest_release_url" --header="Cache-Control: no-cache" -q -O - 2>&1 || true )
     fi

--- a/scripts/get-helm-3
+++ b/scripts/get-helm-3
@@ -114,8 +114,8 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    # Append a cache-busting query string to avoid CDN edge servers
-    # serving stale version files after a new release.
+    # The current CDN does not revalidate on the request no-cache directive,
+    # so use a unique query while retaining no-cache for compliant intermediaries.
     local latest_release_url="https://get.helm.sh/helm3-latest-version?ts=$(date +%s)"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then

--- a/scripts/get-helm-4
+++ b/scripts/get-helm-4
@@ -114,12 +114,13 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
+    # Cache behavior is provider-specific, so this mitigation is best effort.
     # The current CDN does not revalidate on the request no-cache directive,
     # so use a unique query while retaining no-cache for compliant intermediaries.
     local latest_release_url="https://get.helm.sh/helm4-latest-version?ts=$(date +%s)"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail -H "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
+      latest_release_response=$( curl -L --silent --show-error --fail --header "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
       latest_release_response=$( wget "$latest_release_url" --header="Cache-Control: no-cache" -q -O - 2>&1 || true )
     fi

--- a/scripts/get-helm-4
+++ b/scripts/get-helm-4
@@ -114,12 +114,14 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://get.helm.sh/helm4-latest-version"
+    # The current CDN does not revalidate on the request no-cache directive,
+    # so use a unique query while retaining no-cache for compliant intermediaries.
+    local latest_release_url="https://get.helm.sh/helm4-latest-version?ts=$(date +%s)"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      latest_release_response=$( curl -L --silent --show-error --fail -H "Cache-Control: no-cache" "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
-      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
+      latest_release_response=$( wget "$latest_release_url" --header="Cache-Control: no-cache" -q -O - 2>&1 || true )
     fi
     TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
     if [ "x$TAG" == "x" ]; then


### PR DESCRIPTION
## Summary

The `get-helm-3` and `get-helm-4` scripts query version files on `get.helm.sh` to determine the latest release. The CDN serving these files sets no `Cache-Control` response header, so edge servers can serve stale responses for hours after a new Helm release. This can cause machines running the installers at the same time to select different versions.

## Root Cause

As reported in #32329, after Helm v3.21.3 was released, CI machines running `get-helm.sh` installed different versions depending on which CDN edge node they reached. Some got v3.21.3 from an updated edge, while others got v3.21.2 from a stale edge.

## Fix

Both installer scripts now:

1. Append `?ts=$(date +%s)` to the version URL so each request uses a unique cache key.
2. Send `Cache-Control: no-cache` on both the curl and wget paths.

This is a best-effort mitigation because CDN query-string and request-header behavior depends on provider configuration. The current CDN does not revalidate when it receives the request `no-cache` directive, so the unique query key handles its observed behavior. The standard request directive remains useful for other compliant intermediaries.

## Test Plan

- [x] `bash -n scripts/get-helm-3 scripts/get-helm-4`
- [x] `git diff --check`
- [x] Live curl requests returned valid Helm 3 and Helm 4 version tags
- [x] Both curl and wget paths updated in both scripts

These checks guard against installer regressions, but they do not prove cache propagation after a release. An end-to-end cache test requires changing a version file behind the deployed CDN and observing requests during propagation, either after a release or in a controlled CDN test environment.

Fixes #32329
