### PR TITLE
fix: add duplicate key detection for values.yaml

### DIFF
--- a/internal/chart/v3/lint/lint_test.go
+++ b/internal/chart/v3/lint/lint_test.go
@@ -37,6 +37,7 @@ const goodChartDir = "rules/testdata/goodone"
 const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
 const invalidChartFileDir = "rules/testdata/invalidchartfile"
+const duplicateKeysDir = "rules/testdata/duplicatekeys"
 
 func TestBadChartV3(t *testing.T) {
 	var values map[string]any
@@ -239,5 +240,28 @@ func TestMalformedTemplate(t *testing.T) {
 		if !strings.Contains(m[0].Err.Error(), "invalid character '{'") {
 			t.Error("All didn't have the error for invalid character '{'")
 		}
+	}
+}
+
+// TestDuplicateKeysV3 tests that values.yaml with duplicate keys is detected
+// See https://github.com/helm/helm/issues/31102
+func TestDuplicateKeysV3(t *testing.T) {
+	var values map[string]any
+	m := RunAll(duplicateKeysDir, values, namespace).Messages
+	// Expect at least 1 message (the duplicate keys error)
+	if len(m) < 1 {
+		t.Fatalf("All didn't fail with expected errors, got %#v", m)
+	}
+	// Find the duplicate keys error message
+	found := false
+	for _, msg := range m {
+		if msg.Path == "values.yaml" && msg.Severity == support.ErrorSev &&
+			strings.Contains(msg.Err.Error(), "contains duplicate keys") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("All didn't have the error for duplicate YAML keys in values.yaml: %v", m)
 	}
 }

--- a/internal/chart/v3/lint/rules/testdata/duplicatekeys/Chart.yaml
+++ b/internal/chart/v3/lint/rules/testdata/duplicatekeys/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v3
+name: duplicatekeys
+description: testing chart with duplicate keys in values.yaml
+version: 0.1.0

--- a/internal/chart/v3/lint/rules/testdata/duplicatekeys/values.yaml
+++ b/internal/chart/v3/lint/rules/testdata/duplicatekeys/values.yaml
@@ -1,0 +1,4 @@
+invalid:
+  duplicate: default
+  duplicate: value-i-want
+  duplicate: last-one

--- a/internal/chart/v3/lint/rules/values.go
+++ b/internal/chart/v3/lint/rules/values.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"helm.sh/helm/v4/internal/chart/v3/lint/support"
 	"helm.sh/helm/v4/pkg/chart/common"
@@ -54,9 +55,13 @@ func validateValuesFileExistence(valuesPath string) error {
 }
 
 func validateValuesFile(valuesPath string, overrides map[string]any, skipSchemaValidation bool) error {
-	values, err := common.ReadValuesFile(valuesPath)
-	if err != nil {
-		return fmt.Errorf("unable to parse YAML: %w", err)
+	// Try strict parsing first to detect duplicate keys
+	values, strictErr := common.ReadValuesFileStrict(valuesPath)
+	if strictErr != nil {
+		if isDuplicateKeyError(strictErr) {
+			return fmt.Errorf("%s contains duplicate keys: %w", filepath.Base(valuesPath), strictErr)
+		}
+		return fmt.Errorf("unable to parse YAML: %w", strictErr)
 	}
 
 	// Helm 3.0.0 carried over the values linting from Helm 2.x, which only tests the top
@@ -82,4 +87,12 @@ func validateValuesFile(valuesPath string, overrides map[string]any, skipSchemaV
 	}
 
 	return nil
+}
+
+// isDuplicateKeyError checks if an error is related to duplicate YAML keys
+func isDuplicateKeyError(err error) bool {
+	errStr := err.Error()
+	return strings.Contains(errStr, "already set in map") ||
+		strings.Contains(errStr, "already defined") ||
+		strings.Contains(errStr, "duplicate")
 }

--- a/internal/chart/v3/lint/rules/values.go
+++ b/internal/chart/v3/lint/rules/values.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	yamlv2 "go.yaml.in/yaml/v2"
+
 	"helm.sh/helm/v4/internal/chart/v3/lint/support"
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/common/util"
@@ -89,10 +91,16 @@ func validateValuesFile(valuesPath string, overrides map[string]any, skipSchemaV
 	return nil
 }
 
-// isDuplicateKeyError checks if an error is related to duplicate YAML keys
+// isDuplicateKeyError checks if an error is related to duplicate YAML keys.
 func isDuplicateKeyError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "already set in map") ||
