### PR TITLE
pkg/repo/v1: add RedirectURL support to IndexFile (#32528)

### DIFF
--- a/pkg/repo/v1/index.go
+++ b/pkg/repo/v1/index.go
@@ -52,6 +52,8 @@ var (
 	ErrNoChartName = errors.New("no chart name found")
 	// ErrEmptyIndexYaml indicates that the content of index.yaml is empty.
 	ErrEmptyIndexYaml = errors.New("empty index.yaml file")
+	// ErrRepositoryMoved indicates that the repository index has moved to a new URL.
+	ErrRepositoryMoved = errors.New("repository moved to new URL")
 )
 
 // ChartVersions is a list of versioned chart references.
@@ -86,6 +88,9 @@ type IndexFile struct {
 	Generated  time.Time                `json:"generated"`
 	Entries    map[string]ChartVersions `json:"entries"`
 	PublicKeys []string                 `json:"publicKeys,omitempty"`
+
+	// RedirectURL specifies a new repository URL if this repository has moved.
+	RedirectURL string `json:"redirectURL,omitempty"`
 
 	// Annotations are additional mappings uninterpreted by Helm. They are made available for
 	// other applications to add information to the index file.

--- a/pkg/repo/v1/index_test.go
+++ b/pkg/repo/v1/index_test.go
@@ -128,6 +128,17 @@ func TestIndexFile(t *testing.T) {
 	assert.Equal(t, "0.1.8", cv.Version, "Expected version: 0.1.8")
 }
 
+func TestLoadIndex_RedirectURL(t *testing.T) {
+	yamlData := `
+apiVersion: v1
+redirectURL: https://new-org.github.io/charts
+entries: {}
+`
+	i, err := loadIndex([]byte(yamlData), "test")
+	require.NoError(t, err)
+	assert.Equal(t, "https://new-org.github.io/charts", i.RedirectURL)
+}
+
 func TestLoadIndex(t *testing.T) {
 	tests := []struct {
 		Name     string


### PR DESCRIPTION
<!--  TFixes #32528

Adds `RedirectURL` field to `IndexFile` struct in `pkg/repo/v1/index.go` and corresponding unit test `TestLoadIndex_RedirectURL` in `pkg/repo/v1/index_test.go` to support tombstone repository redirection.