### PR TITLE
feat: attach signed Helm binaries to GitHub Releases

### DIFF
--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -1,5 +1,5 @@
 #
-# PoC: signed release with SBOMs and build provenance.
+# Signed release with SBOMs and build provenance.
 # Modeled on https://github.com/goreleaser/example-secure
 #
 name: release-signed
@@ -32,6 +32,7 @@ jobs:
         with:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
+          cache: false
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1

--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -1,0 +1,53 @@
+#
+# PoC: signed release with SBOMs and build provenance.
+# Modeled on https://github.com/goreleaser/example-secure
+#
+name: release-signed
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # needed to write releases
+  id-token: write # needed for keyless signing
+  attestations: write # needed for provenance
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Add variables to environment file
+        run: cat ".github/env" >> "$GITHUB_ENV"
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # pin@7.0.0
+        with:
+          go-version: '${{ env.GOLANG_VERSION }}'
+          check-latest: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-checksums: ./_dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,8 +55,8 @@ builds:
       - goos: windows
         goarch: loong64
     main: ./cmd/helm
-    binary: helm
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    no_unique_dist_dir: true
+    binary: "{{ .Os }}-{{ .Arch }}/helm"
     ldflags:
       - -w -s
       - -extldflags "-static"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,13 +55,56 @@ builds:
       - goos: windows
         goarch: loong64
     main: ./cmd/helm
-    no_unique_dist_dir: true
-    binary: "{{ .Os }}-{{ .Arch }}/helm"
+    binary: helm
+    mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
-      - "{{ .Env.LDFLAGS }}"
+      - -w -s
+      - -extldflags "-static"
+      - -X helm.sh/helm/v4/internal/version.version={{ .Tag }}
+      - -X helm.sh/helm/v4/internal/version.metadata=
+      - -X helm.sh/helm/v4/internal/version.gitCommit={{ .FullCommit }}
+      - -X helm.sh/helm/v4/internal/version.gitTreeState=clean
     flags:
       - -trimpath
     dir: .
+
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}.src"
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "helm-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+    builds_info:
+      mtime: "{{ .CommitTimestamp }}"
+
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+checksum:
+  name_template: "checksums.txt"
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
 
 snapshot:
   version_template: "{{ if index .Env \"GORELEASER_CURRENT_TAG\" }}{{ .Env.GORELEASER_CURRENT_TAG }}{{ else }}{{ incpatch .Version }}-next{{ end }}"

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ $(GOIMPORTS):
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GORELEASER)
-	LDFLAGS='$(LDFLAGS)' $(GORELEASER) build --snapshot --clean
+	$(GORELEASER) build --snapshot --clean
 
 .PHONY: dist
 dist:

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,6 @@ $(GOIMPORTS):
 #  release
 
 .PHONY: build-cross
-build-cross: LDFLAGS += -extldflags "-static"
 build-cross: $(GORELEASER)
 	$(GORELEASER) build --snapshot --clean
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Close: https://github.com/helm/helm/issues/31436

Helm's release binaries ship via Azure with no signature, SBOM, or build provenance. There is no way for a user to verify a downloaded binary actually came from this repo's CI. Also we should permit user to download release from Github as an alternative. This PR adds a release-signed workflow, modeled on goreleaser/example-secure (https://github.com/goreleaser/example-secure), that:

- generates SBOMs for each release archive and the source tarball (syft)
- cosign keyless-signs checksums.txt using GitHub Actions OIDC, so there is no private key to manage or leak, and the signature is anchored in a public Rekor transparency log entry
- attaches a GitHub build-provenance attestation for the checksums

Signing just checksums.txt is enough: every archive and SBOM is covered by a checksum in that file, so the one signature transitively secures all of them.

The workflow is additive. It triggers on v* tags independently of the existing release.yml, which stays untouched and still gates on `github.repository == 'helm/helm'`. Nothing about today's release process changes.

Demoed end-to-end on a fork: signed release, SBOMs, and attestation all verified independently with cosign verify-blob and gh attestation verify against the actual published artifacts. See: https://github.com/benoittgt/helm/releases/tag/v4.2.1-signing-poc.2 and actual workflow can be seen here https://github.com/benoittgt/helm/actions/runs/30461673169/job/90609042209

Output can be verified like this:
```sh
$ gh release download v4.2.1-signing-poc.2 -R benoittgt/helm -p checksums.txt -p checksums.txt.sigstore.json

cosign verify-blob \
  --bundle=checksums.txt.sigstore.json \
  --certificate-identity-regexp='https://github.com/benoittgt/helm/.*release-signed.yml.*' \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
  checksums.txt
Verified OK

$ gh release download v4.2.1-signing-poc.2 -R benoittgt/helm -p 'helm-v4.2.1-signing-poc.2-darwin-arm64.tar.gz'

sha256sum -c checksums.txt --ignore-missing
helm-v4.2.1-signing-poc.2-darwin-arm64.tar.gz: OK
```

It should be documented on `helm-www` after merge.

**Special notes for your reviewer**:

- Open question: should this eventually replace `release.yml`, or run alongside it as a signing pass over the same Azure-published artifacts? This PR does not attempt that migration either way and I think it should be separate.
- It should probably be backported?

Made with the help of Claude Code Opus/Sonnet

**If applicable**:
- [ ] this PR contains user facing changes
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility