### PR TITLE
fix(repo): report the error when creating a missing merge index fails

### DIFF
--- a/pkg/cmd/repo_index.go
+++ b/pkg/cmd/repo_index.go
@@ -101,7 +101,9 @@ func index(dir, url, mergeTo string, json bool) error {
 		var i2 *repo.IndexFile
 		if _, err := os.Stat(mergeTo); errors.Is(err, fs.ErrNotExist) {
 			i2 = repo.NewIndexFile()
-			writeIndexFile(i2, mergeTo, json)
+			if err := writeIndexFile(i2, mergeTo, json); err != nil {
+				return fmt.Errorf("merge failed: %w", err)
+			}
 		} else {
 			i2, err = repo.LoadIndexFile(mergeTo)
 			if err != nil {

--- a/pkg/cmd/repo_index_test.go
+++ b/pkg/cmd/repo_index_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,4 +141,29 @@ func copyFile(dst, src string) error {
 func TestRepoIndexFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "repo index", true)
 	checkFileCompletion(t, "repo index mydir", false)
+}
+
+func TestRepoIndexCmdMergeWriteError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, linkOrCopy("testdata/testcharts/compressedchart-0.1.0.tgz", filepath.Join(dir, "compressedchart-0.1.0.tgz")))
+
+	// The merge target does not exist and its directory is read-only, so
+	// creating it must fail and the error must be reported.
+	roDir := filepath.Join(t.TempDir(), "ro")
+	require.NoError(t, os.Mkdir(roDir, 0o500))
+	mergeTo := filepath.Join(roDir, "index.yaml")
+
+	buf := bytes.NewBuffer(nil)
+	c := newRepoIndexCmd(buf)
+	require.NoError(t, c.ParseFlags([]string{"--merge", mergeTo}))
+
+	err := c.RunE(c, []string{dir})
+	require.Error(t, err, "expected an error when the missing merge target cannot be written")
 }


### PR DESCRIPTION
## What happened

When `helm repo index --merge <target>` is given a merge target that does not exist, the command creates an empty index at that path before merging. If that write fails (e.g., the target's directory is read-only, or the disk is full), the error is silently discarded and the command reports success, leaving no index file at the merge target.

## Root cause

In `pkg/cmd/repo_index.go`, the write in the missing-target branch of `index()` ignores the return value:

```go
if _, err := os.Stat(mergeTo); errors.Is(err, fs.ErrNotExist) {
    i2 = repo.NewIndexFile()
    writeIndexFile(i2, mergeTo, json)   // <-- error discarded
} else {
    i2, err = repo.LoadIndexFile(mergeTo)
    if err != nil {
        return fmt.Errorf("merge failed: %w", err)
    }
}
```

Both sibling operations in the same function — loading the merge index and the final `writeIndexFile(i, out, json)` — propagate their errors; only this one is dropped. The create-if-missing behavior was introduced in 141e0155 ("Create index.yaml if missing when running repo index --merge", #3682).

Reproduction against `main` (fa11636b0): new test `TestRepoIndexCmdMergeWriteError` builds a chart dir, points `--merge` at an `index.yaml` inside a read-only directory, and asserts the command returns an error — it currently returns `nil`.

## What this PR does

- Propagates the error: `return fmt.Errorf("merge failed: %w", err)`, matching the wrapping style used for `LoadIndexFile` in the same function.
- Adds `TestRepoIndexCmdMergeWriteError` with a read-only directory (skipped on Windows and when running as root, following the same guard pattern as `TestDefaultKeyring` in `pkg/cmd/dependency_build_test.go`).

## Verification

Fail-before / pass-after:

```
$ go test ./pkg/cmd/ -run TestRepoIndexCmdMergeWriteError -count=1
# before fix:
Error: An error is expected but got nil.  ... FAIL
# after fix:
--- PASS: TestRepoIndexCmdMergeWriteError
```

Full relevant packages after the fix (existing `TestRepoIndexCmd` merge cases, including the create-if-missing happy path, still pass):

```
$ go test ./pkg/cmd/... ./pkg/repo/... -count=1
ok      helm.sh/helm/v4/pkg/cmd             16.657s
ok      helm.sh/helm/v4/pkg/cmd/require      1.059s
ok      helm.sh/helm/v4/pkg/cmd/search       3.198s
ok      helm.sh/helm/v4/pkg/repo/v1          0.942s
ok      helm.sh/helm/v4/pkg/repo/v1/repotest 2.606s
```

`go vet` clean.

## Notes / risks

- Behavior change limited to the failure path: a previously silent success (with a missing merge index) now exits with an error.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent; the bug, reproduction, fix, and test were all verified locally by me as described above.
