### PR TITLE
fix(template): drop extra blank line before document separators

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -270,6 +270,14 @@ func splitAndDeannotate(postrendered, fallbackPrefix string) (map[string]string,
 	return reconstructed, nil
 }
 
+// writeSourceManifest writes a YAML document with a --- separator and source
+// comment. One trailing newline is trimmed from content so the format's final
+// \n does not create a blank line before the next --- (issue 32565). Extra
+// trailing newlines, such as those required by YAML |+ chomping, are kept.
+func writeSourceManifest(w io.Writer, name, content string) {
+	fmt.Fprintf(w, "---\n# Source: %s\n%s\n", name, strings.TrimSuffix(content, "\n"))
+}
+
 // renderResources renders the templates in a chart
 //
 // TODO: This function is badly in need of a refactor.
@@ -355,7 +363,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 					if strings.TrimSpace(content) == "" {
 						continue
 					}
-					fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, content)
+					writeSourceManifest(b, name, content)
 				}
 				return hs, b, "", err
 			}
@@ -473,7 +481,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 			if strings.TrimSpace(content) == "" {
 				continue
 			}
-			fmt.Fprintf(b, "---\n# Source: %s\n%s\n", name, content)
+			writeSourceManifest(b, name, content)
 		}
 		return hs, b, "", err
 	}
