### PR TITLE
fix(storage/sql): don't leak or silently commit transactions

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -486,6 +487,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
 		return fmt.Errorf("error beginning transaction: %w", err)
 	}
+	defer transaction.Rollback()
 
 	insertQuery, args, err := s.statementBuilder.
 		Insert(sqlReleaseTableName).
@@ -516,9 +518,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 		return err
 	}
 
-	if _, err := transaction.Exec(insertQuery, args...); err != nil {
-		defer transaction.Rollback()
-
+	if _, err := transaction.ExecContext(context.Background(), insertQuery, args...); err != nil {
 		selectQuery, args, buildErr := s.statementBuilder.
 			Select(sqlReleaseTableKeyColumn).
 			From(sqlReleaseTableName).
@@ -558,18 +558,20 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 			).ToSql()
 
 		if err != nil {
-			defer transaction.Rollback()
 			s.Logger().Debug("failed to build insert query", slog.Any("error", err))
 			return err
 		}
 
-		if _, err := transaction.Exec(insertLabelsQuery, args...); err != nil {
-			defer transaction.Rollback()
+		if _, err := transaction.ExecContext(context.Background(), insertLabelsQuery, args...); err != nil {
 			s.Logger().Debug("failed to write Labels", slog.Any("error", err))
 			return err
 		}
 	}
-	defer transaction.Commit()
+
+	if err := transaction.Commit(); err != nil {
+		s.Logger().Debug("failed to commit release creation transaction", slog.Any("error", err))
+		return fmt.Errorf("error committing transaction: %w", err)
+	}
 
 	return nil
 }
@@ -609,7 +611,7 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 		return err
 	}
 
-	if _, err := s.db.Exec(query, args...); err != nil {
+	if _, err := s.db.ExecContext(context.Background(), query, args...); err != nil {
 		s.Logger().Debug("failed to update release in SQL database", slog.String("key", key), slog.Any("error", err))
 		return err
 	}
@@ -624,6 +626,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
 		return nil, fmt.Errorf("error beginning transaction: %w", err)
 	}
+	defer transaction.Rollback()
 
 	selectQuery, args, err := s.statementBuilder.
 		Select(sqlReleaseTableBodyColumn).
@@ -646,10 +649,8 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 	release, err := decodeRelease(record.Body)
 	if err != nil {
 		s.Logger().Debug("failed to decode release", slog.String("key", key), slog.Any("error", err))
-		transaction.Rollback()
 		return nil, err
 	}
-	defer transaction.Commit()
 
 	deleteQuery, args, err := s.statementBuilder.
 		Delete(sqlReleaseTableName).
@@ -661,7 +662,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		return nil, err
 	}
 
-	_, err = transaction.Exec(deleteQuery, args...)
+	_, err = transaction.ExecContext(context.Background(), deleteQuery, args...)
 	if err != nil {
 		s.Logger().Debug("failed perform delete query", slog.Any("error", err))
 		return release, err
@@ -686,8 +687,17 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		s.Logger().Debug("failed to build delete Labels query", slog.Any("error", err))
 		return nil, err
 	}
-	_, err = transaction.Exec(deleteCustomLabelsQuery, args...)
-	return release, err
+	if _, err = transaction.ExecContext(context.Background(), deleteCustomLabelsQuery, args...); err != nil {
+		s.Logger().Debug("failed to delete release custom labels", slog.String("key", key), slog.Any("error", err))
+		return release, err
+	}
+
+	if err := transaction.Commit(); err != nil {
+		s.Logger().Debug("failed to commit release deletion transaction", slog.Any("error", err))
+		return release, fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	return release, nil
 }
 
 // Get release custom labels from database

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package driver
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -560,4 +561,159 @@ func TestSqlCheckAppliedMigrations(t *testing.T) {
 		mock.ExpectCommit()
 		assert.Equal(t, c.expectedResult, sqlDriver.checkAlreadyApplied(c.migrationsToApply), "Test case: %v, Expected: %v, Have: %v, Explanation: %v", i, c.expectedResult, !c.expectedResult, c.errorExplanation)
 	}
