### PR TITLE
Write interactive prompts to stderr and handle echo-disable failures

### DIFF
--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -206,11 +206,12 @@ func (p *Package) Clearsign(filename string) error {
 
 // promptUser implements provenance.PassphraseFetcher
 func promptUser(name string) ([]byte, error) {
-	fmt.Printf("Password for key %q >  ", name)
+	// Prompts go to stderr so stdout stays clean for scripting.
+	fmt.Fprintf(os.Stderr, "Password for key %q >  ", name)
 	// syscall.Stdin is not an int in all environments and needs to be coerced
 	// into one there (e.g., Windows)
 	pw, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	return pw, err
 }
 

--- a/pkg/cmd/plugin_package.go
+++ b/pkg/cmd/plugin_package.go
@@ -172,9 +172,10 @@ func (o *pluginPackageOptions) run(out io.Writer) error {
 }
 
 func (o *pluginPackageOptions) promptUser(name string) ([]byte, error) {
-	fmt.Printf("Password for key %q >  ", name)
+	// Prompts go to stderr so stdout stays clean for scripting.
+	fmt.Fprintf(os.Stderr, "Password for key %q >  ", name)
 	pw, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	return pw, err
 }
 

--- a/pkg/cmd/registry_login.go
+++ b/pkg/cmd/registry_login.go
@@ -136,14 +136,17 @@ func getUsernamePassword(usernameOpt string, passwordOpt string, passwordFromStd
 
 // Copied/adapted from https://github.com/oras-project/oras
 func readLine(prompt string, silent bool) (string, error) {
-	fmt.Print(prompt)
-	if silent {
+	// Prompts go to stderr so stdout stays clean for scripting.
+	fmt.Fprint(os.Stderr, prompt)
+	if silent && term.IsTerminal(os.Stdin.Fd()) {
 		fd := os.Stdin.Fd()
 		state, err := term.SaveState(fd)
 		if err != nil {
 			return "", err
 		}
-		term.DisableEcho(fd, state)
+		if err := term.DisableEcho(fd, state); err != nil {
+			return "", fmt.Errorf("failed to disable terminal echo for password input: %w", err)
+		}
 		defer term.RestoreTerminal(fd, state)
 	}
 
@@ -153,7 +156,7 @@ func readLine(prompt string, silent bool) (string, error) {
 		return "", err
 	}
 	if silent {
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 	}
 
 	return string(line), nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #32392

Moves the interactive prompts from `helm registry login` (username/password/token) and the signing-key passphrase prompts in `helm package` / `helm plugin package` from stdout to stderr, following the docker/kubectl/oras convention so stdout stays machine-readable when captured.

In `registry_login.go`'s `readLine` it also:

- returns an error when `term.DisableEcho` fails instead of silently continuing — previously a failure there meant the password was echoed to the terminal with no warning
- only attempts echo handling when stdin is actually a terminal, so piped input (`echo pw | helm registry login …` without `--password-stdin`) behaves exactly as before — this also means the new DisableEcho error path can't fire for pipes

**Special notes for your reviewer**:

Behavior-wise stdout consumers only ever saw prompt text (never data) from these paths, so nothing that parses stdout can break; the prompts simply become visible again when stdout is redirected. Verified with `go build`/`go vet` on the three packages; the `TestPackage` failures on my Windows machine are pre-existing portability issues also present on clean main (see #32389).

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
