### PR TITLE
fix: prevent nil pointer panic in profiling, unchecked JSON decode, and index out of bounds in lint

### DIFF
--- a/internal/monocular/search.go
+++ b/internal/monocular/search.go
@@ -142,7 +142,9 @@ func (c *Client) SearchWithContext(ctx context.Context, term string) ([]SearchRe
 
 	result := &searchResponse{}
 
-	json.NewDecoder(res.Body).Decode(result)
+	if err := json.NewDecoder(res.Body).Decode(result); err != nil {
+		return nil, fmt.Errorf("failed to decode search results from %s: %w", p.String(), err)
+	}
 
 	return result.Data, nil
 }

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -112,6 +112,9 @@ func lintChart(path string, vals map[string]any, namespace string, kubeVersion *
 		if err != nil {
 			return linter, fmt.Errorf("unable to read temporary output directory %s: %w", tempDir, err)
 		}
+		if len(files) == 0 {
+			return linter, fmt.Errorf("temporary output directory %s is empty after extraction", tempDir)
+		}
 		if !files[0].IsDir() {
 			return linter, fmt.Errorf("unexpected file %s in temporary output directory %s", files[0].Name(), tempDir)
 		}

--- a/pkg/cmd/profiling.go
+++ b/pkg/cmd/profiling.go
@@ -74,12 +74,13 @@ func stopProfiling() error {
 		f, err := os.Create(memProfilePath)
 		if err != nil {
 			errs = append(errs, err)
-		}
-		defer f.Close()
+		} else {
+			defer f.Close()
 
-		runtime.GC() // get up-to-date statistics
-		if err := pprof.WriteHeapProfile(f); err != nil {
-			errs = append(errs, err)
+			runtime.GC() // get up-to-date statistics
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes three bugs that can cause crashes or silent data loss:

### 1. Nil pointer panic in `stopProfiling` (pkg/cmd/profiling.go)

When `os.Create(memProfilePath)` fails, `f` is nil. The code registered `defer f.Close()` unconditionally, and also called `pprof.WriteHeapProfile(f)` on the nil writer. This causes a nil pointer dereference panic when the deferred `Close()` runs.

**Fix:** Move the `defer f.Close()` and `WriteHeapProfile` call inside an `else` block that only executes when `os.Create` succeeds.

### 2. Unchecked JSON decode in `SearchWithContext` (internal/monocular/search.go)

The error from `json.NewDecoder(res.Body).Decode(result)` was completely discarded. If the server returns malformed JSON (e.g., an HTML error page), the function silently returns `(nil, nil)`, making it impossible for callers to distinguish "no results" from a parse error.

**Fix:** Check and return the decode error with a descriptive message.

### 3. Index out of bounds panic in `lintChart` (pkg/action/lint.go)

After extracting a `.tgz` to `tempDir`, the code accesses `files[0]` without checking if the slice is empty. A malformed tarball that produces an empty directory causes an index out of range runtime error.

**Fix:** Add a bounds check for empty directory before accessing `files[0]`.

## Related Issues

## Testing

Each fix handles its edge case correctly:
- Profiling gracefully reports errors instead of crashing
- Search returns parse errors instead of silent nil
- Lint returns a descriptive error instead of panicking

## Checklist

- [x] DCO sign-off included
- [x] Code follows the project's coding style
- [x] Changes are minimal and focused
- [x] No unrelated changes included