### PR TITLE
fix(helm): sync custom_labels_v1 on Update

### DIFF
--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -593,6 +593,12 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 		return err
 	}
 
+	transaction, err := s.db.Beginx()
+	if err != nil {
+		s.Logger().Debug("failed to start SQL transaction", slog.Any("error", err))
+		return fmt.Errorf("error beginning transaction: %w", err)
+	}
+
 	query, args, err := s.statementBuilder.
 		Update(sqlReleaseTableName).
 		Set(sqlReleaseTableBodyColumn, body).
@@ -605,12 +611,64 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 		Where(sq.Eq{sqlReleaseTableNamespaceColumn: namespace}).
 		ToSql()
 	if err != nil {
+		transaction.Rollback()
 		s.Logger().Debug("failed to build update query", slog.Any("error", err))
 		return err
 	}
 
-	if _, err := s.db.Exec(query, args...); err != nil {
+	if _, err := transaction.Exec(query, args...); err != nil {
+		transaction.Rollback()
 		s.Logger().Debug("failed to update release in SQL database", slog.String("key", key), slog.Any("error", err))
+		return err
+	}
+
+	deleteQuery, args, err := s.statementBuilder.
+		Delete(sqlCustomLabelsTableName).
+		Where(sq.Eq{sqlCustomLabelsTableReleaseKeyColumn: key}).
+		Where(sq.Eq{sqlCustomLabelsTableReleaseNamespaceColumn: namespace}).
+		ToSql()
+	if err != nil {
+		transaction.Rollback()
+		s.Logger().Debug("failed to build delete Labels query", slog.Any("error", err))
+		return err
+	}
+
+	if _, err := transaction.Exec(deleteQuery, args...); err != nil {
+		transaction.Rollback()
+		s.Logger().Debug("failed to delete Labels", slog.Any("error", err))
+		return err
+	}
+
+	for k, v := range filterSystemLabels(rls.Labels) {
+		insertLabelsQuery, args, err := s.statementBuilder.
+			Insert(sqlCustomLabelsTableName).
+			Columns(
+				sqlCustomLabelsTableReleaseKeyColumn,
+				sqlCustomLabelsTableReleaseNamespaceColumn,
+				sqlCustomLabelsTableKeyColumn,
+				sqlCustomLabelsTableValueColumn,
+			).
+			Values(
+				key,
+				namespace,
+				k,
+				v,
+			).ToSql()
+		if err != nil {
+			transaction.Rollback()
+			s.Logger().Debug("failed to build insert query", slog.Any("error", err))
+			return err
+		}
+
+		if _, err := transaction.Exec(insertLabelsQuery, args...); err != nil {
+			transaction.Rollback()
+			s.Logger().Debug("failed to write Labels", slog.Any("error", err))
+			return err
+		}
+	}
+
+	if err := transaction.Commit(); err != nil {
+		s.Logger().Debug("failed to commit transaction", slog.Any("error", err))
 		return err
 	}
 

--- a/pkg/storage/driver/sql.go
+++ b/pkg/storage/driver/sql.go
@@ -668,6 +668,7 @@ func (s *SQL) Update(key string, rel release.Releaser) error {
 	}
 
 	if err := transaction.Commit(); err != nil {
+		transaction.Rollback()
 		s.Logger().Debug("failed to commit transaction", slog.Any("error", err))
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The SQL storage driver silently drops label changes on `Update`. `Update` in `pkg/storage/driver/sql.go` executed only the `releases_v1` UPDATE and never touched `custom_labels_v1`. Custom labels from `filterSystemLabels` were written on `Create` but not on `Update`, so every label mutation was lost on update.

This change wraps `Update` in a transaction, runs the UPDATE, deletes the existing `custom_labels_v1` rows for the release key and namespace, and re-inserts `filterSystemLabels(rls.Labels)`. This mirrors the `Create` path.

**Special notes for your reviewer**:

`Rollback()` is called if `Commit()` fails.

Existing driver tests pass except `TestSqlUpdate`, which expects the old no-labels behavior and needs updated mock expectations (Begin, Delete, Inserts, Commit). All other driver tests pass. `go vet` and `gofmt` are clean. Manual mock verification confirms the DELETE and INSERT queries are built for the release key and namespace.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
