### PR TITLE
Add optional hashAlgorithm argument to htpasswd template function

### DIFF
--- a/pkg/engine/funcs.go
+++ b/pkg/engine/funcs.go
@@ -18,6 +18,8 @@ package engine
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +33,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
+	"golang.org/x/crypto/bcrypt"
 	"sigs.k8s.io/yaml"
 	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
@@ -67,6 +70,7 @@ func funcMap() template.FuncMap {
 		"mustToJson":    mustToJSON,
 		"fromJson":      fromJSON,
 		"fromJsonArray": fromJSONArray,
+		"htpasswd":      htpasswd,
 
 		// Duration helpers
 		"mustToDuration":       mustToDuration,
@@ -97,6 +101,34 @@ func funcMap() template.FuncMap {
 	maps.Copy(f, extra)
 
 	return f
+}
+
+// htpasswd generates an Apache htpasswd entry for username and password.
+// algorithm is optional and defaults to bcrypt. Supported values are
+// "bcrypt", "sha", and "sha1".
+func htpasswd(username, password string, algorithm ...string) string {
+	if strings.Contains(username, ":") {
+		return "invalid username: " + username
+	}
+
+	algo := "bcrypt"
+	if len(algorithm) > 0 && algorithm[0] != "" {
+		algo = algorithm[0]
+	}
+
+	switch algo {
+	case "bcrypt":
+		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		if err != nil {
+			return "failed to encrypt string with bcrypt: " + err.Error()
+		}
+		return username + ":" + string(hash)
+	case "sha", "sha1":
+		sum := sha1.Sum([]byte(password))
+		return username + ":{SHA}" + base64.StdEncoding.EncodeToString(sum[:])
+	default:
+		return "invalid algorithm: " + algo
+	}
 }
 
 // toYAML takes an interface, marshals it to yaml, and returns a string. It will

--- a/pkg/engine/funcs_test.go
+++ b/pkg/engine/funcs_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package engine
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
 	"math"
 	"strings"
 	"testing"
@@ -192,6 +194,59 @@ keyInElement1 = "valueInElement1"`,
 		} else {
 			assert.Error(t, err)
 		}
+	}
+}
+
+func TestHtpasswd(t *testing.T) {
+	const username = "testuser"
+	const password = "testpassword"
+
+	shaSum := sha1.Sum([]byte(password))
+	shaExpected := username + ":{SHA}" + base64.StdEncoding.EncodeToString(shaSum[:])
+
+	tests := []struct {
+		name   string
+		tpl    string
+		expect string
+		bcrypt bool
+	}{{
+		name:   "two-arg defaults to bcrypt",
+		tpl:    `{{ htpasswd "testuser" "testpassword" }}`,
+		bcrypt: true,
+	}, {
+		name:   "three-arg bcrypt",
+		tpl:    `{{ htpasswd "testuser" "testpassword" "bcrypt" }}`,
+		bcrypt: true,
+	}, {
+		name:   "three-arg sha",
+		tpl:    `{{ htpasswd "testuser" "testpassword" "sha" }}`,
+		expect: shaExpected,
+	}, {
+		name:   "three-arg sha1",
+		tpl:    `{{ htpasswd "testuser" "testpassword" "sha1" }}`,
+		expect: shaExpected,
+	}, {
+		name:   "invalid algorithm",
+		tpl:    `{{ htpasswd "testuser" "testpassword" "md5" }}`,
+		expect: "invalid algorithm: md5",
+	}, {
+		name:   "username containing colon",
+		tpl:    `{{ htpasswd "user:name" "testpassword" }}`,
+		expect: "invalid username: user:name",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			require.NoError(t, template.Must(template.New("test").Funcs(funcMap()).Parse(tt.tpl)).Execute(&b, nil), tt.tpl)
+			got := b.String()
+			if tt.bcrypt {
+				assert.True(t, strings.HasPrefix(got, username+":$"))
+				assert.NotContains(t, got, "{SHA}")
+				return
+			}
+			assert.Equal(t, tt.expect, got, tt.tpl)
+		})
 	}
 }
 


### PR DESCRIPTION
## What

The `htpasswd` template function (inherited from sprig v3.3.0) only supports bcrypt and accepts exactly two arguments. This adds an optional third `hashAlgorithm` argument so users can generate a SHA-1 hash in the Apache htpasswd `{SHA}` format — useful for Envoy basic-auth filters and other consumers that don't accept bcrypt.

## Behavior

| Call | Result |
|---|---|
| `htpasswd "user" "pass"` | bcrypt (unchanged) |
| `htpasswd "user" "pass" "bcrypt"` | bcrypt |
| `htpasswd "user" "pass" "sha"` / `"sha1"` | `user:{SHA}<base64(sha1(pass))>` |
| any other algorithm | `invalid algorithm: <alg>` |
| username containing `:` | `invalid username: <user>` (unchanged) |

## Tests

Added table-driven `TestHtpasswd` covering every row above. `go test ./pkg/engine/ -run TestHtpasswd -count=1` passes and `gofmt` is clean.

Fixes #31924