### PR TITLE
fix(kube): finish hook waits when the hook is deleted

### DIFF
--- a/pkg/kube/statuswait.go
+++ b/pkg/kube/statuswait.go
@@ -95,7 +95,11 @@ func (w *statusWaiter) WatchUntilReady(resourceList ResourceList, timeout time.D
 		StatusReaders: append(w.readers, jobSR, podSR, genericSR),
 	}
 	sw.StatusReader = sr
-	return w.wait(ctx, resourceList, sw)
+	// Hook resources may legitimately disappear while Helm is waiting for them.
+	// A Job hook with .spec.ttlSecondsAfterFinished is removed by the TTL
+	// controller as soon as it completes, so a hook that is gone is treated as
+	// done rather than as a resource that never became ready.
+	return w.waitFor(ctx, resourceList, sw, true)
 }
 
 func (w *statusWaiter) Wait(resourceList ResourceList, timeout time.Duration) error {
@@ -154,7 +158,7 @@ func (w *statusWaiter) waitForDelete(ctx context.Context, resourceList ResourceL
 		RESTScopeStrategy: watcher.RESTScopeNamespace,
 	})
 	statusCollector := collector.NewResourceStatusCollector(resources)
-	done := statusCollector.ListenWithObserver(eventCh, statusObserver(cancel, status.NotFoundStatus, w.Logger()))
+	done := statusCollector.ListenWithObserver(eventCh, statusObserver(cancel, status.NotFoundStatus, false, w.Logger()))
 	<-done
 
 	if statusCollector.Error != nil {
@@ -180,6 +184,13 @@ func (w *statusWaiter) waitForDelete(ctx context.Context, resourceList ResourceL
 }
 
 func (w *statusWaiter) wait(ctx context.Context, resourceList ResourceList, sw watcher.StatusWatcher) error {
+	return w.waitFor(ctx, resourceList, sw, false)
+}
+
+// waitFor waits until every resource reaches the current status. When
+// deletedIsDone is set, a resource that is not found is considered done
+// instead of blocking until the timeout expires.
+func (w *statusWaiter) waitFor(ctx context.Context, resourceList ResourceList, sw watcher.StatusWatcher, deletedIsDone bool) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	resources := []object.ObjMetadata{}
@@ -198,7 +209,7 @@ func (w *statusWaiter) wait(ctx context.Context, resourceList ResourceList, sw w
 		RESTScopeStrategy: watcher.RESTScopeNamespace,
 	})
 	statusCollector := collector.NewResourceStatusCollector(resources)
