### PR TITLE
chore: group github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - # Keep dev-v3 GitHub Actions up to date, while Helm v3 is within support
     package-ecosystem: "github-actions"
     target-branch: "dev-v3"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all `github-actions` Dependabot updates into a single PR (pattern `*`) for both the `main` and `dev-v3` target branches.

This bundles related action bumps — e.g. `github/codeql-action/init` and `github/codeql-action/analyze` — into one grouped PR instead of opening a separate PR per sub-action, matching the approach used in the oras-project repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)