### PR TITLE
chore: fix gofumpt extra-rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ formatters:
 
     gofumpt:
       module-path: helm.sh/helm/v4
-      extra-rules: false
+      extra-rules: true
 
     goimports:
       local-prefixes:
@@ -95,7 +95,6 @@ linters:
         - exposedSyncMutex
         - hugeParam
         - importShadow
-        - paramTypeCombine
         - ptrToRefParam
         - rangeValCopy
         - todoCommentWithoutDetail
@@ -119,6 +118,7 @@ linters:
       enable-default-rules: true
       max-open-files: 2048
       rules:
+        - name: bare-return
         - name: early-return
           arguments:
             - "preserve-scope"

--- a/internal/plugin/installer/installer.go
+++ b/internal/plugin/installer/installer.go
@@ -153,7 +153,7 @@ func NewForSource(source, version string) (installer Installer, err error) {
 		return installer, fmt.Errorf("cannot get information about plugin source %q (if it's a local directory, does it exist?), last error was: %w", source, err)
 	}
 
-	return
+	return installer, err
 }
 
 // FindSource determines the correct Installer for the given source.

--- a/internal/plugin/installer/plugin_structure.go
+++ b/internal/plugin/installer/plugin_structure.go
@@ -53,7 +53,7 @@ func detectPluginRoot(extractDir string) (string, error) {
 
 // validatePluginName checks if the plugin directory name matches the plugin name
 // from plugin.yaml when the plugin is in a subdirectory.
-func validatePluginName(pluginRoot string, expectedName string) error {
+func validatePluginName(pluginRoot, expectedName string) error {
 	// Only validate if plugin is in a subdirectory
 	dirName := filepath.Base(pluginRoot)
 	if dirName == expectedName {

--- a/internal/plugin/runtime_extismv1.go
+++ b/internal/plugin/runtime_extismv1.go
@@ -212,7 +212,7 @@ func (p *ExtismV1PluginRuntime) Invoke(ctx context.Context, input *Input) (*Outp
 	return output, nil
 }
 
-func buildManifest(pluginDir string, tmpDir string, rc *RuntimeConfigExtismV1) (extism.Manifest, error) {
+func buildManifest(pluginDir, tmpDir string, rc *RuntimeConfigExtismV1) (extism.Manifest, error) {
 	wasmFile := filepath.Join(pluginDir, ExtismV1WasmBinaryFilename)
 
 	allowedHosts := rc.AllowedHosts

--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -112,7 +112,7 @@ func (r *SubprocessPluginRuntime) Invoke(ctx context.Context, input *Input) (*Ou
 
 // InvokeWithEnv executes a plugin command with custom environment and I/O streams
 // This method allows execution with different command/args than the plugin's default
-func (r *SubprocessPluginRuntime) InvokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+func (r *SubprocessPluginRuntime) InvokeWithEnv(main string, argv, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	mainCmdExp := os.ExpandEnv(main)
 	cmd := exec.CommandContext(context.Background(), mainCmdExp, argv...)
 	cmd.Env = slices.Clone(os.Environ())

--- a/internal/plugin/signing_info.go
+++ b/internal/plugin/signing_info.go
@@ -111,7 +111,7 @@ func GetPluginSigningInfo(metadata Metadata) (*SigningInfo, error) {
 	}, nil
 }
 
-func validateProvenanceHash(blockContent string, tarballPath string) bool {
+func validateProvenanceHash(blockContent, tarballPath string) bool {
 	// Parse provenance to get the expected hash
 	_, sums, err := parsePluginMessageBlock([]byte(blockContent))
 	if err != nil {

--- a/internal/release/v2/util/filter.go
+++ b/internal/release/v2/util/filter.go
@@ -41,7 +41,7 @@ func (fn FilterFunc) Filter(rels []*v2.Release) (rets []*v2.Release) {
 			rets = append(rets, rel)
 		}
 	}
-	return
+	return rets
 }
 
 // Any returns a FilterFunc that filters a list of releases

--- a/internal/release/v2/util/kind_sorter.go
+++ b/internal/release/v2/util/kind_sorter.go
@@ -137,7 +137,7 @@ func sortHooksByKind(hooks []*release.Hook, ordering KindSortOrder) []*release.H
 	return h
 }
 
-func lessByKind(_ any, _ any, kindA string, kindB string, o KindSortOrder) bool {
+func lessByKind(_, _ any, kindA, kindB string, o KindSortOrder) bool {
 	ordering := make(map[string]int, len(o))
 	for v, k := range o {
 		ordering[k] = v

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -49,7 +49,7 @@ func AssertGoldenString(t TestingT, actual, filename string) {
 }
 
 // AssertGoldenFile asserts that the content of the actual file matches the contents of the expected file
-func AssertGoldenFile(t TestingT, actualFileName string, expectedFilename string) {
+func AssertGoldenFile(t TestingT, actualFileName, expectedFilename string) {
 	t.Helper()
 
 	actual, err := os.ReadFile(actualFileName)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -476,7 +476,7 @@ func (i *Install) RunWithContext(ctx context.Context, ch ci.Charter, vals map[st
 	return rel, err
 }
 
-func (i *Install) performInstallCtx(ctx context.Context, rel *release.Release, toBeAdopted kube.ResourceList, resources kube.ResourceList) (*release.Release, error) {
+func (i *Install) performInstallCtx(ctx context.Context, rel *release.Release, toBeAdopted, resources kube.ResourceList) (*release.Release, error) {
 	type Msg struct {
 		r *release.Release
 		e error
@@ -503,7 +503,7 @@ func (i *Install) getGoroutineCount() int32 {
 	return i.goroutineCount.Load()
 }
 
-func (i *Install) performInstall(rel *release.Release, toBeAdopted kube.ResourceList, resources kube.ResourceList) (*release.Release, error) {
+func (i *Install) performInstall(rel *release.Release, toBeAdopted, resources kube.ResourceList) (*release.Release, error) {
 	var err error
 	// pre-install hooks
 	if !i.DisableHooks {
@@ -717,7 +717,7 @@ func (i *Install) replaceRelease(rel *release.Release) error {
 }
 
 // write the <data> to <output-dir>/<name>. <appendData> controls if the file is created or content will be appended
-func writeToFile(outputDir string, name string, data string, appendData bool) error {
+func writeToFile(outputDir, name, data string, appendData bool) error {
 	outfileName := outputDir + string(filepath.Separator) + name
 
 	err := ensureDirectoryForFile(outfileName)

--- a/pkg/action/push.go
+++ b/pkg/action/push.go
@@ -90,7 +90,7 @@ func NewPushWithOpts(opts ...PushOpt) *Push {
 }
 
 // Run executes 'helm push' against the given chart archive.
-func (p *Push) Run(chartRef string, remote string) (string, error) {
+func (p *Push) Run(chartRef, remote string) (string, error) {
 	var out strings.Builder
 
 	c := uploader.ChartUploader{

--- a/pkg/action/registry_login.go
+++ b/pkg/action/registry_login.go
@@ -82,7 +82,7 @@ func NewRegistryLogin(cfg *Configuration) *RegistryLogin {
 }
 
 // Run executes the registry login operation
-func (a *RegistryLogin) Run(_ io.Writer, hostname string, username string, password string, opts ...RegistryLoginOpt) error {
+func (a *RegistryLogin) Run(_ io.Writer, hostname, username, password string, opts ...RegistryLoginOpt) error {
 	for _, opt := range opts {
 		if err := opt(a); err != nil {
 			return err

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -453,7 +453,7 @@ func isReleaseApplyMethodClientSideApply(applyMethod string) bool {
 	return applyMethod == "" || applyMethod == string(release.ApplyMethodClientSideApply)
 }
 
-func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *release.Release, current kube.ResourceList, target kube.ResourceList, originalRelease *release.Release, serverSideApply bool) {
+func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *release.Release, current, target kube.ResourceList, originalRelease *release.Release, serverSideApply bool) {
 	// pre-upgrade hooks
 
 	if !u.DisableHooks {
@@ -664,7 +664,7 @@ func mergeCustomLabels(current, desired map[string]string) map[string]string {
 	return labels
 }
 
-func getUpgradeServerSideValue(serverSideOption string, releaseApplyMethod string) (bool, error) {
+func getUpgradeServerSideValue(serverSideOption, releaseApplyMethod string) (bool, error) {
 	switch serverSideOption {
 	case "auto":
 		return releaseApplyMethod == "ssa", nil

--- a/pkg/action/validate_test.go
+++ b/pkg/action/validate_test.go
@@ -75,7 +75,7 @@ func newMissingDeployment(name, namespace string) *resource.Info {
 	return info
 }
 
-func newDeploymentWithOwner(name, namespace string, labels map[string]string, annotations map[string]string) *resource.Info {
+func newDeploymentWithOwner(name, namespace string, labels, annotations map[string]string) *resource.Info {
 	obj := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        name,

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -219,7 +219,7 @@ func envCSV(name string) (ls []string) {
 	if trimmed != "" {
 		ls = strings.Split(trimmed, ",")
 	}
-	return
+	return ls
 }
 
 func envColorMode() string {

--- a/pkg/cli/output/output.go
+++ b/pkg/cli/output/output.go
@@ -85,7 +85,7 @@ func ParseFormat(s string) (out Format, err error) {
 	default:
 		out, err = "", ErrInvalidFormatType
 	}
-	return
+	return out, err
 }
 
 // Writer is an interface that any type can implement to write supported formats

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -268,7 +268,7 @@ func (p *postRendererArgsSlice) GetSlice() []string {
 	return p.options.args
 }
 
-func compVersionFlag(chartRef string, _ string) ([]string, cobra.ShellCompDirective) {
+func compVersionFlag(chartRef, _ string) ([]string, cobra.ShellCompDirective) {
 	chartInfo := strings.Split(chartRef, "/")
 	if len(chartInfo) != 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -155,7 +155,7 @@ type releaseListWriter struct {
 	noColor   bool
 }
 
-func newReleaseListWriter(releases []*release.Release, timeFormat string, noHeaders bool, noColor bool) *releaseListWriter {
+func newReleaseListWriter(releases []*release.Release, timeFormat string, noHeaders, noColor bool) *releaseListWriter {
 	// Initialize the array so no results returns an empty array instead of null
 	elements := make([]releaseElement, 0, len(releases))
 	for _, r := range releases {

--- a/pkg/cmd/pull_test.go
+++ b/pkg/cmd/pull_test.go
@@ -268,7 +268,7 @@ func runPullTests(t *testing.T, tests []struct {
 	wantErrorMsg string
 	expectFile   string
 	expectDir    bool
-}, outdir string, additionalFlags string,
+}, outdir, additionalFlags string,
 ) {
 	t.Helper()
 	for _, tt := range tests {

--- a/pkg/cmd/registry_login.go
+++ b/pkg/cmd/registry_login.go
@@ -91,7 +91,7 @@ func newRegistryLoginCmd(cfg *action.Configuration, out io.Writer) *cobra.Comman
 }
 
 // Adapted from https://github.com/oras-project/oras
-func getUsernamePassword(usernameOpt string, passwordOpt string, passwordFromStdinOpt bool) (string, string, error) {
+func getUsernamePassword(usernameOpt, passwordOpt string, passwordFromStdinOpt bool) (string, string, error) {
 	var err error
 	username := usernameOpt
 	password := passwordOpt

--- a/pkg/cmd/repo_remove_test.go
+++ b/pkg/cmd/repo_remove_test.go
@@ -119,7 +119,7 @@ func TestRepoRemove(t *testing.T) {
 	}
 }
 
-func createCacheFiles(rootDir string, repoName string) (cacheIndexFile string, cacheChartsFile string) {
+func createCacheFiles(rootDir, repoName string) (cacheIndexFile, cacheChartsFile string) {
 	cacheIndexFile = filepath.Join(rootDir, helmpath.CacheIndexFile(repoName))
 	mf, _ := os.Create(cacheIndexFile)
 	mf.Close()
@@ -131,7 +131,7 @@ func createCacheFiles(rootDir string, repoName string) (cacheIndexFile string, c
 	return cacheIndexFile, cacheChartsFile
 }
 
-func testCacheFiles(t *testing.T, cacheIndexFile string, cacheChartsFile string, repoName string) {
+func testCacheFiles(t *testing.T, cacheIndexFile, cacheChartsFile, repoName string) {
 	t.Helper()
 	_, err := os.Stat(cacheIndexFile)
 	require.Errorf(t, err, "Error cache index file was not removed for repository %s", repoName)

--- a/pkg/cmd/search_repo.go
+++ b/pkg/cmd/search_repo.go
@@ -268,7 +268,7 @@ func (r *repoSearchWriter) encodeByFormat(out io.Writer, format output.Format) e
 }
 
 // Provides the list of charts that are part of the specified repo, and that starts with 'prefix'.
-func compListChartsOfRepo(repoName string, prefix string) []string {
+func compListChartsOfRepo(repoName, prefix string) []string {
 	var charts []string
 
 	path := filepath.Join(settings.RepositoryCache, helmpath.CacheChartsFile(repoName))

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -238,7 +238,7 @@ func isTestHook(h *release.Hook) bool {
 // bug introduced by #8156. As part of the todo to refactor renderResources
 // this duplicate code should be removed. It is added here so that the API
 // surface area is as minimally impacted as possible in fixing the issue.
-func writeToFile(outputDir string, name string, data string, appendData bool) error {
+func writeToFile(outputDir, name, data string, appendData bool) error {
 	outfileName := outputDir + string(filepath.Separator) + name
 
 	err := ensureDirectoryForFile(outfileName)

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -736,19 +736,16 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 			// TODO: Where linting is skipped in this function we should
 			// refactor to remove naked returns while ensuring the same
 			// behavior
-			//nolint:nakedret
-			return
+			return url, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err
 		}
 		var ve *repo.ChartVersion
 		ve, err = findVersionedEntry(version, entry)
 		if err != nil {
-			//nolint:nakedret
-			return
+			return url, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err
 		}
 		url, err = repo.ResolveReferenceURL(repoURL, ve.URLs[0])
 		if err != nil {
-			//nolint:nakedret
-			return
+			return url, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err
 		}
 		username = cr.Config.Username
 		password = cr.Config.Password
@@ -757,8 +754,8 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 		caFile = cr.Config.CAFile
 		certFile = cr.Config.CertFile
 		keyFile = cr.Config.KeyFile
-		//nolint:nakedret
-		return
+
+		return url, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err
 	}
 	url, err = repo.FindChartInRepoURL(repoURL, name, m.Getters, repo.WithChartVersion(version), repo.WithClientTLS(certFile, keyFile, caFile))
 	if err == nil {

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -733,9 +733,7 @@ func (m *Manager) findChartURL(name, version, repoURL string, repos map[string]*
 		var entry repo.ChartVersions
 		entry, err = findEntryByName(name, cr)
 		if err != nil {
-			// TODO: Where linting is skipped in this function we should
-			// refactor to remove naked returns while ensuring the same
-			// behavior
+			// TODO: Consider refactoring this function to reduce the number of returned values while preserving behavior.
 			return url, username, password, insecureSkipTLSVerify, passCredentialsAll, caFile, certFile, keyFile, err
 		}
 		var ve *repo.ChartVersion

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -413,7 +413,7 @@ func parseTemplateExecErrorString(s string) (TraceableError, bool) {
 
 // Special case: "template: no template %q associated with template %q"
 // Matches https://cs.opensource.google/go/go/+/refs/tags/go1.23.6:src/text/template/exec.go;l=191
-func parseTemplateNoTemplateError(s string, remainder string) (TraceableError, bool) {
+func parseTemplateNoTemplateError(s, remainder string) (TraceableError, bool) {
 	if strings.HasPrefix(remainder, "no template ") {
 		return TraceableError{message: s}, true
 	}

--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -447,7 +447,7 @@ func durationWeeks(v any) float64 {
 //
 // v and m accept the same forms as asDuration (e.g. "2h13m", "30s").
 // On error, it returns time.Duration(0). If m is invalid, it returns v.
-func durationRoundTo(v any, m any) time.Duration {
+func durationRoundTo(v, m any) time.Duration {
 	d, err := asDuration(v)
 	if err != nil {
 		return 0
@@ -463,7 +463,7 @@ func durationRoundTo(v any, m any) time.Duration {
 // Returns a time.Duration.
 //
 // On error, it returns time.Duration(0). If m is invalid, it returns v.
-func durationTruncateTo(v any, m any) time.Duration {
+func durationTruncateTo(v, m any) time.Duration {
 	d, err := asDuration(v)
 	if err != nil {
 		return 0

--- a/pkg/engine/lookup_func.go
+++ b/pkg/engine/lookup_func.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type lookupFunc = func(apiversion string, resource string, namespace string, name string) (map[string]any, error)
+type lookupFunc = func(apiversion, resource, namespace, name string) (map[string]any, error)
 
 // NewLookupFunction returns a function for looking up objects in the cluster.
 //
@@ -55,7 +55,7 @@ func (c clientProviderFromConfig) GetClientFor(apiVersion, kind string) (dynamic
 }
 
 func newLookupFunction(ctx context.Context, clientProvider ClientProvider) lookupFunc {
-	return func(apiversion string, kind string, namespace string, name string) (map[string]any, error) {
+	return func(apiversion, kind, namespace, name string) (map[string]any, error) {
 		var client dynamic.ResourceInterface
 		c, namespaced, err := clientProvider.GetClientFor(apiversion, kind)
 		if err != nil {
@@ -105,7 +105,7 @@ func newLookupFunction(ctx context.Context, clientProvider ClientProvider) looku
 }
 
 // getDynamicClientOnKind returns a dynamic client on an Unstructured type. This client can be further namespaced.
-func getDynamicClientOnKind(apiversion string, kind string, config *rest.Config) (dynamic.NamespaceableResourceInterface, bool, error) {
+func getDynamicClientOnKind(apiversion, kind string, config *rest.Config) (dynamic.NamespaceableResourceInterface, bool, error) {
 	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
 	apiRes, err := getAPIResourceForGVK(gvk, config)
 	if err != nil {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1237,7 +1237,7 @@ func upgradeClientSideFieldManager(info *resource.Info, dryRun bool, fieldValida
 	return patched, err
 }
 
-// Patch reource using server-side apply
+// Patch resource using server-side apply
 func patchResourceServerSide(target *resource.Info, dryRun, forceConflicts bool, fieldValidationDirective FieldValidationDirective) error {
 	helper := resource.NewHelper(
 		target.Client,

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1238,7 +1238,7 @@ func upgradeClientSideFieldManager(info *resource.Info, dryRun bool, fieldValida
 }
 
 // Patch reource using server-side apply
-func patchResourceServerSide(target *resource.Info, dryRun bool, forceConflicts bool, fieldValidationDirective FieldValidationDirective) error {
+func patchResourceServerSide(target *resource.Info, dryRun, forceConflicts bool, fieldValidationDirective FieldValidationDirective) error {
 	helper := resource.NewHelper(
 		target.Client,
 		target.Mapping).

--- a/pkg/kube/ready_test.go
+++ b/pkg/kube/ready_test.go
@@ -1444,7 +1444,7 @@ func newReplicationController(name string, generationInSync bool) *corev1.Replic
 	}
 }
 
-func newReplicaSet(name string, replicas int, readyReplicas int, generationInSync bool) *appsv1.ReplicaSet {
+func newReplicaSet(name string, replicas, readyReplicas int, generationInSync bool) *appsv1.ReplicaSet {
 	d := newDeployment(name, replicas, 0, 0, generationInSync)
 	return &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1503,7 +1503,7 @@ func newPersistentVolumeClaim(name string, phase corev1.PersistentVolumeClaimPha
 	}
 }
 
-func newJob(name string, backoffLimit int, completions *int32, succeeded int, failed int) *batchv1.Job {
+func newJob(name string, backoffLimit int, completions *int32, succeeded, failed int) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/registry/chart.go
+++ b/pkg/registry/chart.go
@@ -108,7 +108,7 @@ func generateChartOCIAnnotations(meta *chart.Metadata, creationTime string) map[
 }
 
 // addToMap takes an existing map and adds an item if the value is not empty
-func addToMap(inputMap map[string]string, newKey string, newValue string) map[string]string {
+func addToMap(inputMap map[string]string, newKey, newValue string) map[string]string {
 	// Add item to map if its
 	if strings.TrimSpace(newValue) != "" {
 		inputMap[newKey] = newValue

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -276,7 +276,7 @@ func (c *Client) Login(host string, options ...LoginOption) error {
 }
 
 // LoginOptBasicAuth returns a function that sets the username/password settings on login
-func LoginOptBasicAuth(username string, password string) LoginOption {
+func LoginOptBasicAuth(username, password string) LoginOption {
 	return func(o *loginOperation) {
 		o.client.username = username
 		o.client.password = password

--- a/pkg/registry/plugin.go
+++ b/pkg/registry/plugin.go
@@ -49,7 +49,7 @@ type PluginPullResult struct {
 }
 
 // PullPlugin downloads a plugin from an OCI registry using artifact type
-func (c *Client) PullPlugin(ref string, pluginName string, options ...PluginPullOption) (*PluginPullResult, error) {
+func (c *Client) PullPlugin(ref, pluginName string, options ...PluginPullOption) (*PluginPullResult, error) {
 	operation := &pluginPullOperation{
 		pluginName: pluginName,
 	}

--- a/pkg/release/v1/util/filter.go
+++ b/pkg/release/v1/util/filter.go
@@ -41,7 +41,7 @@ func (fn FilterFunc) Filter(rels []*rspb.Release) (rets []*rspb.Release) {
 			rets = append(rets, rel)
 		}
 	}
-	return
+	return rets
 }
 
 // Any returns a FilterFunc that filters a list of releases

--- a/pkg/release/v1/util/kind_sorter.go
+++ b/pkg/release/v1/util/kind_sorter.go
@@ -137,7 +137,7 @@ func sortHooksByKind(hooks []*release.Hook, ordering KindSortOrder) []*release.H
 	return h
 }
 
-func lessByKind(_ any, _ any, kindA string, kindB string, o KindSortOrder) bool {
+func lessByKind(_, _ any, kindA, kindB string, o KindSortOrder) bool {
 	ordering := make(map[string]int, len(o))
 	for v, k := range o {
 		ordering[k] = v

--- a/pkg/repo/v1/chartrepo.go
+++ b/pkg/repo/v1/chartrepo.go
@@ -172,7 +172,7 @@ func WithInsecureSkipTLSVerify(insecureSkipTLSVerify bool) FindChartInRepoURLOpt
 
 // FindChartInRepoURL finds chart in chart repository pointed by repoURL
 // without adding repo to repositories
-func FindChartInRepoURL(repoURL string, chartName string, getters getter.Providers, options ...FindChartInRepoURLOption) (string, error) {
+func FindChartInRepoURL(repoURL, chartName string, getters getter.Providers, options ...FindChartInRepoURLOption) (string, error) {
 	opts := findChartInRepoURLOptions{}
 	for _, option := range options {
 		option(&opts)

--- a/pkg/storage/driver/labels.go
+++ b/pkg/storage/driver/labels.go
@@ -27,7 +27,7 @@ func (lbs labels) keys() (ls []string) {
 	for key := range lbs {
 		ls = append(ls, key)
 	}
-	return
+	return ls
 }
 
 func (lbs labels) match(set labels) bool {

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -281,7 +281,7 @@ type SQLReleaseCustomLabelWrapper struct {
 }
 
 // NewSQL initializes a new sql driver.
-func NewSQL(connectionString string, namespace string) (*SQL, error) {
+func NewSQL(connectionString, namespace string) (*SQL, error) {
 	db, err := sqlx.Connect(postgreSQLDialect, connectionString)
 	if err != nil {
 		return nil, err
@@ -690,7 +690,7 @@ func (s *SQL) Delete(key string) (release.Releaser, error) {
 }
 
 // Get release custom labels from database
-func (s *SQL) getReleaseCustomLabels(key string, _ string) (map[string]string, error) {
+func (s *SQL) getReleaseCustomLabels(key, _ string) (map[string]string, error) {
 	query, args, err := s.statementBuilder.
 		Select(sqlCustomLabelsTableKeyColumn, sqlCustomLabelsTableValueColumn).
 		From(sqlCustomLabelsTableName).

--- a/pkg/storage/driver/sql_test.go
+++ b/pkg/storage/driver/sql_test.go
@@ -493,7 +493,7 @@ func TestSqlDelete(t *testing.T) {
 	assert.Equalf(t, rel, deletedRelease, "Expected release {%v}, got {%v}", rel, deletedRelease)
 }
 
-func mockGetReleaseCustomLabels(mock sqlmock.Sqlmock, key string, namespace string, labels map[string]string) {
+func mockGetReleaseCustomLabels(mock sqlmock.Sqlmock, key, namespace string, labels map[string]string) {
 	query := fmt.Sprintf(
 		regexp.QuoteMeta("SELECT %s, %s FROM %s WHERE %s = $1 AND %s = $2"),
 		sqlCustomLabelsTableKeyColumn,


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable and fix gofumpt extra-rules. Also enable paramTypeCombine from gocritic and bare-return from revive as they are both fixed by the gofumpt extra-rules correction.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
