### PR TITLE
fix(installer): close each file per iteration in OCI extractTar

### DIFF
--- a/internal/plugin/installer/oci_installer.go
+++ b/internal/plugin/installer/oci_installer.go
@@ -238,12 +238,15 @@ func extractTar(r io.Reader, targetDir string) error {
 				return err
 			}
 
-			outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
+			if err := func() error {
+				outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+				if err != nil {
+					return err
+				}
+				defer outFile.Close()
+				_, err = io.Copy(outFile, tarReader)
 				return err
-			}
-			defer outFile.Close()
-			if _, err := io.Copy(outFile, tarReader); err != nil {
+			}(); err != nil {
 				return err
 			}
 		case tar.TypeXGlobalHeader, tar.TypeXHeader:


### PR DESCRIPTION
### What this PR does / why we need it

`extractTar` in the OCI plugin installer extracts each regular file with a
per-entry `defer outFile.Close()`. Because `defer` runs when the enclosing
function returns (Go has no block-scoped defer), the close for every extracted
file is deferred until `extractTar` finishes. All descriptors therefore stay
open for the entire archive, so extracting a plugin archive with many files can
exhaust the process's open-file-descriptor limit (`ulimit -n`) and fail
mid-extraction with "too many open files".

This mirrors the pattern already used by the sibling `TarGzExtractor.Extract`,
which closes each file as soon as its copy completes.

### Fix

Extract each regular file inside an anonymous function so the deferred
`outFile.Close()` fires at the end of every iteration, on the success, error,
and panic-unwind paths alike. At most one file descriptor is open at any time,
and the panic-unwind safety of `defer` is preserved (unlike an explicit
close, which would leak the in-flight descriptor on a recovered panic).

```go
if err := func() error {
    outFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
    if err != nil {
        return err
    }
    defer outFile.Close()
    _, err = io.Copy(outFile, tarReader)
    return err
}(); err != nil {
    return err
}
```

### Special notes for your reviewer

Scope is limited to the `tar.TypeReg` branch of `extractTar`; behavior is
otherwise unchanged. `go build` and `go vet ./internal/plugin/installer/...`
pass.
