### PR TITLE
fix rollback cleanup when no resources were created

### DIFF
--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -241,7 +241,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		targetRelease.Info.Description = msg
 		r.cfg.recordRelease(currentRelease)
 		r.cfg.recordRelease(targetRelease)
-		if r.CleanupOnFail && len(results.Created) > 0 {
+		if r.CleanupOnFail && results != nil && len(results.Created) > 0 {
 			r.cfg.Logger().Debug("cleanup on fail set, cleaning up resources", "count", len(results.Created))
 			_, errs := r.cfg.KubeClient.Delete(results.Created, metav1.DeletePropagationBackground)
 			if errs != nil {

--- a/pkg/action/rollback.go
+++ b/pkg/action/rollback.go
@@ -241,7 +241,7 @@ func (r *Rollback) performRollback(currentRelease, targetRelease *release.Releas
 		targetRelease.Info.Description = msg
 		r.cfg.recordRelease(currentRelease)
 		r.cfg.recordRelease(targetRelease)
-		if r.CleanupOnFail {
+		if r.CleanupOnFail && len(results.Created) > 0 {
 			r.cfg.Logger().Debug("cleanup on fail set, cleaning up resources", "count", len(results.Created))
 			_, errs := r.cfg.KubeClient.Delete(results.Created, metav1.DeletePropagationBackground)
 			if errs != nil {

--- a/pkg/action/rollback_test.go
+++ b/pkg/action/rollback_test.go
@@ -27,6 +27,7 @@ import (
 
 	"helm.sh/helm/v4/pkg/kube"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	"helm.sh/helm/v4/pkg/release/common"
 )
 
 func TestNewRollback(t *testing.T) {
@@ -45,6 +46,42 @@ func TestRollbackRun_UnreachableKubeClient(t *testing.T) {
 
 	client := NewRollback(config)
 	assert.Error(t, client.Run(""))
+}
+
+func TestRollbackRelease_CleanupOnFailSkipsEmptyCreated(t *testing.T) {
+	is := assert.New(t)
+	req := require.New(t)
+	config := actionConfigFixture(t)
+
+	rel1 := releaseStub()
+	rel1.Name = "rollback-cleanup"
+	rel1.Version = 1
+	rel1.Info.Status = common.StatusSuperseded
+	rel1.ApplyMethod = "csa"
+	req.NoError(config.Releases.Create(rel1))
+
+	rel2 := releaseStub()
+	rel2.Name = "rollback-cleanup"
+	rel2.Version = 2
+	rel2.Info.Status = common.StatusDeployed
+	rel2.ApplyMethod = "csa"
+	req.NoError(config.Releases.Create(rel2))
+
+	failer := config.KubeClient.(*kubefake.FailingKubeClient)
+	failer.UpdateError = errors.New("update failed")
+	failer.DeleteError = errors.New("delete should not run")
+	config.KubeClient = failer
+
+	client := NewRollback(config)
+	client.Version = 1
+	client.CleanupOnFail = true
+	client.ServerSideApply = "auto"
+
+	err := client.Run("rollback-cleanup")
+	req.Error(err)
+	is.Contains(err.Error(), "update failed")
+	is.NotContains(err.Error(), "unable to cleanup resources")
+	is.NotContains(err.Error(), "delete should not run")
 }
 
 func TestRollback_WaitOptionsPassedDownstream(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #32350.

When rollback fails with `--cleanup-on-fail`, Helm currently tries to delete `results.Created` even when the failed update did not create any resources. If that cleanup path returns an error for the empty list, the original rollback update error gets hidden behind the cleanup error.

This matches upgrade behavior by only running cleanup when there are created resources, and adds a regression test to keep the original rollback error intact.

**Special notes for your reviewer**:

Tested with:

```
go test ./pkg/action -run TestRollbackRelease_CleanupOnFailSkipsEmptyCreated -count=1
go test ./pkg/action -run TestRollback -count=1
go test ./pkg/action -count=1
```

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