-		strings.Contains(errStr, "already defined") ||
-		strings.Contains(errStr, "duplicate")
+	var typeErr *yamlv2.TypeError
+	if !errors.As(err, &typeErr) {
+		return false
+	}
+	for _, e := range typeErr.Errors {
+		if strings.Contains(e, "already set in map") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/chart/v3/lint/rules/values_test.go
+++ b/internal/chart/v3/lint/rules/values_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package rules
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	yamlv2 "go.yaml.in/yaml/v2"
 
 	"helm.sh/helm/v4/internal/test/ensure"
 )
@@ -180,4 +183,59 @@ func createTestingSchema(t *testing.T, dir string) string {
 		t.Fatalf("Failed to write schema to tmpdir: %s", err)
 	}
 	return schemafile
+}
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "duplicate key error",
+			err:      &yamlv2.TypeError{Errors: []string{`line 2: key "key" already set in map`}},
+			expected: true,
+		},
+		{
+			name:     "wrapped duplicate key error",
+			err:      fmt.Errorf("error converting YAML to JSON: %w", &yamlv2.TypeError{Errors: []string{`line 2: key "key" already set in map`}}),
+			expected: true,
+		},
+		{
+			name:     "non-duplicate key error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "type error but not duplicate-key related",
+			err:      &yamlv2.TypeError{Errors: []string{"cannot unmarshal !!seq into map[string]interface {}"}},
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDuplicateKeyError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateValuesFileDuplicateKeys(t *testing.T) {
+	duplicateYaml := `key: value1
+key: value2
+`
+	tmpdir := ensure.TempFile(t, "values.yaml", []byte(duplicateYaml))
+	valfile := filepath.Join(tmpdir, "values.yaml")
+
+	err := validateValuesFile(valfile, map[string]any{}, false)
+	if err == nil {
+		t.Fatal("expected values file with duplicate keys to fail parsing")
+	}
+	assert.Contains(t, err.Error(), "contains duplicate keys")
 }

--- a/pkg/chart/common/values.go
+++ b/pkg/chart/common/values.go
@@ -118,6 +118,26 @@ func ReadValuesFile(filename string) (Values, error) {
 	return ReadValues(data)
 }
 
+// ReadValuesFileStrict will parse a YAML file into a map of values using strict unmarshaling.
+// This will detect duplicate keys in the YAML.
+func ReadValuesFileStrict(filename string) (Values, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return map[string]any{}, err
+	}
+	return ReadValuesStrict(data)
+}
+
+// ReadValuesStrict will parse YAML byte data into a Values using strict unmarshaling.
+// This will detect duplicate keys in the YAML.
+func ReadValuesStrict(data []byte) (vals Values, err error) {
+	err = yaml.UnmarshalStrict(data, &vals)
+	if len(vals) == 0 {
+		vals = Values{}
+	}
+	return vals, err
+}
+
 // ReleaseOptions represents the additional release options needed
 // for the composition of the final values struct
 type ReleaseOptions struct {

--- a/pkg/chart/common/values_test.go
+++ b/pkg/chart/common/values_test.go
@@ -19,6 +19,7 @@ package common
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -201,5 +202,36 @@ chapter:
 		if v != "Moby Dick" {
 			t.Error("Failed to return values for root key title")
 		}
+	}
+}
+
+func TestReadValuesStrict(t *testing.T) {
+	doc := `# Test YAML parse
+poet: "Coleridge"
+title: "Rime of the Ancient Mariner"
+`
+
+	data, err := ReadValuesStrict([]byte(doc))
+	if err != nil {
+		t.Fatalf("Error parsing bytes: %s", err)
+	}
+	if data["poet"] != "Coleridge" {
+		t.Errorf("Unexpected poet: %v", data["poet"])
+	}
+}
+
+func TestReadValuesStrictDuplicateKeys(t *testing.T) {
+	doc := `invalid:
+  duplicate: default
+  duplicate: value-i-want
+  duplicate: last-one
+`
+
+	_, err := ReadValuesStrict([]byte(doc))
+	if err == nil {
+		t.Fatal("Expected error for duplicate keys, got nil")
+	}
+	if !strings.Contains(err.Error(), "already") && !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("Expected duplicate-key error, got: %s", err)
 	}
 }