@@ -484,7 +492,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 	if includeCrds {
 		for _, crd := range ch.CRDObjects() {
 			if outputDir == "" {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", crd.Filename, string(crd.File.Data))
+				writeSourceManifest(b, crd.Filename, string(crd.File.Data))
 			} else {
 				err = writeToFile(outputDir, crd.Filename, string(crd.File.Data), fileWritten[crd.Filename])
 				if err != nil {
@@ -500,7 +508,7 @@ func (cfg *Configuration) renderResources(ctx context.Context, ch *chart.Chart, 
 			if hideSecret && m.Head.Kind == "Secret" && m.Head.Version == "v1" {
 				fmt.Fprintf(b, "---\n# Source: %s\n# HIDDEN: The Secret output has been suppressed\n", m.Name)
 			} else {
-				fmt.Fprintf(b, "---\n# Source: %s\n%s\n", m.Name, m.Content)
+				writeSourceManifest(b, m.Name, m.Content)
 			}
 		} else {
 			newDir := outputDir

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1826,15 +1826,12 @@ func TestRenderResources_PostRenderer_Success(t *testing.T) {
 	expectedBuf := `---
 # Source: yellow/templates/foodpie
 foodpie: world
-
 ---
 # Source: yellow/templates/with-partials
 yellow: Earth
-
 ---
 # Source: yellow/templates/yellow
 yellow: world
-
 `
 	expectedHook := `kind: ConfigMap
 metadata:
@@ -1946,17 +1943,14 @@ func TestRenderResources_PostRenderer_Integration(t *testing.T) {
 # Source: hello/templates/goodbye
 goodbye: world
 color: blue
-
 ---
 # Source: hello/templates/hello
 hello: world
 color: blue
-
 ---
 # Source: hello/templates/with-partials
 hello: Earth
 color: blue
-
 `
 	assert.Contains(t, output, "color: blue")
 	assert.Equal(t, 3, strings.Count(output, "color: blue"))
@@ -1978,6 +1972,50 @@ func TestRenderResources_NoPostRenderer(t *testing.T) {
 	assert.NotNil(t, hooks)
 	assert.NotNil(t, buf)
 	assert.Empty(t, notes)
+}
+
+func TestRenderResources_StdoutHasNoExtraBlankLineBeforeDocumentSeparator(t *testing.T) {
+	cfg := actionConfigFixture(t)
+	modTime := time.Now()
+
+	// Reproduces https://github.com/helm/helm/issues/32565: a template that
+	// already ends with a newline must not gain a blank line before the next ---.
+	ch := buildChartWithTemplates([]*common.File{
+		{Name: "templates/one.yaml", ModTime: modTime, Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: one\n")},
+		{Name: "templates/two.yaml", ModTime: modTime, Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: two")},
+	})
+
+	_, buf, _, err := cfg.renderResources(
+		t.Context(), ch, map[string]any{}, "test-release", "", false, false, false,
+		nil, false, false, false, PostRenderStrategyCombined,
+	)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "\n\n---", "helm template stdout must not insert a blank line before ---")
+	assert.Contains(t, out, "name: one\n---\n")
+	assert.True(t, strings.HasSuffix(out, "name: two\n"), "final document should end with a single newline")
+}
+
+func TestRenderResources_StdoutPreservesExtraTrailingNewlines(t *testing.T) {
+	cfg := actionConfigFixture(t)
+	modTime := time.Now()
+
+	// YAML |+ keep relies on extra trailing newlines surviving in non-final
+	// documents (issue 32326). Trim only the printer's extra \n, not all of them.
+	ch := buildChartWithTemplates([]*common.File{
+		{Name: "templates/keep.yaml", ModTime: modTime, Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: keep\ndata:\n  key: |+\n    hello\n\n\n")},
+		{Name: "templates/zlast.yaml", ModTime: modTime, Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: zlast")},
+	})
+
+	_, buf, _, err := cfg.renderResources(
+		t.Context(), ch, map[string]any{}, "test-release", "", false, false, false,
+		nil, false, false, false, PostRenderStrategyCombined,
+	)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "    hello\n\n\n---\n", "extra trailing newlines from |+ must be preserved")
 }
 
 func TestRenderResources_PostRenderer_DuplicateResourceInHookAndTemplate(t *testing.T) {

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -127,7 +127,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 							continue
 						}
 						if client.OutputDir == "" {
-							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)
+							fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, strings.TrimSuffix(m.Manifest, "\n"))
 						} else {
 							newDir := client.OutputDir
 							if client.UseReleaseName {
@@ -195,7 +195,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						}
 					}
 					for _, m := range manifestsToRender {
-						fmt.Fprintf(out, "---\n%s\n", m)
+						fmt.Fprintf(out, "---\n%s\n", strings.TrimSuffix(m, "\n"))
 					}
 				} else {
 					fmt.Fprintf(out, "%s", manifests.String())

--- a/pkg/cmd/testdata/output/install-dry-run-with-secret-hidden.txt
+++ b/pkg/cmd/testdata/output/install-dry-run-with-secret-hidden.txt
@@ -19,4 +19,3 @@ metadata:
 data:
   foo: bar
 
-

--- a/pkg/cmd/testdata/output/install-dry-run-with-secret.txt
+++ b/pkg/cmd/testdata/output/install-dry-run-with-secret.txt
@@ -15,7 +15,6 @@ metadata:
   name: test-secret
 stringData:
   foo: bar
-
 ---
 # Source: chart-with-secret/templates/configmap.yaml
 apiVersion: v1
@@ -24,5 +23,4 @@ metadata:
   name: test-configmap
 data:
   foo: bar
-
 

--- a/pkg/cmd/testdata/output/issue-9027.txt
+++ b/pkg/cmd/testdata/output/issue-9027.txt
@@ -15,7 +15,6 @@ hash:
   key4: 4
   key5: 5
   key6: 6
-
 ---
 # Source: issue-9027/templates/values.yaml
 global:

--- a/pkg/cmd/testdata/output/object-order.txt
+++ b/pkg/cmd/testdata/output/object-order.txt
@@ -11,7 +11,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/01-a.yml
 # 2
@@ -24,7 +23,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/01-a.yml
@@ -39,7 +37,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/02-b.yml
 # 5
@@ -52,7 +49,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/02-b.yml
@@ -67,7 +63,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/02-b.yml
 # 8
@@ -80,7 +75,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/02-b.yml
@@ -95,7 +89,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/02-b.yml
 # 10
@@ -108,7 +101,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/02-b.yml
@@ -123,7 +115,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/02-b.yml
 # 12
@@ -136,7 +127,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/02-b.yml
@@ -151,7 +141,6 @@ spec:
     - Egress
     - Ingress
 
-
 ---
 # Source: object-order/templates/02-b.yml
 # 14
@@ -164,7 +153,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 
 ---
 # Source: object-order/templates/02-b.yml
@@ -179,7 +167,6 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 ---
 # Source: object-order/templates/01-a.yml
 # 4 (Deployment should come after all NetworkPolicy manifests, since 'helm template' outputs in install order)
@@ -214,5 +201,4 @@ spec:
   policyTypes:
     - Egress
     - Ingress
-
 

--- a/pkg/cmd/testdata/output/template-name-template.txt
+++ b/pkg/cmd/testdata/output/template-name-template.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -98,7 +93,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -118,4 +112,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-set.txt
+++ b/pkg/cmd/testdata/output/template-set.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -98,7 +93,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -118,4 +112,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-show-only-glob.txt
+++ b/pkg/cmd/testdata/output/template-show-only-glob.txt
@@ -8,8 +8,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -24,5 +22,3 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
-

--- a/pkg/cmd/testdata/output/template-show-only-multiple.txt
+++ b/pkg/cmd/testdata/output/template-show-only-multiple.txt
@@ -19,7 +19,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -37,5 +36,3 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
-

--- a/pkg/cmd/testdata/output/template-show-only-one.txt
+++ b/pkg/cmd/testdata/output/template-show-only-one.txt
@@ -19,4 +19,3 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchart
-

--- a/pkg/cmd/testdata/output/template-skip-tests.txt
+++ b/pkg/cmd/testdata/output/template-skip-tests.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1

--- a/pkg/cmd/testdata/output/template-subchart-cm-set-file.txt
+++ b/pkg/cmd/testdata/output/template-subchart-cm-set-file.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/configmap.yaml
 apiVersion: v1
@@ -23,7 +22,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,7 +36,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -56,7 +53,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -74,7 +70,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -106,7 +101,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -126,4 +120,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-subchart-cm-set.txt
+++ b/pkg/cmd/testdata/output/template-subchart-cm-set.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/configmap.yaml
 apiVersion: v1
@@ -23,7 +22,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,7 +36,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -56,7 +53,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -74,7 +70,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -106,7 +101,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -126,4 +120,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-subchart-cm.txt
+++ b/pkg/cmd/testdata/output/template-subchart-cm.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/configmap.yaml
 apiVersion: v1
@@ -23,7 +22,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,7 +36,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -56,7 +53,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -74,7 +70,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -106,7 +101,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -126,4 +120,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-values-files.txt
+++ b/pkg/cmd/testdata/output/template-values-files.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -98,7 +93,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -118,4 +112,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-with-api-version.txt
+++ b/pkg/cmd/testdata/output/template-with-api-version.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -100,7 +95,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -120,4 +114,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-with-crds.txt
+++ b/pkg/cmd/testdata/output/template-with-crds.txt
@@ -14,14 +14,12 @@ spec:
     shortNames:
       - tc
     singular: authconfig
-
 ---
 # Source: subchart/templates/subdir/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,7 +30,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,7 +44,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -65,7 +61,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -83,7 +78,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -115,7 +109,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -135,4 +128,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template-with-kube-version.txt
+++ b/pkg/cmd/testdata/output/template-with-kube-version.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -98,7 +93,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -118,4 +112,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-

--- a/pkg/cmd/testdata/output/template.txt
+++ b/pkg/cmd/testdata/output/template.txt
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: subchart-sa
-
 ---
 # Source: subchart/templates/subdir/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch"]
-
 ---
 # Source: subchart/templates/subdir/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +28,6 @@ subjects:
 - kind: ServiceAccount
   name: subchart-sa
   namespace: default
-
 ---
 # Source: subchart/charts/subcharta/templates/service.yaml
 apiVersion: v1
@@ -48,7 +45,6 @@ spec:
     name: apache
   selector:
     app.kubernetes.io/name: subcharta
-
 ---
 # Source: subchart/charts/subchartb/templates/service.yaml
 apiVersion: v1
@@ -66,7 +62,6 @@ spec:
     name: nginx
   selector:
     app.kubernetes.io/name: subchartb
-
 ---
 # Source: subchart/templates/service.yaml
 apiVersion: v1
@@ -98,7 +93,6 @@ metadata:
     "helm.sh/hook": test
 data:
   message: Hello World
-
 ---
 # Source: subchart/templates/tests/test-nothing.yaml
 apiVersion: v1
@@ -118,4 +112,3 @@ spec:
         - echo
         - "$message"
   restartPolicy: Never
-


### PR DESCRIPTION
## Summary

Restore v4.1.x `helm template` stdout: do not insert a blank line before each `---` document separator when a rendered manifest already ends with a newline.

## Related Issue

Fixes #32565

## Changes Made

- `writeSourceManifest` trims **one** trailing newline (`strings.TrimSuffix`) before writing `---\n# Source: %s\n%s\n`.
- The same trim is applied on the `helm template` hook and `--show-only` stdout paths.
- `--output-dir` / `writeToFile` is unchanged (that path is #32163 / #32170).

This is not a revert of #32327. SplitManifests still preserves trailing newlines for YAML `|` / `|+` chomping. Only the printer-added extra `\n` is removed. `strings.TrimRight` is intentionally not used, because stripping all trailing newlines would reintroduce #32326.

## Testing

- `TestRenderResources_StdoutHasNoExtraBlankLineBeforeDocumentSeparator` — first template ends with `\n`, second does not; no blank line before `---`.
- `TestRenderResources_StdoutPreservesExtraTrailingNewlines` — extra newlines from YAML `|+` keep survive in a non-final document.
- Golden files for `helm template` / `helm install --dry-run` updated to drop the extra blank line.
- `go test ./pkg/action/ ./pkg/cmd/ ./pkg/release/v1/util/ -count=1` passed.

## Notes

- #32566 attempted the same issue with `strings.TrimRight`, which would undo #32327. This PR uses `TrimSuffix` (one newline) and adds regression tests.
- User-facing stdout of `helm template` (and dry-run manifests) changes back to v4.1.x spacing at document boundaries. Kubernetes objects are unchanged.

**What this PR does / why we need it**: Restore byte-stable `helm template` stdout across minor versions without dropping intentional extra trailing newlines.

**Special notes for your reviewer**: Golden-file diffs are only the extra blank line before `---`. object-order still keeps the blank line that exists in the source templates.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility