### PR TITLE
fix(scripts): add Azure CDN invalidation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,21 @@ jobs:
           container_name: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
           connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Purge Azure CDN Cache
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az cdn endpoint purge \
+              --content-paths "/helm-latest-version" "/helm4-latest-version" \
+              --resource-group "${{ secrets.AZURE_CDN_RESOURCE_GROUP }}" \
+              --profile-name "${{ secrets.AZURE_CDN_PROFILE_NAME }}" \
+              --name "${{ secrets.AZURE_CDN_ENDPOINT_NAME }}"
+
   canary-release:
     runs-on: ubuntu-latest-16-cores
     if: github.ref == 'refs/heads/main' && github.repository == 'helm/helm'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a step to the release workflow to invalidate the Azure CDN cache for the `helm-latest-version` and `helm4-latest-version` files immediately after they are uploaded.

As discussed in issue #32329, without explicit CDN invalidation on the server-side, CDN edge nodes can serve stale cached responses for the latest version tag files for hours after a new release. The `bacongobbler/azure-blob-storage-upload` action currently used does not support CDN purging, so this PR introduces an `azure/CLI@v1` step to execute `az cdn endpoint purge` specifically targeting those version files. 

Fixes #32329

**Special notes for your reviewer**:
This change requires the following GitHub secrets to be configured in the repository:
- `AZURE_CREDENTIALS` (for `azure/login@v1`)
- `AZURE_CDN_RESOURCE_GROUP`
- `AZURE_CDN_PROFILE_NAME`
- `AZURE_CDN_ENDPOINT_NAME`

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
