### PR TITLE
fix(package): normalize StampModTimes timestamp and add Chart.lock reproducibility test

### DIFF
--- a/pkg/action/package_test.go
+++ b/pkg/action/package_test.go
@@ -17,10 +17,18 @@ limitations under the License.
 package action
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"errors"
+	"io"
 	"os"
 	"path"
+	"strings"
 	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
@@ -169,4 +177,70 @@ func TestRun(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "empty-0.1.0.tgz", filename)
 	require.NoError(t, os.Remove(filename))
+}
+
+func TestRunWithSourceDateEpochAndLock(t *testing.T) {
+	tmp := t.TempDir()
+	epoch := time.Unix(1609459200, 0).UTC()
+
+	// Build twice with the same SourceDateEpoch and assert byte-identical output.
+	var first []byte
+	for i := range 2 {
+		client := NewPackage()
+		client.Destination = tmp
+		client.SourceDateEpoch = &epoch
+
+		dest, err := client.Run("testdata/charts/chart-with-lock", nil)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(dest)
+		require.NoError(t, err)
+
+		if i == 0 {
+			first = data
+		} else {
+			require.Equal(t, first, data, "two builds with the same SourceDateEpoch must be byte-identical")
+		}
+		require.NoError(t, os.Remove(dest))
+	}
+
+	// Open the archive and inspect Chart.lock content.
+	gz, err := gzip.NewReader(bytes.NewReader(first))
+	require.NoError(t, err)
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var lockData []byte
+	var lockHdr *tar.Header
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if strings.HasSuffix(hdr.Name, "Chart.lock") {
+			lockHdr = hdr
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, tr)
+			require.NoError(t, err)
+			lockData = buf.Bytes()
+			break
+		}
+	}
+	require.NotNil(t, lockHdr, "Chart.lock not found in archive")
+	require.NotNil(t, lockData)
+
+	// Validate the generated field in the YAML is the epoch (not the fixture's original timestamp).
+	var lock struct {
+		Generated string `yaml:"generated"`
+	}
+	err = yaml.Unmarshal(lockData, &lock)
+	require.NoError(t, err)
+	require.Equal(t, "2021-01-01T00:00:00Z", lock.Generated,
+		"Chart.lock generated field must match SourceDateEpoch")
+
+	// Tar header ModTime must also match.
+	require.True(t, lockHdr.ModTime.Equal(epoch),
+		"Chart.lock tar header ModTime must match SourceDateEpoch: got %v, want %v",
+		lockHdr.ModTime, epoch)
 }

--- a/pkg/action/testdata/charts/chart-with-lock/Chart.lock
+++ b/pkg/action/testdata/charts/chart-with-lock/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: nginx
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:abc123def456
+generated: "2024-01-01T12:00:00Z"

--- a/pkg/action/testdata/charts/chart-with-lock/Chart.yaml
+++ b/pkg/action/testdata/charts/chart-with-lock/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: chart-with-lock
+description: Test chart with Chart.lock for reproducibility testing
+version: 0.1.0

