### PR TITLE
refactor(version): avoid linking Kubernetes clientset for build info

### DIFF
--- a/internal/version/clientgo_test.go
+++ b/internal/version/clientgo_test.go
@@ -27,8 +27,9 @@ import (
 )
 
 func TestK8sClientGoModVersion(t *testing.T) {
-	// Unfortunately, test builds don't include debug info / module info
-	// So we expect "K8sIOClientGoModVersion" to return error
+	// Generated test binaries omit dependency modules from embedded build info,
+	// even when the package under test imports them. The built-binary test below
+	// covers the normal executable path where dependency modules are present.
 	_, err := K8sIOClientGoModVersion()
 	require.ErrorContains(t, err, "k8s.io/client-go not found in build info")
 }

--- a/internal/version/clientgo_test.go
+++ b/internal/version/clientgo_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package version
 
 import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,4 +31,37 @@ func TestK8sClientGoModVersion(t *testing.T) {
 	// So we expect "K8sIOClientGoModVersion" to return error
 	_, err := K8sIOClientGoModVersion()
 	require.ErrorContains(t, err, "k8s.io/client-go not found in build info")
+}
+
+func TestK8sClientGoModVersionFromBuiltBinary(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "go", "list", "-m", "-f={{.Version}}", "k8s.io/client-go")
+	expectedVersion, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(expectedVersion))
+
+	binary := filepath.Join(t.TempDir(), "clientgo-version")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+
+	cmd = exec.CommandContext(t.Context(), "go", "build", "-o", binary, "./testdata/clientgo-version")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.CommandContext(t.Context(), binary)
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Equal(t, strings.TrimSpace(string(expectedVersion)), strings.TrimSpace(string(output)))
+}
+
+func TestK8sClientGoDependencyIsLightweight(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "go", "list", "-deps", ".")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	dependencies := strings.Fields(string(output))
+	require.Contains(t, dependencies, "k8s.io/client-go/pkg/version")
+	for _, dependency := range dependencies {
+		require.NotEqual(t, "k8s.io/client-go/kubernetes", dependency)
+		require.NotContains(t, dependency, "k8s.io/client-go/kubernetes/")
+	}
 }

--- a/internal/version/testdata/clientgo-version/main.go
+++ b/internal/version/testdata/clientgo-version/main.go
@@ -14,31 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package main
 
 import (
-	"errors"
-	"runtime/debug"
-	"slices"
+	"fmt"
+	"os"
 
-	_ "k8s.io/client-go/pkg/version" // Force the k8s.io/client-go module version into build info
+	"helm.sh/helm/v4/internal/version"
 )
 
-func K8sIOClientGoModVersion() (string, error) {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "", errors.New("failed to read build info")
+func main() {
+	clientGoVersion, err := version.K8sIOClientGoModVersion()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
-	idx := slices.IndexFunc(info.Deps, func(m *debug.Module) bool {
-		return m.Path == "k8s.io/client-go"
-	})
-
-	if idx == -1 {
-		return "", errors.New("k8s.io/client-go not found in build info")
-	}
-
-	m := info.Deps[idx]
-
-	return m.Version, nil
+	fmt.Print(clientGoVersion)
 }


### PR DESCRIPTION
Refs #32468.

### Benefits to Helm

- Keeps `internal/version` focused on version reporting instead of coupling it to the complete Kubernetes clientset.
- Turns the BuildInfo behavior introduced in #31296 into an executable regression contract and protects the intended lightweight dependency boundary.
- Reduces the blast radius of client-go changes for Helm SDK packages, enabling future package separation without changing Helm CLI behavior.

**What this PR does / why we need it**:

`K8sIOClientGoModVersion` needs the `k8s.io/client-go` module to remain in `runtime/debug.ReadBuildInfo`. #31296 ensured that by blank-importing `k8s.io/client-go/kubernetes`, but that package pulls the complete Kubernetes clientset into every binary that reaches `internal/version`.

This PR instead blank-imports `k8s.io/client-go/pkg/version`. The lightweight package keeps the same module entry in build information without adding the clientset dependency.

It also adds two regression tests:

- a real non-test executable verifies that `K8sIOClientGoModVersion` still returns the client-go version declared by the module; and
- a `go list -deps` check requires the lightweight version package and prevents the Kubernetes clientset from returning to this dependency boundary.

There are no public API or Helm CLI behavior changes. The Helm CLI already imports the clientset through its Kubernetes functionality, so its binary size is unchanged. This change benefits lighter Go consumers that do not otherwise require Kubernetes clients and is a prerequisite for the package separation proposed in #32468.

For an isolated stripped executable that only calls `K8sIOClientGoModVersion` (Go 1.26.5, darwin/arm64, `-trimpath -ldflags='-s -w'`):

| Import used by `internal/version` | Total dependencies | `client-go/kubernetes` packages | Bytes |
|---|---:|---:|---:|
| `k8s.io/client-go/kubernetes` | 559 | 55 | 21,582,338 |
| `k8s.io/client-go/pkg/version` | 86 | 0 | 2,081,394 |

Both variants return `v0.36.3` from the built executable.

This is complementary to #32047 and #32169, but does not depend on or overlap their changed files.

**Special notes for your reviewer**:

The public rendering API and any HIP requested for it remain separate from this internal, backward-compatible dependency cleanup.

Validation:

- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./internal/version`
- `make test-style`
- `git diff --check`

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
