### PR TITLE
Fix test compilation on Windows in plugin installer package

### DIFF
--- a/internal/plugin/installer/http_installer_test.go
+++ b/internal/plugin/installer/http_installer_test.go
@@ -29,7 +29,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,8 +166,7 @@ func TestExtract(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Get current umask to predict expected permissions
-	currentUmask := syscall.Umask(0)
-	syscall.Umask(currentUmask)
+	currentUmask := processUmask()
 
 	// Write a tarball to a buffer for us to extract
 	var tarbuf bytes.Buffer
@@ -226,8 +224,10 @@ func TestExtract(t *testing.T) {
 		require.NotErrorIs(t, err, fs.ErrNotExist, "Expected %s to exist but doesn't", pluginYAMLFullPath)
 	}
 	require.NoError(t, err)
-	require.Equalf(t, expectedPluginYAMLPerm, info.Mode().Perm(), "Expected %s to have %o mode but has %o (umask: %o)",
-		pluginYAMLFullPath, expectedPluginYAMLPerm, info.Mode().Perm(), currentUmask)
+	if posixPermsSupported {
+		require.Equalf(t, expectedPluginYAMLPerm, info.Mode().Perm(), "Expected %s to have %o mode but has %o (umask: %o)",
+			pluginYAMLFullPath, expectedPluginYAMLPerm, info.Mode().Perm(), currentUmask)
+	}
 
 	readmeFullPath := filepath.Join(tempDir, "README.md")
 	info, err = os.Stat(readmeFullPath)
@@ -235,8 +235,10 @@ func TestExtract(t *testing.T) {
 		require.NotErrorIs(t, err, fs.ErrNotExist, "Expected %s to exist but doesn't", readmeFullPath)
 	}
 	require.NoError(t, err)
-	require.Equalf(t, expectedReadmePerm, info.Mode().Perm(), "Expected %s to have %o mode but has %o (umask: %o)",
-		readmeFullPath, expectedReadmePerm, info.Mode().Perm(), currentUmask)
+	if posixPermsSupported {
+		require.Equalf(t, expectedReadmePerm, info.Mode().Perm(), "Expected %s to have %o mode but has %o (umask: %o)",
+			readmeFullPath, expectedReadmePerm, info.Mode().Perm(), currentUmask)
+	}
 }
 
 func TestCleanJoin(t *testing.T) {

--- a/internal/plugin/installer/umask_unix_test.go
+++ b/internal/plugin/installer/umask_unix_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build !windows
+
+package installer
+
+import "syscall"
+
+// posixPermsSupported reports whether the platform honors POSIX file
+// permission bits, allowing tests to assert on extracted file modes.
+const posixPermsSupported = true
+
+// processUmask returns the current process umask without changing it.
+func processUmask() int {
+	umask := syscall.Umask(0)
+	syscall.Umask(umask)
+	return umask
+}

--- a/internal/plugin/installer/umask_unix_test.go
+++ b/internal/plugin/installer/umask_unix_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
 Copyright The Helm Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build !windows
 
 package installer
 

--- a/internal/plugin/installer/umask_windows_test.go
+++ b/internal/plugin/installer/umask_windows_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build windows
+
+package installer
+
+// posixPermsSupported reports whether the platform honors POSIX file
+// permission bits, allowing tests to assert on extracted file modes.
+// Windows does not, so permission assertions are skipped there.
+const posixPermsSupported = false
+
+// processUmask returns 0 on Windows, which has no umask concept.
+func processUmask() int {
+	return 0
+}

--- a/internal/plugin/installer/umask_windows_test.go
+++ b/internal/plugin/installer/umask_windows_test.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
 Copyright The Helm Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build windows
 
 package installer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #32389

`TestExtract` in `internal/plugin/installer/http_installer_test.go` calls `syscall.Umask`, which doesn't exist on Windows and the file has no build constraint, so `go vet ./...` and `go test ./internal/plugin/installer/` fail to compile there:

```
vet.exe: internal\plugin\installer\http_installer_test.go:212:26: undefined: syscall.Umask
```

This PR moves the umask lookup behind build-tag-guarded test helpers:

- `umask_unix_test.go` (`//go:build !windows`) — real `syscall.Umask` round-trip
- `umask_windows_test.go` (`//go:build windows`) — returns 0, and exposes `posixPermsSupported = false`

The POSIX permission assertions in `TestExtract` are skipped on Windows (file modes aren't honored there), but the test itself still runs so the extraction path handling stays covered on all platforms.

**Special notes for your reviewer**:

Verified on windows/amd64 with `go vet ./internal/plugin/installer/` and `go test -run TestExtract -v ./internal/plugin/installer/` (passes), plus `GOOS=linux go vet` and `GOOS=darwin go vet` cross-checks to confirm the Unix helper compiles.

Note: with the compile break fixed, three other tests in this package surface pre-existing Windows portability failures (`TestPath` path separators, `TestLocalInstaller` symlink privilege, `TestOCIInstaller_Install_ComponentExtraction` exec-bit assertion). Kept out of scope here — detailed in #32389.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
