### PR TITLE
fix: check dependency version in --dependency-update presence check

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -844,7 +844,7 @@ OUTER:
 			if err != nil {
 				return err
 			}
-			if dac.Name() == rac.Name() {
+			if dac.Name() == rac.Name() && (rac.Version() == "" || chartutil.IsCompatibleRange(rac.Version(), dac.Version())) {
 				continue OUTER
 			}
 		}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1196,6 +1196,27 @@ func TestCheckDependencies_MissingDependency(t *testing.T) {
 	assert.ErrorContains(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}), "missing in charts")
 }
 
+func TestCheckDependencies_MatchingVersion(t *testing.T) {
+	dependency := chart.Dependency{Name: "hello", Version: "0.1.0"}
+	mockChart := buildChart(withDependency())
+
+	assert.NoError(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}))
+}
+
+func TestCheckDependencies_MismatchedVersion(t *testing.T) {
+	mismatched := chart.Dependency{Name: "hello", Version: "0.2.0"}
+	mockChart := buildChart(withDependency())
+
+	assert.ErrorContains(t, CheckDependencies(mockChart, []ci.Dependency{&mismatched}), "missing in charts")
+}
+
+func TestCheckDependencies_WithoutVersionConstraint(t *testing.T) {
+	dependency := chart.Dependency{Name: "hello"}
+	mockChart := buildChart(withDependency())
+
+	assert.NoError(t, CheckDependencies(mockChart, []ci.Dependency{&dependency}))
+}
+
 func TestInstallCRDs_CheckNilErrors(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/chart/common.go
+++ b/pkg/chart/common.go
@@ -51,6 +51,10 @@ func (r *v2Accessor) Name() string {
 	return r.chrt.Metadata.Name
 }
 
+func (r *v2Accessor) Version() string {
+	return r.chrt.Metadata.Version
+}
+
 func (r *v2Accessor) IsRoot() bool {
 	return r.chrt.IsRoot()
 }
@@ -118,6 +122,10 @@ type v3Accessor struct {
 
 func (r *v3Accessor) Name() string {
 	return r.chrt.Metadata.Name
+}
+
+func (r *v3Accessor) Version() string {
+	return r.chrt.Metadata.Version
 }
 
 func (r *v3Accessor) IsRoot() bool {

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -47,6 +47,10 @@ func (r *v2DependencyAccessor) Name() string {
 	return r.dep.Name
 }
 
+func (r *v2DependencyAccessor) Version() string {
+	return r.dep.Version
+}
+
 func (r *v2DependencyAccessor) Alias() string {
 	return r.dep.Alias
 }
@@ -57,6 +61,10 @@ type v3DependencyAccessor struct {
 
 func (r *v3DependencyAccessor) Name() string {
 	return r.dep.Name
+}
+
+func (r *v3DependencyAccessor) Version() string {
+	return r.dep.Version
 }
 
 func (r *v3DependencyAccessor) Alias() string {

--- a/pkg/chart/interfaces.go
+++ b/pkg/chart/interfaces.go
@@ -25,6 +25,7 @@ type Dependency any
 
 type Accessor interface {
 	Name() string
+	Version() string
 	IsRoot() bool
 	MetadataAsMap() map[string]any
 	Files() []*common.File
@@ -40,5 +41,6 @@ type Accessor interface {
 
 type DependencyAccessor interface {
 	Name() string
+	Version() string
 	Alias() string
 }


### PR DESCRIPTION
Closes #31455

**What this PR does / why we need it**

When a dependency has already been downloaded into `charts/`, `helm install` and `helm template` with `--dependency-update` considered it satisfied by matching the **name only** (`CheckDependencies` in `pkg/action/install.go`). If the chart author then bumps the dependency's version constraint in `Chart.yaml`, the outdated copy in `charts/` is silently kept — `--dependency-update` does not actually update it.

This PR makes the presence check also compare the installed chart's version against the requested constraint (`IsCompatibleRange`). A dependency is treated as present only when the name matches **and** either no version constraint is declared or the installed version satisfies it. When it no longer satisfies the constraint, the dependency is re-fetched and updated.

To do this, `Version()` was added to the `Accessor` and `DependencyAccessor` interfaces and their v2/v3 implementations.

**Special notes for your reviewer**

- Prior attempts (#31517, #32051) addressed the same issue but were auto-closed by the stale-bot before review; this is a minimal, focused version (5 files, +40/-1) with unit-level regression tests rather than a broad CLI integration fixture.
- Backward compatible: a dependency with no version constraint in `Chart.yaml` keeps the previous name-only behavior (`TestCheckDependencies_WithoutVersionConstraint`).

**If applicable**

- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
