### PR TITLE
fix(install): add nil check for chart in RunWithContext

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -280,6 +280,10 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 	var hs []*release.Hook
 	b := bytes.NewBuffer(nil)
 
+	if ch == nil {
+		return hs, b, "", errors.New("chart is nil")
+	}
+
 	caps, err := cfg.getCapabilities()
 	if err != nil {
 		return hs, b, "", err

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -291,6 +291,9 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	default:
 		return nil, errors.New("invalid chart apiVersion")
 	}
+	if chrt == nil {
+		return nil, errors.New("chart is nil")
+	}
 
 	if interactWithServer(i.DryRunStrategy) {
 		if err := i.cfg.KubeClient.IsReachable(); err != nil {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1245,3 +1245,16 @@ func TestInstallRelease_WaitOptionsPassedDownstream(t *testing.T) {
 	// Verify that WaitOptions were passed to GetWaiter
 	is.NotEmpty(failer.RecordedWaitOptions, "WaitOptions should be passed to GetWaiter")
 }
+
+func TestInstallRun_NilChart(t *testing.T) {
+	is := assert.New(t)
+
+	instAction := installAction(t)
+	instAction.DryRunStrategy = DryRunClient
+
+	vals := map[string]any{}
+	// Pass a typed nil *chart.Chart as the ci.Charter interface
+	_, err := instAction.Run((*chart.Chart)(nil), vals)
+	is.Error(err)
+	is.Contains(err.Error(), "chart is nil")
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

Adds a nil check for the chart parameter in `Install.RunWithContext` and `renderResources`. When a nil chart is passed (e.g., via `helm template NAME CHART` with a problematic chart), the current code dereferences the nil pointer and crashes with SIGSEGV. This PR returns a descriptive error instead.

**Which issue(s) this PR fixes:**

Fixes #31552

**Special notes for your reviewer:**

The nil check is added in two places for defense in depth:
1. `Install.RunWithContext` – right after the `ci.Charter` type switch, before any chart fields are accessed
2. `Configuration.renderResources` – before accessing `ch.Metadata`

**Checklist:**

- [x] Added nil check guards
- [x] Added test TestInstallRun_NilChart
- [x] All existing tests unchanged