-	done := statusCollector.ListenWithObserver(eventCh, statusObserver(cancel, status.CurrentStatus, w.Logger()))
+	done := statusCollector.ListenWithObserver(eventCh, statusObserver(cancel, status.CurrentStatus, deletedIsDone, w.Logger()))
 	<-done
 
 	if statusCollector.Error != nil {
@@ -209,6 +220,9 @@ func (w *statusWaiter) wait(ctx context.Context, resourceList ResourceList, sw w
 	for _, id := range resources {
 		rs := statusCollector.ResourceStatuses[id]
 		if rs.Status == status.CurrentStatus {
+			continue
+		}
+		if deletedIsDone && rs.Status == status.NotFoundStatus {
 			continue
 		}
 		errs = append(errs, fmt.Errorf("resource %s/%s/%s not ready. status: %s, message: %s",
@@ -237,7 +251,7 @@ func contextWithTimeout(ctx context.Context, timeout time.Duration) (context.Con
 	return watchtools.ContextWithOptionalTimeout(ctx, timeout)
 }
 
-func statusObserver(cancel context.CancelFunc, desired status.Status, logger *slog.Logger) collector.ObserverFunc {
+func statusObserver(cancel context.CancelFunc, desired status.Status, deletedIsDone bool, logger *slog.Logger) collector.ObserverFunc {
 	return func(statusCollector *collector.ResourceStatusCollector, _ event.Event) {
 		var rss []*event.ResourceStatus
 		var nonDesiredResources []*event.ResourceStatus
@@ -253,6 +267,12 @@ func statusObserver(cancel context.CancelFunc, desired status.Status, logger *sl
 			// Failed is a terminal state. This check ensures we don't wait forever for a resource
 			// that has already failed, as intervention is required to resolve the failure.
 			if rs.Status == status.FailedStatus && desired == status.CurrentStatus {
+				continue
+			}
+			// A hook that is gone has finished its job: the TTL controller
+			// removes completed Jobs that set .spec.ttlSecondsAfterFinished, and
+			// the legacy waiter treated a delete event as the end of the wait.
+			if deletedIsDone && rs.Status == status.NotFoundStatus {
 				continue
 			}
 			rss = append(rss, rs)

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -1777,3 +1777,70 @@ func TestWatchUntilReadyWithCustomReaders(t *testing.T) {
 		})
 	}
 }
+
+// TestWatchUntilReadyHookDeletedWhileWaiting covers a Job hook that sets
+// .spec.ttlSecondsAfterFinished: the TTL controller removes the Job as soon as
+// it completes, so the hook can disappear while Helm is still waiting for it.
+// The wait has to end there instead of running until the timeout expires.
+func TestWatchUntilReadyHookDeletedWhileWaiting(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t)
+	timeout := 3 * time.Second
+	timeUntilJobDelete := 500 * time.Millisecond
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+	fakeMapper := testutil.NewFakeRESTMapper(
+		batchv1.SchemeGroupVersion.WithKind("Job"),
+	)
+	statusWaiter := statusWaiter{
+		restMapper: fakeMapper,
+		client:     fakeClient,
+	}
+	statusWaiter.SetLogger(slog.Default().Handler())
+
+	// The Job never reports completion, so only its deletion can end the wait.
+	objs := getRuntimeObjFromManifests(t, []string{jobNoStatusManifest})
+	u := objs[0].(*unstructured.Unstructured)
+	gvr := getGVR(t, fakeMapper, u)
+	require.NoError(t, fakeClient.Tracker().Create(gvr, u, u.GetNamespace()))
+
+	go func() {
+		time.Sleep(timeUntilJobDelete)
+		assert.NoError(t, fakeClient.Tracker().Delete(gvr, u.GetNamespace(), u.GetName()))
+	}()
+
+	resourceList := getResourceListFromRuntimeObjs(t, c, objs)
+	start := time.Now()
+	require.NoError(t, statusWaiter.WatchUntilReady(resourceList, timeout))
+	assert.Less(t, time.Since(start), timeout, "wait should end when the hook is deleted, not on timeout")
+}
+
+// TestStatusWaitDeletedResourceStillFails makes sure the hook behaviour above
+// does not leak into Wait, where a resource that goes away is still an error.
+func TestStatusWaitDeletedResourceStillFails(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t)
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+	fakeMapper := testutil.NewFakeRESTMapper(
+		batchv1.SchemeGroupVersion.WithKind("Job"),
+	)
+	statusWaiter := statusWaiter{
+		restMapper: fakeMapper,
+		client:     fakeClient,
+	}
+	statusWaiter.SetLogger(slog.Default().Handler())
+
+	objs := getRuntimeObjFromManifests(t, []string{jobNoStatusManifest})
+	u := objs[0].(*unstructured.Unstructured)
+	gvr := getGVR(t, fakeMapper, u)
+	require.NoError(t, fakeClient.Tracker().Create(gvr, u, u.GetNamespace()))
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		assert.NoError(t, fakeClient.Tracker().Delete(gvr, u.GetNamespace(), u.GetName()))
+	}()
+
+	resourceList := getResourceListFromRuntimeObjs(t, c, objs)
+	err := statusWaiter.Wait(resourceList, time.Second)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "resource Job/qual/test not ready. status: NotFound")
+}


### PR DESCRIPTION
### What this PR does

The legacy waiter ended a hook wait as soon as it received a delete event for the watched resource:

https://github.com/helm/helm/blob/5b78ee8dff513f402aba593eb7e6b286714518fd/pkg/kube/wait.go#L280-L282

The kstatus watcher, the default in Helm 4, has no equivalent rule. `WatchUntilReady` waits for `CurrentStatus`, so a hook that goes away while Helm is waiting is reported as `NotFound`, never reaches the desired status, and blocks until the hook timeout expires. The release then fails with:

```
resource Job/<ns>/<name> not ready. status: NotFound, message: Resource not found
context deadline exceeded
```

That is the normal lifecycle of a Job hook that sets [`.spec.ttlSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/): the TTL controller removes the Job as soon as it completes. The ingress-nginx chart sets that field on its admission webhook patch Jobs, so installs and upgrades of charts like that hang for the entire hook timeout and then fail.

`WatchUntilReady` is used only for hooks, so it now treats a resource that is not found as done, restoring the Helm 3 behaviour. `Wait` and `WaitWithJobs` are deliberately left alone: for regular chart resources a resource that disappears is still an error.

`Unknown` is intentionally *not* treated as done. kstatus also reports `Unknown` for a resource whose status could not be read at all (RBAC denials, API errors), and swallowing those would hide real failures.

### Which issue this PR fixes

Closes #31786

### Special notes for your reviewer

The change is internal to `pkg/kube`: `wait` gained a `deletedIsDone` parameter (via a small `waitFor` helper) and `statusObserver` takes the same flag. No exported signatures change.

Tests added in `pkg/kube/statuswait_test.go`:

* `TestWatchUntilReadyHookDeletedWhileWaiting` — a Job hook that never reports completion is deleted 500ms into the wait. On `main` this fails after the full timeout with `status: NotFound`; with this change the wait returns as soon as the hook is gone.
* `TestStatusWaitDeletedResourceStillFails` — the same deletion during a plain `Wait` still returns `resource Job/qual/test not ready. status: NotFound`, guarding against the hook behaviour leaking into regular resource waits.
