### PR TITLE
fix(downloader): pass getter options when fetching cached provenance

### DIFF
--- a/pkg/downloader/chart_downloader.go
+++ b/pkg/downloader/chart_downloader.go
@@ -290,7 +290,7 @@ func (c *ChartDownloader) DownloadToCache(ref, version string) (string, *provena
 				return pth, ver, err
 			}
 
-			body, err := g.Get(u.String() + ".prov")
+			body, err := g.Get(u.String()+".prov", c.Options...)
 			if err != nil {
 				if c.Verify == VerifyAlways {
 					return pth, ver, fmt.Errorf("failed to fetch provenance %q", u.String()+".prov")

--- a/pkg/downloader/chart_downloader_test.go
+++ b/pkg/downloader/chart_downloader_test.go
@@ -18,6 +18,8 @@ package downloader
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -428,6 +430,55 @@ func TestDownloadToCache(t *testing.T) {
 		c.Verify = VerifyNever
 		c.Keyring = ""
 	})
+}
+
+func TestDownloadToCachePassesOptionsToProvenance(t *testing.T) {
+	chartData, err := os.ReadFile("testdata/signtest-0.1.0.tgz")
+	require.NoError(t, err)
+	provData, err := os.ReadFile("testdata/signtest-0.1.0.tgz.prov")
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "username" || password != "password" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/signtest-0.1.0.tgz":
+			_, _ = w.Write(chartData)
+		case "/signtest-0.1.0.tgz.prov":
+			_, _ = w.Write(provData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	contentCache := t.TempDir()
+	c := ChartDownloader{
+		Out:              os.Stderr,
+		Verify:           VerifyLater,
+		RepositoryConfig: repoConfig,
+		RepositoryCache:  repoCache,
+		Getters: getter.All(&cli.EnvSettings{
+			RepositoryConfig: repoConfig,
+			RepositoryCache:  repoCache,
+			ContentCache:     contentCache,
+		}),
+		Options: []getter.Option{
+			getter.WithBasicAuth("username", "password"),
+		},
+		Cache: &DiskCache{Root: contentCache},
+	}
+
+	_, _, err = c.DownloadToCache(srv.URL+"/signtest-0.1.0.tgz", "")
+	require.NoError(t, err)
+
+	digest := sha256.Sum256(chartData)
+	_, err = c.Cache.Get(digest, CacheProv)
+	require.NoError(t, err, "provenance file should be in cache")
 }
 
 func TestStripDigestAlgorithm(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

`ChartDownloader.DownloadToCache` passed getter options when fetching the chart but omitted them when fetching its provenance file.

Because `Providers.ByScheme` creates the getter without `ChartDownloader.Options`, per-request settings such as Basic Auth and TLS configuration were missing from the `.prov` request. This caused provenance downloads from authenticated or custom-TLS repositories to fail even though the chart download succeeded.

Pass `c.Options` to the provenance `Get` call, matching the behavior of `DownloadTo`.



**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
