### PR TITLE
fix(repo): accept gzip-compressed index.yaml responses

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -17,6 +17,7 @@ package getter
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"helm.sh/helm/v4/internal/tlsutil"
@@ -57,6 +59,10 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 
 	if opts.acceptHeader != "" {
 		req.Header.Set("Accept", opts.acceptHeader)
+	}
+	acceptCompressedIndex := strings.HasSuffix(req.URL.Path, "/index.yaml")
+	if acceptCompressedIndex {
+		req.Header.Set("Accept-Encoding", "gzip")
 	}
 
 	req.Header.Set("User-Agent", version.GetUserAgent())
@@ -101,7 +107,16 @@ func (g *HTTPGetter) get(href string, opts getterOptions) (*bytes.Buffer, error)
 	}
 
 	buf := bytes.NewBuffer(nil)
-	_, err = io.Copy(buf, resp.Body)
+	body := io.Reader(resp.Body)
+	if acceptCompressedIndex && resp.Header.Get("Content-Encoding") == "gzip" {
+		gz, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		body = gz
+	}
+	_, err = io.Copy(buf, body)
 	return buf, err
 }
 

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -19,6 +19,7 @@ package repo
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -288,6 +289,28 @@ func TestDownloadIndexFile(t *testing.T) {
 		b, err := os.ReadFile(idx)
 		require.NoErrorf(t, err, "error reading charts file")
 		verifyLocalChartsFile(t, b, i)
+	})
+
+	t.Run("should accept gzip-compressed index responses", func(t *testing.T) {
+		fileBytes, err := os.ReadFile(testfile)
+		require.NoError(t, err)
+		srv, err := startLocalServerForTests(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			_, _ = gz.Write(fileBytes)
+			_ = gz.Close()
+		}))
+		require.NoError(t, err)
+		defer srv.Close()
+
+		r, err := NewChartRepository(&Entry{Name: testRepo, URL: srv.URL}, getter.All(&cli.EnvSettings{}))
+		require.NoError(t, err)
+		idx, err := r.DownloadIndexFile()
+		require.NoError(t, err)
+		i, err := LoadIndexFile(idx)
+		require.NoError(t, err)
+		verifyLocalIndex(t, i)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #32479.

`HTTPGetter` currently disables HTTP compression across the board. That is correct for chart archive downloads, but it also means repository index requests never advertise gzip support.

This change keeps chart downloads unchanged and narrowly opts `index.yaml` requests into gzip by:
- sending `Accept-Encoding: gzip` only for `index.yaml` requests
- transparently decompressing gzip responses only for those requests

That allows large repository indexes to be transferred compressed without changing `.tgz` download behavior.

**Special notes for your reviewer**:

This is intentionally narrow. Enabling HTTP compression globally in `HTTPGetter` would risk transparently decompressing chart archives when servers send `Content-Encoding: gzip`.

Validation run locally:
- `go test ./pkg/repo/v1 -run TestDownloadIndexFile/should_accept_gzip-compressed_index_responses -count=1`
- `go test ./pkg/getter ./pkg/repo/v1 -count=1`
- `PATH="$(go env GOPATH)/bin:$PATH" make test-style`

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
