### PR TITLE
feat(push): add -o/--output flag (table|json|yaml) to helm push

### DIFF
--- a/pkg/action/push.go
+++ b/pkg/action/push.go
@@ -38,6 +38,7 @@ type Push struct {
 	insecureSkipTLSVerify bool
 	plainHTTP             bool
 	out                   io.Writer
+	pushResultHandler     func(*registry.PushResult)
 }
 
 // PushOpt is a type of function that sets options for a push action.
@@ -80,6 +81,14 @@ func WithPushOptWriter(out io.Writer) PushOpt {
 	}
 }
 
+// WithPushResultHandler sets a handler on the push configuration object which
+// is called with the result of a successful push.
+func WithPushResultHandler(handler func(result *registry.PushResult)) PushOpt {
+	return func(p *Push) {
+		p.pushResultHandler = handler
+	}
+}
+
 // NewPushWithOpts creates a new push, with configuration options.
 func NewPushWithOpts(opts ...PushOpt) *Push {
 	p := &Push{}
@@ -100,6 +109,7 @@ func (p *Push) Run(chartRef string, remote string) (string, error) {
 			pusher.WithTLSClientConfig(p.certFile, p.keyFile, p.caFile),
 			pusher.WithInsecureSkipTLSVerify(p.insecureSkipTLSVerify),
 			pusher.WithPlainHTTP(p.plainHTTP),
+			pusher.WithPushResultHandler(p.pushResultHandler),
 		},
 	}
 

--- a/pkg/action/push_test.go
+++ b/pkg/action/push_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/v4/pkg/registry"
 )
 
 func TestNewPushWithPushConfig(t *testing.T) {
@@ -63,4 +65,11 @@ func TestNewPushWithPushOptWriter(t *testing.T) {
 
 	assert.NotNil(t, client)
 	assert.Equal(t, buf, client.out)
+}
+
+func TestNewPushWithPushResultHandler(t *testing.T) {
+	client := NewPushWithOpts(WithPushResultHandler(func(_ *registry.PushResult) {}))
+
+	assert.NotNil(t, client)
+	assert.NotNil(t, client.pushResultHandler)
 }

--- a/pkg/cmd/push.go
+++ b/pkg/cmd/push.go
@@ -23,8 +23,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/cli/output"
 	"helm.sh/helm/v4/pkg/cmd/require"
 	"helm.sh/helm/v4/pkg/pusher"
+	"helm.sh/helm/v4/pkg/registry"
 )
 
 const pushDesc = `
@@ -46,6 +48,7 @@ type registryPushOptions struct {
 
 func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	o := &registryPushOptions{}
+	var outfmt output.Format
 
 	cmd := &cobra.Command{
 		Use:   "push [chart] [remote]",
@@ -70,8 +73,15 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			return noMoreArgsComp()
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			// The registry client writes a human-readable push summary
+			// directly to its writer. Suppress it for the machine-readable
+			// output formats so that only the structured result is written.
+			registryClientOut := out
+			if outfmt != output.Table {
+				registryClientOut = io.Discard
+			}
 			registryClient, err := newRegistryClient(
-				out, o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSVerify, o.plainHTTP, o.username, o.password,
+				registryClientOut, o.certFile, o.keyFile, o.caFile, o.insecureSkipTLSVerify, o.plainHTTP, o.username, o.password,
 			)
 
 			if err != nil {
@@ -80,18 +90,28 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			cfg.RegistryClient = registryClient
 			chartRef := args[0]
 			remote := args[1]
+			var result *registry.PushResult
 			client := action.NewPushWithOpts(action.WithPushConfig(cfg),
 				action.WithTLSClientConfig(o.certFile, o.keyFile, o.caFile),
 				action.WithInsecureSkipTLSVerify(o.insecureSkipTLSVerify),
 				action.WithPlainHTTP(o.plainHTTP),
-				action.WithPushOptWriter(out))
+				action.WithPushOptWriter(out),
+				action.WithPushResultHandler(func(r *registry.PushResult) {
+					result = r
+				}))
 			client.Settings = settings
-			output, err := client.Run(chartRef, remote)
+			uploadOutput, err := client.Run(chartRef, remote)
 			if err != nil {
 				return err
 			}
-			fmt.Fprint(out, output)
-			return nil
+			if outfmt == output.Table {
+				fmt.Fprint(out, uploadOutput)
+				return nil
+			}
+			if result == nil {
+				return fmt.Errorf("no push result available to write as %s", outfmt)
+			}
+			return outfmt.Write(out, newPushWriter(result))
 		},
 	}
 
@@ -104,5 +124,44 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&o.username, "username", "", "chart repository username where to locate the requested chart")
 	f.StringVar(&o.password, "password", "", "chart repository password where to locate the requested chart")
 
+	bindOutputFlag(cmd, &outfmt)
+
 	return cmd
+}
+
+// pushResult is the structure written by the push command for the
+// machine-readable output formats.
+type pushResult struct {
+	Ref    string `json:"ref"`
+	Digest string `json:"digest"`
+}
+
+type pushWriter struct {
+	result pushResult
+}
+
+func newPushWriter(result *registry.PushResult) *pushWriter {
+	w := &pushWriter{result: pushResult{Ref: result.Ref}}
+	if result.Manifest != nil {
+		w.result.Digest = result.Manifest.Digest
+	}
+	return w
+}
+
+// WriteTable mirrors the push summary the registry client writes for the
+// default table output format.
+func (w *pushWriter) WriteTable(out io.Writer) error {
+	if _, err := fmt.Fprintf(out, "Pushed: %s\n", w.result.Ref); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "Digest: %s\n", w.result.Digest)
+	return err
+}
+
+func (w *pushWriter) WriteJSON(out io.Writer) error {
+	return output.EncodeJSON(out, w.result)
+}
+
+func (w *pushWriter) WriteYAML(out io.Writer) error {
+	return output.EncodeYAML(out, w.result)
 }

--- a/pkg/cmd/push_test.go
+++ b/pkg/cmd/push_test.go
@@ -17,8 +17,101 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"helm.sh/helm/v4/pkg/repo/v1/repotest"
 )
+
+func TestPushCmd(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	require.NoError(t, err)
+	ociSrv.Run(t)
+
+	ref := ociSrv.RegistryURL + "/u/ocitestuser/compressedchart:0.1.0"
+	digestPattern := `^sha256:[0-9a-f]{64}$`
+
+	tests := []struct {
+		name   string
+		format string
+		check  func(t *testing.T, out string)
+	}{
+		{
+			name: "push with default table output",
+			check: func(t *testing.T, out string) {
+				t.Helper()
+				assert.Contains(t, out, fmt.Sprintf("Pushed: %s\n", ref))
+				assert.Regexp(t, `Digest: sha256:[0-9a-f]{64}\n`, out)
+			},
+		},
+		{
+			name:   "push with table output",
+			format: "table",
+			check: func(t *testing.T, out string) {
+				t.Helper()
+				assert.Contains(t, out, fmt.Sprintf("Pushed: %s\n", ref))
+				assert.Regexp(t, `Digest: sha256:[0-9a-f]{64}\n`, out)
+			},
+		},
+		{
+			name:   "push with json output",
+			format: "json",
+			check: func(t *testing.T, out string) {
+				t.Helper()
+				result := map[string]string{}
+				require.NoError(t, json.Unmarshal([]byte(out), &result), "expected pure JSON output, got %q", out)
+				assert.Equal(t, ref, result["ref"])
+				assert.Regexp(t, digestPattern, result["digest"])
+			},
+		},
+		{
+			name:   "push with yaml output",
+			format: "yaml",
+			check: func(t *testing.T, out string) {
+				t.Helper()
+				result := map[string]string{}
+				require.NoError(t, yaml.Unmarshal([]byte(out), &result), "expected pure YAML output, got %q", out)
+				assert.Equal(t, ref, result["ref"])
+				assert.Regexp(t, digestPattern, result["digest"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := fmt.Sprintf("push testdata/testcharts/compressedchart-0.1.0.tgz oci://%s/u/ocitestuser --registry-config %s --plain-http",
+				ociSrv.RegistryURL,
+				filepath.Join(srv.Root(), "config.json"),
+			)
+			if tt.format != "" {
+				cmd += " --output " + tt.format
+			}
+			_, out, err := executeActionCommand(cmd)
+			require.NoError(t, err)
+			tt.check(t, out)
+		})
+	}
+}
+
+func TestPushOutputCompletion(t *testing.T) {
+	runTestCmd(t, []cmdTestCase{{
+		name:   "completion for output flag of push",
+		cmd:    "__complete push --output ''",
+		golden: "output/output-comp.txt",
+	}})
+}
 
 func TestPushFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "push", true)

--- a/pkg/pusher/ocipusher.go
+++ b/pkg/pusher/ocipusher.go
@@ -93,8 +93,14 @@ func (pusher *OCIPusher) push(chartRef, href string) error {
 	chartArchiveFileCreatedTime := stat.ModTime()
 	pushOpts = append(pushOpts, registry.PushOptCreationTime(chartArchiveFileCreatedTime.Format(time.RFC3339)))
 
-	_, err = client.Push(chartBytes, ref, pushOpts...)
-	return err
+	result, err := client.Push(chartBytes, ref, pushOpts...)
+	if err != nil {
+		return err
+	}
+	if pusher.opts.pushResultHandler != nil {
+		pusher.opts.pushResultHandler(result)
+	}
+	return nil
 }
 
 // NewOCIPusher constructs a valid OCI client as a Pusher

--- a/pkg/pusher/ocipusher_test.go
+++ b/pkg/pusher/ocipusher_test.go
@@ -70,6 +70,16 @@ func TestNewOCIPusher(t *testing.T) {
 	op, ok = p.(*OCIPusher)
 	require.True(t, ok, "expected NewOCIPusher to produce an *OCIPusher")
 	assert.Equal(t, registryClient, op.opts.registryClient, "Expected NewOCIPusher to contain %p as RegistryClient, got %p", registryClient, op.opts.registryClient)
+
+	// Test if setting pushResultHandler is being passed to the ops
+	p, err = NewOCIPusher(
+		WithPushResultHandler(func(_ *registry.PushResult) {}),
+	)
+	require.NoError(t, err)
+
+	op, ok = p.(*OCIPusher)
+	require.True(t, ok, "expected NewOCIPusher to produce an *OCIPusher")
+	assert.NotNil(t, op.opts.pushResultHandler, "Expected NewOCIPusher to contain a push result handler")
 }
 
 func TestOCIPusher_Push_ErrorHandling(t *testing.T) {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -34,6 +34,7 @@ type options struct {
 	caFile                string
 	insecureSkipTLSVerify bool
 	plainHTTP             bool
+	pushResultHandler     func(*registry.PushResult)
 }
 
 // Option allows specifying various settings configurable by the user for overriding the defaults
@@ -66,6 +67,14 @@ func WithInsecureSkipTLSVerify(insecureSkipTLSVerify bool) Option {
 func WithPlainHTTP(plainHTTP bool) Option {
 	return func(opts *options) {
 		opts.plainHTTP = plainHTTP
+	}
+}
+
+// WithPushResultHandler sets a handler which is called with the result of a
+// successful push. Pushers which do not produce a push result ignore it.
+func WithPushResultHandler(handler func(result *registry.PushResult)) Option {
+	return func(opts *options) {
+		opts.pushResultHandler = handler
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`helm push` currently only prints a human-readable summary (`Pushed: ...` / `Digest: ...`), which makes it awkward to consume the pushed reference and manifest digest programmatically — e.g. to immediately sign the chart with cosign. This PR adds the standard `-o/--output` flag (`table`, `json`, `yaml`) to `helm push`, consistent with `helm install`, `helm status`, `helm get metadata`, etc.

```console
$ helm push mychart-0.1.0.tgz oci://registry.example.com/charts -o json
{"ref":"registry.example.com/charts/mychart:0.1.0","digest":"sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55"}