--- a/pkg/chart/v2/lint/lint_test.go
+++ b/pkg/chart/v2/lint/lint_test.go
@@ -37,6 +37,7 @@ const goodChartDir = "rules/testdata/goodone"
 const subChartValuesDir = "rules/testdata/withsubchart"
 const malformedTemplate = "rules/testdata/malformed-template"
 const invalidChartFileDir = "rules/testdata/invalidchartfile"
+const duplicateKeysDir = "rules/testdata/duplicatekeys"
 
 func TestBadChart(t *testing.T) {
 	var values map[string]any
@@ -243,5 +244,28 @@ func TestMalformedTemplate(t *testing.T) {
 		if !strings.Contains(m[0].Err.Error(), "invalid character '{'") {
 			t.Error("All didn't have the error for invalid character '{'")
 		}
+	}
+}
+
+// TestDuplicateKeys tests that values.yaml with duplicate keys is detected
+// See https://github.com/helm/helm/issues/31102
+func TestDuplicateKeys(t *testing.T) {
+	var values map[string]any
+	m := RunAll(duplicateKeysDir, values, namespace).Messages
+	// Expect at least 1 message (the duplicate keys error)
+	if len(m) < 1 {
+		t.Fatalf("All didn't fail with expected errors, got %#v", m)
+	}
+	// Find the duplicate keys error message
+	found := false
+	for _, msg := range m {
+		if msg.Path == "values.yaml" && msg.Severity == support.ErrorSev &&
+			strings.Contains(msg.Err.Error(), "contains duplicate keys") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("All didn't have the error for duplicate YAML keys in values.yaml: %v", m)
 	}
 }

--- a/pkg/chart/v2/lint/rules/testdata/duplicatekeys/Chart.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/duplicatekeys/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: duplicatekeys
+description: testing chart with duplicate keys in values.yaml
+version: 0.1.0

--- a/pkg/chart/v2/lint/rules/testdata/duplicatekeys/values.yaml
+++ b/pkg/chart/v2/lint/rules/testdata/duplicatekeys/values.yaml
@@ -1,0 +1,4 @@
+invalid:
+  duplicate: default
+  duplicate: value-i-want
+  duplicate: last-one

--- a/pkg/chart/v2/lint/rules/values.go
+++ b/pkg/chart/v2/lint/rules/values.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/common/util"
@@ -54,9 +55,13 @@ func validateValuesFileExistence(valuesPath string) error {
 }
 
 func validateValuesFile(valuesPath string, overrides map[string]any, skipSchemaValidation bool) error {
-	values, err := common.ReadValuesFile(valuesPath)
-	if err != nil {
-		return fmt.Errorf("unable to parse YAML: %w", err)
+	// Try strict parsing first to detect duplicate keys
+	values, strictErr := common.ReadValuesFileStrict(valuesPath)
+	if strictErr != nil {
+		if isDuplicateKeyError(strictErr) {
+			return fmt.Errorf("%s contains duplicate keys: %w", filepath.Base(valuesPath), strictErr)
+		}
+		return fmt.Errorf("unable to parse YAML: %w", strictErr)
 	}
 
 	// Helm 3.0.0 carried over the values linting from Helm 2.x, which only tests the top
@@ -82,4 +87,12 @@ func validateValuesFile(valuesPath string, overrides map[string]any, skipSchemaV
 	}
 
 	return nil
+}
+
+// isDuplicateKeyError checks if an error is related to duplicate YAML keys
+func isDuplicateKeyError(err error) bool {
+	errStr := err.Error()
+	return strings.Contains(errStr, "already set in map") ||
+		strings.Contains(errStr, "already defined") ||
+		strings.Contains(errStr, "duplicate")
 }


### PR DESCRIPTION
## Description

This PR adds a lint rule to detect duplicate keys in . This addresses the issue where Helm allows installing charts with invalid YAML that contains duplicate keys, which silently takes the last value.

## Changes

- Add  and  functions in  that use 
- Add  function in both v2 and v3 lint rules to check for duplicate keys
- Add test data with duplicate keys for both v2 and v3
- Add tests to verify duplicate key detection works

## Testing

The new lint rule will detect duplicate keys in  and report an error. For example:



Will produce an error like:


## Related Issues

Closes #31102