### PR TITLE
fix(plugin): skip sockets when copying repositories

### DIFF
--- a/internal/third_party/dep/fs/fs.go
+++ b/internal/third_party/dep/fs/fs.go
@@ -132,6 +132,10 @@ func CopyDir(src, dst string) error {
 		srcPath := filepath.Join(src, entry.Name())
 		dstPath := filepath.Join(dst, entry.Name())
 
+		if entry.Type()&os.ModeSocket != 0 {
+			continue
+		}
+
 		if entry.IsDir() {
 			if err = CopyDir(srcPath, dstPath); err != nil {
 				return fmt.Errorf("copying directory failed: %w", err)

--- a/internal/third_party/dep/fs/fs_test.go
+++ b/internal/third_party/dep/fs/fs_test.go
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package fs
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -116,6 +117,30 @@ func TestCopyDir(t *testing.T) {
 		require.Equalf(t, file.fi.Mode(), gotinfo.Mode(), "expected %s: %#v\n to be the same mode as %s: %#v",
 			file.path, file.fi.Mode(), fn, gotinfo.Mode())
 	}
+}
+
+func TestCopyDirSkipsSocket(t *testing.T) {
+	dir := t.TempDir()
+	srcdir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(srcdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcdir, "file"), []byte("contents"), 0o644))
+
+	socketPath := filepath.Join(srcdir, "socket")
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	destdir := filepath.Join(dir, "dest")
+	require.NoError(t, CopyDir(srcdir, destdir))
+
+	contents, err := os.ReadFile(filepath.Join(destdir, "file"))
+	require.NoError(t, err)
+	require.Equal(t, "contents", string(contents))
+
+	_, err = os.Lstat(filepath.Join(destdir, "socket"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestCopyDirFail_SrcInaccessible(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Git's FSMonitor daemon can leave a Unix-domain socket inside a plugin repository's `.git` directory. Copying that repository currently fails when `CopyFile` attempts to open the socket, which prevents plugin installation.

Skip directory entries marked `os.ModeSocket` during recursive `CopyDir` operations. Add a regression test with a real Unix-domain socket that verifies the regular file reaches the destination while the socket is omitted.

Fixes #12125.

**Special notes for your reviewer**:

The change preserves `.git` copying, the `CopyDir` API, and existing handling of regular files, directories and symlinks. It only filters socket entries.

Validation on Go 1.27.0:

- Regression fails on the original main implementation and passes on this patch.
- macOS: full `make test-unit`, filesystem/installer `-race` tests, `make test-style` (0 issues; golangci-lint 2.13.2), `go mod tidy -diff`, and CLI build pass.
- [Native Linux and Windows run](https://github.com/ruslan-shaydullin/helm/actions/runs/34329037316): Linux filesystem/installer tests pass; the socket regression also passes on Windows Server 2025.
- The broader Windows suite exposes existing failures: filesystem handle/symlink tests and installer tests using `syscall.Umask`. A [baseline-versus-patch Windows comparison](https://github.com/ruslan-shaydullin/helm/actions/runs/34329571576) confirms identical failing test sets on main and this patch, while the new socket test and production package builds pass. The full Windows suite is not claimed green.

The native checks explicitly test contribution commit `c2689c955`; the validation-only workflow stays in the fork and is not part of this PR.

AI assistance: Codex assisted with implementation, review, testing and preparation of this description.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
