### PR TITLE
fix(plugin): write slash-separated paths in plugin tarballs

### DIFF
--- a/internal/plugin/sign.go
+++ b/internal/plugin/sign.go
@@ -130,8 +130,8 @@ func CreatePluginTarball(sourceDir, pluginName string, w io.Writer) error {
 			return err
 		}
 
-		// Include the base directory name in the tarball
-		header.Name = filepath.Join(baseDir, relPath)
+		// Tar member names must use / even when packaging on Windows.
+		header.Name = filepath.ToSlash(filepath.Join(baseDir, relPath))
 
 		// Write header
 		if err := tw.WriteHeader(header); err != nil {

--- a/internal/plugin/sign_test.go
+++ b/internal/plugin/sign_test.go
@@ -16,6 +16,11 @@ limitations under the License.
 package plugin
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,4 +82,43 @@ runtimeConfig:
 	require.NoError(t, err)
 	// The signature should contain the tarball hash
 	assert.Contains(t, sig, "sha256:"+expectedHash, "signature does not contain expected tarball hash: sha256:%s", expectedHash)
+}
+
+func TestCreatePluginTarballUsesSlashSeparatedNames(t *testing.T) {
+	tempDir := t.TempDir()
+	pluginDir := filepath.Join(tempDir, "test-plugin")
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, "bin"), 0o755))
+
+	pluginYAML := `apiVersion: v1
+name: test-plugin
+type: cli/v1
+runtime: subprocess
+version: 1.0.0
+runtimeConfig:
+  platformCommand:
+    - command: echo`
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(pluginYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "bin", "helper"), []byte("echo\n"), 0o755))
+
+	var buf bytes.Buffer
+	require.NoError(t, CreatePluginTarball(pluginDir, "test-plugin", &buf))
+
+	gzr, err := gzip.NewReader(&buf)
+	require.NoError(t, err)
+	t.Cleanup(func() { gzr.Close() })
+
+	tr := tar.NewReader(gzr)
+	var names []string
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		assert.Equalf(t, filepath.ToSlash(header.Name), header.Name, "tar member %q must use slash separators", header.Name)
+		names = append(names, header.Name)
+	}
+
+	assert.Contains(t, names, "test-plugin/plugin.yaml")
+	assert.Contains(t, names, "test-plugin/bin/helper")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

`CreatePluginTarball` (used by `helm plugin package`) built tar member names with `filepath.Join`. On Windows that inserts `\`. POSIX tar and Unix extractors treat a backslash as a literal character, so a plugin packaged on Windows ships names like `myplugin\plugin.yaml`. `ExtractTgzPluginMetadata` then fails with `plugin.yaml not found in tarball` on Linux.

Chart packaging already converts names with `filepath.ToSlash` in `writeToTar`. Do the same for plugin tarballs.

Verified on windows/amd64:

```
go test ./internal/plugin/ -run 'TestCreatePluginTarballUsesSlashSeparatedNames|TestSignPlugin'
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
