### PR TITLE
fix: us secure randomized temporary directories in chart downloader

### DIFF
--- a/pkg/cmd/dependency_update_test.go
+++ b/pkg/cmd/dependency_update_test.go
@@ -206,9 +206,14 @@ func TestDependencyUpdateCmd_DoNotDeleteOldChartsOnError(t *testing.T) {
 	}
 
 	// Make sure tmpcharts-x is deleted
-	tmpPath := filepath.Join(dir(chartname), fmt.Sprintf("tmpcharts-%d", os.Getpid()))
-	if _, err := os.Stat(tmpPath); !errors.Is(err, fs.ErrNotExist) {
-		t.Fatal("tmpcharts dir still exists")
+	entries, err := os.ReadDir(dir(chartname))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "tmpcharts-") {
+			t.Fatalf("tmpcharts directory still exists: %s", entry.Name())
+		}
 	}
 }
 

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -249,7 +249,6 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	}
 
 	destPath := filepath.Join(m.ChartPath, "charts")
-	tmpPath := filepath.Join(m.ChartPath, fmt.Sprintf("tmpcharts-%d", os.Getpid()))
 
 	// Check if 'charts' directory is not actually a directory. If it does not exist, create it.
 	if fi, err := os.Stat(destPath); err == nil {
@@ -265,8 +264,13 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 	}
 
 	// Prepare tmpPath
-	if err := os.MkdirAll(tmpPath, 0o755); err != nil {
+	tmpPath, err := os.MkdirTemp(m.ChartPath, "tmpcharts-*")
+	if err != nil {
 		return err
+	}
+	// Maintain compatibility with existing permissions
+	if err := os.Chmod(tmpPath, 0o755); err != nil && m.Debug {
+		fmt.Fprintf(m.Out, "warning: failed to set permissions on temporary directory %s: %v\n", tmpPath, err)
 	}
 	defer os.RemoveAll(tmpPath)
 


### PR DESCRIPTION
While going through the dependency downloader code in pkg/downloader/manager.go, I noticed that the downloader creates its temporary workspace using a predictable naming convention: tmpcharts-<PID>.

Using process IDs for temporary directories can easily lead to filename collisions and race conditions if multiple Helm commands run concurrently (such as in parallel CI/CD environments or when Helm is integrated as a library). It's also an anti-pattern for secure temp-path generation.

To harden this, I refactored the downloader to use Go’s native os.MkdirTemp to generate a secure, randomized subdirectory (tmpcharts-*) under m.ChartPath. I also ensured we call os.Chmod to restore 0755 permissions for compatibility with shared environments and updated the tests in pkg/cmd/dependency_update_test.go to scan for cleanups robustly.