### PR TITLE
fix(template): trim trailing newline from rendered manifests to restore v4.1.x stdout output

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -473,7 +473,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 			if strings.TrimSpace(content) == "" {
 				continue
 			}
-			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, content)
+			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, strings.TrimRight(content, "\n"))
 		}
 		return hs, b, "", err
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -355,7 +355,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 					if strings.TrimSpace(content) == "" {
 						continue
 					}
-					fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, content)
+					fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, strings.TrimRight(content, "\n"))
 				}
 				return hs, b, "", err
 			}
@@ -484,7 +484,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
 			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data))
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, strings.TrimRight(string(crd.File.Data), "\n"))
 			} else {
 				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data), fileWritten[crd.Filename])
 				if err != nil {
@@ -500,7 +500,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 			if hideSecret && m.Head.Kind == "Secret" && m.Head.Version == "v1" {
 				fmt.Fprintf(b, "---\n# Source: %s\n# HIDDEN: The Secret output has been suppressed\n", m.Name)
 			} else {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, m.Content)
+				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, strings.TrimRight(m.Content, "\n"))
 			}
 		} else {
 			newDir := outputDir

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -127,7 +127,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							continue
 						}
 						if client.OutputDir == "" {
-							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)
+							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, strings.TrimRight(m.Manifest, "\n"))
 						} else {
 							newDir := client.OutputDir
 							if client.UseReleaseName {
@@ -195,7 +195,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						}
 					}
 					for _, m := range manifestsToRender {
-						fmt.Fprintf(out, "---\n%s\n", m)
+						fmt.Fprintf(out, "---\n%s\n", strings.TrimRight(m, "\n"))
 					}
 				} else {
 					fmt.Fprintf(out, "%s", manifests.String())


### PR DESCRIPTION
## What this PR does

Fixes #32565. `helm template` stdout output in v4.2.0+ emits an extra blank line before each `---` document separator when the template file ends with a trailing newline (which is the common case). This regressed from v4.1.x where document boundaries were clean.

## Root cause

Helm v4.2.0 changed `SplitManifests` in `pkg/release/v1/util/manifest.go` from `strings.TrimSpace(d)` to `strings.TrimLeftFunc(d, unicode.IsSpace)` (to support Chart API v3 / kio compatibility). This means each split document **retains its trailing newline**. When `renderResources` writes each manifest with `fmt.Fprintf(b, "---\n# Source: %s\n%s\n", ...)`, the `%s` expands to content that already ends with `\n`, producing `\n\n` — a blank line — before the next `---` separator.

## Fix

In the manifest output path (`pkg/action/action.go` `renderResources`) and the hook/`--show-only` output path (`pkg/cmd/template.go`), trim the trailing newline from the content before writing with `%s\n`. This ensures each document ends with exactly one newline, restoring v4.1.x behaviour.

## Related

- PR #32170 (Cloud-Architect-Emma) fixes the same root cause for the `--output-dir` write path (`writeToFile`). This PR addresses the **stdout** path (`renderResources` buffer + template.go hooks).

## Test plan

- `helm template` on a two-document chart (one template with trailing newline, one without) should produce identical output to v4.1.x
- Existing golden-file tests in `pkg/cmd/testdata/output/template*.txt` should continue to pass
- `--output-dir` path continues to be handled by PR #32170 (no change to `writeToFile`)