--- a/pkg/action/testdata/charts/chart-with-lock/templates/empty.yaml
+++ b/pkg/action/testdata/charts/chart-with-lock/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/pkg/chart/v2/chart.go
+++ b/pkg/chart/v2/chart.go
@@ -179,32 +179,33 @@ func (ch *Chart) CRDObjects() []CRD {
 
 // StampModTimes sets timestamps on the chart (and dependencies) to epoch.
 // This is used for reproducible builds via SOURCE_DATE_EPOCH.
-func (ch *Chart) StampModTimes(epoch time.Time) {
-	ch.ModTime = epoch
+func (ch *Chart) StampModTimes(t time.Time) {
+	t = t.UTC().Truncate(time.Second)
+	ch.ModTime = t
 	if len(ch.Schema) > 0 {
-		ch.SchemaModTime = epoch
+		ch.SchemaModTime = t
 	}
 	if ch.Lock != nil {
-		ch.Lock.Generated = epoch
+		ch.Lock.Generated = t
 	}
 
 	for _, f := range ch.Raw {
 		if f != nil {
-			f.ModTime = epoch
+			f.ModTime = t
 		}
 	}
 	for _, f := range ch.Templates {
 		if f != nil {
-			f.ModTime = epoch
+			f.ModTime = t
 		}
 	}
 	for _, f := range ch.Files {
 		if f != nil {
-			f.ModTime = epoch
+			f.ModTime = t
 		}
 	}
 	for _, dep := range ch.Dependencies() {
-		dep.StampModTimes(epoch)
+		dep.StampModTimes(t)
 	}
 }
 

--- a/pkg/chart/v2/chart.go
+++ b/pkg/chart/v2/chart.go
@@ -179,33 +179,33 @@ func (ch *Chart) CRDObjects() []CRD {
 
 // StampModTimes sets timestamps on the chart (and dependencies) to epoch.
 // This is used for reproducible builds via SOURCE_DATE_EPOCH.
-func (ch *Chart) StampModTimes(t time.Time) {
-	t = t.UTC().Truncate(time.Second)
-	ch.ModTime = t
+func (ch *Chart) StampModTimes(epoch time.Time) {
+	epoch = epoch.UTC().Truncate(time.Second)
+	ch.ModTime = epoch
 	if len(ch.Schema) > 0 {
-		ch.SchemaModTime = t
+		ch.SchemaModTime = epoch
 	}
 	if ch.Lock != nil {
-		ch.Lock.Generated = t
+		ch.Lock.Generated = epoch
 	}
 
 	for _, f := range ch.Raw {
 		if f != nil {
-			f.ModTime = t
+			f.ModTime = epoch
 		}
 	}
 	for _, f := range ch.Templates {
 		if f != nil {
-			f.ModTime = t
+			f.ModTime = epoch
 		}
 	}
 	for _, f := range ch.Files {
 		if f != nil {
-			f.ModTime = t
+			f.ModTime = epoch
 		}
 	}
 	for _, dep := range ch.Dependencies() {
-		dep.StampModTimes(t)
+		dep.StampModTimes(epoch)
 	}
 }
 


### PR DESCRIPTION
StampModTimes now normalizes the input time.Time to UTC and truncates
to whole seconds before stamping, ensuring Chart.lock generated field
is deterministic regardless of how the caller constructs the time.Time.
Add chart-with-lock test fixture and TestRunWithSourceDateEpochAndLock
to verify that a chart with a Chart.lock gets its generated field
stamped with the SourceDateEpoch, and that two builds with the same
epoch produce byte-identical output.
Closes #32396
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
**What this PR does / why we need it**:
Ports two refinements from the now-closed #32173 into `main`, as tracked
by #32396:
1. **Normalize timestamp in `StampModTimes`** — Adds
   `t = t.UTC().Truncate(time.Second)` at the top of
   `Chart.StampModTimes()` so that SDK callers passing a local-zone or
   sub-second `time.Time` still produce deterministic `Chart.lock` YAML.
   Without this, the `generated:` field could contain timezone offsets
   or fractional seconds, defeating reproducibility across machines.
2. **Test coverage for `Chart.lock` reproducibility** — Adds a
   `chart-with-lock` test fixture and
   `TestRunWithSourceDateEpochAndLock` that:
   - Packages a chart with a pre-existing `Chart.lock` using
     `SourceDateEpoch`
   - Asserts the marshaled `generated:` field equals the epoch
   - Asserts two builds with the same epoch produce byte-identical
     output
The CLI path (`sourceDateEpochFromEnv`) already normalizes to UTC, but
`StampModTimes` is a public API in `pkg/chart/v2/` — the normalization
belongs at that boundary.
**Special notes for your reviewer**:
Everything else in #32173 duplicates the already-merged #32162 — only
these two items are ported. Reference implementations for both exist in
the closed #32173 branch.
**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility