### PR TITLE
feature/http-gzip-index.yaml

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"helm.sh/helm/v4/internal/tlsutil"
@@ -55,8 +57,13 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 		return nil, err
 	}
 
+	isRepositoryIndexRequest := isRepositoryIndexRequestURL(href)
+
 	if opts.acceptHeader != "" {
 		req.Header.Set("Accept", opts.acceptHeader)
+	}
+	if isRepositoryIndexRequest {
+		req.Header.Set("Accept-Encoding", "gzip")
 	}
 
 	req.Header.Set("User-Agent", version.GetUserAgent())
@@ -100,9 +107,40 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 		return nil, fmt.Errorf("failed to fetch %s : %s", href, resp.Status)
 	}
 
+	reader := io.Reader(resp.Body)
+	if isRepositoryIndexRequest && isGzipEncoded(resp.Header) {
+		gzipReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer gzipReader.Close()
+		reader = gzipReader
+	}
+
 	buf := bytes.NewBuffer(nil)
-	_, err = io.Copy(buf, resp.Body)
+	_, err = io.Copy(buf, reader)
 	return buf, err
+}
+
+func isRepositoryIndexRequestURL(href string) bool {
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+
+	return u.Path == "index.yaml" || strings.HasSuffix(u.Path, "/index.yaml")
+}
+
+func isGzipEncoded(header http.Header) bool {
+	for _, value := range header.Values("Content-Encoding") {
+		for _, encoding := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(encoding), "gzip") {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // NewHTTPGetter constructs a valid http/https client as a Getter

--- a/pkg/repo/v1/chartrepo_test.go
+++ b/pkg/repo/v1/chartrepo_test.go
@@ -18,6 +18,7 @@ package repo
 
 import (
 	"bytes"
+	"compress/gzip"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -122,6 +123,47 @@ func TestConcurrencyDownloadIndex(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+func TestDownloadIndexFileWithGzipContentEncoding(t *testing.T) {
+	fileBytes, err := os.ReadFile("testdata/local-index.yaml")
+	require.NoError(t, err)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+
+		w.Header().Set("Content-Encoding", "gzip")
+		gzipWriter := gzip.NewWriter(w)
+		defer gzipWriter.Close()
+
+		_, err := gzipWriter.Write(fileBytes)
+		require.NoError(t, err)
+	})
+
+	srv, err := startLocalServerForTests(handler)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	r, err := NewChartRepository(&Entry{
+		Name: testRepo,
+		URL:  srv.URL,
+	}, getter.All(&cli.EnvSettings{}))
+	require.NoError(t, err)
+
+	idx, err := r.DownloadIndexFile()
+	require.NoError(t, err)
+
+	i, err := LoadIndexFile(idx)
+	require.NoError(t, err)
+	verifyLocalIndex(t, i)
+
+	writtenIndex, err := os.ReadFile(idx)
+	require.NoError(t, err)
+	assert.Equal(t, fileBytes, writtenIndex)
+	assert.NotContains(t, string(writtenIndex), "\x1f\x8b")
+	assert.NotEmpty(t, writtenIndex)
+	assert.Equal(t, filepath.Base(idx), helmpath.CacheIndexFile(r.Config.Name))
+	assert.Equal(t, filepath.Dir(idx), r.CachePath)
 }
 
 // startLocalServerForTests Start the local helm server

--- a/pkg/repo/v1/chartrepo_test.go
+++ b/pkg/repo/v1/chartrepo_test.go
@@ -134,10 +134,10 @@ func TestDownloadIndexFileWithGzipContentEncoding(t *testing.T) {
 
 		w.Header().Set("Content-Encoding", "gzip")
 		gzipWriter := gzip.NewWriter(w)
-		defer gzipWriter.Close()
 
 		_, err := gzipWriter.Write(fileBytes)
 		require.NoError(t, err)
+		require.NoError(t, gzipWriter.Close())
 	})
 
 	srv, err := startLocalServerForTests(handler)


### PR DESCRIPTION
**What this PR does / why we need it**:

As index.yaml can become big, sending it uncompressed over network becomes a problem.
Fortunately web servers offer compression of content on the fly.
http client must come with proper headers and then server responds accordingly if it supports it.

How it works
client -> "Accept-Encoding: gzip"
server -> "Content-Encoding: gzip"
server -> gzipped content

**Special notes for your reviewer**:

this solution is completely transparent. it will work only when web server supports it.
it is added only in case of reaching for index.yaml. otherwise httpClient works as before.

**If applicable**:
- [X] this PR has been tested for backwards compatibility
