### PR TITLE
fix: prevent file descriptor exhaustion during OCI plugin extraction

### DIFF
--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -222,7 +222,9 @@ func extractFile(path string, mode int64, src io.Reader) error {
 	}
 
 	if _, err := io.Copy(outFile, src); err != nil {
-		outFile.Close()
+		if cErr := outFile.Close(); cErr != nil {
+			return fmt.Errorf("%w (also failed to close: %v)", err, cErr)
+		}
 		return err
 	}
 

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -209,24 +209,24 @@ func extractTarGz(r io.Reader, targetDir string) error {
 	return extractTar(gzr, targetDir)
 }
 
-// extractFile creates a single file from the tar archive
+// extractFile creates a single file from the tar archive.
 func extractFile(path string, mode int64, src io.Reader) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
-	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(mode))
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(mode))
 	if err != nil {
 		return err
 	}
-	defer outFile.Close()
 
 	if _, err := io.Copy(outFile, src); err != nil {
+		outFile.Close()
 		return err
 	}
 
-	return nil
+	return outFile.Close()
 }
 
 // extractTar extracts a tar archive to a directory

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -216,7 +216,7 @@ func extractFile(path string, mode int64, src io.Reader) error {
 		return err
 	}
 
-	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(mode))
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(mode))
 	if err != nil {
 		return err
 	}

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -216,7 +216,7 @@ func extractFile(path string, mode int64, src io.Reader) error {
 		return err
 	}
 
-	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(mode))
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(mode))
 	if err != nil {
 		return err
 	}

--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -209,6 +209,26 @@ func extractTarGz(r io.Reader, targetDir string) error {
 	return extractTar(gzr, targetDir)
 }
 
+// extractFile creates a single file from the tar archive
+func extractFile(path string, mode int64, src io.Reader) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(mode))
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, src); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // extractTar extracts a tar archive to a directory
 func extractTar(r io.Reader, targetDir string) error {
 	tarReader := tar.NewReader(r)
@@ -233,17 +253,7 @@ func extractTar(r io.Reader, targetDir string) error {
 				return err
 			}
 		case tar.TypeReg:
-			dir := filepath.Dir(path)
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return err
-			}
-
-			outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-			defer outFile.Close()
-			if _, err := io.Copy(outFile, tarReader); err != nil {
+			if err := extractFile(path, header.Mode, tarReader); err != nil {
 				return err
 			}
 		case tar.TypeXGlobalHeader, tar.TypeXHeader:

--- a/internal/plugin/installer/oci_installer_unix_test.go
+++ b/internal/plugin/installer/oci_installer_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build unix
 
 /*
 Copyright The Helm Authors.

--- a/internal/plugin/installer/oci_installer_unix_test.go
+++ b/internal/plugin/installer/oci_installer_unix_test.go
@@ -56,7 +56,7 @@ func TestExtractTarFileDescriptorLeak(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		hdr := &tar.Header{
 			Name:     fmt.Sprintf("file_%d.txt", i),
-			Mode:     0600,
+			Mode:     0o600,
 			Size:     0,
 			Typeflag: tar.TypeReg,
 		}

--- a/internal/plugin/installer/oci_installer_unix_test.go
+++ b/internal/plugin/installer/oci_installer_unix_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+func TestExtractTarFileDescriptorLeak(t *testing.T) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		t.Skipf("Skipping test because Getrlimit failed: %v", err)
+	}
+
+	// Lower the limit to 50
+	oldLimit := rLimit
+	rLimit.Cur = 50
+	if rLimit.Max < 50 {
+		rLimit.Max = 50
+	}
+
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		t.Skipf("Skipping test because Setrlimit failed: %v", err)
+	}
+	defer func() {
+		// Restore the original limit
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &oldLimit); err != nil {
+			t.Logf("Failed to restore RLIMIT_NOFILE: %v", err)
+		}
+	}()
+
+	// Create a dummy tar archive with 100 files (more than the limit of 50)
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i := 0; i < 100; i++ {
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("file_%d.txt", i),
+			Mode:     0600,
+			Size:     0,
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("Failed to write header: %v", err)
+		}
+		if _, err := tw.Write([]byte{}); err != nil {
+			t.Fatalf("Failed to write content: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Failed to close tar writer: %v", err)
+	}
+
+	// Extract the tar archive
+	tempDir := t.TempDir()
+	if err := extractTar(&buf, tempDir); err != nil {
+		t.Fatalf("extractTar failed, likely due to file descriptor exhaustion: %v", err)
+	}
+}

--- a/internal/plugin/installer/oci_installer_unix_test.go
+++ b/internal/plugin/installer/oci_installer_unix_test.go
@@ -34,10 +34,10 @@ func TestExtractTarFileDescriptorLeak(t *testing.T) {
 
 	// Lower the limit to 50
 	oldLimit := rLimit
-	rLimit.Cur = 50
 	if rLimit.Max < 50 {
-		rLimit.Max = 50
+		t.Skipf("Skipping test because Max limit (%d) is too low", rLimit.Max)
 	}
+	rLimit.Cur = 50
 
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {


### PR DESCRIPTION
Closes #32344

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This fixes a bug where Helm can crash with a "too many open files" error if you try to extract an OCI plugin that has a ton of files inside its tarball.

In `oci_installer.go`, we were using `defer outFile.Close()` right in the middle of a `for` loop. Because of how `defer` works in Go, none of the files were actually getting closed until the entire `extractTar` function finished. So if a tarball had 5,000 files, Helm would try to keep 5,000 file descriptors open all at once, which usually hits the OS limits and crashes.

To fix this, I just extracted the file-copying code into a small `extractFile` helper function. This forces the `defer outFile.Close()` to trigger immediately after each file is done, keeping our open file count super low regardless of how big the tarball is.

**Special notes for your reviewer**:
The core extraction logic hasn't changed at all! I just lifted the `tar.TypeReg` block into its own function so the `defer` is safely scoped. I also updated the file extraction flags to use os.O_WRONLY|os.O_TRUNC to prevent trailing bytes from corrupting cached plugin extractions

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
