### PR TITLE
fix(list): return an error for a negative offset

### DIFF
--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"errors"
 	"path"
 	"regexp"
 
@@ -149,6 +150,12 @@ func NewList(cfg *Configuration) *List {
 func (l *List) Run() ([]ri.Releaser, error) {
 	if err := l.cfg.KubeClient.IsReachable(); err != nil {
 		return nil, err
+	}
+
+	// A negative offset would otherwise panic in the slice expression below,
+	// as the out-of-bounds guard only covers offsets past the end of the list.
+	if l.Offset < 0 {
+		return nil, errors.New("list offset cannot be negative")
 	}
 
 	var filter *regexp.Regexp

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -179,6 +179,15 @@ func TestList_LimitOffsetOutOfBounds(t *testing.T) {
 	is.Len(list, 2)
 }
 
+func TestList_NegativeOffset(t *testing.T) {
+	req := require.New(t)
+	lister := newListFixture(t)
+	lister.Offset = -1
+	makeMeSomeReleases(t, lister.cfg.Releases)
+	_, err := lister.Run()
+	req.Error(err)
+}
+
 func TestList_StateMask(t *testing.T) {
 	is := assert.New(t)
 	req := require.New(t)


### PR DESCRIPTION
## What happened

`helm list --offset <negative>` panics with a slice bounds out of range when at least one release exists.

## Root cause

In `pkg/action/list.go`, the out-of-bounds guard only covers offsets **past the end** of the result list:

```go
// Guard on offset
if l.Offset >= len(rresults) {
    return releaseV1ListToReleaserList([]*release.Release{})
}
```

A negative offset passes this guard (`-1 >= len` is false), and the subsequent slice expression panics:

```go
rresults = rresults[l.Offset:last]
```

`--offset` is bound via `IntVar` in `pkg/cmd/list.go` with no validation, so `helm list --offset -1` is directly CLI-reachable.

Reproduction against `main` (fa11636b0), new test `TestList_NegativeOffset` before the fix:

```
panic: runtime error: slice bounds out of range [-1:2]
helm.sh/helm/v4/pkg/action.(*List).Run(...)
    pkg/action/list.go:223
```

Note the behavior is currently inconsistent: with an empty release store the same command returns an empty list without error (the early `results == nil` return fires before the guard), while with any release present it panics.

## What this PR does

- Validates `Offset` at the start of `List.Run()` and returns `errors.New("list offset cannot be negative")` for negative values, so both CLI and SDK consumers get a clean error instead of a panic, regardless of how many releases exist.
- Adds `TestList_NegativeOffset` to `pkg/action/list_test.go` asserting that a negative offset yields an error.

## Verification

Fail-before / pass-after:

```
$ go test ./pkg/action/ -run TestList_NegativeOffset -count=1
# before fix:
panic: runtime error: slice bounds out of range [-1:2]  ... FAIL
# after fix:
ok      helm.sh/helm/v4/pkg/action
```

Full relevant packages after the fix:

```
$ go test ./pkg/action/... ./pkg/cmd/... -count=1
ok      helm.sh/helm/v4/pkg/action        59.963s
ok      helm.sh/helm/v4/pkg/cmd           21.158s
ok      helm.sh/helm/v4/pkg/cmd/require    0.389s
ok      helm.sh/helm/v4/pkg/cmd/search     0.998s
```

## Notes / risks

- Behavior change: `helm list --offset -1` previously panicked (or, with an empty store, printed nothing); it now exits with an error message. Scripts relying on the old behavior would have been relying on a panic.
- No public API signature changed.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent; the bug, reproduction, fix, and test were all verified locally by me as described above.
