### PR TITLE
fix: 'gocritic: filepathJoin path seperator' lint error

### DIFF
--- a/pkg/helmpath/lazypath_darwin_test.go
+++ b/pkg/helmpath/lazypath_darwin_test.go
@@ -36,13 +36,12 @@ func TestDataPath(t *testing.T) {
 	os.Unsetenv(xdg.DataHomeEnvVar)
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", appName, testFile)
-
 	assert.Equal(t, expected, lazy.dataPath(testFile))
 
-	t.Setenv(xdg.DataHomeEnvVar, "/tmp")
+	tmpDir := t.TempDir()
+	t.Setenv(xdg.DataHomeEnvVar, tmpDir)
 
-	expected = filepath.Join("/tmp", appName, testFile)
-
+	expected = filepath.Join(tmpDir, appName, testFile)
 	assert.Equal(t, expected, lazy.dataPath(testFile))
 }
 
@@ -50,13 +49,12 @@ func TestConfigPath(t *testing.T) {
 	os.Unsetenv(xdg.ConfigHomeEnvVar)
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", "Preferences", appName, testFile)
-
 	assert.Equal(t, expected, lazy.configPath(testFile))
 
-	t.Setenv(xdg.ConfigHomeEnvVar, "/tmp")
+	tmpDir := t.TempDir()
+	t.Setenv(xdg.ConfigHomeEnvVar, tmpDir)
 
-	expected = filepath.Join("/tmp", appName, testFile)
-
+	expected = filepath.Join(tmpDir, appName, testFile)
 	assert.Equal(t, expected, lazy.configPath(testFile))
 }
 
@@ -64,12 +62,11 @@ func TestCachePath(t *testing.T) {
 	os.Unsetenv(xdg.CacheHomeEnvVar)
 
 	expected := filepath.Join(homedir.HomeDir(), "Library", "Caches", appName, testFile)
-
 	assert.Equal(t, expected, lazy.cachePath(testFile))
 
-	t.Setenv(xdg.CacheHomeEnvVar, "/tmp")
+	tmpDir := t.TempDir()
+	t.Setenv(xdg.CacheHomeEnvVar, tmpDir)
 
-	expected = filepath.Join("/tmp", appName, testFile)
-
+	expected = filepath.Join(tmpDir, appName, testFile)
 	assert.Equal(t, expected, lazy.cachePath(testFile))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Current `main` branch fails linting (`make test-style`) on MacOS with (`gocritic` rule enabled here: https://github.com/helm/helm/pull/32321/changes#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L95) :

```
pkg/helmpath/lazypath_darwin_test.go:44:27: filepathJoin: "/tmp" contains a path separator (gocritic)
        expected = filepath.Join("/tmp", appName, testFile)
                                 ^
pkg/helmpath/lazypath_darwin_test.go:58:27: filepathJoin: "/tmp" contains a path separator (gocritic)
        expected = filepath.Join("/tmp", appName, testFile)
                                 ^
pkg/helmpath/lazypath_darwin_test.go:72:27: filepathJoin: "/tmp" contains a path separator (gocritic)
        expected = filepath.Join("/tmp", appName, testFile)
                                 ^
3 issues:
* gocritic: 3
make: *** [test-style] Error 1
```

While this is (probably) a bug in gocritic: https://github.com/go-critic/go-critic/issues/1507 , in this case the tests should probably be using `t.TempDir()` anyway

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
