### PR TITLE
refactor(registry): use typed OCI layer sorting

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -700,8 +700,8 @@ func (c *Client) Push(data []byte, ref string, options ...PushOption) (*PushResu
 	}
 
 	// sort layers for determinism, similar to how ORAS v1 does it
-	sort.Slice(layers, func(i, j int) bool {
-		return layers[i].Digest < layers[j].Digest
+	slices.SortFunc(layers, func(a, b ocispec.Descriptor) int {
+		return strings.Compare(a.Digest.String(), b.Digest.String())
 	})
 
 	ociAnnotations := generateOCIAnnotations(meta, operation.creationTime)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Replace the index-based sort.Slice call used for deterministic OCI layer ordering with slices.SortFunc. Descriptor digests are still compared lexically, so generated manifests retain the same layer order.

**Special notes for your reviewer**:

No user-facing or compatibility change; this only makes the comparator typed.

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
