### PR TITLE
refactor(repo): Use byte buffer to build index file

### DIFF
--- a/pkg/repo/v1/chartrepo.go
+++ b/pkg/repo/v1/chartrepo.go
@@ -104,14 +104,15 @@ func (r *ChartRepository) DownloadIndexFile() (string, error) {
 	}
 
 	// Create the chart list file in the cache directory
-	var charts strings.Builder
+	var charts bytes.Buffer
 	for name := range indexFile.Entries {
-		fmt.Fprintln(&charts, name)
+		charts.WriteString(name)
+		charts.WriteByte('\n') // Terminate each entry with a newline
 	}
 	chartsFile := filepath.Join(r.CachePath, helmpath.CacheChartsFile(r.Config.Name))
 	os.MkdirAll(filepath.Dir(chartsFile), 0o755)
 
-	fileutil.AtomicWriteFile(chartsFile, bytes.NewReader([]byte(charts.String())), 0o644)
+	fileutil.AtomicWriteFile(chartsFile, &charts, 0o644)
 
 	// Create the index file in the cache directory
 	fname := filepath.Join(r.CachePath, helmpath.CacheIndexFile(r.Config.Name))


### PR DESCRIPTION
**What this PR does / why we need it**:

The string returned by the string builder was cast to a byte slice anyways. Remove this indirection. Also, write directly to the buffer instead of using `fmt.Fprintln(...)`.

**Special notes for your reviewer**:

Random find while spelunking through the codebase.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
