### PR TITLE
fix(chartutil): clarify unclear 'table' coalesce warnings

### DIFF
--- a/pkg/chart/common/util/coalesce.go
+++ b/pkg/chart/common/util/coalesce.go
@@ -245,7 +245,7 @@ func coalesceValues(printf printFn, c chart.Charter, v map[string]any, prefix st
 					// If the original value is nil, there is nothing to coalesce, so we don't print
 					// the warning
 					if val != nil {
-						printf("warning: skipped value for %s.%s: Not a table.", subPrefix, key)
+						printf("warning: skipped value for %s.%s: the chart default here is a table (a nested map of keys), but the supplied value is not, so it was ignored.", subPrefix, key)
 					}
 				} else {
 					// If the key is a child chart, coalesce tables with Merge set to true
@@ -349,10 +349,10 @@ func coalesceTablesFullKey(printf printFn, dst, src map[string]any, prefix strin
 			if istable(dv) {
 				coalesceTablesFullKey(printf, dv.(map[string]any), val.(map[string]any), fullkey, merge)
 			} else {
-				printf("warning: cannot overwrite table with non table for %s (%v)", fullkey, val)
+				printf("warning: cannot overwrite table with non table for %s (%v): the destination is a table (a nested map of keys) but the source value is not, so the source value was ignored.", fullkey, val)
 			}
 		case istable(dv) && val != nil:
-			printf("warning: destination for %s is a table. Ignoring non-table value (%v)", fullkey, val)
+			printf("warning: destination for %s is a table (a nested map of keys), but the supplied value (%v) is not a table, so it was ignored. If you meant to replace the whole table, unset it first.", fullkey, val)
 		}
 	}
 	return dst

--- a/pkg/chart/common/util/coalesce_test.go
+++ b/pkg/chart/common/util/coalesce_test.go
@@ -616,9 +616,9 @@ func TestCoalesceValuesWarnings(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("vals: %v", vals)
-	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: Not a table.")
-	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table. Ignoring non-table value (true)")
-	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true])")
+	assert.Contains(t, warnings, "warning: skipped value for level1.level2.level3.boat: the chart default here is a table (a nested map of keys), but the supplied value is not, so it was ignored.")
+	assert.Contains(t, warnings, "warning: destination for level1.level2.level3.spear.tip is a table (a nested map of keys), but the supplied value (true) is not a table, so it was ignored. If you meant to replace the whole table, unset it first.")
+	assert.Contains(t, warnings, "warning: cannot overwrite table with non table for level1.level2.level3.spear.sail (map[cotton:true]): the destination is a table (a nested map of keys) but the source value is not, so the source value was ignored.")
 }
 
 func TestConcatPrefix(t *testing.T) {


### PR DESCRIPTION
Fixes #11118

## What this does

The value-coalescing logic emits warnings that use the terms "table" and "non-table value" without explaining them. As #11118 notes, these terms are undefined for end users and even reading the source does not make them clear.

This PR expands the three affected warnings in `pkg/chart/common/util/coalesce.go` to explain, in plain language, that a "table" is a nested map of keys, why the supplied value was ignored, and (where applicable) how to resolve it.

### Before

```
warning: destination for cassandra.dbUser.existingSecret is a table. Ignoring non-table value ()
```

### After

```
warning: destination for cassandra.dbUser.existingSecret is a table (a nested map of keys), but the supplied value () is not a table, so it was ignored. If you meant to replace the whole table, unset it first.
```

## Notes

- I kept the word "table" (it matches the existing Helm vocabulary and docs) and appended a plain-English clarification, rather than replacing the term outright. **Happy to adjust the exact wording** — e.g. drop "table" entirely in favour of "map/section" — if maintainers prefer a particular direction.
- Updated the assertions in `TestCoalesceValuesWarnings` to match the new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)