### PR TITLE
chore: Add AI Vendor specific paths to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .DS_Store
 .coverage/
 .idea
-.claude
 .vimrc
 .vscode/
 .devcontainer/
@@ -11,7 +10,14 @@ _dist/
 _dist_versions/
 bin/
 vendor/
+.pre-commit-config.yaml
+
 # Ignores charts pulled for dependency build tests
 cmd/helm/testdata/testcharts/issue-7233/charts/*
 pkg/cmd/testdata/testcharts/issue-7233/charts/*
-.pre-commit-config.yaml
+
+# AI Vendor specific paths
+CLAUDE.md
+.claude/
+.codex/
+.cursor/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add AI Vendor specific paths to `.gitignore`. Helm should standardize on the vendor-neutral `AGENTS.md`, `.agents/`, etc

(if more are known, please suggest!)

**Special notes for your reviewer**:
Minor re-arrangement of `.gitignore` contents

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