+}
+
+// TestSqlCreateCommitError verifies that a commit-time failure is surfaced to
+// the caller. A deferred, error-discarding Commit would report success even
+// though nothing was persisted.
+func TestSqlCreateCommitError(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, common.StatusDeployed)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+	body, _ := encodeRelease(rel)
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s,%s,%s,%s,%s,%s,%s,%s,%s) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableTypeColumn,
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableNameColumn,
+		sqlReleaseTableNamespaceColumn,
+		sqlReleaseTableVersionColumn,
+		sqlReleaseTableStatusColumn,
+		sqlReleaseTableOwnerColumn,
+		sqlReleaseTableCreatedAtColumn,
+	)
+
+	mock.ExpectBegin()
+	mock.
+		ExpectExec(regexp.QuoteMeta(query)).
+		WithArgs(
+			key,
+			sqlReleaseDefaultType,
+			body,
+			rel.Name,
+			rel.Namespace,
+			int(rel.Version),
+			rel.Info.Status.String(),
+			sqlReleaseDefaultOwner,
+			recentUnixTimestamp(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	labelsQuery := fmt.Sprintf(
+		"INSERT INTO %s (%s,%s,%s,%s) VALUES ($1,$2,$3,$4)",
+		sqlCustomLabelsTableName,
+		sqlCustomLabelsTableReleaseKeyColumn,
+		sqlCustomLabelsTableReleaseNamespaceColumn,
+		sqlCustomLabelsTableKeyColumn,
+		sqlCustomLabelsTableValueColumn,
+	)
+
+	mock.MatchExpectationsInOrder(false)
+	for k, v := range filterSystemLabels(rel.Labels) {
+		mock.
+			ExpectExec(regexp.QuoteMeta(labelsQuery)).
+			WithArgs(key, rel.Namespace, k, v).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+	}
+	mock.ExpectCommit().WillReturnError(errors.New("transaction commit failed"))
+
+	err := sqlDriver.Create(key, rel)
+	require.Error(t, err, "expected Create to surface the commit error, got nil")
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
+// TestSqlDeleteCommitError verifies that a commit-time failure during Delete is
+// surfaced to the caller instead of being silently discarded.
+func TestSqlDeleteCommitError(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, common.StatusDeployed)
+	body, _ := encodeRelease(rel)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	selectQuery := fmt.Sprintf(
+		"SELECT %s FROM %s WHERE %s = $1 AND %s = $2",
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	mock.ExpectBegin()
+	mock.
+		ExpectQuery(regexp.QuoteMeta(selectQuery)).
+		WithArgs(key, namespace).
+		WillReturnRows(
+			mock.NewRows([]string{sqlReleaseTableBodyColumn}).AddRow(body),
+		).RowsWillBeClosed()
+
+	deleteQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s = $1 AND %s = $2",
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+	mock.
+		ExpectExec(regexp.QuoteMeta(deleteQuery)).
+		WithArgs(key, namespace).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mockGetReleaseCustomLabels(mock, key, namespace, rel.Labels)
+
+	deleteLabelsQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s = $1 AND %s = $2",
+		sqlCustomLabelsTableName,
+		sqlCustomLabelsTableReleaseKeyColumn,
+		sqlCustomLabelsTableReleaseNamespaceColumn,
+	)
+	mock.
+		ExpectExec(regexp.QuoteMeta(deleteLabelsQuery)).
+		WithArgs(key, namespace).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit().WillReturnError(errors.New("transaction commit failed"))
+
+	_, err := sqlDriver.Delete(key)
+	require.Error(t, err, "expected Delete to surface the commit error, got nil")
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
+// TestSqlDeleteNotFoundReleasesTransaction verifies that the not-found path
+// rolls back the transaction rather than leaking its pooled connection.
+func TestSqlDeleteNotFoundReleasesTransaction(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	selectQuery := fmt.Sprintf(
+		"SELECT %s FROM %s WHERE %s = $1 AND %s = $2",
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	mock.ExpectBegin()
+	mock.
+		ExpectQuery(regexp.QuoteMeta(selectQuery)).
+		WithArgs(key, namespace).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectRollback()
+
+	_, err := sqlDriver.Delete(key)
+	require.ErrorIs(t, err, ErrReleaseNotFound)
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The SQL storage driver mishandles its explicit transactions in `Create` and `Delete`, in two distinct ways.

**1. Leaked transactions.** `Delete`'s not-found and build-select-failure early returns returned without calling either `Rollback` or `Commit`:

```go
transaction, err := s.db.Beginx()
// ...
err = transaction.Get(&record, selectQuery, args...)
if err != nil {
    return nil, ErrReleaseNotFound   // transaction never released
}
```

`sql.Tx` pins a pooled connection from `Begin()` until `Commit()` or `Rollback()` is called; nothing else releases it. So every `helm uninstall` of a release that does not exist permanently leaked a connection and left an open server-side transaction holding locks. Enough of them exhaust the pool and hang the client.

**2. Silently discarded commit errors.** Both methods ended with:

```go
defer transaction.Commit()

return nil
```

A deferred call's return values are discarded by the language, and both methods return an *unnamed* `error`, so the commit error could not reach the caller even if it were captured in a closure. When a commit failed (connection drop, serialization failure under a strict isolation level, disk full) the database rolled the whole transaction back while `Create` reported success. Helm then recorded an install that was never persisted: invisible to `helm list` and not rollbackable. In `Delete`, the deferred commit also fired on the post-delete error paths, committing a partial delete.

The fix registers a single `defer transaction.Rollback()` immediately after `Beginx()`, which is a no-op once committed (it returns `sql.ErrTxDone`), so every return path releases the transaction. Both methods then commit explicitly at the success point and return any commit error.

**Special notes for your reviewer**:

Split into two commits so the bugs are demonstrable rather than asserted. The first adds three regression tests that fail against the current driver; the second fixes it. Checking out the test commit alone reproduces:

```
--- FAIL: TestSqlCreateCommitError
    expected Create to surface the commit error, got nil
--- FAIL: TestSqlDeleteCommitError
    expected Delete to surface the commit error, got nil
--- FAIL: TestSqlDeleteNotFoundReleasesTransaction
    there is a remaining expectation which was not matched: ExpectedRollback
```

Two notes on scope:

- `Update` has no transaction at all, so it is untouched here. Whether its release-row update and label writes should be atomic is a separate question, and a larger change.
- `Delete` returns `ErrReleaseNotFound` for *any* error from the select, not just `sql.ErrNoRows`, so a dropped connection currently reports "release not found". `Get` already distinguishes these correctly. I left this alone to keep the diff focused on the transaction handling, but I am happy to fold in a fix if you would prefer it here.

On the user-facing checkbox below: no documented behavior changes, but calls that previously returned `nil` on a commit failure now return an error. That is the intent of the fix, and it surfaces a failure that was already causing silent data loss. I do not think it needs a docs update, but flagging it for your judgement.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
