### PR TITLE
ci: fix zizmor security findings in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
           - "k8s.io/cli-runtime"
           - "k8s.io/client-go"
           - "k8s.io/kubectl"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     target-branch: "main"
     directory: "/"
@@ -32,6 +34,8 @@ updates:
           - "k8s.io/cli-runtime"
           - "k8s.io/client-go"
           - "k8s.io/kubectl"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     target-branch: "main"
     directory: "/"
@@ -41,6 +45,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - # Keep dev-v3 GitHub Actions up to date, while Helm v3 is within support
     package-ecosystem: "github-actions"
     target-branch: "dev-v3"
@@ -51,3 +57,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           go-version: '${{ env.GOLANG_VERSION }}'
           check-latest: true
+          cache: false
       - name: Test source headers are present
         run: make test-source-headers
       - name: Check if go modules need to be tidied

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+        with:
+          persist-credentials: false
       - name: Add variables to environment file
         run: cat ".github/env" >> "$GITHUB_ENV"
       - name: Setup Go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+        with:
+          persist-credentials: false
       - name: Add variables to environment file
         run: cat ".github/env" >> "$GITHUB_ENV"
       - name: Setup Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           set -eu -o pipefail
 
-          make build-cross VERSION="${{ github.ref_name }}"
-          make dist checksum VERSION="${{ github.ref_name }}"
+          make build-cross VERSION="${GITHUB_REF_NAME}"
+          make dist checksum VERSION="${GITHUB_REF_NAME}"
 
       - name: Set latest version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Add variables to environment file
         run: cat ".github/env" >> "$GITHUB_ENV"
@@ -88,6 +89,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Add variables to environment file
         run: cat ".github/env" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Note the only differences between release and canary-release jobs are:
 # - only canary passes --overwrite flag


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves all zizmor findings across the GitHub Actions workflows: a 7-day Dependabot cooldown, `persist-credentials: false` on every checkout, `cache: false` on setup-go to prevent cache poisoning, the release ref name passed via `GITHUB_REF_NAME` to block template injection, and the release workflow token scoped down to `contents: read`.

<img width="1204" height="1964" alt="image" src="https://github.com/user-attachments/assets/ed78c785-2f60-438b-9ac5-a4c2a3123bbe" />


**Special notes for your reviewer**:

One commit per finding type. All fixes come from `zizmor --fix=all` except the `contents: read` scope-down, which was done by hand. The release jobs use `GITHUB_TOKEN` only for checkout (goreleaser runs `build --snapshot`, and uploads authenticate with Azure secrets), so the narrower scope is safe.

Made with the help of Claude Code Opus/Sonnet

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
