### PR TITLE
fix: route OCI pull metadata to stderr instead of stdout

### DIFF
--- a/pkg/cmd/helpers_test.go
+++ b/pkg/cmd/helpers_test.go
@@ -81,13 +81,11 @@ func executeActionCommandC(store *storage.Storage, cmd string) (*cobra.Command, 
 	return executeActionCommandStdinC(store, nil, cmd)
 }
 
-func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string) (*cobra.Command, string, error) {
+func executeActionCommandWithWriters(store *storage.Storage, in *os.File, outWriter, errWriter io.Writer, cmd string) (*cobra.Command, error) {
 	args, err := shellwords.Parse(cmd)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-
-	buf := new(bytes.Buffer)
 
 	actionConfig := &action.Configuration{
 		Releases:     store,
@@ -95,13 +93,13 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		Capabilities: common.DefaultCapabilities,
 	}
 
-	root, err := newRootCmdWithConfig(actionConfig, buf, args, SetupLogging)
+	root, err := newRootCmdWithConfig(actionConfig, outWriter, args, SetupLogging)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	root.SetOut(buf)
-	root.SetErr(buf)
+	root.SetOut(outWriter)
+	root.SetErr(errWriter)
 	root.SetArgs(args)
 
 	oldStdin := os.Stdin
@@ -118,10 +116,13 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		mem.SetNamespace(settings.Namespace())
 	}
 	c, err := root.ExecuteC()
+	return c, err
+}
 
-	result := buf.String()
-
-	return c, result, err
+func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string) (*cobra.Command, string, error) {
+	buf := new(bytes.Buffer)
+	c, err := executeActionCommandWithWriters(store, in, buf, buf, cmd)
+	return c, buf.String(), err
 }
 
 // cmdTestCase describes a test case that works with releases.
@@ -300,4 +301,11 @@ func TestCmdGetDryRunFlagStrategy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func executeActionCommandErr(store *storage.Storage, in *os.File, cmd string) (*cobra.Command, string, string, error) {
+	bufOut := new(bytes.Buffer)
+	bufErr := new(bytes.Buffer)
+	c, err := executeActionCommandWithWriters(store, in, bufOut, bufErr, cmd)
+	return c, bufOut.String(), bufErr.String(), err
 }

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -82,9 +82,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showAllDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowAll
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -103,9 +103,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showValuesDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowValues
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -124,9 +124,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showChartDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowChart
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -145,9 +145,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              readmeChartDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowReadme
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}
@@ -166,9 +166,9 @@ func newShowCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 		Long:              showCRDsDesc,
 		Args:              require.ExactArgs(1),
 		ValidArgsFunction: validArgsFunc,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowCRDs
-			err := addRegistryClient(out, client)
+			err := addRegistryClient(cmd.ErrOrStderr(), client)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/show_test.go
+++ b/pkg/cmd/show_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,6 +84,43 @@ func TestShowPreReleaseChart(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestShowOCIChartRegistryPullMetadataGoesToStderr(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ociSrv.Run(t)
+
+	contentTmp := t.TempDir()
+	outdir := srv.Root()
+	cmdStr := fmt.Sprintf("show chart oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0 --registry-config %s --content-cache %s --plain-http",
+		ociSrv.RegistryURL,
+		filepath.Join(outdir, "config.json"),
+		contentTmp,
+	)
+
+	_, outStr, errStr, err := executeActionCommandErr(storageFixture(), nil, cmdStr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(outStr, "Pulled: ") || strings.Contains(outStr, "Digest: ") {
+		t.Fatalf("expected stdout to exclude registry pull metadata, got: %s", outStr)
+	}
+	if !strings.Contains(errStr, "Pulled: ") {
+		t.Fatalf("expected stderr to contain registry pull metadata, got: %s", errStr)
+	}
+	if !strings.Contains(outStr, "apiVersion:") {
+		t.Fatalf("expected chart metadata in output, got: %s", outStr)
 	}
 }
 

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -85,7 +85,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				client.KubeVersion = parsedKubeVersion
 			}
 
-			registryClient, err := newRegistryClient(out, client.CertFile, client.KeyFile, client.CaFile,
+			registryClient, err := newRegistryClient(cmd.ErrOrStderr(), client.CertFile, client.KeyFile, client.CaFile,
 				client.InsecureSkipTLSVerify, client.PlainHTTP, client.Username, client.Password)
 			if err != nil {
 				return fmt.Errorf("missing registry client: %w", err)

--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -19,7 +19,10 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"helm.sh/helm/v4/pkg/repo/v1/repotest"
 )
 
 var chartPath = "testdata/testcharts/subchart"
@@ -174,6 +177,43 @@ func TestTemplateCmd(t *testing.T) {
 		},
 	}
 	runTestCmd(t, tests)
+}
+
+func TestTemplateOCIChartRegistryPullMetadataGoesToStderr(t *testing.T) {
+	srv := repotest.NewTempServer(
+		t,
+		repotest.WithChartSourceGlob("testdata/testcharts/*.tgz*"),
+	)
+	defer srv.Stop()
+
+	ociSrv, err := repotest.NewOCIServer(t, srv.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ociSrv.Run(t)
+
+	contentTmp := t.TempDir()
+	outdir := srv.Root()
+	cmdStr := fmt.Sprintf("template --generate-name oci://%s/u/ocitestuser/oci-dependent-chart --version 0.1.0 --registry-config %s --content-cache %s --plain-http",
+		ociSrv.RegistryURL,
+		filepath.Join(outdir, "config.json"),
+		contentTmp,
+	)
+
+	_, outStr, errStr, err := executeActionCommandErr(storageFixture(), nil, cmdStr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(outStr, "Pulled: ") || strings.Contains(outStr, "Digest: ") {
+		t.Fatalf("expected stdout to exclude registry pull metadata, got: %s", outStr)
+	}
+	if !strings.Contains(errStr, "Pulled: ") {
+		t.Fatalf("expected stderr to contain registry pull metadata, got: %s", errStr)
+	}
+	if !strings.Contains(outStr, "# Source:") {
+		t.Fatalf("expected rendered manifests in output, got: %s", outStr)
+	}
 }
 
 func TestTemplateVersionCompletion(t *testing.T) {


### PR DESCRIPTION
This addresses the issue where helm template/show included registry pull metadata in machine-readable output, by routing it to stderr via cmd.ErrOrStderr().

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
