### PR TITLE
fix(action): do not mutate shared Configuration in client-only install

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -327,6 +327,16 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	}
 
 	if !interactWithServer(i.DryRunStrategy) {
+		// Work on a local copy of the Configuration so client-only mocks
+		// (fake KubeClient, in-memory Releases, default Capabilities) do
+		// not mutate the shared *Configuration passed to NewInstall.
+		// Callers that reuse the same cfg for a later real install must
+		// still observe the original client and storage. See #11463.
+		origCfg := i.cfg
+		cfgCopy := *i.cfg
+		i.cfg = &cfgCopy
+		defer func() { i.cfg = origCfg }()
+
 		// Add mock objects in here so it doesn't use Kube API server
 		// NOTE(bacongobbler): used for `helm template`
 		i.cfg.Capabilities = common.DefaultCapabilities.Copy()

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -332,9 +332,22 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 		// not mutate the shared *Configuration passed to NewInstall.
 		// Callers that reuse the same cfg for a later real install must
 		// still observe the original client and storage. See #11463.
+		//
+		// Copy fields explicitly: Configuration embeds sync.Mutex and
+		// logging.LogHolder (atomic.Pointer), which must not be copied
+		// by value (govet copylocks).
 		origCfg := i.cfg
-		cfgCopy := *i.cfg
-		i.cfg = &cfgCopy
+		cfgCopy := &Configuration{
+			RESTClientGetter:    origCfg.RESTClientGetter,
+			Releases:            origCfg.Releases,
+			KubeClient:          origCfg.KubeClient,
+			RegistryClient:      origCfg.RegistryClient,
+			Capabilities:        origCfg.Capabilities,
+			CustomTemplateFuncs: origCfg.CustomTemplateFuncs,
+			HookOutputFunc:      origCfg.HookOutputFunc,
+		}
+		cfgCopy.SetLogger(origCfg.Logger().Handler())
+		i.cfg = cfgCopy
 		defer func() { i.cfg = origCfg }()
 
 		// Add mock objects in here so it doesn't use Kube API server

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -333,8 +333,8 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 		// Callers that reuse the same cfg for a later real install must
 		// still observe the original client and storage. See #11463.
 		//
-		// Copy fields explicitly: Configuration embeds sync.Mutex and
-		// logging.LogHolder (atomic.Pointer), which must not be copied
+		// Copy exported fields only. Configuration has an unexported mutex and
+		// embeds logging.LogHolder (atomic.Pointer); both must not be copied
 		// by value (govet copylocks).
 		origCfg := i.cfg
 		cfgCopy := &Configuration{

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1316,3 +1316,39 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	// Verify that WaitOptions were passed to GetWaiter
 	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
 }
+
+// TestInstallDryRunClientDoesNotMutateSharedConfiguration ensures that a
+// client-only install does not permanently replace the shared Configuration's
+// KubeClient, Releases, or Capabilities (issue #11463).
+func TestInstallDryRunClientDoesNotMutateSharedConfiguration(t *testing.T) {
+	req := require.New(t)
+
+	config := actionConfigFixture(t)
+	originalKubeClient := config.KubeClient
+	originalCapabilities := config.Capabilities
+	originalReleases := config.Releases
+
+	clientOnly := NewInstall(config)
+	clientOnly.DryRunStrategy = DryRunClient
+	clientOnly.ReleaseName = "test-client-only"
+	clientOnly.Namespace = "spaced"
+
+	_, err := clientOnly.Run(buildChart(), nil)
+	req.NoError(err)
+
+	req.Same(originalKubeClient, config.KubeClient, "KubeClient must not be replaced by client-only install")
+	req.Same(originalCapabilities, config.Capabilities, "Capabilities must not be replaced by client-only install")
+	req.Same(originalReleases, config.Releases, "Releases must not be replaced by client-only install")
+
+	// A subsequent real install sharing the same Configuration must still work.
+	realInstall := NewInstall(config)
+	realInstall.DryRunStrategy = DryRunNone
+	realInstall.ReleaseName = "test-real-install"
+	realInstall.Namespace = "spaced"
+
+	_, err = realInstall.Run(buildChart(), nil)
+	req.NoError(err)
+
+	req.Same(originalKubeClient, config.KubeClient, "KubeClient must still be original after real install")
+	req.Same(originalReleases, config.Releases, "Releases must still be original after real install")
+}


### PR DESCRIPTION
## Description

Fixes #11463

When `Install.Run` / `RunWithContext` runs with `DryRunStrategy = DryRunClient` (formerly `ClientOnly`), it replaces `cfg.KubeClient`, `cfg.Releases`, and `cfg.Capabilities` on the shared `*Configuration` passed to `NewInstall`. Any later action that reuses the same configuration then silently uses the fake kube client and in-memory release storage, so a real install appears to succeed but never deploys.

This change takes a local shallow copy of `Configuration` for the client-only path and points `i.cfg` at that copy for the remainder of the run (restored via `defer`). The mutated fields are all reassigned wholesale on the copy, so a shallow copy is sufficient and the caller's configuration is never modified.

This is the simple approach suggested in the issue discussion (and used in prior unmerged attempts such as #31892), with a regression test covering the multi-action reuse scenario.

## Checklist

- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility (client-only path behavior unchanged for a single action; shared cfg no longer permanently polluted)

## Related

- Closes prior attempts: #31357, #31892 (both stale/closed without merge)