### PR TITLE
test(kube): WaitForDelete must return promptly for cluster-scoped objects

### DIFF
--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -410,7 +410,7 @@ func TestStatusWaitForDeleteClusterScopedReturnsPromptly(t *testing.T) {
 	}()
 	select {
 	case err := <-errCh:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(time.Second * 10):
 		t.Fatal("WaitForDelete blocked on a cluster-scoped resource that receives no status events; it must return promptly instead of waiting out the timeout")
 	}

--- a/pkg/kube/statuswait_test.go
+++ b/pkg/kube/statuswait_test.go
@@ -375,6 +375,47 @@ func TestStatusWaitForDeleteNonExistentObject(t *testing.T) {
 	assert.NoError(t, statusWaiter.WaitForDelete(resourceList, timeout))
 }
 
+func TestStatusWaitForDeleteClusterScopedReturnsPromptly(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t)
+	// The timeout is deliberately generous: the regression this test guards
+	// against (#32224) made WaitForDelete block for the entire timeout, so
+	// completion well before this timeout is what separates correct behavior
+	// from the regression.
+	timeout := time.Second * 60
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+	fakeMapper := testutil.NewFakeRESTMapper(
+		schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"}.WithKind("ClusterRole"),
+	)
+	statusWaiter := statusWaiter{
+		restMapper: fakeMapper,
+		client:     fakeClient,
+	}
+	statusWaiter.SetLogger(slog.Default().Handler())
+	// The ClusterRole is intentionally never created. waitForDelete watches
+	// with RESTScopeNamespace, so a cluster-scoped resource can receive no
+	// status events and stay UnknownStatus for the entire wait. An
+	// Unknown-only set must aggregate to NotFound so the wait returns
+	// promptly. In v4.2.1, 360d4835d deferred cancellation until a real
+	// status event arrived, which made this scenario block for the full
+	// timeout; pre-install hooks with cluster-scoped resources were then
+	// never created (#32224). The commit was reverted in b05881cf9, and
+	// #32261 tracks re-attempting it without reintroducing this hang.
+	objManifest := getRuntimeObjFromManifests(t, []string{clusterRoleManifest})
+	resourceList := getResourceListFromRuntimeObjs(t, c, objManifest)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- statusWaiter.WaitForDelete(resourceList, timeout)
+	}()
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(time.Second * 10):
+		t.Fatal("WaitForDelete blocked on a cluster-scoped resource that receives no status events; it must return promptly instead of waiting out the timeout")
+	}
+}
+
 func TestStatusWait(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Relates to #32224 and #32261. Test only, no production code changed.

**What this PR does / why we need it**:

`WaitForDelete` watches with a namespace-scoped RESTScope, so a cluster-scoped resource can receive no status events at all. In v4.2.1, 360d4835d deferred cancellation until a real status event arrived, which made delete-waits on such objects block for the full timeout: pre-install hooks containing cluster-scoped resources (ingress-nginx's admission RBAC for example) were never created and installs sat in pending-install (#32224). That commit was reverted in v4.2.2, and #32261 tracks re-attempting the underlying flake fix.

This adds the regression test pinning the required behavior, so the re-attempt cannot bring the hang back: a delete-wait over a cluster-scoped object that receives no events must return promptly.

With the reverted commit re-applied locally the test fails:

```
--- FAIL: TestStatusWaitForDeleteClusterScopedReturnsPromptly (10.01s)
```

On main it passes in 0.11s. The margin is wall-clock (60s timeout against a 10s gate) because the buggy path returned nil after timing out, so a plain error assertion would not catch it.

`go test ./pkg/kube/... -count=1` passes, gofmt clean.

**Checklist**
- [x] my commits are signed off
- [x] the title of the PR is suitable for the changelog
