### PR TITLE
fix: prevent plugin tarball corruption, file descriptor leak, and error swallowing

### DIFF
--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -242,9 +242,13 @@ func extractTar(r io.Reader, targetDir string) error {
 			if err != nil {
 				return err
 			}
-			defer outFile.Close()
-			if _, err := io.Copy(outFile, tarReader); err != nil {
-				return err
+			_, copyErr := io.Copy(outFile, tarReader)
+			closeErr := outFile.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
 			}
 		case tar.TypeXGlobalHeader, tar.TypeXHeader:
 			// Skip these

--- a/internal/plugin/sign.go
+++ b/internal/plugin/sign.go
@@ -104,16 +104,13 @@ func parsePluginMessageBlock(data []byte) (*Metadata, *provenance.SumCollection,
 // CreatePluginTarball creates a gzipped tarball from a plugin directory
 func CreatePluginTarball(sourceDir, pluginName string, w io.Writer) error {
 	gzw := gzip.NewWriter(w)
-	defer gzw.Close()
-
 	tw := tar.NewWriter(gzw)
-	defer tw.Close()
 
 	// Use the plugin name as the base directory in the tarball
 	baseDir := pluginName
 
 	// Walk the directory tree
-	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -153,4 +150,15 @@ func CreatePluginTarball(sourceDir, pluginName string, w io.Writer) error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("closing tar writer: %w", err)
+	}
+	if err := gzw.Close(); err != nil {
+		return fmt.Errorf("closing gzip writer: %w", err)
+	}
+	return nil
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -691,7 +691,10 @@ func (i *Install) recordRelease(r *release.Release) error {
 // This allows us to reuse names by superseding an existing release with a new one
 func (i *Install) replaceRelease(rel *release.Release) error {
 	hist, err := i.cfg.Releases.History(rel.Name)
-	if err != nil || len(hist) == 0 {
+	if err != nil {
+		return err
+	}
+	if len(hist) == 0 {
 		// No releases exist for this name, so we can return early
 		return nil
 	}


### PR DESCRIPTION
## Summary

This PR fixes three bugs that can cause data corruption, resource exhaustion, and silent errors:

### 1. Plugin tarball corruption from deferred Close() errors (internal/plugin/sign.go)

`CreatePluginTarball` used `defer gzw.Close()` and `defer tw.Close()` for the gzip and tar writers. These Close() calls are critical — they flush final blocks, write checksums, and finalize the archive footer. But the function returns the error from `filepath.Walk`, and deferred Close() errors are silently discarded. If Walk succeeds but Close() fails, the function returns nil (success) while producing a corrupt, incomplete tarball.

**Fix:** Remove deferred Close() and explicitly close writers after Walk completes, returning any errors.

### 2. File descriptor leak in OCI plugin extraction (internal/plugin/installer/oci_installer.go)

`defer outFile.Close()` inside a loop accumulates open file descriptors until the function returns. For tarballs with hundreds of files, this exhausts the process's file descriptor limit and causes "too many open files" errors.

**Fix:** Close files immediately after use instead of deferring.

### 3. Error swallowing in replaceRelease (pkg/action/install.go)

The `History()` error was grouped with the "no releases" case using `||`, silently returning nil on storage backend errors. This could cause version conflicts when Kubernetes API errors occur during `helm install --replace`.

**Fix:** Separate the error check from the empty-history check.

## Related Issues

## Testing

Each fix handles its edge case correctly:
- Tarball writers properly flush and finalize on success
- Files are closed immediately, preventing fd exhaustion
- Storage errors are propagated instead of silently ignored

## Checklist

- [x] DCO sign-off included
- [x] Code follows the project's coding style
- [x] Changes are minimal and focused
- [x] No unrelated changes included