$ helm push mychart-0.1.0.tgz oci://registry.example.com/charts -o yaml
digest: sha256:e5ef611620fb97704d8751c16bab17fedb68883bfb0edc76f78a70e9173f9b55
ref: registry.example.com/charts/mychart:0.1.0
```

closes #11735

**How it works**:

The OCI registry client already returns a `*registry.PushResult`, but `OCIPusher` discarded it, so the result never reached the CLI. This PR plumbs it through with purely additive functional options, keeping all public Go SDK signatures unchanged per [HIP-0004](https://github.com/helm/community/blob/main/hips/hip-0004.md):

- `pkg/pusher`: new `WithPushResultHandler(func(*registry.PushResult)) Option`; `OCIPusher` invokes the handler after a successful push.
- `pkg/action`: new `WithPushResultHandler(...) PushOpt` on the push action that forwards the handler to the pusher. `Push.Run`'s signature is unchanged.
- `pkg/cmd`: `helm push` binds the shared output flag, captures the result via the handler, and renders it with the existing `pkg/cli/output` machinery.

**Special notes for your reviewer**:

- Default (`table`) output is byte-for-byte identical to today: the registry client keeps writing the `Pushed:`/`Digest:` summary (including the underscore warning) directly, exactly as before.
- For `json`/`yaml`, the registry client's writer is set to `io.Discard` so stdout contains only the structured result (this also means the OCI "underscore in ref" warning is not printed in these modes; the ref itself is part of the structured output).
- The structured output is intentionally minimal (`ref` + manifest `digest`, mirroring the table summary). More fields from `registry.PushResult` (chart/prov digests, sizes) can be added later without breaking consumers; happy to include them now if preferred.
- The `Pusher` interface, `uploader.UploadTo`, and `action.Push.Run` signatures are deliberately untouched. #32009 implements the same feature by changing those public signatures; this PR takes a non-breaking approach so it can land within v4.
- The new `TestPushCmd` exercises the real push path end-to-end against the in-process `repotest` OCI registry (same infrastructure as `TestPullCmd`), asserting that `-o json`/`-o yaml` stdout parses cleanly and that table output is unchanged.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
