### PR TITLE
fix: disable file completion after chart URL prefixes

### DIFF
--- a/pkg/cmd/search_repo.go
+++ b/pkg/cmd/search_repo.go
@@ -339,16 +339,25 @@ func compListCharts(toComplete string, includeFiles bool) ([]string, cobra.Shell
 	cobra.CompDebugln(fmt.Sprintf("Completions after repos: %v", completions), settings.Debug)
 
 	// Now handle completions for url prefixes
-	for _, url := range []string{"oci://\tChart OCI prefix", "https://\tChart URL prefix", "http://\tChart URL prefix", "file://\tChart local URL prefix"} {
-		if strings.HasPrefix(toComplete, url) {
+	urlPrefixes := []struct {
+		value string
+		desc  string
+	}{
+		{value: "oci://", desc: "Chart OCI prefix"},
+		{value: "https://", desc: "Chart URL prefix"},
+		{value: "http://", desc: "Chart URL prefix"},
+		{value: "file://", desc: "Chart local URL prefix"},
+	}
+	for _, prefix := range urlPrefixes {
+		if strings.HasPrefix(toComplete, prefix.value) {
 			// The user already put in the full url prefix; we don't have
 			// anything to add, but make sure the shell does not default
 			// to file completion since we could be returning an empty array.
 			noFile = true
 			noSpace = true
-		} else if strings.HasPrefix(url, toComplete) {
+		} else if strings.HasPrefix(prefix.value, toComplete) {
 			// We are completing a url prefix
-			completions = append(completions, url)
+			completions = append(completions, fmt.Sprintf("%s\t%s", prefix.value, prefix.desc))
 			noSpace = true
 		}
 	}

--- a/pkg/cmd/search_repo_test.go
+++ b/pkg/cmd/search_repo_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSearchRepositoriesCmd(t *testing.T) {
@@ -105,4 +109,30 @@ func TestSearchRepoOutputCompletion(t *testing.T) {
 
 func TestSearchRepoFileCompletion(t *testing.T) {
 	checkFileCompletion(t, "search repo", true) // File completion may be useful when inputting a keyword
+}
+
+func TestCompListChartsURLPrefix(t *testing.T) {
+	originalRepositoryConfig := settings.RepositoryConfig
+	originalRepositoryCache := settings.RepositoryCache
+	settings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+	settings.RepositoryCache = t.TempDir()
+	t.Cleanup(func() {
+		settings.RepositoryConfig = originalRepositoryConfig
+		settings.RepositoryCache = originalRepositoryCache
+	})
+
+	tests := []struct {
+		name       string
+		toComplete string
+	}{
+		{name: "OCI URL", toComplete: "oci://registry.example/chart"},
+		{name: "HTTPS URL", toComplete: "https://example.com/chart.tgz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, directive := compListCharts(tt.toComplete, true)
+			assert.Equal(t, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace, directive)
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Closes https://github.com/helm/helm/issues/32626

`compListCharts` used the complete Cobra completion strings, including their tab-separated descriptions, when checking whether the user's input started with a chart URL prefix.

As a result, inputs such as `oci://registry.example/chart` and `https://example.com/chart.tgz` did not match the URL prefixes, so file completion remained enabled and the `NoSpace` directive was not returned.


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
