### PR TITLE
feat(cli): add a --context flag alias of --kube-context

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -152,6 +152,7 @@ func New() *EnvSettings {
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace scope for this request")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", "", "path to the kubeconfig file")
+	fs.StringVar(&s.KubeContext, "context", s.KubeContext, "name of the kubeconfig context to use (alias for --kube-context)")
 	fs.StringVar(&s.KubeContext, "kube-context", s.KubeContext, "name of the kubeconfig context to use")
 	fs.StringVar(&s.KubeToken, "kube-token", s.KubeToken, "bearer token used for authentication")
 	fs.StringVar(&s.KubeAsUser, "kube-as-user", s.KubeAsUser, "username to impersonate for the operation")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -233,8 +233,8 @@ func newRootCmdWithConfig(actionConfig *action.Configuration, out io.Writer, arg
 		log.Fatal(err)
 	}
 
-	// Setup shell completion for the kube-context flag
-	err = cmd.RegisterFlagCompletionFunc("kube-context", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	// Setup shell completion for the kube-context flag (and its --context alias)
+	kubeContextCompletionFunc := func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		cobra.CompDebugln("About to get the different kube-contexts", settings.Debug)
 
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -251,7 +251,12 @@ func newRootCmdWithConfig(actionConfig *action.Configuration, out io.Writer, arg
 			return comps, cobra.ShellCompDirectiveNoFileComp
 		}
 		return nil, cobra.ShellCompDirectiveNoFileComp
-	})
+	}
+	err = cmd.RegisterFlagCompletionFunc("kube-context", kubeContextCompletionFunc)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = cmd.RegisterFlagCompletionFunc("context", kubeContextCompletionFunc)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
For parity with kubectl.

**What this PR does / why we need it**:

Adds `--context` as an alias for the existing `--kube-context` flag, so
users switching between `kubectl` and `helm` don't have to remember two
different flag names for the same thing.

This has been requested before in #8859 and #1127. #8859 was closed as
stale after a maintainer raised a separation-of-concerns objection
(worrying that flags without a `kube-` prefix could be ambiguous about
whether they affect Helm or Kubernetes). `--context` doesn't have that
ambiguity: Helm has no other concept of "context", so there's only one
thing it could mean. The reporter on #8859 suggested revisiting this
now that Helm 4 is out.

**Special notes for your reviewer**:

This supersedes #32130, which was closed after Copilot's automated
review flagged two issues:
1. `--context` was registered with a default of `""` instead of
   `s.KubeContext`, which reset the `HELM_KUBECONTEXT` env default
   before `--kube-context` was registered. Fixed by using
   `s.KubeContext` as the default, matching `--kube-context`.
2. The flag was hidden from `--help` via `MarkHidden`, which undercuts
   the stated goal of kubectl parity, and the `MarkHidden` error was
   ignored. Fixed by dropping `MarkHidden` and registering shell
   completion for `--context` using the same completion function
   already used for `--kube-context`.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility