### PR TITLE
fix(logging): fall back to the slog default logger in LogHolder

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -104,18 +104,20 @@ type LogHolder struct {
 	logger atomic.Pointer[slog.Logger]
 }
 
-// Logger returns the logger for the LogHolder. If nil, returns slog.Default().
+// Logger returns the logger for the LogHolder. When no logger has been set,
+// it returns slog.Default() so log records are not silently dropped.
 func (l *LogHolder) Logger() *slog.Logger {
 	if lg := l.logger.Load(); lg != nil {
 		return lg
 	}
-	return slog.New(slog.DiscardHandler) // Should never be reached
+	return slog.Default()
 }
 
-// SetLogger sets the logger for the LogHolder. If nil, sets the default logger.
+// SetLogger sets the logger for the LogHolder. A nil handler clears the logger,
+// so Logger() falls back to slog.Default() again.
 func (l *LogHolder) SetLogger(newHandler slog.Handler) {
 	if newHandler == nil {
-		l.logger.Store(slog.New(slog.DiscardHandler)) // Assume nil as discarding logs
+		l.logger.Store(nil)
 		return
 	}
 	l.logger.Store(slog.New(newHandler))

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -43,12 +43,73 @@ func TestLogHolder_Logger(t *testing.T) {
 		assert.Contains(t, buf.String(), "test message")
 	})
 
-	t.Run("should return discard - defaultlogger when no handler is set", func(t *testing.T) {
+	t.Run("should return the slog default logger when no handler is set", func(t *testing.T) {
 		holder := &LogHolder{}
 		logger := holder.Logger()
 
-		assert.Equal(t, slog.Handler(slog.DiscardHandler), logger.Handler())
+		assert.Equal(t, slog.Default(), logger)
 	})
+}
+
+// TestLogHolder_DefaultHandler covers where a LogHolder sends records for each
+// way of (not) configuring it, against a capture handler installed with
+// slog.SetDefault.
+func TestLogHolder_DefaultHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(holder *LogHolder, ownHandler slog.Handler)
+		wantDefault bool // record lands in the slog default buffer
+		wantOwn     bool // record lands in the handler set on the holder
+	}{
+		{
+			name:        "fresh holder logs through the slog default",
+			setup:       func(_ *LogHolder, _ slog.Handler) {},
+			wantDefault: true,
+		},
+		{
+			name: "handler set on the holder wins over the slog default",
+			setup: func(holder *LogHolder, ownHandler slog.Handler) {
+				holder.SetLogger(ownHandler)
+			},
+			wantOwn: true,
+		},
+		{
+			name: "nil handler falls back to the slog default",
+			setup: func(holder *LogHolder, ownHandler slog.Handler) {
+				holder.SetLogger(ownHandler)
+				holder.SetLogger(nil)
+			},
+			wantDefault: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defaultBuf := &bytes.Buffer{}
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(defaultBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(previous) })
+
+			ownBuf := &bytes.Buffer{}
+			ownHandler := slog.NewTextHandler(ownBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+			holder := &LogHolder{}
+			tt.setup(holder, ownHandler)
+
+			holder.Logger().Info("test message")
+
+			if tt.wantDefault {
+				assert.Contains(t, defaultBuf.String(), "test message")
+			} else {
+				assert.Empty(t, defaultBuf.String())
+			}
+			if tt.wantOwn {
+				assert.Contains(t, ownBuf.String(), "test message")
+			} else {
+				assert.Empty(t, ownBuf.String())
+			}
+		})
+	}
 }
 
 func TestLogHolder_SetLogger(t *testing.T) {
@@ -66,15 +127,17 @@ func TestLogHolder_SetLogger(t *testing.T) {
 		assert.Equal(t, handler, logger.Handler())
 	})
 
-	t.Run("sets discard logger with nil handler", func(t *testing.T) {
+	t.Run("clears the logger with nil handler", func(t *testing.T) {
 		holder := &LogHolder{}
+		buf := &bytes.Buffer{}
+		holder.SetLogger(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 		holder.SetLogger(nil)
 		logger := holder.Logger()
 
 		assert.NotNil(t, logger)
 
-		assert.Equal(t, slog.Handler(slog.DiscardHandler), logger.Handler())
+		assert.Equal(t, slog.Default(), logger)
 	})
 
 	t.Run("can replace existing logger", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`internal/logging.LogHolder` contradicted its own documentation. `Logger()` said *"If nil, returns slog.Default()"* but its body returned `slog.New(slog.DiscardHandler)` behind a `// Should never be reached` comment, so any `LogHolder` whose `SetLogger` was never called silently dropped every record. `SetLogger`'s comment likewise said a nil handler *"sets the default logger"* while it stored a discard handler.

This changes the fallback to the documented behavior:

- `Logger()` returns `slog.Default()` when no logger has been set.
- `SetLogger(nil)` clears the stored logger, so the same `slog.Default()` fallback applies (instead of freezing a discard handler in place).
- Both doc comments now match the code, and the `// Should never be reached` line is gone.

That is what #31433 asks for: default to the slog default handler so callers do not have to call `SetLogger` everywhere. Existing explicit `SetLogger` calls keep winning over the default, so this is purely additive for embedders.

**Special notes for your reviewer**:

- No CLI output change: `pkg/cmd/root.go` still calls `actionConfig.SetLogger(slog.Default().Handler())`, and the storage/kube/action constructors inject handlers of their own, so nothing in the CLI path relies on the old discard fallback. I ran the golden-output-heavy suites to confirm no new noise.
- The observable fix is for SDK consumers who construct e.g. an `action.Configuration` or a driver without wiring a handler: their logs went nowhere before and now go to `slog.Default()`.
- `SetLogger(nil)` semantics were decided explicitly: clear rather than store a default snapshot, so a later `slog.SetDefault` is still honored.

Validation run locally (go1.26.1, darwin/arm64):

- Before the change, a probe test that installs a capture handler via `slog.SetDefault` and logs through a fresh `LogHolder` failed with the line dropped. That probe is now part of the committed table test.
- `go test ./internal/logging/...` — ok
- `go test ./pkg/action/... ./pkg/cmd/... ./pkg/storage/... ./pkg/kube/...` — all ok
- `gofmt -l internal/logging` clean, `go vet ./internal/logging/...` clean. (golangci-lint is not installed in my environment, so `make test-style` was not run.)

New/updated tests in `internal/logging/logging_test.go`: a table test covering (a) a fresh `LogHolder` logging through a `slog.SetDefault`-installed capture handler, (b) a handler set via `SetLogger` still winning over the default, (c) `SetLogger(nil)` falling back to the default; plus the two pre-existing subtests that asserted the discard handler updated to the new documented behavior.

Closes #31433

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

