### PR TITLE
fix(action): preserve YAML list documents through post-render roundtrip

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -204,16 +204,14 @@ func annotateAndMerge(files map[string]string) (string, error) {
 			if strings.TrimSpace(doc) == "" {
 				continue
 			}
-			manifests, err := kio.ParseAll(doc)
+			manifest, err := kyaml.Parse(doc)
 			if err != nil {
 				return "", fmt.Errorf("parsing %s: %w", fname, err)
 			}
-			for _, manifest := range manifests {
-				if err := manifest.PipeE(kyaml.SetAnnotation(filenameAnnotation, fname)); err != nil {
-					return "", fmt.Errorf("annotating %s: %w", fname, err)
-				}
-				combinedManifests = append(combinedManifests, manifest)
+			if err := manifest.PipeE(kyaml.SetAnnotation(filenameAnnotation, fname)); err != nil {
+				return "", fmt.Errorf("annotating %s: %w", fname, err)
 			}
+			combinedManifests = append(combinedManifests, manifest)
 		}
 	}
 
@@ -234,13 +232,13 @@ func annotateAndMerge(files map[string]string) (string, error) {
 // group), so that merging results from different invocations does not collide
 // on the same synthetic key.
 func splitAndDeannotate(postrendered, fallbackPrefix string) (map[string]string, error) {
-	manifests, err := kio.ParseAll(postrendered)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing YAML: %w", err)
-	}
-
+	docs := releaseutil.SplitManifests(postrendered)
 	manifestsByFilename := make(map[string][]*kyaml.RNode)
-	for i, manifest := range manifests {
+	for i := 0; i < len(docs); i++ {
+		manifest, err := kyaml.Parse(docs[fmt.Sprintf("manifest-%d", i)])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing YAML: %w", err)
+		}
 		meta, err := manifest.GetMeta()
 		if err != nil {
 			return nil, fmt.Errorf("getting metadata: %w", err)

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1704,7 +1704,7 @@ data:
 		{
 			name:          "invalid yaml input",
 			input:         "invalid: yaml: content:",
-			expectedError: "error parsing YAML: MalformedYAMLError",
+			expectedError: "error parsing YAML:",
 		},
 		{
 			name: "manifest without filename annotation",
@@ -1797,6 +1797,33 @@ data:
 
 		assert.Equal(t, normalizeContent(originalContent), normalizeContent(reconstructedContent))
 	}
+}
+
+func TestRenderResources_PostRenderer_ListAnchorRoundTrip(t *testing.T) {
+	cfg := actionConfigFixture(t)
+	ch := buildChartWithTemplates([]*common.File{{
+		Name:    "templates/list.yaml",
+		ModTime: time.Now(),
+		Data: []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-a
+  data: &shared
+    key: value
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-b
+  data: *shared`),
+	}})
+
+	_, buf, _, err := cfg.renderResources(t.Context(), ch, nil, "test-release", "", false, false, false, &mockPostRenderer{}, false, false, false, PostRenderStrategyCombined)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "name: cm-a")
+	assert.Contains(t, buf.String(), "name: cm-b")
 }
 
 func TestRenderResources_PostRenderer_Success(t *testing.T) {
@@ -1915,7 +1942,7 @@ func TestRenderResources_PostRenderer_SplitError(t *testing.T) {
 		mockPR, false, false, false, PostRenderStrategyCombined,
 	)
 
-	assert.ErrorContains(t, err, "error while parsing post rendered output: error parsing YAML: MalformedYAMLError:")
+	assert.ErrorContains(t, err, "error while parsing post rendered output: error parsing YAML:")
 }
 
 func TestRenderResources_PostRenderer_Integration(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #32203.

Post-render roundtrips currently use `kio.ParseAll` in the annotate/split helpers. For `kind: List` manifests, `kio.ParseAll` expands the list into separate resources. That breaks YAML anchors shared across list items, so even a no-op post-renderer can turn valid Helm output into YAML that fails to parse with `unknown anchor referenced`.

This change preserves each YAML document as a whole document during the post-render annotate/split flow, so `kind: List` manifests keep their anchors intact.

**Special notes for your reviewer**:

Cluster-free repro from the issue fails before this change and passes after it.

Repro:
1. Render a chart containing a `kind: List` with two items sharing a YAML anchor/alias.
2. Configure a no-op post-renderer.
3. Run install/template path with post-rendering enabled.
4. Before fix: post-render reparse fails with `unknown anchor referenced`.
5. After fix: render succeeds.

Validation run locally:
- `go test ./pkg/action -run TestRenderResources_PostRenderer_ListAnchorRoundTrip -count=1`
- `make test-unit PKG=./pkg/action`
- `PATH="$(go env GOPATH)/bin:$PATH" make test-style`

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
