### PR TITLE
ci: auto-label PRs targeting dev-v3

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-"dev-v3":
+"v3.x":
   - base-branch: "dev-v3"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+"dev-v3":
+  - base-branch: "dev-v3"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,8 @@
 name: Label PRs
 on:
   pull_request_target:
-    types: [opened]
+    branches: [dev-v3]
+    types: [opened, reopened, edited, synchronize]
 permissions: {}
 jobs:
   label:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # pin@v5.0.0
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # pin@v6.2.0
         with:
           sync-labels: true

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,15 @@
+name: Label PRs
+on:
+  pull_request_target:
+    types: [opened]
+permissions: {}
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # pin@v5.0.0
+        with:
+          sync-labels: true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Use actions/labeler to automatically apply a "v3.x" label on PRs opened against the dev-v3 branch, so we do not need to do it manually, change the PR name to include [dev-v3], or risk forgetting altogether...

**Special notes for your reviewer**:

Made using Claude Opus 4-6, reviewed with [Zizmor](https://docs.zizmor.sh/). There are a few issues flagged, but none introduced by the code I added.

I'm not sure whether this addition is part of a broader change.

- [ ] Create this label !

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
