### PR TITLE
test: add missing tests for CacheIndexFile and CacheChartsFile

### DIFF
--- a/pkg/helmpath/home_test.go
+++ b/pkg/helmpath/home_test.go
@@ -1,0 +1,74 @@
+// Copyright The Helm Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helmpath
+
+import (
+	"testing"
+)
+
+func TestCacheIndexFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoName string
+		expected string
+	}{
+		{
+			name:     "empty repository name",
+			repoName: "",
+			expected: "index.yaml",
+		},
+		{
+			name:     "standard repository name",
+			repoName: "stable",
+			expected: "stable-index.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := CacheIndexFile(tt.repoName)
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCacheChartsFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoName string
+		expected string
+	}{
+		{
+			name:     "empty repository name",
+			repoName: "",
+			expected: "charts.txt",
+		},
+		{
+			name:     "standard repository name",
+			repoName: "stable",
+			expected: "stable-charts.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := CacheChartsFile(tt.repoName)
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `pkg/helmpath` package contained two untested utility functions: `CacheIndexFile(name string)` and `CacheChartsFile(name string)`. This PR adds an OS-independent table-driven unit test suite for them to ensure correct path construction for repository caching files, raising the package test coverage to 95.5%.