### PR TITLE
Fix SQL driver error mapping for reads and duplicate creates

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -525,7 +526,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 		return err
 	}
 
-	if _, err := transaction.Exec(insertQuery, args...); err != nil {
+	if _, err := transaction.ExecContext(context.Background(), insertQuery, args...); err != nil {
 		// The failed statement leaves the transaction in an aborted state -
 		// PostgreSQL rejects every subsequent statement on it with "current
 		// transaction is aborted" - so roll it back before checking whether the
@@ -577,7 +578,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 			return err
 		}
 
-		if _, err := transaction.Exec(insertLabelsQuery, args...); err != nil {
+		if _, err := transaction.ExecContext(context.Background(), insertLabelsQuery, args...); err != nil {
 			defer transaction.Rollback()
 			s.Logger().Debug("failed to write Labels", slog.Any("error", err))
 			return err
@@ -622,7 +623,7 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 		return err
 	}
 
-	if _, err := s.db.Exec(query, args...); err != nil {
+	if _, err := s.db.ExecContext(context.Background(), query, args...); err != nil {
 		s.Logger().Debug("failed to update release in SQL database", slog.String("key", key), slog.Any("error", err))
 		return err
 	}
@@ -678,7 +679,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		return nil, err
 	}
 
-	_, err = transaction.Exec(deleteQuery, args...)
+	_, err = transaction.ExecContext(context.Background(), deleteQuery, args...)
 	if err != nil {
 		s.Logger().Debug("failed perform delete query", slog.Any("error", err))
 		return release, err
@@ -702,7 +703,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 		s.Logger().Debug("failed to build delete Labels query", slog.Any("error", err))
 		return nil, err
 	}
-	_, err = transaction.Exec(deleteCustomLabelsQuery, args...)
+	_, err = transaction.ExecContext(context.Background(), deleteCustomLabelsQuery, args...)
 	return release, err
 }
 

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -542,7 +542,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 			ToSql()
 		if buildErr != nil {
 			s.Logger().Debug("failed to build select query", "error", buildErr)
-			return err
+			return fmt.Errorf("failed to create release %q: %w", key, err)
 		}
 
 		var record SQLReleaseWrapper
@@ -552,7 +552,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 		}
 
 		s.Logger().Debug("failed to store release in SQL database", slog.String("key", key), slog.Any("error", err))
-		return err
+		return fmt.Errorf("failed to create release %q: %w", key, err)
 	}
 
 	// Filtering labels before insert cause in SQL storage driver system releases are stored in separate columns of release table

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -318,10 +320,15 @@ func (s *SQL) Get(key string) (release.Releaser, error) {
 		return nil, err
 	}
 
-	// Get will return an error if the result is empty
+	// Get will return sql.ErrNoRows if the result is empty. Any other error
+	// (connection failure, permission denied, timeout, ...) means we do not
+	// know whether the release exists, so it must not be reported as missing.
 	if err := s.db.Get(&record, query, args...); err != nil {
 		s.Logger().Debug("got SQL error when getting release", slog.String("key", key), slog.Any("error", err))
-		return nil, ErrReleaseNotFound
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrReleaseNotFound
+		}
+		return nil, fmt.Errorf("failed to get release %q: %w", key, err)
 	}
 
 	release, err := decodeRelease(record.Body)
@@ -519,7 +526,13 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 	}
 
 	if _, err := transaction.Exec(insertQuery, args...); err != nil {
-		defer transaction.Rollback()
+		// The failed statement leaves the transaction in an aborted state -
+		// PostgreSQL rejects every subsequent statement on it with "current
+		// transaction is aborted" - so roll it back before checking whether the
+		// insert failed because the release already exists. Running that check
+		// on the transaction always errors out, which made ErrReleaseExists
+		// unreachable and surfaced the raw driver error instead.
+		transaction.Rollback()
 
 		selectQuery, args, buildErr := s.statementBuilder.
 			Select(sqlReleaseTableKeyColumn).
@@ -533,7 +546,7 @@ func (s *SQL) Create(key string, rel release.Releaser) error {
 		}
 
 		var record SQLReleaseWrapper
-		if err := transaction.Get(&record, selectQuery, args...); err == nil {
+		if getErr := s.db.Get(&record, selectQuery, args...); getErr == nil {
 			s.Logger().Debug("release already exists", slog.String("key", key))
 			return ErrReleaseExists
 		}
@@ -639,8 +652,12 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 	var record SQLReleaseWrapper
 	err = transaction.Get(&record, selectQuery, args...)
 	if err != nil {
-		s.Logger().Debug("release not found", slog.String("key", key), slog.Any("error", err))
-		return nil, ErrReleaseNotFound
+		s.Logger().Debug("failed to get release for deletion", slog.String("key", key), slog.Any("error", err))
+		transaction.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrReleaseNotFound
+		}
+		return nil, fmt.Errorf("failed to get release %q: %w", key, err)
 	}
 
 	release, err := decodeRelease(record.Body)

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package driver
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -100,6 +101,97 @@ func TestSQLGet(t *testing.T) {
 	require.NoError(t, err, "Failed to get release")
 
 	assert.Equalf(t, rel, got, "Expected release {%v}, got {%v}", rel, got)
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
+// A real database failure must not be reported as "release not found": callers
+// branch on ErrReleaseNotFound and would treat an outage as an absent release.
+func TestSQLGetDatabaseError(t *testing.T) {
+	vers := int(1)
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	query := fmt.Sprintf(
+		regexp.QuoteMeta("SELECT %s FROM %s WHERE %s = $1 AND %s = $2"),
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	dbErr := errors.New("connection refused")
+	mock.
+		ExpectQuery(query).
+		WithArgs(key, namespace).
+		WillReturnError(dbErr)
+
+	_, err := sqlDriver.Get(key)
+	require.Error(t, err, "expected an error when the database query fails")
+	require.NotErrorIs(t, err, ErrReleaseNotFound, "database failure must not be reported as ErrReleaseNotFound")
+	require.ErrorIs(t, err, dbErr, "expected the underlying database error to be wrapped")
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
+// An empty result set is the only case that means "release not found".
+func TestSQLGetNotFound(t *testing.T) {
+	vers := int(1)
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	query := fmt.Sprintf(
+		regexp.QuoteMeta("SELECT %s FROM %s WHERE %s = $1 AND %s = $2"),
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	mock.
+		ExpectQuery(query).
+		WithArgs(key, namespace).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := sqlDriver.Get(key)
+	require.ErrorIs(t, err, ErrReleaseNotFound)
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
+// Same contract for Delete's existence check, which must also not leave the
+// transaction open when the lookup fails.
+func TestSQLDeleteDatabaseError(t *testing.T) {
+	vers := int(1)
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+
+	selectQuery := fmt.Sprintf(
+		"SELECT %s FROM %s WHERE %s = $1 AND %s = $2",
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	dbErr := errors.New("connection refused")
+	mock.ExpectBegin()
+	mock.
+		ExpectQuery(regexp.QuoteMeta(selectQuery)).
+		WithArgs(key, namespace).
+		WillReturnError(dbErr)
+	mock.ExpectRollback()
+
+	_, err := sqlDriver.Delete(key)
+	require.Error(t, err, "expected an error when the database query fails")
+	require.NotErrorIs(t, err, ErrReleaseNotFound, "database failure must not be reported as ErrReleaseNotFound")
+	require.ErrorIs(t, err, dbErr, "expected the underlying database error to be wrapped")
 	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
 }
 
@@ -269,6 +361,11 @@ func TestSqlCreateAlreadyExists(t *testing.T) {
 		sqlReleaseTableNamespaceColumn,
 	)
 
+	// The failed insert aborts the transaction, so it is rolled back before the
+	// existence check runs - the check has to happen outside the transaction or
+	// PostgreSQL rejects it and ErrReleaseExists can never be returned.
+	mock.ExpectRollback()
+
 	// Let's check that we do make sure the error is due to a release already existing
 	mock.
 		ExpectQuery(selectQuery).
@@ -280,9 +377,10 @@ func TestSqlCreateAlreadyExists(t *testing.T) {
 				key,
 			),
 		).RowsWillBeClosed()
-	mock.ExpectRollback()
 
-	require.Errorf(t, sqlDriver.Create(key, rel), "failed to create release with key %s", key)
+	err := sqlDriver.Create(key, rel)
+	require.Errorf(t, err, "expected Create to fail for an existing release with key %s", key)
+	require.ErrorIs(t, err, ErrReleaseExists)
 	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
 }
 

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -384,6 +384,63 @@ func TestSqlCreateAlreadyExists(t *testing.T) {
 	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
 }
 
+func TestSqlCreateInsertFailureNotAlreadyExists(t *testing.T) {
+	vers := 1
+	name := "smug-pigeon"
+	namespace := "default"
+	key := testKey(name, vers)
+	rel := releaseStub(name, vers, namespace, common.StatusDeployed)
+
+	sqlDriver, mock := newTestFixtureSQL(t)
+	body, _ := encodeRelease(rel)
+
+	insertQuery := fmt.Sprintf(
+		"INSERT INTO %s (%s,%s,%s,%s,%s,%s,%s,%s,%s) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableTypeColumn,
+		sqlReleaseTableBodyColumn,
+		sqlReleaseTableNameColumn,
+		sqlReleaseTableNamespaceColumn,
+		sqlReleaseTableVersionColumn,
+		sqlReleaseTableStatusColumn,
+		sqlReleaseTableOwnerColumn,
+		sqlReleaseTableCreatedAtColumn,
+	)
+
+	// The insert fails for a reason unrelated to a duplicate key, e.g. the
+	// database is unreachable.
+	insertErr := errors.New("connection refused")
+	mock.ExpectBegin()
+	mock.
+		ExpectExec(regexp.QuoteMeta(insertQuery)).
+		WithArgs(key, sqlReleaseDefaultType, body, rel.Name, rel.Namespace, int(rel.Version), rel.Info.Status.String(), sqlReleaseDefaultOwner, recentUnixTimestamp()).
+		WillReturnError(insertErr)
+
+	selectQuery := fmt.Sprintf(
+		regexp.QuoteMeta("SELECT %s FROM %s WHERE %s = $1 AND %s = $2"),
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableName,
+		sqlReleaseTableKeyColumn,
+		sqlReleaseTableNamespaceColumn,
+	)
+
+	mock.ExpectRollback()
+
+	// No row comes back, so the release does not already exist and the original
+	// insert error has to be surfaced instead of ErrReleaseExists.
+	mock.
+		ExpectQuery(selectQuery).
+		WithArgs(key, namespace).
+		WillReturnError(sql.ErrNoRows)
+
+	err := sqlDriver.Create(key, rel)
+	require.Errorf(t, err, "expected Create to fail when the insert fails with key %s", key)
+	require.NotErrorIs(t, err, ErrReleaseExists)
+	require.ErrorIs(t, err, insertErr)
+	assert.NoErrorf(t, mock.ExpectationsWereMet(), "sql expectations weren't met")
+}
+
 func TestSqlUpdate(t *testing.T) {
 	vers := 1
 	name := "smug-pigeon"


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #32394 (items 2 and 3 — second PR of the series).

Two related error-contract problems in the SQL storage driver:

**`Get`/`Delete` map every read error to `ErrReleaseNotFound`.** A connection failure, a permission error or a timeout is currently indistinguishable from a release that genuinely doesn't exist, with the real cause only visible at debug level. Callers make control-flow decisions on that sentinel, so a transient database outage can be read as "release absent". Only `sql.ErrNoRows` now maps to `ErrReleaseNotFound`; everything else is wrapped and returned. While there, `Delete` also left its transaction open on that path, so it now rolls back.

**`Create` can never return `ErrReleaseExists`.** After the INSERT fails, the transaction is in an aborted state and PostgreSQL rejects every subsequent statement on it (`current transaction is aborted, commands ignored until end of transaction block`). The follow-up SELECT that's supposed to distinguish "already exists" from a genuine error therefore always errors out, and the raw driver error is surfaced instead — where the Secrets and ConfigMaps drivers return Helm's `ErrReleaseExists`. The transaction is now rolled back first and the existence check runs outside it.

**Special notes for your reviewer**:

- `TestSqlCreateAlreadyExists` needed its expectation order updated (rollback now precedes the existence check, which is the point of the change), and it now asserts `errors.Is(err, ErrReleaseExists)` — previously it only checked that *some* error came back, which is why the unreachable branch went unnoticed.
- Added `TestSQLGetDatabaseError`, `TestSQLGetNotFound` and `TestSQLDeleteDatabaseError` covering both sides of the mapping.
- This is independent of #32395 (different hunks in the same file); happy to rebase whichever lands second.
- Item 5 (`s.namespace` mutation) and item 6 (`Update` not syncing labels) from #32394 are still open if anyone wants them — @mazenessam77 expressed interest in the file.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
